### PR TITLE
Render missing signals as empty instead of erroring

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -224,6 +224,7 @@ impl WebUIHandler {
     ///
     /// Looks up the value in the context first (for local variables), then in the global state.
     /// This prioritization allows local variables (like loop items) to override global state.
+    /// If the value is not found in either scope, an empty string is returned.
     fn process_signal(
         &self,
         signal: &webui_protocol::WebUIFragmentSignal,
@@ -253,7 +254,7 @@ impl WebUIHandler {
             return self.format_signal_value(&value, signal.raw);
         }
 
-        Err(HandlerError::MissingData(path.clone()))
+        Ok(String::new())
     }
 
     /// Helper function to format a signal value based on the raw flag
@@ -634,5 +635,34 @@ mod tests {
         } else {
             panic!("Expected MissingFragment error");
         }
+    }
+
+    #[test]
+    fn test_missing_signal_renders_empty() {
+        // A signal referencing a field absent from state should render as empty
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("Hello, "),
+                    WebUIFragment::signal("missing_field", false),
+                    WebUIFragment::raw("!"),
+                ],
+            },
+        );
+
+        let protocol = WebUIProtocol { fragments };
+        let state = test_json!({});
+
+        let mut writer = TestWriter::new();
+
+        assert!(
+            handle(&protocol, &state, &mut writer).is_ok(),
+            "Missing signal should not produce an error"
+        );
+
+        assert_eq!(writer.get_content(), "Hello, !");
+        assert!(writer.is_ended());
     }
 }


### PR DESCRIPTION
## Summary
- The handler's `process_signal()` previously returned a `MissingData` error when a signal referenced a field absent from the state JSON. This caused render failures for parser-injected signals like `body_start` and `body_end` that are optional injection points, not required data bindings.
- Missing signals now resolve to an empty string instead of erroring.
- Adds `test_missing_signal_renders_empty` test to cover this case.

## Test plan
- [x] `cargo test --workspace` — all 96 tests pass, including new `test_missing_signal_renders_empty`
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Verify `cargo run` in `examples/integration/tiny_http` no longer errors on initial render

🤖 Generated with [Claude Code](https://claude.com/claude-code)