### PR TITLE
chore: rename streams to fragments

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,62 +27,62 @@ The protocol defines the serializable structure representing UI templates.
 ```rust
 /// The root protocol structure representing a complete webpage configuration.
 pub struct WebUIProtocol {
-    /// Map of stream identifiers to their associated streams.
-    pub streams: WebUIStreamRecords,
+    /// Map of fragment identifiers to their associated fragments.
+    pub fragments: WebUIFragmentRecords,
 }
 
-/// A mapping of unique stream identifiers to their corresponding stream vectors.
-pub type WebUIStreamRecords = HashMap<String, Vec<WebUIStream>>;
+/// A mapping of unique fragment identifiers to their corresponding fragment vectors.
+pub type WebUIFragmentRecords = HashMap<String, Vec<WebUIFragment>>;
 
-/// Defines the various types of streams in the WebUI protocol.
+/// Defines the various types of fragments in the WebUI protocol.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum WebUIStream {
+pub enum WebUIFragment {
     /// Outputs static content.
-    Raw(WebUIStreamRaw),
+    Raw(WebUIFragmentRaw),
     /// A reusable component with styling.
-    Component(WebUIStreamComponent),
+    Component(WebUIFragmentComponent),
     /// Iterates over a collection to generate repeated content.
-    For(WebUIStreamFor),
+    For(WebUIFragmentFor),
     /// Connects dynamic content via signals.
-    Signal(WebUIStreamSignal),
+    Signal(WebUIFragmentSignal),
     /// Renders content conditionally.
-    If(WebUIStreamIf),
+    If(WebUIFragmentIf),
     /// Represents a boolean attribute (e.g., disabled, checked).
-    BooleanAttribute(WebUIStreamBooleanAttribute),
+    BooleanAttribute(WebUIFragmentBooleanAttribute),
 }
 ```
-### Stream Types
-#### Raw Stream
+### Fragment Types
+#### Raw Fragment
 ```rust
-pub struct WebUIStreamRaw {
+pub struct WebUIFragmentRaw {
     /// The content to render.
     pub value: String,
 }
 ```
-#### Component Stream
+#### Component Fragment
 ```rust
-pub struct WebUIStreamComponent {
-    /// The identifier for the associated stream record.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+pub struct WebUIFragmentComponent {
+    /// The identifier for the associated fragment record.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 ```
-#### For Loop Stream
+#### For Loop Fragment
 ```rust
-pub struct WebUIStreamFor {
+pub struct WebUIFragmentFor {
     /// The name representing a singular item (e.g., "person").
     pub item: String,
     /// The collection name (e.g., "people").
     pub collection: String,
-    /// The identifier for the stream to render for each item.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+    /// The identifier for the fragment to render for each item.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 ```
-#### Signal Stream
+#### Signal Fragment
 ```rust
-pub struct WebUIStreamSignal {
+pub struct WebUIFragmentSignal {
     /// The value or identifier of the signal.
     pub value: String,
     /// Determines if the value should be rendered as raw content.
@@ -90,21 +90,21 @@ pub struct WebUIStreamSignal {
     pub raw: bool,
 }
 ```
-#### Conditional Stream
+#### Conditional Fragment
 ```rust
-pub struct WebUIStreamIf {
+pub struct WebUIFragmentIf {
     /// The condition expression to evaluate.
     pub condition: ConditionExpr,
-    /// The identifier for the stream record to render if true.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+    /// The identifier for the fragment record to render if true.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 ```
-#### Boolean Attribute Stream
+#### Boolean Attribute Fragment
 ```rust
 /// Represents a boolean attribute on an element.
 /// Boolean attributes must start with '?' (e.g., ?disabled).
-pub struct WebUIStreamBooleanAttribute {
+pub struct WebUIFragmentBooleanAttribute {
     /// The boolean attribute name (e.g., "disabled").
     pub name: String,
     /// The attribute value to render, if false, attribute is ignored.
@@ -175,8 +175,8 @@ pub struct Predicate {
 - Support for custom error types and propagation
 - Validation of protocol structure during deserialization
 - Performance optimizations for large protocol structures
-- Support for stream reference validation
-- Attribute names starting with '?' are treated as boolean attributes using the `BooleanAttribute` stream type. The attribute is rendered only if the value/expression evaluates to true.
+- Support for fragment reference validation
+- Attribute names starting with '?' are treated as boolean attributes using the `BooleanAttribute` fragment type. The attribute is rendered only if the value/expression evaluates to true.
 
 ## State Management (webui-state)
 ### Path Resolution
@@ -234,41 +234,41 @@ pub trait Writer {
     fn end(&mut self) -> Result<(), io::Error>;
 }
 ```
-### Stream Processing
-- **Raw streams:** Write value directly to output
-- **Signal streams:**
+### Fragment Processing
+- **Raw fragments:** Write value directly to output
+- **Signal fragments:**
   - Resolve value from state using `find_value_by_dotted_path`
   - Escape value if `raw` is false, otherwise write as-is
-- **Boolean attribute streams:**
+- **Boolean attribute fragments:**
   - Evaluate the value; if true, render the attribute name.
   - If false, omit the attribute.
-- **If streams:**
+- **If fragments:**
   - Evaluate condition using `evaluate`
-  - If true, process referenced stream
+  - If true, process referenced fragment
   - Track false conditions for template generation
-  - When the `If` streams are enclosed in one or more `For` streams it can access the states of those `For` streams'
+  - When the `If` fragments are enclosed in one or more `For` fragments it can access the states of those `For` fragments'
     current item thorugh their corresponding item monikers. It can also access global state.
-  - `If` stream conditions can have tokens from different state objects i.e. local states from enclosing `For` stream
+  - `If` fragment conditions can have tokens from different state objects i.e. local states from enclosing `For` fragment
     items and/or the global state mixed in the condition expression.
-- **For streams:**
+- **For fragments:**
   - Iterate over collection from state
-  - Process referenced stream for each item with current item's state accessible thorugh a moniker and the global state
+  - Process referenced fragment for each item with current item's state accessible thorugh a moniker and the global state
     as a fallback.
-- **Component streams:** Process referenced stream directly. `Component` streams enclosed in a For stream has access to
-    the fields of the current item being looped over and the global state. The `Component` stream doesn't need to use
-    the `For` stream item moniker and can access the fields without the qualification. If the `Component` stream is
-    nested in multiple `For` streams only the closest enclosing `For` stream item's state is accessible to it.
+- **Component fragments:** Process referenced fragment directly. `Component` fragments enclosed in a For fragment has access to
+    the fields of the current item being looped over and the global state. The `Component` fragment doesn't need to use
+    the `For` fragment item moniker and can access the fields without the qualification. If the `Component` fragment is
+    nested in multiple `For` fragments only the closest enclosing `For` fragment item's state is accessible to it.
 
 ### State Management
-- Global state refers to the global application state that is available to all streams at all times.
-- Local state refers to the state corresponding to the current item being looped over in a `For` stream.
-- When nested `For` streams are present local state of the current item being looped over for any of the `For` stream in the
-  hierarchy can be accessed through the corresponding item moniker with an exception for `Component` streams.
-- For `Component` streams only the closest enclosing `For` stream's current item state is available and can be accessed
-  directly without the item moniker qualification. `Component` streams also have access to the global application state.
+- Global state refers to the global application state that is available to all fragments at all times.
+- Local state refers to the state corresponding to the current item being looped over in a `For` fragment.
+- When nested `For` fragments are present local state of the current item being looped over for any of the `For` fragment in the
+  hierarchy can be accessed through the corresponding item moniker with an exception for `Component` fragments.
+- For `Component` fragments only the closest enclosing `For` fragment's current item state is available and can be accessed
+  directly without the item moniker qualification. `Component` fragments also have access to the global application state.
 
 ### Error Handling
-- Report missing stream references
+- Report missing fragment references
 - Handle state resolution failures
 - Propagate writer errors
 - Validate protocol before processing
@@ -314,8 +314,8 @@ pub struct HtmlParser {
 ```
 #### Primary Method
 ```rust
-pub fn parse(&mut self, stream_id: &str, html_content: &str) -> Result<(), ParserError>
-pub fn into_stream_records(self) -> WebUIStreamRecords
+pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<(), ParserError>
+pub fn into_fragment_records(self) -> WebUIFragmentRecords
 ```
 #### Content Processing
 
@@ -325,8 +325,8 @@ pub fn into_stream_records(self) -> WebUIStreamRecords
 - Flush buffer when transitioning to non-raw content
 
 ##### Directive Processing
-- **<for>:** Extract item/collection pair and process children into separate stream
-- **<if>:** Extract and parse condition, process children into separate stream
+- **<for>:** Extract item/collection pair and process children into separate fragment
+- **<if>:** Extract and parse condition, process children into separate fragment
 - **Components:** Check component registry, process as component if found
 
 ##### Element Processing
@@ -344,7 +344,7 @@ pub fn into_stream_records(self) -> WebUIStreamRecords
 pub struct HandlebarsParser;
 
 impl HandlebarsParser {
-    pub fn parse(&self, text: &str) -> Result<Vec<WebUIStream>, ParserError>
+    pub fn parse(&self, text: &str) -> Result<Vec<WebUIFragment>, ParserError>
 }
 ```
 #### Requirements
@@ -383,8 +383,8 @@ pub struct CssParser {
 }
 
 impl CssParser {
-    pub fn parse(&mut self, css_content: &str) -> Result<WebUIStreamRecords, ParserError>
-    pub fn process_css(&mut self, css_content: &str, streams: &mut WebUIStreamRecords) -> Result<(), ParserError>
+    pub fn parse(&mut self, css_content: &str) -> Result<WebUIFragmentRecords, ParserError>
+    pub fn process_css(&mut self, css_content: &str, fragments: &mut WebUIFragmentRecords) -> Result<(), ParserError>
     pub fn parse_inline_css(&mut self, style_content: &str) -> Result<String, ParserError>
 }
 ```
@@ -468,14 +468,14 @@ Hello, WebUI!
 ### Generated Protocol
 ```json
 {
-    "streams": {
+    "fragments": {
         "index.html": [
             { "type": "raw", "value": "Hello, WebUI!\n" },
             {
                 "type": "for",
                 "item": "person",
                 "collection": "people",
-                "streamId": "for-1"
+                "fragmentId": "for-1"
             },
             {
                 "type": "signal",
@@ -488,7 +488,7 @@ Hello, WebUI!
                     "kind": "identifier",
                     "value": "contact"
                 },
-                "streamId": "if-1"
+                "fragmentId": "if-1"
             }
         ],
         "for-1": [
@@ -507,7 +507,7 @@ Hello, WebUI!
             },
             {
                 "type": "component",
-                "streamId": "person_card",
+                "fragmentId": "person_card",
                 "raw": false
             },
             {

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use thiserror::Error;
 use webui_expressions::evaluate;
-use webui_protocol::{WebUIProtocol, WebUIStream};
+use webui_protocol::{WebUIFragment, WebUIProtocol};
 use webui_state::find_value_by_dotted_path;
 
 /// Error types for the WebUI handler.
@@ -16,8 +16,8 @@ pub enum HandlerError {
     #[error("Rendering error: {0}")]
     Rendering(String),
 
-    #[error("Missing stream: {0}")]
-    MissingStream(String),
+    #[error("Missing fragment: {0}")]
+    MissingFragment(String),
 
     #[error("Missing data field: {0}")]
     MissingData(String),
@@ -54,7 +54,7 @@ pub struct WebUIHandler {
     // Configuration options could go here
 }
 
-/// Context object for processing WebUI streams
+/// Context object for processing WebUI fragments
 struct WebUIProcessContext<'a> {
     protocol: &'a WebUIProtocol,
     state: &'a Value,
@@ -80,13 +80,13 @@ impl WebUIHandler {
         state: &Value,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
-        // Start with the main stream (typically "index.html")
-        let main_stream_id = "index.html";
-        if !protocol.streams.contains_key(main_stream_id) {
-            return Err(HandlerError::MissingStream(main_stream_id.to_string()));
+        // Start with the main fragment (typically "index.html")
+        let main_fragment_id = "index.html";
+        if !protocol.fragments.contains_key(main_fragment_id) {
+            return Err(HandlerError::MissingFragment(main_fragment_id.to_string()));
         }
 
-        // Process the main stream with an empty initial context
+        // Process the main fragment with an empty initial context
         let mut context = WebUIProcessContext {
             protocol,
             state,
@@ -94,7 +94,7 @@ impl WebUIHandler {
             writer,
             local_vars: HashMap::new(),
         };
-        self.process_stream_id(main_stream_id, &mut context)?;
+        self.process_fragment_id(main_fragment_id, &mut context)?;
 
         // Finalize the output
         writer.end()?;
@@ -102,43 +102,47 @@ impl WebUIHandler {
         Ok(())
     }
 
-    /// Process a stream by its ID.
+    /// Process a fragment by its ID.
     ///
     /// The `context` parameter contains scope-local variables that are accessible during rendering,
     /// such as loop iteration variables. This is separate from the global `state`.
-    fn process_stream_id(&self, stream_id: &str, context: &mut WebUIProcessContext) -> Result<()> {
-        if let Some(stream) = context.protocol.streams.get(stream_id) {
-            self.process_stream(stream, context)
+    fn process_fragment_id(
+        &self,
+        fragment_id: &str,
+        context: &mut WebUIProcessContext,
+    ) -> Result<()> {
+        if let Some(fragment) = context.protocol.fragments.get(fragment_id) {
+            self.process_fragment(fragment, context)
         } else {
-            Err(HandlerError::MissingStream(stream_id.to_string()))
+            Err(HandlerError::MissingFragment(fragment_id.to_string()))
         }
     }
 
-    /// Process a vector of streams.
+    /// Process a vector of fragments.
     ///
-    /// The `context` maintains scope-specific variables that can be accessed by streams
+    /// The `context` maintains scope-specific variables that can be accessed by fragments
     /// during rendering, while `state` contains the global application state.
-    fn process_stream(
+    fn process_fragment(
         &self,
-        stream: &Vec<WebUIStream>,
+        fragment: &Vec<WebUIFragment>,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
-        for item in stream {
+        for item in fragment {
             match item {
-                WebUIStream::Raw(raw) => {
+                WebUIFragment::Raw(raw) => {
                     context.writer.write(&raw.value)?;
                 }
-                WebUIStream::Component(component) => {
+                WebUIFragment::Component(component) => {
                     self.process_component(component, context)?;
                 }
-                WebUIStream::For(for_loop) => {
+                WebUIFragment::For(for_loop) => {
                     self.process_for_loop(for_loop, context)?;
                 }
-                WebUIStream::Signal(signal) => {
+                WebUIFragment::Signal(signal) => {
                     let content = self.process_signal(signal, context)?;
                     context.writer.write(&content)?;
                 }
-                WebUIStream::If(if_cond) => {
+                WebUIFragment::If(if_cond) => {
                     self.process_if(if_cond, context)?;
                 }
             }
@@ -146,31 +150,31 @@ impl WebUIHandler {
         Ok(())
     }
 
-    /// Process a component stream.
+    /// Process a component fragment.
     fn process_component(
         &self,
-        component: &webui_protocol::WebUIStreamComponent,
+        component: &webui_protocol::WebUIFragmentComponent,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
         // Write CSS once per component at the first level
         if context.depth == 0 {
             context.writer.write(&format!(
                 "<link rel=\"stylesheet\" href=\"./{}.css\">",
-                component.stream_id
+                component.fragment_id
             ))?;
         }
 
-        self.process_stream_id(&component.stream_id, context)
+        self.process_fragment_id(&component.fragment_id, context)
     }
 
-    /// Process a for loop stream.
+    /// Process a for loop fragment.
     ///
     /// Creates a new context for each iteration that includes the current loop item.
     /// This allows nested templates to access both the loop variable and any parent context.
     /// Example: `for item in items` makes "item" available in the loop body.
     fn process_for_loop(
         &self,
-        for_loop: &webui_protocol::WebUIStreamFor,
+        for_loop: &webui_protocol::WebUIFragmentFor,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
         // Get the collection to iterate over
@@ -202,8 +206,8 @@ impl WebUIHandler {
             // Add the current item to the context
             context.local_vars.insert(item_name.clone(), item.clone());
 
-            // Process the stream with the updated context
-            self.process_stream_id(&for_loop.stream_id, context)?;
+            // Process the fragment with the updated context
+            self.process_fragment_id(&for_loop.fragment_id, context)?;
 
             // Restore the original context
             context.local_vars = saved_vars;
@@ -212,13 +216,13 @@ impl WebUIHandler {
         Ok(())
     }
 
-    /// Process a signal stream.
+    /// Process a signal fragment.
     ///
     /// Looks up the value in the context first (for local variables), then in the global state.
     /// This prioritization allows local variables (like loop items) to override global state.
     fn process_signal(
         &self,
-        signal: &webui_protocol::WebUIStreamSignal,
+        signal: &webui_protocol::WebUIFragmentSignal,
         context: &WebUIProcessContext,
     ) -> Result<String> {
         // Parse the path (could be nested like "person.name")
@@ -266,10 +270,10 @@ impl WebUIHandler {
         Ok(result)
     }
 
-    /// Process an if condition stream.
+    /// Process an if condition fragment.
     fn process_if(
         &self,
-        if_cond: &webui_protocol::WebUIStreamIf,
+        if_cond: &webui_protocol::WebUIFragmentIf,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
         // Evaluate the condition
@@ -278,7 +282,7 @@ impl WebUIHandler {
 
         if condition_met {
             // Process the content if condition is true
-            self.process_stream_id(&if_cond.stream_id, context)?;
+            self.process_fragment_id(&if_cond.fragment_id, context)?;
         }
 
         Ok(())
@@ -299,7 +303,7 @@ impl WebUIHandler {
             local_vars: HashMap::new(),
         };
 
-        self.process_stream_id("index.html", &mut context)
+        self.process_fragment_id("index.html", &mut context)
     }
 }
 
@@ -364,15 +368,15 @@ mod tests {
     #[test]
     fn test_handle_raw() {
         // Create a simple protocol
-        let mut streams = HashMap::new();
-        streams.insert(
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
-            vec![WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+            vec![WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                 value: "Hello, WebUI!".to_string(),
             })],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
         let state = test_json!({});
 
         // Create a test writer
@@ -392,24 +396,24 @@ mod tests {
     #[test]
     fn test_handle_signal() {
         // Create a protocol with a signal
-        let mut streams = HashMap::new();
-        streams.insert(
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
             vec![
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "Hello, ".to_string(),
                 }),
-                WebUIStream::Signal(webui_protocol::WebUIStreamSignal {
+                WebUIFragment::Signal(webui_protocol::WebUIFragmentSignal {
                     value: "name".to_string(),
                     raw: false,
                 }),
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "!".to_string(),
                 }),
             ],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
         let state = test_json!({"name": "WebUI"});
 
         // Create a test writer
@@ -429,35 +433,35 @@ mod tests {
     #[test]
     fn test_handle_for_loop() {
         // Create a protocol with a for loop
-        let mut streams = HashMap::new();
-        streams.insert(
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
             vec![
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "People: ".to_string(),
                 }),
-                WebUIStream::For(webui_protocol::WebUIStreamFor {
+                WebUIFragment::For(webui_protocol::WebUIFragmentFor {
                     item: "person".to_string(),
                     collection: "people".to_string(),
-                    stream_id: "person-item".to_string(),
+                    fragment_id: "person-item".to_string(),
                 }),
             ],
         );
 
-        streams.insert(
+        fragments.insert(
             "person-item".to_string(),
             vec![
-                WebUIStream::Signal(webui_protocol::WebUIStreamSignal {
+                WebUIFragment::Signal(webui_protocol::WebUIFragmentSignal {
                     value: "person.name".to_string(),
                     raw: false,
                 }),
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: ", ".to_string(),
                 }),
             ],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
         let state = test_json!({
             "people": [
                 {"name": "Alice"},
@@ -483,33 +487,33 @@ mod tests {
     #[test]
     fn test_handle_if_condition() {
         // Create a protocol with an if condition
-        let mut streams = HashMap::new();
-        streams.insert(
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
             vec![
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "Status: ".to_string(),
                 }),
-                WebUIStream::If(webui_protocol::WebUIStreamIf {
+                WebUIFragment::If(webui_protocol::WebUIFragmentIf {
                     condition: webui_protocol::ConditionExpr::Identifier {
                         value: "isActive".to_string(),
                     },
-                    stream_id: "active-content".to_string(),
+                    fragment_id: "active-content".to_string(),
                 }),
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "End".to_string(),
                 }),
             ],
         );
 
-        streams.insert(
+        fragments.insert(
             "active-content".to_string(),
-            vec![WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+            vec![WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                 value: "Active".to_string(),
             })],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
 
         // Test with isActive = true
         let state_true = test_json!({"isActive": true});
@@ -535,27 +539,27 @@ mod tests {
     #[test]
     fn test_handle_component() {
         // Create a protocol with a component
-        let mut streams = HashMap::new();
-        streams.insert(
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
             vec![
-                WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+                WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                     value: "Component: ".to_string(),
                 }),
-                WebUIStream::Component(webui_protocol::WebUIStreamComponent {
-                    stream_id: "my-component".to_string(),
+                WebUIFragment::Component(webui_protocol::WebUIFragmentComponent {
+                    fragment_id: "my-component".to_string(),
                 }),
             ],
         );
 
-        streams.insert(
+        fragments.insert(
             "my-component".to_string(),
-            vec![WebUIStream::Raw(webui_protocol::WebUIStreamRaw {
+            vec![WebUIFragment::Raw(webui_protocol::WebUIFragmentRaw {
                 value: "<div>Component Content</div>".to_string(),
             })],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
         let state = test_json!({});
 
         // Create a test writer
@@ -576,19 +580,19 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_stream() {
-        // Create a protocol with a missing stream reference
-        let mut streams = HashMap::new();
-        streams.insert(
+    fn test_missing_fragment() {
+        // Create a protocol with a missing fragment reference
+        let mut fragments = HashMap::new();
+        fragments.insert(
             "index.html".to_string(),
-            vec![WebUIStream::Component(
-                webui_protocol::WebUIStreamComponent {
-                    stream_id: "missing-component".to_string(),
+            vec![WebUIFragment::Component(
+                webui_protocol::WebUIFragmentComponent {
+                    fragment_id: "missing-component".to_string(),
                 },
             )],
         );
 
-        let protocol = WebUIProtocol { streams };
+        let protocol = WebUIProtocol { fragments };
         let state = test_json!({});
 
         // Create a test writer
@@ -599,10 +603,10 @@ mod tests {
 
         // Expect an error
         assert!(result.is_err());
-        if let Err(HandlerError::MissingStream(stream_id)) = result {
-            assert_eq!(stream_id, "missing-component");
+        if let Err(HandlerError::MissingFragment(fragment_id)) = result {
+            assert_eq!(fragment_id, "missing-component");
         } else {
-            panic!("Expected MissingStream error");
+            panic!("Expected MissingFragment error");
         }
     }
 }

--- a/crates/webui-parser/src/css_parser.rs
+++ b/crates/webui-parser/src/css_parser.rs
@@ -5,7 +5,7 @@
 
 use crate::{ParserError, Result};
 use tree_sitter::{Parser, Tree};
-use webui_protocol::WebUIStreamRecords;
+use webui_protocol::WebUIFragmentRecords;
 
 // Replace extern "C" block with proper import
 use tree_sitter_css::LANGUAGE;
@@ -27,26 +27,26 @@ impl CssParser {
         Self { parser }
     }
 
-    /// Parse CSS content and return streams.
-    pub fn parse(&mut self, css_content: &str) -> Result<WebUIStreamRecords> {
+    /// Parse CSS content and return fragments.
+    pub fn parse(&mut self, css_content: &str) -> Result<WebUIFragmentRecords> {
         // Parse CSS with tree-sitter
         let _tree = self
             .parser
             .parse(css_content, None)
             .ok_or_else(|| ParserError::Css("Failed to parse CSS".to_string()))?;
 
-        // Create empty streams for now
-        // In a real implementation, would convert CSS to streams
-        let streams = WebUIStreamRecords::new();
+        // Create empty fragments for now
+        // In a real implementation, would convert CSS to fragments
+        let fragments = WebUIFragmentRecords::new();
 
-        Ok(streams)
+        Ok(fragments)
     }
 
-    /// Process CSS content and merge it into streams.
+    /// Process CSS content and merge it into fragments.
     pub fn process_css(
         &mut self,
         css_content: &str,
-        streams: &mut WebUIStreamRecords,
+        fragments: &mut WebUIFragmentRecords,
     ) -> Result<()> {
         // Parse CSS with tree-sitter
         let tree = self
@@ -55,7 +55,7 @@ impl CssParser {
             .ok_or_else(|| ParserError::Css("Failed to parse CSS".to_string()))?;
 
         // Extract and process CSS rules
-        self.process_css_rules(tree, css_content, streams)?;
+        self.process_css_rules(tree, css_content, fragments)?;
 
         Ok(())
     }
@@ -65,13 +65,13 @@ impl CssParser {
         &self,
         _tree: Tree,
         _source: &str,
-        _streams: &mut WebUIStreamRecords,
+        _fragments: &mut WebUIFragmentRecords,
     ) -> Result<()> {
         // This is a placeholder for CSS processing logic
         // In a real implementation, you would:
         // 1. Extract selectors and rules from the CSS
         // 2. Associate styles with components
-        // 3. Update component streams with the appropriate styles
+        // 3. Update component fragments with the appropriate styles
 
         // For now, we'll just return Ok as a placeholder
         Ok(())

--- a/crates/webui-parser/src/handlebars_parser.rs
+++ b/crates/webui-parser/src/handlebars_parser.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use webui_protocol::{WebUIStream, WebUIStreamRaw, WebUIStreamSignal};
+use webui_protocol::{WebUIFragment, WebUIFragmentRaw, WebUIFragmentSignal};
 
 /// Parser for handlebars-style template syntax.
 pub struct HandlebarsParser;
@@ -11,14 +11,14 @@ impl HandlebarsParser {
     }
 
     /// Simplified parse method (no nested brace support)
-    pub fn parse(&self, text: &str) -> Result<Vec<WebUIStream>> {
-        let mut streams = Vec::new();
+    pub fn parse(&self, text: &str) -> Result<Vec<WebUIFragment>> {
+        let mut fragments = Vec::new();
         let mut pos = 0;
         while let Some(start) = text[pos..].find("{{") {
             let start_idx = pos + start;
             if start_idx > pos {
                 // Add preceding raw text.
-                streams.push(WebUIStream::Raw(WebUIStreamRaw {
+                fragments.push(WebUIFragment::Raw(WebUIFragmentRaw {
                     value: text[pos..start_idx].to_string(),
                 }));
             }
@@ -33,25 +33,25 @@ impl HandlebarsParser {
                 let var_start = start_idx + open_delim.len();
                 let var_end = var_start + end;
                 let var_name = text[var_start..var_end].trim().to_string();
-                streams.push(WebUIStream::Signal(WebUIStreamSignal {
+                fragments.push(WebUIFragment::Signal(WebUIFragmentSignal {
                     value: var_name,
                     raw: is_raw,
                 }));
                 pos = var_end + close_delim.len();
             } else {
                 // No closing delimiter: treat the rest as raw text.
-                streams.push(WebUIStream::Raw(WebUIStreamRaw {
+                fragments.push(WebUIFragment::Raw(WebUIFragmentRaw {
                     value: text[start_idx..].to_string(),
                 }));
                 pos = text.len();
             }
         }
         if pos < text.len() {
-            streams.push(WebUIStream::Raw(WebUIStreamRaw {
+            fragments.push(WebUIFragment::Raw(WebUIFragmentRaw {
                 value: text[pos..].to_string(),
             }));
         }
-        Ok(streams)
+        Ok(fragments)
     }
 }
 
@@ -74,8 +74,8 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         match &result[0] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "Hello, World!"),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "Hello, World!"),
+            _ => panic!("Expected Raw fragment"),
         }
     }
 
@@ -89,21 +89,21 @@ mod tests {
         assert_eq!(result.len(), 3);
 
         match &result[0] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "Hello, "),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "Hello, "),
+            _ => panic!("Expected Raw fragment"),
         }
 
         match &result[1] {
-            WebUIStream::Signal(signal) => {
+            WebUIFragment::Signal(signal) => {
                 assert_eq!(signal.value, "name");
                 assert!(!signal.raw);
             }
-            _ => panic!("Expected Signal stream"),
+            _ => panic!("Expected Signal fragment"),
         }
 
         match &result[2] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "!"),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "!"),
+            _ => panic!("Expected Raw fragment"),
         }
     }
 
@@ -117,16 +117,16 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         match &result[0] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "Content: "),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "Content: "),
+            _ => panic!("Expected Raw fragment"),
         }
 
         match &result[1] {
-            WebUIStream::Signal(signal) => {
+            WebUIFragment::Signal(signal) => {
                 assert_eq!(signal.value, "html_content");
                 assert!(signal.raw);
             }
-            _ => panic!("Expected Signal stream"),
+            _ => panic!("Expected Signal fragment"),
         }
     }
 
@@ -140,29 +140,29 @@ mod tests {
         assert_eq!(result.len(), 4);
 
         match &result[0] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "Hello, "),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "Hello, "),
+            _ => panic!("Expected Raw fragment"),
         }
 
         match &result[1] {
-            WebUIStream::Signal(signal) => {
+            WebUIFragment::Signal(signal) => {
                 assert_eq!(signal.value, "name");
                 assert!(!signal.raw);
             }
-            _ => panic!("Expected Signal stream"),
+            _ => panic!("Expected Signal fragment"),
         }
 
         match &result[2] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "! "),
-            _ => panic!("Expected Raw stream"),
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "! "),
+            _ => panic!("Expected Raw fragment"),
         }
 
         match &result[3] {
-            WebUIStream::Signal(signal) => {
+            WebUIFragment::Signal(signal) => {
                 assert_eq!(signal.value, "html_content");
                 assert!(signal.raw);
             }
-            _ => panic!("Expected Signal stream"),
+            _ => panic!("Expected Signal fragment"),
         }
     }
 }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -17,25 +17,25 @@ use std::collections::HashMap;
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIteratorMut};
 use tree_sitter_html::LANGUAGE;
 use webui_protocol::{
-    WebUIStream, WebUIStreamComponent, WebUIStreamFor, WebUIStreamIf, WebUIStreamRaw,
-    WebUIStreamRecords,
+    WebUIFragment, WebUIFragmentComponent, WebUIFragmentFor, WebUIFragmentIf, WebUIFragmentRaw,
+    WebUIFragmentRecords,
 };
 
-/// Counter for generating unique stream IDs.
-struct StreamIdCounter {
+/// Counter for generating unique fragment IDs.
+struct FragmentIdCounter {
     /// Map of counter types to their current values.
     counters: HashMap<String, usize>,
 }
 
-impl StreamIdCounter {
-    /// Create a new stream ID counter.
+impl FragmentIdCounter {
+    /// Create a new fragment ID counter.
     fn new() -> Self {
         Self {
             counters: HashMap::new(),
         }
     }
 
-    /// Generate a unique stream ID.
+    /// Generate a unique fragment ID.
     fn next_id(&mut self, prefix: &str) -> String {
         let count = self.counters.entry(prefix.to_string()).or_insert(0);
         *count += 1;
@@ -57,8 +57,8 @@ pub struct HtmlParser {
     /// Tree-sitter parser for HTML.
     parser: Parser,
 
-    /// Stream ID counter.
-    id_counter: StreamIdCounter,
+    /// Fragment ID counter.
+    id_counter: FragmentIdCounter,
 
     /// Condition parser for parsing conditions in directives.
     condition_parser: ConditionParser,
@@ -69,8 +69,8 @@ pub struct HtmlParser {
     /// Component registry for WebUI components.
     component_registry: ComponentRegistry,
 
-    /// Map of stream IDs to their streams
-    stream_records: WebUIStreamRecords,
+    /// Map of fragment IDs to their fragments
+    fragment_records: WebUIFragmentRecords,
 
     /// Buffer for accumulating raw content
     raw_buffer: String,
@@ -87,22 +87,22 @@ impl HtmlParser {
         Self {
             component_registry: ComponentRegistry::new(),
             css_parser: CssParser::new(),
-            id_counter: StreamIdCounter::new(),
+            id_counter: FragmentIdCounter::new(),
             condition_parser: ConditionParser::new(),
             handlebars_parser: HandlebarsParser::new(),
             raw_buffer: String::new(),
-            stream_records: WebUIStreamRecords::new(),
+            fragment_records: WebUIFragmentRecords::new(),
             parser,
         }
     }
 
-    pub fn into_stream_records(mut self) -> WebUIStreamRecords {
-        std::mem::take(&mut self.stream_records)
+    pub fn into_fragment_records(mut self) -> WebUIFragmentRecords {
+        std::mem::take(&mut self.fragment_records)
     }
 
-    /// Parse HTML content to generate WebUI streams.
-    pub fn parse(&mut self, stream_id: &str, html_content: &str) -> Result<()> {
-        // Reset sub-streams for new parse
+    /// Parse HTML content to generate WebUI fragments.
+    pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<()> {
+        // Reset sub-fragments for new parse
         self.raw_buffer.clear();
 
         // Parse HTML
@@ -111,91 +111,93 @@ impl HtmlParser {
             .parse(html_content, None)
             .ok_or_else(|| ParserError::Html("Failed to parse HTML".to_string()))?;
 
-        let mut entry_stream: Vec<WebUIStream> = Vec::new();
+        let mut entry_fragment: Vec<WebUIFragment> = Vec::new();
 
         // Start processing the HTML node.
-        self.process_html_node(tree.root_node(), html_content, &mut entry_stream)?;
+        self.process_html_node(tree.root_node(), html_content, &mut entry_fragment)?;
 
-        self.flush_raw_buffer(&mut entry_stream);
+        self.flush_raw_buffer(&mut entry_fragment);
 
         // Insert the entry record.
-        self.stream_records
-            .insert(stream_id.to_string(), entry_stream);
+        self.fragment_records
+            .insert(fragment_id.to_string(), entry_fragment);
 
-        // Return all streams including generated sub-streams
+        // Return all fragments including generated sub-fragments
         Ok(())
     }
 
     /// Add raw content to the buffer
-    fn add_raw_stream(&mut self, content: &str) {
+    fn add_raw_fragment(&mut self, content: &str) {
         if !content.is_empty() {
-            println!("Storing raw stream: {}", content);
+            println!("Storing raw fragment: {}", content);
             self.raw_buffer.push_str(content);
         }
     }
 
-    /// Add a for stream, flushing raw buffer first
-    fn add_for_stream(
+    /// Add a for fragment, flushing raw buffer first
+    fn add_for_fragment(
         &mut self,
         item: String,
         collection: String,
-        stream_id: String,
-        streams: &mut Vec<WebUIStream>,
+        fragment_id: String,
+        fragments: &mut Vec<WebUIFragment>,
     ) {
-        self.flush_raw_buffer(streams);
-        println!("Adding for stream: {} in {}", item, collection);
-        streams.push(WebUIStream::For(WebUIStreamFor {
+        self.flush_raw_buffer(fragments);
+        println!("Adding for fragment: {} in {}", item, collection);
+        fragments.push(WebUIFragment::For(WebUIFragmentFor {
             item,
             collection,
-            stream_id,
+            fragment_id,
         }));
     }
 
-    /// Add an if stream, flushing raw buffer first
-    fn add_if_stream(
+    /// Add an if fragment, flushing raw buffer first
+    fn add_if_fragment(
         &mut self,
         condition: webui_protocol::ConditionExpr,
-        stream_id: String,
-        streams: &mut Vec<WebUIStream>,
+        fragment_id: String,
+        fragments: &mut Vec<WebUIFragment>,
     ) {
-        self.flush_raw_buffer(streams);
-        println!("Adding if stream: {}", condition);
-        streams.push(WebUIStream::If(WebUIStreamIf {
+        self.flush_raw_buffer(fragments);
+        println!("Adding if fragment: {}", condition);
+        fragments.push(WebUIFragment::If(WebUIFragmentIf {
             condition,
-            stream_id,
+            fragment_id,
         }));
     }
 
-    /// Add a component stream, flushing raw buffer first
-    fn add_component_stream(&mut self, stream_id: String, streams: &mut Vec<WebUIStream>) {
-        self.flush_raw_buffer(streams);
-        println!("Adding component stream: {}", stream_id);
-        streams.push(WebUIStream::Component(WebUIStreamComponent { stream_id }));
+    /// Add a component fragment, flushing raw buffer first
+    fn add_component_fragment(&mut self, fragment_id: String, fragments: &mut Vec<WebUIFragment>) {
+        self.flush_raw_buffer(fragments);
+        println!("Adding component fragment: {}", fragment_id);
+        fragments.push(WebUIFragment::Component(WebUIFragmentComponent {
+            fragment_id,
+        }));
     }
 
-    /// Add a non-raw stream, flushing the raw buffer first if needed
-    fn add_stream(&mut self, stream: WebUIStream, streams: &mut Vec<WebUIStream>) {
-        self.flush_raw_buffer(streams);
-        println!("Adding stream: {:?}", stream);
-        streams.push(stream);
+    /// Add a non-raw fragment, flushing the raw buffer first if needed
+    fn add_fragment(&mut self, fragment: WebUIFragment, fragments: &mut Vec<WebUIFragment>) {
+        self.flush_raw_buffer(fragments);
+        println!("Adding fragment: {:?}", fragment);
+        fragments.push(fragment);
     }
 
-    /// Flush the raw buffer into streams if not empty
-    fn flush_raw_buffer(&mut self, streams: &mut Vec<WebUIStream>) {
+    /// Flush the raw buffer into fragments if not empty
+    fn flush_raw_buffer(&mut self, fragments: &mut Vec<WebUIFragment>) {
         if !self.raw_buffer.is_empty() {
             println!("Flushing raw buffer: {}", self.raw_buffer);
-            streams.push(WebUIStream::Raw(WebUIStreamRaw {
+            fragments.push(WebUIFragment::Raw(WebUIFragmentRaw {
                 value: std::mem::take(&mut self.raw_buffer),
             }));
         }
     }
 
-    /// Process an HTML node to generate WebUI streams.
+    /// Process an HTML node to generate WebUI fragments.
     fn process_html_node(
         &mut self,
         node: Node,
         source: &str,
-        streams: &mut Vec<WebUIStream>,
+        fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         let mut cursor = node.walk();
 
@@ -206,7 +208,7 @@ impl HtmlParser {
                     let child = cursor.node();
 
                     // Process child node
-                    self.process_child_node(child, source, streams)?;
+                    self.process_child_node(child, source, fragments)?;
 
                     if !cursor.goto_next_sibling() {
                         break;
@@ -215,10 +217,10 @@ impl HtmlParser {
                 cursor.goto_parent();
             }
         } else {
-            // Add text content as raw stream
+            // Add text content as raw fragment
             let content = &source[node.start_byte()..node.end_byte()];
             if !content.trim().is_empty() {
-                self.add_raw_stream(content);
+                self.add_raw_fragment(content);
             }
         }
 
@@ -230,7 +232,7 @@ impl HtmlParser {
         &mut self,
         node: Node,
         source: &str,
-        streams: &mut Vec<WebUIStream>,
+        fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         match node.kind() {
             "element" => {
@@ -239,14 +241,14 @@ impl HtmlParser {
 
                 // Handle WebUI directives
                 match tag_name.as_str() {
-                    "for" => return self.process_for_directive(node, source, streams),
-                    "if" => return self.process_if_directive(node, source, streams),
+                    "for" => return self.process_for_directive(node, source, fragments),
+                    "if" => return self.process_if_directive(node, source, fragments),
                     _ => {
                         if self.component_registry.contains(tag_name.as_str()) {
                             return self.process_component_directive(
                                 node,
                                 source,
-                                streams,
+                                fragments,
                                 tag_name.as_str(),
                             );
                         }
@@ -260,19 +262,19 @@ impl HtmlParser {
                         if let Some(close_bracket_pos) = full_content.find('>') {
                             // Add opening tag as raw content
                             let opening_tag = &full_content[0..=close_bracket_pos];
-                            self.add_raw_stream(opening_tag);
+                            self.add_raw_fragment(opening_tag);
 
                             // Process children
                             for child in node.named_children(&mut node.walk()) {
                                 if child.kind() != "start_tag" && child.kind() != "end_tag" {
-                                    self.process_child_node(child, source, streams)?;
+                                    self.process_child_node(child, source, fragments)?;
                                 }
                             }
 
                             // Find closing tag and add it
                             if let Some(last_open_pos) = full_content.rfind('<') {
                                 let closing_tag = &full_content[last_open_pos..];
-                                self.add_raw_stream(closing_tag);
+                                self.add_raw_fragment(closing_tag);
                             }
                         }
 
@@ -289,7 +291,7 @@ impl HtmlParser {
 
                         // Add the style tag with processed CSS
                         let style_tag = format!("<style>{}</style>", processed_css);
-                        self.add_raw_stream(&style_tag);
+                        self.add_raw_fragment(&style_tag);
                     }
                 }
             }
@@ -298,11 +300,11 @@ impl HtmlParser {
                 if !content.trim().is_empty() {
                     let handlebars_result = self.handlebars_parser.parse(content);
                     match handlebars_result {
-                        Ok(parsed_streams) => {
-                            for stream in parsed_streams {
-                                match stream {
-                                    WebUIStream::Raw(raw) => self.add_raw_stream(&raw.value),
-                                    _ => self.add_stream(stream, streams),
+                        Ok(parsed_fragments) => {
+                            for fragment in parsed_fragments {
+                                match fragment {
+                                    WebUIFragment::Raw(raw) => self.add_raw_fragment(&raw.value),
+                                    _ => self.add_fragment(fragment, fragments),
                                 }
                             }
                         }
@@ -312,7 +314,7 @@ impl HtmlParser {
             }
             // For other node types (like doctype, head, body), traverse their children
             _ => {
-                self.process_html_node(node, source, streams)?;
+                self.process_html_node(node, source, fragments)?;
             }
         }
 
@@ -397,7 +399,7 @@ impl HtmlParser {
         &mut self,
         node: Node,
         source: &str,
-        streams: &mut Vec<WebUIStream>,
+        fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         // Extract each attribute
         let each = self
@@ -430,9 +432,9 @@ impl HtmlParser {
         let item = parts[0];
         let collection = parts[2];
 
-        // Generate a unique stream ID for the for loop content
-        let stream_id = self.id_counter.next_id("for");
-        let mut for_stream: Vec<WebUIStream> = Vec::new();
+        // Generate a unique fragment ID for the for loop content
+        let fragment_id = self.id_counter.next_id("for");
+        let mut for_fragment: Vec<WebUIFragment> = Vec::new();
 
         // Create a temporary buffer for for loop content
         let mut temp_buffer = String::new();
@@ -441,21 +443,27 @@ impl HtmlParser {
         // Process the for loop body
         for child in node.named_children(&mut node.walk()) {
             if child.kind() != "start_tag" && child.kind() != "end_tag" {
-                self.process_child_node(child, source, &mut for_stream)?;
+                self.process_child_node(child, source, &mut for_fragment)?;
             }
         }
 
-        // Ensure any remaining content is flushed to the for loop's stream
-        self.flush_raw_buffer(&mut for_stream);
+        // Ensure any remaining content is flushed to the for loop's fragment
+        self.flush_raw_buffer(&mut for_fragment);
 
         // Restore the original buffer
         std::mem::swap(&mut self.raw_buffer, &mut temp_buffer);
 
         // Store the record
-        self.stream_records.insert(stream_id.clone(), for_stream);
+        self.fragment_records
+            .insert(fragment_id.clone(), for_fragment);
 
-        // Add the for directive stream to the parent stream
-        self.add_for_stream(item.to_string(), collection.to_string(), stream_id, streams);
+        // Add the for directive fragment to the parent fragment
+        self.add_for_fragment(
+            item.to_string(),
+            collection.to_string(),
+            fragment_id,
+            fragments,
+        );
 
         Ok(())
     }
@@ -465,7 +473,7 @@ impl HtmlParser {
         &mut self,
         node: Node,
         source: &str,
-        streams: &mut Vec<WebUIStream>,
+        fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         // Extract condition attribute
         let condition_str = self
@@ -486,14 +494,14 @@ impl HtmlParser {
             }
         };
 
-        // Generate a unique stream ID for the if content
-        let stream_id = self.id_counter.next_id("if");
+        // Generate a unique fragment ID for the if content
+        let fragment_id = self.id_counter.next_id("if");
 
-        // Flush any existing content in the parent stream before switching context
-        self.flush_raw_buffer(streams);
+        // Flush any existing content in the parent fragment before switching context
+        self.flush_raw_buffer(fragments);
 
-        // Create a separate stream for the if condition content
-        let mut if_stream: Vec<WebUIStream> = Vec::new();
+        // Create a separate fragment for the if condition content
+        let mut if_fragment: Vec<WebUIFragment> = Vec::new();
 
         // Save the current raw buffer and create a new one for the if condition
         let parent_buffer = std::mem::take(&mut self.raw_buffer);
@@ -501,21 +509,22 @@ impl HtmlParser {
         // Process the if body - capture all content including closing tags
         for child in node.named_children(&mut node.walk()) {
             if child.kind() != "start_tag" && child.kind() != "end_tag" {
-                self.process_child_node(child, source, &mut if_stream)?;
+                self.process_child_node(child, source, &mut if_fragment)?;
             }
         }
 
-        // Make sure all content in the if buffer is flushed to the if stream
-        self.flush_raw_buffer(&mut if_stream);
+        // Make sure all content in the if buffer is flushed to the if fragment
+        self.flush_raw_buffer(&mut if_fragment);
 
-        // Store the if stream in the records
-        self.stream_records.insert(stream_id.clone(), if_stream);
+        // Store the if fragment in the records
+        self.fragment_records
+            .insert(fragment_id.clone(), if_fragment);
 
         // Restore the parent buffer - only after we've processed all if content
         self.raw_buffer = parent_buffer;
 
-        // Add the if directive to the parent stream
-        self.add_if_stream(condition, stream_id, streams);
+        // Add the if directive to the parent fragment
+        self.add_if_fragment(condition, fragment_id, fragments);
 
         Ok(())
     }
@@ -525,7 +534,7 @@ impl HtmlParser {
         &mut self,
         node: Node,
         source: &str,
-        streams: &mut Vec<WebUIStream>,
+        fragments: &mut Vec<WebUIFragment>,
         tag_name: &str,
     ) -> Result<()> {
         // Build opening tag with attributes
@@ -540,10 +549,10 @@ impl HtmlParser {
 
         // Add shadow DOM template opening
         let start_content = format!("{}<template shadowrootmode=\"open\">", opening_tag);
-        self.add_raw_stream(&start_content);
+        self.add_raw_fragment(&start_content);
 
-        // Explicitly flush the buffer to create a Raw stream with the opening content
-        self.flush_raw_buffer(streams);
+        // Explicitly flush the buffer to create a Raw fragment with the opening content
+        self.flush_raw_buffer(fragments);
 
         // Get the component data we need
         let html_content;
@@ -555,16 +564,16 @@ impl HtmlParser {
         }
 
         // Check if we need to parse the component template
-        if !self.stream_records.contains_key(tag_name) {
-            // Parse component HTML content and add to stream records
+        if !self.fragment_records.contains_key(tag_name) {
+            // Parse component HTML content and add to fragment records
             let _ = self.parse(tag_name, &html_content);
         }
 
-        // Add component stream directly to output streams - buffer is already flushed
-        self.add_component_stream(tag_name.to_string(), streams);
+        // Add component fragment directly to output fragments - buffer is already flushed
+        self.add_component_fragment(tag_name.to_string(), fragments);
 
         // Start building the closing part with template end
-        self.add_raw_stream("</template>");
+        self.add_raw_fragment("</template>");
 
         // Process slot content
         for child in node.named_children(&mut node.walk()) {
@@ -572,16 +581,16 @@ impl HtmlParser {
                 if child.kind() == "element" {
                     // For element slots, extract the full source text
                     let slot_content = &source[child.start_byte()..child.end_byte()];
-                    self.add_raw_stream(slot_content);
+                    self.add_raw_fragment(slot_content);
                 } else {
                     // For text nodes and others, use normal processing
-                    self.process_child_node(child, source, streams)?;
+                    self.process_child_node(child, source, fragments)?;
                 }
             }
         }
 
         // Add closing component tag
-        self.add_raw_stream(&format!("</{}>", tag_name));
+        self.add_raw_fragment(&format!("</{}>", tag_name));
 
         // Don't flush here to let it combine with any subsequent raw content
 
@@ -602,20 +611,22 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok());
-        let stream_records = parser.into_stream_records();
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 3);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 3);
 
-        // Verify each stream
-        assert!(matches!(streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "Hello, "));
+        // Verify each fragment
         assert!(
-            matches!(streams.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "Hello, ")
+        );
+        assert!(
+            matches!(fragments.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "name" && !signal.raw
             )
         );
-        assert!(matches!(streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "!"));
+        assert!(matches!(fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "!"));
     }
 
     #[test]
@@ -625,20 +636,22 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok());
-        let stream_records = parser.into_stream_records();
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 3);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 3);
 
-        // Verify each stream
-        assert!(matches!(streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "Hello, "));
+        // Verify each fragment
         assert!(
-            matches!(streams.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "Hello, ")
+        );
+        assert!(
+            matches!(fragments.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "html_content" && signal.raw
             )
         );
-        assert!(matches!(streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "!"));
+        assert!(matches!(fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "!"));
     }
 
     #[test]
@@ -648,37 +661,39 @@ mod tests {
 
         let result = parser.parse("test.html", html);
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
-        println!("Stream records: {:#?}", stream_records);
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        println!("Fragment records: {:#?}", fragment_records);
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
+            .expect("Failed to get test.html fragment");
 
-        // Verify each stream
-        assert_eq!(streams.len(), 1);
+        // Verify each fragment
+        assert_eq!(fragments.len(), 1);
 
         assert!(
-            matches!(streams.first(), Some(WebUIStream::For(for_loop)) if
+            matches!(fragments.first(), Some(WebUIFragment::For(for_loop)) if
                 for_loop.item == "item" &&
                 for_loop.collection == "items" &&
-                for_loop.stream_id == "for-1"
+                for_loop.fragment_id == "for-1"
             )
         );
 
-        // Verify the sub-stream contains our item content
-        let for_stream = stream_records
+        // Verify the sub-fragment contains our item content
+        let for_fragment = fragment_records
             .get("for-1")
-            .expect("Failed to get for-1 stream");
-        assert_eq!(for_stream.len(), 3);
+            .expect("Failed to get for-1 fragment");
+        assert_eq!(for_fragment.len(), 3);
         assert!(
-            matches!(for_stream.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<div class=\"item\">")
+            matches!(for_fragment.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<div class=\"item\">")
         );
         assert!(
-            matches!(for_stream.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(for_fragment.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "item.name" && !signal.raw
             )
         );
-        assert!(matches!(for_stream.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</div>"));
+        assert!(
+            matches!(for_fragment.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</div>")
+        );
     }
 
     #[test]
@@ -689,32 +704,36 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
-        println!("Stream records: {:#?}", stream_records);
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        println!("Fragment records: {:#?}", fragment_records);
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 1);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 1);
 
-        assert!(matches!(streams.first(), Some(WebUIStream::If(if_cond)) if
-            matches!(&if_cond.condition, ConditionExpr::Identifier { value } if value == "isLoggedIn") &&
-            if_cond.stream_id == "if-1"
-        ));
-
-        // Verify the sub-stream contains our content
-        let if_stream = stream_records
-            .get("if-1")
-            .expect("Failed to get if-1 stream");
-        assert_eq!(if_stream.len(), 3);
         assert!(
-            matches!(if_stream.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<div>Welcome back, ")
+            matches!(fragments.first(), Some(WebUIFragment::If(if_cond)) if
+                matches!(&if_cond.condition, ConditionExpr::Identifier { value } if value == "isLoggedIn") &&
+                if_cond.fragment_id == "if-1"
+            )
+        );
+
+        // Verify the sub-fragment contains our content
+        let if_fragment = fragment_records
+            .get("if-1")
+            .expect("Failed to get if-1 fragment");
+        assert_eq!(if_fragment.len(), 3);
+        assert!(
+            matches!(if_fragment.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<div>Welcome back, ")
         );
         assert!(
-            matches!(if_stream.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(if_fragment.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "username" && !signal.raw
             )
         );
-        assert!(matches!(if_stream.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "!</div>"));
+        assert!(
+            matches!(if_fragment.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "!</div>")
+        );
     }
 
     #[test]
@@ -738,32 +757,32 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
-        println!("Stream records: {:#?}", stream_records);
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        println!("Fragment records: {:#?}", fragment_records);
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 3);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 3);
 
         assert!(
-            matches!(streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<my-component><template shadowrootmode=\"open\">")
+            matches!(fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<my-component><template shadowrootmode=\"open\">")
         );
         assert!(
-            matches!(streams.get(1), Some(WebUIStream::Component(component)) if
-                component.stream_id == "my-component"
+            matches!(fragments.get(1), Some(WebUIFragment::Component(component)) if
+                component.fragment_id == "my-component"
             )
         );
         assert!(
-            matches!(streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</template></my-component>")
+            matches!(fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</template></my-component>")
         );
 
-        // Verify the sub-stream contains our component content
-        let component_stream = stream_records
+        // Verify the sub-fragment contains our component content
+        let component_fragment = fragment_records
             .get("my-component")
-            .expect("Failed to get my-component stream");
-        assert_eq!(component_stream.len(), 1);
+            .expect("Failed to get my-component fragment");
+        assert_eq!(component_fragment.len(), 1);
         assert!(
-            matches!(component_stream.first(), Some(WebUIStream::Raw(raw)) if
+            matches!(component_fragment.first(), Some(WebUIFragment::Raw(raw)) if
                 raw.value == "<div>My Component</div>"
             )
         );
@@ -790,32 +809,32 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
-        println!("Stream records: {:#?}", stream_records);
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        println!("Fragment records: {:#?}", fragment_records);
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 3);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 3);
 
         assert!(
-            matches!(streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "Hello<my-component><template shadowrootmode=\"open\">")
+            matches!(fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "Hello<my-component><template shadowrootmode=\"open\">")
         );
         assert!(
-            matches!(streams.get(1), Some(WebUIStream::Component(component)) if
-                component.stream_id == "my-component"
+            matches!(fragments.get(1), Some(WebUIFragment::Component(component)) if
+                component.fragment_id == "my-component"
             )
         );
         assert!(
-            matches!(streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</template><p>World</p></my-component>")
+            matches!(fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</template><p>World</p></my-component>")
         );
 
-        // Verify the sub-stream contains our component content
-        let component_stream = stream_records
+        // Verify the sub-fragment contains our component content
+        let component_fragment = fragment_records
             .get("my-component")
-            .expect("Failed to get my-component stream");
-        assert_eq!(component_stream.len(), 1);
+            .expect("Failed to get my-component fragment");
+        assert_eq!(component_fragment.len(), 1);
         assert!(
-            matches!(component_stream.first(), Some(WebUIStream::Raw(raw)) if
+            matches!(component_fragment.first(), Some(WebUIFragment::Raw(raw)) if
                 raw.value == "<div>My Component</div>"
             )
         );
@@ -835,49 +854,49 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
+        let fragment_records = parser.into_fragment_records();
 
-        let streams = stream_records
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 1);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 1);
         assert!(
-            matches!(streams.first(), Some(WebUIStream::For(for_loop)) if
+            matches!(fragments.first(), Some(WebUIFragment::For(for_loop)) if
                 for_loop.item == "category" &&
                 for_loop.collection == "categories" &&
-                for_loop.stream_id == "for-1"
+                for_loop.fragment_id == "for-1"
             )
         );
 
-        let for_stream = stream_records
+        let for_fragment = fragment_records
             .get("for-1")
-            .expect("Failed to get for-1 stream");
-        assert_eq!(for_stream.len(), 1);
+            .expect("Failed to get for-1 fragment");
+        assert_eq!(for_fragment.len(), 1);
         assert!(
-            matches!(for_stream.first(), Some(WebUIStream::If(if_cond)) if
+            matches!(for_fragment.first(), Some(WebUIFragment::If(if_cond)) if
                 matches!(&if_cond.condition, ConditionExpr::Identifier { value } if value == "category.hasItems") &&
-                if_cond.stream_id == "if-1"
+                if_cond.fragment_id == "if-1"
             )
         );
 
-        let if_stream = stream_records
+        let if_fragment = fragment_records
             .get("if-1")
-            .expect("Failed to get if-1 stream");
-        assert_eq!(if_stream.len(), 1);
+            .expect("Failed to get if-1 fragment");
+        assert_eq!(if_fragment.len(), 1);
         assert!(
-            matches!(if_stream.first(), Some(WebUIStream::For(for_loop)) if
+            matches!(if_fragment.first(), Some(WebUIFragment::For(for_loop)) if
                 for_loop.item == "item" &&
                 for_loop.collection == "category.items" &&
-                for_loop.stream_id == "for-2"
+                for_loop.fragment_id == "for-2"
             )
         );
 
-        let nested_for_stream = stream_records
+        let nested_for_fragment = fragment_records
             .get("for-2")
-            .expect("Failed to get for-2 stream");
-        assert_eq!(nested_for_stream.len(), 1);
+            .expect("Failed to get for-2 fragment");
+        assert_eq!(nested_for_fragment.len(), 1);
         assert!(
-            matches!(nested_for_stream.first(), Some(WebUIStream::Signal(signal)) if
+            matches!(nested_for_fragment.first(), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "item.title" && !signal.raw
             )
         );
@@ -902,72 +921,80 @@ mod tests {
         let result = parser.parse("test.html", html);
 
         assert!(result.is_ok(), "Parse error: {:?}", result.err());
-        let stream_records = parser.into_stream_records();
-        let streams = stream_records
+        let fragment_records = parser.into_fragment_records();
+        let fragments = fragment_records
             .get("test.html")
-            .expect("Failed to get test.html stream");
-        assert_eq!(streams.len(), 1);
+            .expect("Failed to get test.html fragment");
+        assert_eq!(fragments.len(), 1);
 
         assert!(
-            matches!(streams.first(), Some(WebUIStream::For(for_loop)) if
+            matches!(fragments.first(), Some(WebUIFragment::For(for_loop)) if
                 for_loop.item == "category" &&
                 for_loop.collection == "categories" &&
-                for_loop.stream_id == "for-1"
+                for_loop.fragment_id == "for-1"
             )
         );
 
-        // Verify for streams contains the category.name signal
-        let for_streams: &Vec<WebUIStream> = stream_records
+        // Verify for fragments contains the category.name signal
+        let for_fragments: &Vec<WebUIFragment> = fragment_records
             .get("for-1")
-            .expect("Failed to get for-1 stream");
-        assert_eq!(for_streams.len(), 5);
+            .expect("Failed to get for-1 fragment");
+        assert_eq!(for_fragments.len(), 5);
         assert!(
-            matches!(for_streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<div class=\"category\"><h2>")
+            matches!(for_fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<div class=\"category\"><h2>")
         );
         assert!(
-            matches!(for_streams.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(for_fragments.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "category.name" && !signal.raw
             )
         );
-        assert!(matches!(for_streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</h2>"));
         assert!(
-            matches!(for_streams.get(3), Some(WebUIStream::If(if_cond)) if
+            matches!(for_fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</h2>")
+        );
+        assert!(
+            matches!(for_fragments.get(3), Some(WebUIFragment::If(if_cond)) if
                 matches!(&if_cond.condition, ConditionExpr::Identifier { value } if value == "category.hasItems") &&
-                if_cond.stream_id == "if-1"
+                if_cond.fragment_id == "if-1"
             )
         );
-        assert!(matches!(for_streams.get(4), Some(WebUIStream::Raw(raw)) if raw.value == "</div>"));
+        assert!(
+            matches!(for_fragments.get(4), Some(WebUIFragment::Raw(raw)) if raw.value == "</div>")
+        );
 
         // Verify nested if condition.
-        let if_streams: &Vec<WebUIStream> = stream_records
+        let if_fragments: &Vec<WebUIFragment> = fragment_records
             .get("if-1")
-            .expect("Failed to get if-1 stream");
-        assert_eq!(if_streams.len(), 3);
-        assert!(matches!(if_streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<ul>"));
+            .expect("Failed to get if-1 fragment");
+        assert_eq!(if_fragments.len(), 3);
         assert!(
-            matches!(if_streams.get(1), Some(WebUIStream::For(for_loop)) if
+            matches!(if_fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<ul>")
+        );
+        assert!(
+            matches!(if_fragments.get(1), Some(WebUIFragment::For(for_loop)) if
                 for_loop.item == "item" &&
                 for_loop.collection == "category.items" &&
-                for_loop.stream_id == "for-2"
+                for_loop.fragment_id == "for-2"
             )
         );
-        assert!(matches!(if_streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</ul>"));
+        assert!(
+            matches!(if_fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</ul>")
+        );
 
         // Verify nested for each.
-        let nested_for_streams: &Vec<WebUIStream> = stream_records
+        let nested_for_fragments: &Vec<WebUIFragment> = fragment_records
             .get("for-2")
-            .expect("Failed to get for-2 stream");
-        assert_eq!(nested_for_streams.len(), 3);
+            .expect("Failed to get for-2 fragment");
+        assert_eq!(nested_for_fragments.len(), 3);
         assert!(
-            matches!(nested_for_streams.first(), Some(WebUIStream::Raw(raw)) if raw.value == "<li>")
+            matches!(nested_for_fragments.first(), Some(WebUIFragment::Raw(raw)) if raw.value == "<li>")
         );
         assert!(
-            matches!(nested_for_streams.get(1), Some(WebUIStream::Signal(signal)) if
+            matches!(nested_for_fragments.get(1), Some(WebUIFragment::Signal(signal)) if
                 signal.value == "item.title" && !signal.raw
             )
         );
         assert!(
-            matches!(nested_for_streams.get(2), Some(WebUIStream::Raw(raw)) if raw.value == "</li>")
+            matches!(nested_for_fragments.get(2), Some(WebUIFragment::Raw(raw)) if raw.value == "</li>")
         );
     }
 }

--- a/crates/webui-protocol/benches/protocol_bench.rs
+++ b/crates/webui-protocol/benches/protocol_bench.rs
@@ -2,96 +2,97 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::collections::HashMap;
 use std::hint::black_box;
 use webui_protocol::{
-    ComparisonOperator, ConditionExpr, LogicalOperator, Predicate, WebUIProtocol, WebUIStream,
-    WebUIStreamComponent, WebUIStreamFor, WebUIStreamIf, WebUIStreamRaw, WebUIStreamSignal,
+    ComparisonOperator, ConditionExpr, LogicalOperator, Predicate, WebUIFragment,
+    WebUIFragmentComponent, WebUIFragmentFor, WebUIFragmentIf, WebUIFragmentRaw,
+    WebUIFragmentSignal, WebUIProtocol,
 };
 
 #[allow(dead_code)]
 fn create_test_protocol() -> WebUIProtocol {
-    let mut streams = HashMap::new();
+    let mut fragments = HashMap::new();
 
     // Create the protocol structure directly in Rust
-    streams.insert(
+    fragments.insert(
         "index.html".to_string(),
         vec![
-            WebUIStream::Raw(WebUIStreamRaw {
+            WebUIFragment::Raw(WebUIFragmentRaw {
                 value: "Hello, WebUI!\n".to_string(),
             }),
-            WebUIStream::For(WebUIStreamFor {
+            WebUIFragment::For(WebUIFragmentFor {
                 item: "person".to_string(),
                 collection: "people".to_string(),
-                stream_id: "for-1".to_string(),
+                fragment_id: "for-1".to_string(),
             }),
-            WebUIStream::Signal(WebUIStreamSignal {
+            WebUIFragment::Signal(WebUIFragmentSignal {
                 value: "description".to_string(),
                 raw: true,
             }),
-            WebUIStream::If(WebUIStreamIf {
+            WebUIFragment::If(WebUIFragmentIf {
                 condition: ConditionExpr::Identifier {
                     value: "contact".to_string(),
                 },
-                stream_id: "if-1".to_string(),
+                fragment_id: "if-1".to_string(),
             }),
         ],
     );
 
-    streams.insert(
+    fragments.insert(
         "for-1".to_string(),
-        vec![WebUIStream::Signal(WebUIStreamSignal {
+        vec![WebUIFragment::Signal(WebUIFragmentSignal {
             value: "person.name".to_string(),
             raw: false,
         })],
     );
 
-    streams.insert(
+    fragments.insert(
         "if-1".to_string(),
-        vec![WebUIStream::Component(WebUIStreamComponent {
-            stream_id: "contact-card".to_string(),
+        vec![WebUIFragment::Component(WebUIFragmentComponent {
+            fragment_id: "contact-card".to_string(),
         })],
     );
 
-    streams.insert(
+    fragments.insert(
         "contact-card".to_string(),
         vec![
-            WebUIStream::Raw(WebUIStreamRaw {
+            WebUIFragment::Raw(WebUIFragmentRaw {
                 value: "Hello, ".to_string(),
             }),
-            WebUIStream::Signal(WebUIStreamSignal {
+            WebUIFragment::Signal(WebUIFragmentSignal {
                 value: "name".to_string(),
                 raw: false,
             }),
         ],
     );
 
-    WebUIProtocol { streams }
+    WebUIProtocol { fragments }
 }
 
 fn create_simple_protocol() -> WebUIProtocol {
-    let mut streams = HashMap::new();
+    let mut fragments = HashMap::new();
 
-    streams.insert(
+    fragments.insert(
         "index.html".to_string(),
         vec![
-            WebUIStream::Raw(WebUIStreamRaw {
+            WebUIFragment::Raw(WebUIFragmentRaw {
                 value: "Hello, WebUI!\n".to_string(),
             }),
-            WebUIStream::For(WebUIStreamFor {
+            WebUIFragment::For(WebUIFragmentFor {
                 item: "person".to_string(),
                 collection: "people".to_string(),
-                stream_id: "for-1".to_string(),
+                fragment_id: "for-1".to_string(),
             }),
         ],
     );
 
-    streams.insert(
+    fragments.insert(
         "for-1".to_string(),
-        vec![WebUIStream::Signal(WebUIStreamSignal {
+        vec![WebUIFragment::Signal(WebUIFragmentSignal {
             value: "person.name".to_string(),
             raw: false,
         })],
     );
 
-    WebUIProtocol { streams }
+    WebUIProtocol { fragments }
 }
 
 fn serialize_json_benchmark(c: &mut Criterion) {

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Predicate {
     pub right: String,
 }
 
-/// Represents a condition expression that can be used in an `if` stream.
+/// Represents a condition expression that can be used in an `if` fragment.
 /// The condition can be:
 /// - A simple predicate,
 /// - A negated condition,
@@ -272,7 +272,7 @@ impl<'de> Deserialize<'de> for ConditionExpr {
     }
 }
 
-/// Defines the various types of streams in the WebUI protocol.
+/// Defines the various types of fragments in the WebUI protocol.
 /// Each variant specifies a different kind of UI operation:
 /// - Raw contents,
 /// - Components with additional styling,
@@ -281,50 +281,50 @@ impl<'de> Deserialize<'de> for ConditionExpr {
 /// - Conditional rendering.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum WebUIStream {
+pub enum WebUIFragment {
     /// Outputs static content.
-    Raw(WebUIStreamRaw),
+    Raw(WebUIFragmentRaw),
     /// A reusable component with styling.
-    Component(WebUIStreamComponent),
+    Component(WebUIFragmentComponent),
     /// Iterates over a collection to generate repeated content.
-    For(WebUIStreamFor),
+    For(WebUIFragmentFor),
     /// Connects dynamic content via signals.
-    Signal(WebUIStreamSignal),
+    Signal(WebUIFragmentSignal),
     /// Renders content conditionally.
-    If(WebUIStreamIf),
+    If(WebUIFragmentIf),
 }
 
-/// A raw stream containing static text or HTML content.
+/// A raw fragment containing static text or HTML content.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct WebUIStreamRaw {
+pub struct WebUIFragmentRaw {
     /// The content to render.
     pub value: String,
 }
 
-/// A component stream which includes CSS styling and references a nested stream record.
+/// A component fragment which includes CSS styling and references a nested fragment record.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct WebUIStreamComponent {
-    /// The identifier for the associated stream record.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+pub struct WebUIFragmentComponent {
+    /// The identifier for the associated fragment record.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 
-/// A loop (or "for") stream that iterates over items in a collection.
+/// A loop (or "for") fragment that iterates over items in a collection.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct WebUIStreamFor {
+pub struct WebUIFragmentFor {
     /// The name representing a singular item (e.g., "person").
     pub item: String,
     /// The collection name (e.g., "people").
     pub collection: String,
-    /// The identifier for the stream to render for each item.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+    /// The identifier for the fragment to render for each item.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 
-/// A signal stream used for real-time or dynamic data binding.
+/// A signal fragment used for real-time or dynamic data binding.
 /// The `raw` property indicates whether the signal value is rendered directly.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct WebUIStreamSignal {
+pub struct WebUIFragmentSignal {
     /// The value or identifier of the signal.
     pub value: String,
     /// Determines if the value should be rendered as raw content.
@@ -333,27 +333,27 @@ pub struct WebUIStreamSignal {
     pub raw: bool,
 }
 
-/// A conditional stream that evaluates a condition before rendering its content.
-/// If the provided condition is met, the content identified by `streamId` is rendered.
+/// A conditional fragment that evaluates a condition before rendering its content.
+/// If the provided condition is met, the content identified by `fragmentId` is rendered.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct WebUIStreamIf {
+pub struct WebUIFragmentIf {
     /// The condition expression to evaluate.
     pub condition: ConditionExpr,
-    /// The identifier for the stream record to render if the condition evaluates to true.
-    #[serde(rename = "streamId")]
-    pub stream_id: String,
+    /// The identifier for the fragment record to render if the condition evaluates to true.
+    #[serde(rename = "fragmentId")]
+    pub fragment_id: String,
 }
 
-/// A mapping of unique stream identifiers to their corresponding stream vectors.
+/// A mapping of unique fragment identifiers to their corresponding fragment vectors.
 /// This facilitates organizing the different parts of a webpage.
-pub type WebUIStreamRecords = HashMap<String, Vec<WebUIStream>>;
+pub type WebUIFragmentRecords = HashMap<String, Vec<WebUIFragment>>;
 
 /// The root protocol structure that represents the complete configuration for a webpage.
-/// It contains all the stream records.
+/// It contains all the fragment records.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct WebUIProtocol {
-    /// A map linking stream identifiers to their associated streams.
-    pub streams: WebUIStreamRecords,
+    /// A map linking fragment identifiers to their associated fragments.
+    pub fragments: WebUIFragmentRecords,
 }
 
 impl WebUIProtocol {
@@ -379,30 +379,30 @@ impl WebUIProtocol {
     // Helper method to validate and return the protocol
     fn validate_protocol(protocol: Self) -> Result<Self> {
         // Validation check
-        let streams = &protocol.streams;
+        let fragments = &protocol.fragments;
 
         // Use an iterator-based approach to check for valid references
-        // This avoids multiple hash lookups for each stream
-        let invalid_ref = streams.iter().find_map(|(_, stream_vec)| {
-            stream_vec.iter().find_map(|stream| match stream {
-                WebUIStream::Component(component)
-                    if !streams.contains_key(&component.stream_id) =>
+        // This avoids multiple hash lookups for each fragment
+        let invalid_ref = fragments.iter().find_map(|(_, fragment_vec)| {
+            fragment_vec.iter().find_map(|fragment| match fragment {
+                WebUIFragment::Component(component)
+                    if !fragments.contains_key(&component.fragment_id) =>
                 {
                     Some(ProtocolError::Validation(format!(
-                        "Component references non-existent stream ID: {}",
-                        component.stream_id
+                        "Component references non-existent fragment ID: {}",
+                        component.fragment_id
                     )))
                 }
-                WebUIStream::For(for_loop) if !streams.contains_key(&for_loop.stream_id) => {
+                WebUIFragment::For(for_loop) if !fragments.contains_key(&for_loop.fragment_id) => {
                     Some(ProtocolError::Validation(format!(
-                        "For loop references non-existent stream ID: {}",
-                        for_loop.stream_id
+                        "For loop references non-existent fragment ID: {}",
+                        for_loop.fragment_id
                     )))
                 }
-                WebUIStream::If(if_cond) if !streams.contains_key(&if_cond.stream_id) => {
+                WebUIFragment::If(if_cond) if !fragments.contains_key(&if_cond.fragment_id) => {
                     Some(ProtocolError::Validation(format!(
-                        "If condition references non-existent stream ID: {}",
-                        if_cond.stream_id
+                        "If condition references non-existent fragment ID: {}",
+                        if_cond.fragment_id
                     )))
                 }
                 _ => None,
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn test_parse_valid_protocol() {
         let json = r#"{
-            "streams": {
+            "fragments": {
                 "index.html": [
                     {
                         "type": "raw",
@@ -462,7 +462,7 @@ mod tests {
                         "type": "for",
                         "item": "person",
                         "collection": "people",
-                        "streamId": "for-1"
+                        "fragmentId": "for-1"
                     }
                 ],
                 "for-1": [
@@ -475,51 +475,51 @@ mod tests {
         }"#;
 
         let protocol = WebUIProtocol::from_json(json).expect("Failed to parse valid protocol");
-        assert_eq!(protocol.streams.len(), 2);
+        assert_eq!(protocol.fragments.len(), 2);
 
-        let index_stream = &protocol.streams["index.html"];
-        assert_eq!(index_stream.len(), 2);
+        let index_fragment = &protocol.fragments["index.html"];
+        assert_eq!(index_fragment.len(), 2);
 
-        let raw_stream = &index_stream[0];
-        assert!(matches!(raw_stream, WebUIStream::Raw(_)));
-        if let WebUIStream::Raw(raw) = raw_stream {
+        let raw_fragment = &index_fragment[0];
+        assert!(matches!(raw_fragment, WebUIFragment::Raw(_)));
+        if let WebUIFragment::Raw(raw) = raw_fragment {
             assert_eq!(raw.value, "Hello, WebUI!\n");
         } else {
-            panic!("Expected raw stream");
+            panic!("Expected raw fragment");
         }
 
-        let for_stream = &index_stream[1];
-        assert!(matches!(for_stream, WebUIStream::For(_)));
-        if let WebUIStream::For(for_loop) = for_stream {
+        let for_fragment = &index_fragment[1];
+        assert!(matches!(for_fragment, WebUIFragment::For(_)));
+        if let WebUIFragment::For(for_loop) = for_fragment {
             assert_eq!(for_loop.item, "person");
             assert_eq!(for_loop.collection, "people");
-            assert_eq!(for_loop.stream_id, "for-1");
+            assert_eq!(for_loop.fragment_id, "for-1");
         } else {
-            panic!("Expected signal stream");
+            panic!("Expected signal fragment");
         }
 
-        let for_stream = &protocol.streams["for-1"];
-        assert_eq!(for_stream.len(), 1);
-        let signal_stream = &for_stream[0];
-        assert!(matches!(signal_stream, WebUIStream::Signal(_)));
-        if let WebUIStream::Signal(signal) = signal_stream {
+        let for_fragment = &protocol.fragments["for-1"];
+        assert_eq!(for_fragment.len(), 1);
+        let signal_fragment = &for_fragment[0];
+        assert!(matches!(signal_fragment, WebUIFragment::Signal(_)));
+        if let WebUIFragment::Signal(signal) = signal_fragment {
             assert_eq!(signal.value, "person.name");
             assert!(!signal.raw);
         } else {
-            panic!("Expected signal stream");
+            panic!("Expected signal fragment");
         }
     }
 
     #[test]
     fn test_invalid_reference() {
         let json = r#"{
-            "streams": {
+            "fragments": {
                 "index.html": [
                     {
                         "type": "for",
                         "item": "person",
                         "collection": "people",
-                        "streamId": "non-existent"
+                        "fragmentId": "non-existent"
                     }
                 ]
             }
@@ -530,15 +530,15 @@ mod tests {
     }
 
     #[test]
-    fn test_all_stream_types() {
+    fn test_all_fragment_types() {
         let json = r#"{
-            "streams": {
+            "fragments": {
                 "index.html": [
                     { "type": "raw", "value": "Raw Content" },
-                    { "type": "component", "streamId": "component-1" },
-                    { "type": "for", "item": "item", "collection": "items", "streamId": "for-1" },
+                    { "type": "component", "fragmentId": "component-1" },
+                    { "type": "for", "item": "item", "collection": "items", "fragmentId": "for-1" },
                     { "type": "signal", "value": "user.name", "raw": true },
-                    { "type": "if", "condition": {"kind": "identifier", "value": "isLoggedIn"}, "streamId": "if-1" }
+                    { "type": "if", "condition": {"kind": "identifier", "value": "isLoggedIn"}, "fragmentId": "if-1" }
                 ],
                 "component-1": [{ "type": "raw", "value": "Component Content" }],
                 "for-1": [{ "type": "raw", "value": "Item Content" }],
@@ -546,50 +546,50 @@ mod tests {
             }
         }"#;
 
-        let protocol =
-            WebUIProtocol::from_json(json).expect("Failed to parse protocol with all stream types");
-        let streams = &protocol.streams["index.html"];
+        let protocol = WebUIProtocol::from_json(json)
+            .expect("Failed to parse protocol with all fragment types");
+        let fragments = &protocol.fragments["index.html"];
 
-        assert_eq!(streams.len(), 5);
+        assert_eq!(fragments.len(), 5);
 
-        match &streams[0] {
-            WebUIStream::Raw(raw) => assert_eq!(raw.value, "Raw Content"),
-            _ => panic!("Expected raw stream"),
+        match &fragments[0] {
+            WebUIFragment::Raw(raw) => assert_eq!(raw.value, "Raw Content"),
+            _ => panic!("Expected raw fragment"),
         }
 
-        match &streams[1] {
-            WebUIStream::Component(component) => {
-                assert_eq!(component.stream_id, "component-1");
+        match &fragments[1] {
+            WebUIFragment::Component(component) => {
+                assert_eq!(component.fragment_id, "component-1");
             }
-            _ => panic!("Expected component stream"),
+            _ => panic!("Expected component fragment"),
         }
 
-        match &streams[2] {
-            WebUIStream::For(for_loop) => {
+        match &fragments[2] {
+            WebUIFragment::For(for_loop) => {
                 assert_eq!(for_loop.item, "item");
                 assert_eq!(for_loop.collection, "items");
-                assert_eq!(for_loop.stream_id, "for-1");
+                assert_eq!(for_loop.fragment_id, "for-1");
             }
-            _ => panic!("Expected for stream"),
+            _ => panic!("Expected for fragment"),
         }
 
-        match &streams[3] {
-            WebUIStream::Signal(signal) => {
+        match &fragments[3] {
+            WebUIFragment::Signal(signal) => {
                 assert_eq!(signal.value, "user.name");
                 assert!(signal.raw);
             }
-            _ => panic!("Expected signal stream"),
+            _ => panic!("Expected signal fragment"),
         }
 
-        match &streams[4] {
-            WebUIStream::If(if_cond) => {
+        match &fragments[4] {
+            WebUIFragment::If(if_cond) => {
                 match &if_cond.condition {
                     ConditionExpr::Identifier { value } => assert_eq!(value, "isLoggedIn"),
                     _ => panic!("Expected identifier condition"),
                 }
-                assert_eq!(if_cond.stream_id, "if-1");
+                assert_eq!(if_cond.fragment_id, "if-1");
             }
-            _ => panic!("Expected if stream"),
+            _ => panic!("Expected if fragment"),
         }
     }
 
@@ -712,27 +712,27 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip() {
         let protocol = WebUIProtocol {
-            streams: {
+            fragments: {
                 let mut map = HashMap::new();
                 map.insert(
                     "main".to_string(),
                     vec![
-                        WebUIStream::Raw(WebUIStreamRaw {
+                        WebUIFragment::Raw(WebUIFragmentRaw {
                             value: "Hello".to_string(),
                         }),
-                        WebUIStream::If(WebUIStreamIf {
+                        WebUIFragment::If(WebUIFragmentIf {
                             condition: ConditionExpr::Predicate(Predicate {
                                 left: "user.logged_in".to_string(),
                                 operator: ComparisonOperator::Equal,
                                 right: "true".to_string(),
                             }),
-                            stream_id: "welcome".to_string(),
+                            fragment_id: "welcome".to_string(),
                         }),
                     ],
                 );
                 map.insert(
                     "welcome".to_string(),
-                    vec![WebUIStream::Signal(WebUIStreamSignal {
+                    vec![WebUIFragment::Signal(WebUIFragmentSignal {
                         value: "user.name".to_string(),
                         raw: false,
                     })],
@@ -760,13 +760,13 @@ mod tests {
 
     #[test]
     fn test_validation_errors() {
-        // Test missing stream reference in component
+        // Test missing fragment reference in component
         let invalid_component = r#"{
-            "streams": {
+            "fragments": {
                 "main": [
                     {
                         "type": "component",
-                        "streamId": "missing-component"
+                        "fragmentId": "missing-component"
                     }
                 ]
             }
@@ -781,15 +781,15 @@ mod tests {
             panic!("Expected validation error");
         }
 
-        // Test missing stream reference in for loop
+        // Test missing fragment reference in for loop
         let invalid_for = r#"{
-            "streams": {
+            "fragments": {
                 "main": [
                     {
                         "type": "for",
                         "item": "item",
                         "collection": "items",
-                        "streamId": "missing-for"
+                        "fragmentId": "missing-for"
                     }
                 ]
             }
@@ -804,14 +804,14 @@ mod tests {
             panic!("Expected validation error");
         }
 
-        // Test missing stream reference in if condition
+        // Test missing fragment reference in if condition
         let invalid_if = r#"{
-            "streams": {
+            "fragments": {
                 "main": [
                     {
                         "type": "if",
                         "condition": {"kind": "identifier", "value": "isLoggedIn"},
-                        "streamId": "missing-if"
+                        "fragmentId": "missing-if"
                     }
                 ]
             }

--- a/docs/guide/concepts/components/index.md
+++ b/docs/guide/concepts/components/index.md
@@ -32,7 +32,7 @@ When WebUI discovers components:
    - The component's HTML is parsed and tokenized
    - Any directives (`<if>`, `<for>`, etc.) and signals (`{{}}`) are processed
    - The component's CSS is analyzed and included in the protocol
-   - A unique `streamId` is assigned to each component
+   - A unique `fragmentId` is assigned to each component
 
 2. **Runtime**:
    - The server-side handler renders components based on state

--- a/docs/guide/concepts/directives/for.md
+++ b/docs/guide/concepts/directives/for.md
@@ -63,7 +63,7 @@ Where:
 
 ## Protocol Output
 
-When the parser processes a `<for>` directive, it generates a `WebUIStreamFor` in the protocol with the following properties:
+When the parser processes a `<for>` directive, it generates a `WebUIFragmentFor` in the protocol with the following properties:
 - `item`: The name of the loop variable
 - `collection`: The name of the array to iterate over
-- `streamId`: A reference to the content template for each iteration
+- `fragmentId`: A reference to the content template for each iteration

--- a/docs/guide/concepts/directives/if.md
+++ b/docs/guide/concepts/directives/if.md
@@ -78,8 +78,8 @@ When the WebUI parser processes an `<if>` directive, it generates a protocol ent
     "kind": "identifier",
     "value": "isLoggedIn"
   },
-  "streamId": "if-1"
+  "fragmentId": "if-1"
 }
 ```
 
-The content inside the `<if>` directive is stored in a separate stream with the ID specified in `streamId`.
+The content inside the `<if>` directive is stored in a separate fragment with the ID specified in `fragmentId`.

--- a/docs/guide/concepts/handlers/rust.md
+++ b/docs/guide/concepts/handlers/rust.md
@@ -143,7 +143,7 @@ The WebUI handler provides detailed error types through the `HandlerError` enum:
 ```rust
 pub enum HandlerError {
     Rendering(String),
-    MissingStream(String),
+    MissingFragment(String),
     MissingData(String),
     TypeError(String),
     Protocol(webui_protocol::ProtocolError),


### PR DESCRIPTION
Rename all WebUI 'stream' terminology to 'fragment' to follow web platform naming conventions (issue #34).

- WebUIStream* types → WebUIFragment* (protocol, parser, handler, bench)
- stream_id fields → fragment_id
- StreamIdCounter → FragmentIdCounter
- MissingStream → MissingFragment
- JSON keys: streams → fragments, streamId → fragmentId
- Updated all docs (DESIGN.md, guides)
- Preserved unrelated streaming references (StreamingIteratorMut, StreamWriter)

Closes #34