### PR TITLE
feat: add custom for template, handlebars edge cases, and DOCTYPE support

### DIFF
--- a/crates/webui-parser/src/handlebars_parser.rs
+++ b/crates/webui-parser/src/handlebars_parser.rs
@@ -10,38 +10,112 @@ impl HandlebarsParser {
         Self
     }
 
-    /// Simplified parse method (no nested brace support)
+    /// Parse handlebars expressions from text, handling edge cases with
+    /// triple/double brace disambiguation.
+    ///
+    /// Rules for consecutive opening braces (N) without matching `}}}`:
+    /// - N >= 5: first (N-2) braces are raw, remaining `{{…}}` is a valid double
+    /// - N == 3 or 4: entire sequence through `}}` is treated as raw text
     pub fn parse(&self, text: &str) -> Result<Vec<WebUIFragment>> {
+        let bytes = text.as_bytes();
+        let len = bytes.len();
         let mut fragments = Vec::new();
+        let mut raw_buf = String::new();
         let mut pos = 0;
-        while let Some(start) = text[pos..].find("{{") {
-            let start_idx = pos + start;
-            if start_idx > pos {
-                // Add preceding raw text.
-                fragments.push(WebUIFragment::raw(text[pos..start_idx].to_string()));
-            }
-            // Determine if it's triple or double brace.
-            let (is_raw, open_delim, close_delim) = if text[start_idx..].starts_with("{{{") {
-                (true, "{{{", "}}}")
-            } else {
-                (false, "{{", "}}")
+
+        while pos < len {
+            let remaining = &text[pos..];
+            let Some(offset) = remaining.find("{{") else {
+                raw_buf.push_str(&text[pos..]);
+                break;
             };
-            // Look for the closing delimiter.
-            if let Some(end) = text[start_idx + open_delim.len()..].find(close_delim) {
-                let var_start = start_idx + open_delim.len();
-                let var_end = var_start + end;
-                let var_name = text[var_start..var_end].trim().to_string();
-                fragments.push(WebUIFragment::signal(var_name, is_raw));
-                pos = var_end + close_delim.len();
-            } else {
-                // No closing delimiter: treat the rest as raw text.
-                fragments.push(WebUIFragment::raw(text[start_idx..].to_string()));
-                pos = text.len();
+
+            let start = pos + offset;
+            if start > pos {
+                raw_buf.push_str(&text[pos..start]);
             }
+
+            // Count consecutive opening braces
+            let mut brace_count = 0;
+            let mut i = start;
+            while i < len && bytes[i] == b'{' {
+                brace_count += 1;
+                i += 1;
+            }
+
+            if brace_count >= 3 {
+                // Try triple brace: look for }}}
+                if let Some(end_offset) = text[i..].find("}}}") {
+                    let var_end = i + end_offset;
+                    let var_name = text[i..var_end].trim();
+                    if !var_name.is_empty() {
+                        // Extra braces beyond 3 become raw prefix
+                        for _ in 0..(brace_count - 3) {
+                            raw_buf.push('{');
+                        }
+                        if !raw_buf.is_empty() {
+                            fragments.push(WebUIFragment::raw(std::mem::take(&mut raw_buf)));
+                        }
+                        fragments.push(WebUIFragment::signal(var_name.to_string(), true));
+                        pos = var_end + 3;
+                        continue;
+                    }
+                }
+
+                // }}} not found. If N >= 5 we can extract a valid {{…}} from the tail.
+                if brace_count >= 5 {
+                    if let Some(end_offset) = text[i..].find("}}") {
+                        let var_end = i + end_offset;
+                        let var_name = text[i..var_end].trim();
+                        if !var_name.is_empty() {
+                            for _ in 0..(brace_count - 2) {
+                                raw_buf.push('{');
+                            }
+                            if !raw_buf.is_empty() {
+                                fragments.push(WebUIFragment::raw(std::mem::take(&mut raw_buf)));
+                            }
+                            fragments.push(WebUIFragment::signal(var_name.to_string(), false));
+                            pos = var_end + 2;
+                            continue;
+                        }
+                    }
+                }
+
+                // Failed triple (N < 5): consume everything through }} as raw
+                if let Some(end_offset) = text[i..].find("}}") {
+                    let raw_end = i + end_offset + 2;
+                    raw_buf.push_str(&text[start..raw_end]);
+                    pos = raw_end;
+                } else {
+                    raw_buf.push_str(&text[start..]);
+                    pos = len;
+                }
+                continue;
+            }
+
+            // Double brace: look for }}
+            if let Some(end_offset) = text[i..].find("}}") {
+                let var_end = i + end_offset;
+                let var_name = text[i..var_end].trim();
+                if !var_name.is_empty() {
+                    if !raw_buf.is_empty() {
+                        fragments.push(WebUIFragment::raw(std::mem::take(&mut raw_buf)));
+                    }
+                    fragments.push(WebUIFragment::signal(var_name.to_string(), false));
+                    pos = var_end + 2;
+                    continue;
+                }
+            }
+
+            // No valid closing — rest is raw
+            raw_buf.push_str(&text[start..]);
+            pos = len;
         }
-        if pos < text.len() {
-            fragments.push(WebUIFragment::raw(text[pos..].to_string()));
+
+        if !raw_buf.is_empty() {
+            fragments.push(WebUIFragment::raw(raw_buf));
         }
+
         Ok(fragments)
     }
 }
@@ -153,6 +227,46 @@ mod tests {
             Some(Fragment::Signal(signal)) => {
                 assert_eq!(signal.value, "html_content");
                 assert!(signal.raw);
+            }
+            _ => panic!("Expected Signal fragment"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_triple_open() {
+        let parser = HandlebarsParser::new();
+        let result = parser.parse("{{{invalid}}").expect("parse failed");
+        assert_eq!(result.len(), 1);
+        match result[0].fragment.as_ref() {
+            Some(Fragment::Raw(raw)) => assert_eq!(raw.value, "{{{invalid}}"),
+            _ => panic!("Expected Raw fragment"),
+        }
+    }
+
+    #[test]
+    fn test_four_open_braces() {
+        let parser = HandlebarsParser::new();
+        let result = parser.parse("{{{{invalid}}").expect("parse failed");
+        assert_eq!(result.len(), 1);
+        match result[0].fragment.as_ref() {
+            Some(Fragment::Raw(raw)) => assert_eq!(raw.value, "{{{{invalid}}"),
+            _ => panic!("Expected Raw fragment"),
+        }
+    }
+
+    #[test]
+    fn test_five_braces_with_valid_double() {
+        let parser = HandlebarsParser::new();
+        let result = parser.parse("{{{{{invalid}}").expect("parse failed");
+        assert_eq!(result.len(), 2);
+        match result[0].fragment.as_ref() {
+            Some(Fragment::Raw(raw)) => assert_eq!(raw.value, "{{{"),
+            _ => panic!("Expected Raw fragment for prefix"),
+        }
+        match result[1].fragment.as_ref() {
+            Some(Fragment::Signal(s)) => {
+                assert_eq!(s.value, "invalid");
+                assert!(!s.raw);
             }
             _ => panic!("Expected Signal fragment"),
         }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -285,7 +285,15 @@ impl HtmlParser {
                     }
                 }
             }
-            // For other node types (like doctype, head, body), traverse their children
+            // Preserve <!DOCTYPE ...> as raw content. Tree-sitter parses it as a
+            // "doctype" node whose children are tokens (< ! DOCTYPE etc.), so we
+            // grab the original source text verbatim to ensure full-page HTML
+            // templates round-trip correctly.
+            "doctype" => {
+                let content = &source[node.start_byte()..node.end_byte()];
+                self.add_raw_fragment(content);
+            }
+            // For other node types (like head, body), traverse their children
             _ => {
                 self.process_html_node(node, source, fragments)?;
             }
@@ -667,8 +675,10 @@ impl HtmlParser {
         let item = parts[0];
         let collection = parts[2];
 
-        // Generate a unique fragment ID for the for loop content
-        let fragment_id = self.id_counter.next_id("for");
+        // Use custom template attribute if provided, otherwise auto-generate
+        let fragment_id = self
+            .get_element_attribute(node, "template", source)?
+            .unwrap_or_else(|| self.id_counter.next_id("for"));
         let mut for_fragment: Vec<WebUIFragment> = Vec::new();
 
         // Create a temporary buffer for for loop content
@@ -1794,6 +1804,189 @@ mod tests {
         assert_eq!(fragments.len(), 1);
         assert!(
             matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == r#"<div></div><img src="test.jpg"/><span></span>"#)
+        );
+    }
+
+    // ── Feature 1: Custom template attribute on <for> ────────────────────
+
+    #[test]
+    fn test_for_custom_template_attribute() {
+        // Port of: 'should process transient node for with template'
+        let (fragments, records) = parse_and_get_fragments(
+            r#"<for each="item in items" template="static"><span>Item</span></for>"#,
+        );
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::ForLoop(fl)) if
+            fl.item == "item" && fl.collection == "items" && fl.fragment_id == "static")
+        );
+        let stream = records.get("static").expect("Missing 'static' stream");
+        assert_eq!(stream.fragments.len(), 1);
+        assert!(
+            matches!(stream.fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "<span>Item</span>")
+        );
+    }
+
+    #[test]
+    fn test_for_recursive_template() {
+        // Port of: 'should process recursive transient nodes'
+        let mut parser = HtmlParser::new();
+        let html = r#"<for template="static" each="outerItem in outerItems"><div><span>{{outerItem.name}}</span><for template="static" each="innerItem in innerItems" /></div></for>"#;
+        let result = parser.parse("index.html", html);
+        assert!(result.is_ok(), "Parse error: {:?}", result.err());
+        let records = parser.into_fragment_records();
+        let entry = &records["index.html"].fragments;
+        assert_eq!(entry.len(), 1);
+        assert!(
+            matches!(entry[0].fragment.as_ref(), Some(Fragment::ForLoop(fl)) if
+            fl.item == "outerItem" && fl.collection == "outerItems" && fl.fragment_id == "static")
+        );
+        let static_stream = records.get("static").expect("Missing 'static' stream");
+        assert_eq!(static_stream.fragments.len(), 5);
+        assert!(
+            matches!(static_stream.fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "<div><span>")
+        );
+        assert!(
+            matches!(static_stream.fragments[1].fragment.as_ref(), Some(Fragment::Signal(s)) if s.value == "outerItem.name")
+        );
+        assert!(
+            matches!(static_stream.fragments[2].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "</span>")
+        );
+        assert!(
+            matches!(static_stream.fragments[3].fragment.as_ref(), Some(Fragment::ForLoop(fl)) if
+            fl.item == "innerItem" && fl.collection == "innerItems" && fl.fragment_id == "static")
+        );
+        assert!(
+            matches!(static_stream.fragments[4].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "</div>")
+        );
+    }
+
+    // ── Feature 2: <if> / <for> with multiple children ──────────────────
+
+    #[test]
+    fn test_if_multiple_children() {
+        // Port of: 'should handle <if> with multiple children'
+        let (fragments, records) =
+            parse_and_get_fragments(r#"<if condition="valid"><p>hello</p><p>world</p></if>"#);
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::IfCond(ic)) if ic.fragment_id == "if-1")
+        );
+        let if_stream = records.get("if-1").expect("Missing if-1");
+        assert_eq!(if_stream.fragments.len(), 1);
+        assert!(
+            matches!(if_stream.fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "<p>hello</p><p>world</p>")
+        );
+    }
+
+    #[test]
+    fn test_for_multiple_children() {
+        // Port of: 'should handle <for> with multiple children'
+        let (fragments, records) =
+            parse_and_get_fragments(r#"<for each="item in items"><p>hello</p><p>world</p></for>"#);
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::ForLoop(fl)) if fl.fragment_id == "for-1")
+        );
+        let for_stream = records.get("for-1").expect("Missing for-1");
+        assert_eq!(for_stream.fragments.len(), 1);
+        assert!(
+            matches!(for_stream.fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "<p>hello</p><p>world</p>")
+        );
+    }
+
+    // ── Feature 3: Handlebars at beginning/end of text ──────────────────
+
+    #[test]
+    fn test_handlebars_at_beginning() {
+        // Port of: 'should process handlebars from text at beginning'
+        let (fragments, _) = parse_and_get_fragments("{{first}}");
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Signal(s)) if s.value == "first")
+        );
+    }
+
+    #[test]
+    fn test_handlebars_at_beginning_and_raw() {
+        // Port of: 'should process handlebars from text at beginning and raw'
+        let (fragments, _) = parse_and_get_fragments("{{first}}test");
+        assert_eq!(fragments.len(), 2);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Signal(s)) if s.value == "first")
+        );
+        assert!(
+            matches!(fragments[1].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "test")
+        );
+    }
+
+    #[test]
+    fn test_handlebars_raw_and_end() {
+        // Port of: 'should process handlebars from text at raw and end'
+        let (fragments, _) = parse_and_get_fragments("test{{first}}");
+        assert_eq!(fragments.len(), 2);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "test")
+        );
+        assert!(
+            matches!(fragments[1].fragment.as_ref(), Some(Fragment::Signal(s)) if s.value == "first")
+        );
+    }
+
+    // ── Feature 4: Handlebars edge cases ────────────────────────────────
+
+    #[test]
+    fn test_handlebars_invalid_triple_open() {
+        // Port of: 'should not process handlebars when invalid'
+        let (fragments, _) = parse_and_get_fragments("{{{invalid}}");
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "{{{invalid}}")
+        );
+    }
+
+    #[test]
+    fn test_handlebars_four_open_braces() {
+        // Port of: 'should not process handlebars when invalid since triple exists'
+        let (fragments, _) = parse_and_get_fragments("{{{{invalid}}");
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "{{{{invalid}}")
+        );
+    }
+
+    #[test]
+    fn test_handlebars_five_open_with_valid_double() {
+        // Port of: 'should not process handlebars when invalid but with valid triple'
+        let (fragments, _) = parse_and_get_fragments("{{{{{invalid}}");
+        assert_eq!(fragments.len(), 2);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "{{{")
+        );
+        assert!(
+            matches!(fragments[1].fragment.as_ref(), Some(Fragment::Signal(s)) if s.value == "invalid")
+        );
+    }
+
+    #[test]
+    fn test_entities_preserved() {
+        // Port of: 'should process entities correctly'
+        let (fragments, _) = parse_and_get_fragments("<p>Hello&#125;World</p>");
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value == "<p>Hello&#125;World</p>")
+        );
+    }
+
+    // ── Feature 5: DOCTYPE handling ─────────────────────────────────────
+
+    #[test]
+    fn test_doctype_preserved() {
+        // DOCTYPE should be preserved as raw content
+        let (fragments, _) = parse_and_get_fragments("<!DOCTYPE html><html><head></head></html>");
+        assert!(fragments.len() >= 1);
+        assert!(
+            matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value.contains("<!DOCTYPE html>"))
         );
     }
 }


### PR DESCRIPTION
Parser:
- Support custom template attribute on <for> elements to use provided fragment ID instead of auto-generating for-N
- Rewrite HandlebarsParser for correct N-brace edge case handling: {{{invalid}} → raw, {{{{invalid}} → raw, {{{{{x}} → raw+signal
- Verify <if>/<for> with multiple children (already worked)
- Verify handlebars at beginning/end of text (already worked)

15 new tests (68 total parser tests).