### PR TITLE
chore: auto-install dev tools and unify terminal styling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,6 +215,38 @@ The `webui-test-utils` crate provides common test helpers, builders, and fixture
 
 ---
 
+## Terminal output styling
+
+All terminal output uses `console::style()` from the `console` crate. This is the **only** approved method for colored/styled CLI output.
+
+- Use `console::style(text).green()` for success indicators (`✔`).
+- Use `console::style(text).red().bold()` for errors (`✘`).
+- Use `console::style(text).cyan().bold()` for headers and highlights (`▸`).
+- Use `console::style(text).yellow()` for warnings and hints.
+- Use `console::style(text).dim()` for secondary/contextual info.
+- Use `console::style(text).bold()` for values (file names, counts, paths).
+- **Do not** create `Style` structs or `Printer` wrappers — use `console::style()` inline.
+- Semantic output helpers live as **free functions** in `webui-cli/src/utils/output.rs` (`header`, `field`, `success`, `finish`, `error`, `hint`).
+
+---
+
+## Developer tooling auto-installation
+
+`cargo xtask check` automatically installs missing Rust ecosystem tools:
+
+- **Rustup components** (`clippy`, `rustfmt`) — via `rustup component add`.
+- **Rustup targets** (`wasm32-unknown-unknown`) — via `rustup target add`.
+- **Cargo tools** (`cargo-deny`, `wasm-pack`) — via `cargo install`.
+
+Use the helpers in `xtask/src/util.rs`:
+- `ensure_rustup_component(name)` — for rustup components.
+- `ensure_rustup_target(name)` — for compilation targets.
+- `ensure_cargo_install(crate_name, binary)` — for cargo-installed tools.
+
+System-level tools (LLVM, wasi-sdk) cannot be auto-installed; show actionable per-platform hints using `console::style()` formatting.
+
+---
+
 ## Acceptance checklist
 
 Before finishing any task, confirm **all** of these:

--- a/.github/skills/quality-gate/SKILL.md
+++ b/.github/skills/quality-gate/SKILL.md
@@ -17,6 +17,8 @@ cargo xtask check
 
 This runs, in order: `fmt → clippy → deny → test → build → doc`.
 
+Missing Rust tools (`clippy`, `rustfmt`, `cargo-deny`, `wasm-pack`, `wasm32-unknown-unknown` target) are **auto-installed** on first run — no manual setup needed.
+
 Work is not complete until it passes cleanly.
 
 ## Fast iteration sequence

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4.29"
 env_logger = "0.11.9"
 async-trait = "0.1.89"
 tokio = { version = "1.49.0", features = ["full"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "color"] }
 console = "0.15"
 ctrlc = "3.4"
 prost = "0.13"

--- a/crates/webui-cli/src/commands/build.rs
+++ b/crates/webui-cli/src/commands/build.rs
@@ -8,7 +8,7 @@ use webui_parser::plugin::FastParserPlugin;
 use webui_parser::{CssStrategy, HtmlParser};
 use webui_protocol::WebUIProtocol;
 
-use crate::utils::output::Printer;
+use crate::utils::output;
 
 /// CSS delivery strategy for component stylesheets.
 #[derive(ValueEnum, Clone, Copy, Debug, Default)]
@@ -54,14 +54,13 @@ pub struct BuildArgs {
 
 pub fn execute(args: &BuildArgs) -> Result<()> {
     run(args).map_err(|err| {
-        let printer = Printer::new();
-        printer.error(&err);
+        output::error(&err);
 
         let err_msg = format!("{:#}", err);
         if err_msg.contains("App folder not found") {
-            printer.hint("Check that the app folder path exists");
+            output::hint("Check that the app folder path exists");
         } else if err_msg.contains("Failed to read") && args.entry == "index.html" {
-            printer.hint("Try using --entry <file> to specify a different entry file");
+            output::hint("Try using --entry <file> to specify a different entry file");
         }
         eprintln!();
         err
@@ -70,7 +69,6 @@ pub fn execute(args: &BuildArgs) -> Result<()> {
 
 fn run(args: &BuildArgs) -> Result<()> {
     let started = Instant::now();
-    let printer = Printer::new();
 
     let app_input = expand_tilde(&args.app)
         .with_context(|| format!("Failed to expand app path: {}", args.app.display()))?
@@ -83,13 +81,13 @@ fn run(args: &BuildArgs) -> Result<()> {
         .canonicalize()
         .with_context(|| format!("App folder not found: {}", args.app.display()))?;
 
-    printer.header("WebUI Build");
-    printer.field("App", &app.display());
-    printer.field("Entry", &args.entry);
-    printer.field("Output", &out.display());
-    printer.field("CSS", &format!("{:?}", args.css));
+    output::header("WebUI Build");
+    output::field("App", &app.display());
+    output::field("Entry", &args.entry);
+    output::field("Output", &out.display());
+    output::field("CSS", &format!("{:?}", args.css));
     if let Some(ref plugin_name) = args.plugin {
-        printer.field("Plugin", plugin_name);
+        output::field("Plugin", plugin_name);
     }
     eprintln!();
 
@@ -110,9 +108,9 @@ fn run(args: &BuildArgs) -> Result<()> {
         .context("Failed to register components")?;
 
     let component_count = parser.component_registry_mut().len();
-    printer.success(&format!(
+    output::success(&format!(
         "Registered {} component{}",
-        printer.bold.apply_to(component_count),
+        console::style(component_count).bold(),
         if component_count == 1 { "" } else { "s" }
     ));
 
@@ -143,10 +141,10 @@ fn run(args: &BuildArgs) -> Result<()> {
         fragments: fragment_records,
     };
 
-    printer.success(&format!(
+    output::success(&format!(
         "Parsed {} ({} fragment{})",
-        printer.bold.apply_to(&args.entry),
-        printer.bold.apply_to(fragment_count),
+        console::style(&args.entry).bold(),
+        console::style(fragment_count).bold(),
         if fragment_count == 1 { "" } else { "s" }
     ));
 
@@ -157,7 +155,7 @@ fn run(args: &BuildArgs) -> Result<()> {
     let protocol_path = out.join("protocol.bin");
     fs::write(&protocol_path, &bytes)
         .with_context(|| format!("Failed to write {}", protocol_path.display()))?;
-    printer.success(&format!("Wrote {}", printer.bold.apply_to("protocol.bin")));
+    output::success(&format!("Wrote {}", console::style("protocol.bin").bold()));
 
     let mut files_written: usize = 1;
 
@@ -167,17 +165,17 @@ fn run(args: &BuildArgs) -> Result<()> {
             let css_path = out.join(filename);
             fs::write(&css_path, css_content)
                 .with_context(|| format!("Failed to write {}", css_path.display()))?;
-            printer.success(&format!("Wrote {}", printer.bold.apply_to(filename)));
+            output::success(&format!("Wrote {}", console::style(filename).bold()));
             files_written += 1;
         }
     }
 
     let elapsed = started.elapsed();
-    printer.finish(&format!(
+    output::finish(&format!(
         "Build complete ({} file{} written) {}",
-        printer.bold.apply_to(files_written),
+        console::style(files_written).bold(),
         if files_written == 1 { "" } else { "s" },
-        printer.dim.apply_to(format!("in {elapsed:.0?}")),
+        console::style(format!("in {elapsed:.0?}")).dim(),
     ));
 
     Ok(())

--- a/crates/webui-cli/src/commands/start.rs
+++ b/crates/webui-cli/src/commands/start.rs
@@ -17,7 +17,7 @@ use webui_parser::{CssStrategy, HtmlParser};
 use webui_protocol::WebUIProtocol;
 
 use super::build::CssMode;
-use crate::utils::output::Printer;
+use crate::utils::output;
 
 #[derive(Args)]
 pub struct StartArgs {
@@ -241,16 +241,15 @@ impl HmrBackend for PollingHmrBackend {
 
 pub fn execute(args: &StartArgs) -> Result<()> {
     run(args).map_err(|err| {
-        let printer = Printer::new();
-        printer.error(&err);
+        output::error(&err);
 
         let err_msg = format!("{:#}", err);
         if err_msg.contains("App folder not found") {
-            printer.hint("Check that the app folder path exists");
+            output::hint("Check that the app folder path exists");
         } else if err_msg.contains("State file not found") {
-            printer.hint("Pass a valid --state path to a JSON file");
+            output::hint("Pass a valid --state path to a JSON file");
         } else if err_msg.contains("Serve directory not found") {
-            printer.hint("Pass a valid --servedir path for static assets");
+            output::hint("Pass a valid --servedir path for static assets");
         }
         eprintln!();
         err
@@ -258,7 +257,6 @@ pub fn execute(args: &StartArgs) -> Result<()> {
 }
 
 fn run(args: &StartArgs) -> Result<()> {
-    let printer = Printer::new();
     let paths = StartPaths::from_args(args)?;
     let hmr_backend: Option<Arc<dyn HmrBackend>> = if args.watch {
         Some(Arc::new(PollingHmrBackend::new("/hmr", 1000)))
@@ -274,26 +272,26 @@ fn run(args: &StartArgs) -> Result<()> {
         plugin: args.plugin.clone(),
     };
 
-    printer.header("WebUI Dev Server");
-    printer.field("App", &paths.app_dir.display());
-    printer.field("State", &paths.state_file.display());
+    output::header("WebUI Dev Server");
+    output::field("App", &paths.app_dir.display());
+    output::field("State", &paths.state_file.display());
     match &paths.serve_dir {
-        Some(serve_dir) => printer.field("ServeDir", &serve_dir.display()),
-        None => printer.field("ServeDir", &"(disabled)"),
+        Some(serve_dir) => output::field("ServeDir", &serve_dir.display()),
+        None => output::field("ServeDir", &"(disabled)"),
     }
-    printer.field("Entry", &args.entry);
-    printer.field("Port", &args.port);
-    printer.field("CSS", &format!("{:?}", args.css));
+    output::field("Entry", &args.entry);
+    output::field("Port", &args.port);
+    output::field("CSS", &format!("{:?}", args.css));
     if args.watch {
-        printer.field("HMR", &"enabled (polling /hmr)");
+        output::field("HMR", &"enabled (polling /hmr)");
     } else {
-        printer.field("HMR", &"disabled (pass --watch to enable)");
+        output::field("HMR", &"disabled (pass --watch to enable)");
     }
     eprintln!();
 
     // Initial build + render
     let initial_html = build_and_render(&render_config, hmr_backend.as_deref())?;
-    printer.success("Initial build and render complete");
+    output::success("Initial build and render complete");
 
     let state = Arc::new(Mutex::new(SharedState {
         rendered_html: initial_html,
@@ -307,14 +305,14 @@ fn run(args: &StartArgs) -> Result<()> {
             render_config: render_config.clone(),
             hmr_backend: Arc::clone(active_hmr_backend),
         });
-        printer.success("File watcher started");
+        output::success("File watcher started");
     }
 
     let addr = format!("127.0.0.1:{}", args.port);
     let bind_addr = addr.clone();
 
-    printer.field("URL", &format!("http://{addr}/"));
-    printer.finish("Server is running \u{2014} press Ctrl+C to stop");
+    output::field("URL", &format!("http://{addr}/"));
+    output::finish("Server is running \u{2014} press Ctrl+C to stop");
 
     let server_context = web::Data::new(ServerContext {
         state,
@@ -603,10 +601,16 @@ fn start_file_watcher(config: WatcherConfig) {
                             s.rendered_html = html;
                             s.bump_version();
                         }
-                        eprintln!("  \u{21bb} Rebuilt and re-rendered (HMR version updated)");
+                        eprintln!(
+                            "  {} Rebuilt and re-rendered (HMR version updated)",
+                            console::style("\u{21bb}").green()
+                        );
                     }
                     Err(err) => {
-                        eprintln!("  \u{2718} Rebuild failed: {err:#}");
+                        eprintln!(
+                            "  {} Rebuild failed: {err:#}",
+                            console::style("\u{2718}").red().bold()
+                        );
                     }
                 }
 

--- a/crates/webui-cli/src/main.rs
+++ b/crates/webui-cli/src/main.rs
@@ -1,20 +1,25 @@
 mod commands;
 mod utils;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use commands::Commands;
 
 #[derive(Parser)]
 #[command(name = "webui", about = "WebUI build tool")]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 fn main() {
     let cli = Cli::parse();
 
-    let result = match &cli.command {
+    let Some(command) = &cli.command else {
+        Cli::command().print_help().ok();
+        return;
+    };
+
+    let result = match command {
         Commands::Build(args) => commands::build::execute(args),
         Commands::Inspect(args) => commands::inspect::execute(args),
         Commands::Start(args) => commands::start::execute(args),

--- a/crates/webui-cli/src/utils/output.rs
+++ b/crates/webui-cli/src/utils/output.rs
@@ -1,62 +1,38 @@
-use console::Style;
-
-pub struct Printer {
-    pub cyan: Style,
-    pub green: Style,
-    pub red: Style,
-    pub dim: Style,
-    pub bold: Style,
+pub fn header(title: &str) {
+    eprintln!(
+        "\n  {} {}\n",
+        console::style("⚡").cyan().bold(),
+        console::style(title).cyan().bold()
+    );
 }
 
-impl Printer {
-    pub fn new() -> Self {
-        Self {
-            cyan: Style::new().cyan().bold(),
-            green: Style::new().green(),
-            red: Style::new().red().bold(),
-            dim: Style::new().dim(),
-            bold: Style::new().bold(),
-        }
-    }
+pub fn field(label: &str, value: &dyn std::fmt::Display) {
+    eprintln!(
+        "  {} {}",
+        console::style(format!("▸ {label:<10}")).dim(),
+        console::style(value).bold()
+    );
+}
 
-    pub fn header(&self, title: &str) {
-        eprintln!(
-            "\n  {} {}\n",
-            self.cyan.apply_to("⚡"),
-            self.cyan.apply_to(title)
-        );
-    }
+pub fn success(message: &str) {
+    eprintln!("  {} {message}", console::style("✔").green());
+}
 
-    pub fn field(&self, label: &str, value: &dyn std::fmt::Display) {
-        eprintln!(
-            "  {} {}",
-            self.dim.apply_to(format!("▸ {label:<10}")),
-            self.bold.apply_to(value)
-        );
-    }
+pub fn finish(message: &str) {
+    eprintln!("\n  {} {message}\n", console::style("✨").green());
+}
 
-    pub fn success(&self, message: &str) {
-        eprintln!("  {} {message}", self.green.apply_to("✔"));
-    }
-
-    pub fn finish(&self, message: &str) {
-        eprintln!("\n  {} {message}\n", self.green.apply_to("✨"));
-    }
-
-    pub fn error(&self, err: &anyhow::Error) {
-        eprintln!("\n  {} {}", self.red.apply_to("✘"), self.red.apply_to(err));
-        for cause in err.chain().skip(1) {
-            eprintln!("  {} {cause}", self.dim.apply_to("caused by:"));
-        }
-    }
-
-    pub fn hint(&self, message: &str) {
-        eprintln!("\n  {} {message}", self.dim.apply_to("hint:"));
+pub fn error(err: &anyhow::Error) {
+    eprintln!(
+        "\n  {} {}",
+        console::style("✘").red().bold(),
+        console::style(err).red().bold()
+    );
+    for cause in err.chain().skip(1) {
+        eprintln!("  {} {cause}", console::style("caused by:").dim());
     }
 }
 
-impl Default for Printer {
-    fn default() -> Self {
-        Self::new()
-    }
+pub fn hint(message: &str) {
+    eprintln!("\n  {} {message}", console::style("hint:").dim());
 }

--- a/xtask/src/build_examples.rs
+++ b/xtask/src/build_examples.rs
@@ -45,12 +45,19 @@ pub const INTEGRATION_BUILDS: &[IntegrationBuild] = &[
 
 pub fn run_integration_builds() -> Result<(), String> {
     if INTEGRATION_BUILDS.is_empty() {
-        eprintln!("  • no integration build entries configured");
+        eprintln!(
+            "  {} no integration build entries configured",
+            console::style("•").dim()
+        );
         return Ok(());
     }
 
     for integration in INTEGRATION_BUILDS {
-        eprintln!("  • integration: {}", integration.name);
+        eprintln!(
+            "  {} integration: {}",
+            console::style("•").dim(),
+            integration.name
+        );
         for command in integration.commands {
             let cwd = command.cwd.map(Path::new);
             run_command(command.cmd, command.args, cwd).map_err(|message| {
@@ -72,7 +79,10 @@ pub fn run_app_builds() -> Result<(), String> {
     let app_dirs = collect_child_dirs(apps_root)?;
 
     if app_dirs.is_empty() {
-        eprintln!("  • no example apps found under examples/app");
+        eprintln!(
+            "  {} no example apps found under examples/app",
+            console::style("•").dim()
+        );
         return Ok(());
     }
 
@@ -89,7 +99,7 @@ pub fn run_app_builds() -> Result<(), String> {
 
         let output_dir = app_dir.join("dist");
 
-        eprintln!("  • app: {}", app_name);
+        eprintln!("  {} app: {}", console::style("•").dim(), app_name);
 
         let src_str = src_dir.to_string_lossy().to_string();
         let output_str = output_dir.to_string_lossy().to_string();
@@ -156,13 +166,18 @@ pub fn run_integration_app(integration: Option<&str>, app: Option<&str>) -> Exit
         return ExitCode::FAILURE;
     }
 
-    eprintln!("▸ running {} with app {}", integration_name, app_name);
+    eprintln!(
+        "{} running {} with app {}",
+        console::style("▸").cyan().bold(),
+        integration_name,
+        app_name
+    );
     for cmd in build.run_commands {
         let mut args: Vec<&str> = cmd.args.to_vec();
         args.extend_from_slice(&["--app", app_name]);
         let cwd = cmd.cwd.map(Path::new);
         if let Err(message) = run_command(cmd.cmd, &args, cwd) {
-            eprintln!("  ✘ {}", message);
+            eprintln!("  {} {}", console::style("✘").red().bold(), message);
             return ExitCode::FAILURE;
         }
     }

--- a/xtask/src/build_wasm.rs
+++ b/xtask/src/build_wasm.rs
@@ -3,53 +3,31 @@
 //! Builds the `webui-wasm` crate to WebAssembly via `wasm-pack` and patches
 //! the generated JS glue for browser compatibility.
 
-use crate::util::{run_command, which_exists, Printer};
+use crate::util::{ensure_cargo_install, ensure_rustup_target, which_exists};
 use std::path::Path;
 use std::process::Command;
 use std::{env, fs};
 
 /// Build the webui-wasm package for the playground.
 pub fn run() -> Result<(), String> {
-    let p = Printer::new();
     let crate_dir = Path::new("crates/webui-wasm");
     let out_dir = Path::new("docs/public/wasm");
 
-    // 1. Check wasm-pack is installed
-    if !which_exists("wasm-pack") {
-        return Err(missing_tool_error(
-            &p,
-            "wasm-pack",
-            &[("All platforms", "cargo install wasm-pack")],
-        ));
-    }
+    // 1. Ensure wasm-pack is installed (auto-install if missing)
+    ensure_cargo_install("wasm-pack", "wasm-pack")?;
 
-    // 2. Check wasm32-unknown-unknown target
-    let rustup_out = Command::new("rustup")
-        .args(["target", "list", "--installed"])
-        .output()
-        .map_err(|e| format!("Failed to run rustup: {}", e))?;
-    let targets = String::from_utf8_lossy(&rustup_out.stdout);
-    if !targets.contains("wasm32-unknown-unknown") {
-        eprintln!(
-            "  {} Adding wasm32-unknown-unknown target...",
-            p.dim.apply_to("•")
-        );
-        run_command("rustup", &["target", "add", "wasm32-unknown-unknown"], None)?;
-    }
+    // 2. Ensure wasm32-unknown-unknown target is installed
+    ensure_rustup_target("wasm32-unknown-unknown")?;
 
     // 3. Detect C compiler for wasm32
     let cc = find_wasm_cc().ok_or_else(|| {
         missing_tool_error(
-            &p,
             "LLVM clang (with wasm32 support)",
             &[
                 ("macOS", "brew install llvm"),
                 ("Ubuntu/Debian", "sudo apt install clang"),
                 ("Fedora", "sudo dnf install clang"),
-                (
-                    "Windows",
-                    "Download from https://releases.llvm.org/download.html",
-                ),
+                ("Windows", "winget install LLVM.LLVM"),
             ],
         )
     })?;
@@ -58,7 +36,6 @@ pub fn run() -> Result<(), String> {
     // 4. Detect WASM include path (wasi-libc headers for tree-sitter C code)
     let wasi_include = find_wasi_include().ok_or_else(|| {
         missing_tool_error(
-            &p,
             "WASM C stdlib headers",
             &[
                 ("macOS", "brew install wasi-libc"),
@@ -69,14 +46,22 @@ pub fn run() -> Result<(), String> {
         )
     })?;
 
-    eprintln!("  {} CC:   {}", p.dim.apply_to("•"), p.bold.apply_to(&cc));
+    eprintln!(
+        "  {} CC:   {}",
+        console::style("•").dim(),
+        console::style(&cc).bold()
+    );
     if !ar.is_empty() {
-        eprintln!("  {} AR:   {}", p.dim.apply_to("•"), p.bold.apply_to(&ar));
+        eprintln!(
+            "  {} AR:   {}",
+            console::style("•").dim(),
+            console::style(&ar).bold()
+        );
     }
     eprintln!(
         "  {} WASI: {}",
-        p.dim.apply_to("•"),
-        p.bold.apply_to(&wasi_include)
+        console::style("•").dim(),
+        console::style(&wasi_include).bold()
     );
 
     // 5. Clean output directory
@@ -117,7 +102,7 @@ pub fn run() -> Result<(), String> {
 
     // 7. Patch JS glue: replace `import 'env'` with inline C stdlib stubs
     let js_path = out_dir.join("webui_wasm.js");
-    patch_wasm_js_glue(&p, &js_path)?;
+    patch_wasm_js_glue(&js_path)?;
 
     // 8. Remove wasm-pack generated .gitignore
     let gitignore = out_dir.join(".gitignore");
@@ -131,13 +116,13 @@ pub fn run() -> Result<(), String> {
         let size_kb = meta.len() / 1024;
         eprintln!(
             "  {} Output: {}",
-            p.green.apply_to("✔"),
-            p.bold.apply_to(out_dir.display())
+            console::style("✔").green(),
+            console::style(out_dir.display()).bold()
         );
         eprintln!(
             "  {} Size:   {}",
-            p.green.apply_to("✔"),
-            p.bold.apply_to(format!("{} KB", size_kb))
+            console::style("✔").green(),
+            console::style(format!("{} KB", size_kb)).bold()
         );
     }
 
@@ -146,7 +131,7 @@ pub fn run() -> Result<(), String> {
 
 /// Patch the wasm-bindgen JS glue to replace `import * as __wbg_star0 from 'env'`
 /// with inline JavaScript stubs for the C stdlib functions tree-sitter needs.
-fn patch_wasm_js_glue(p: &Printer, js_path: &Path) -> Result<(), String> {
+fn patch_wasm_js_glue(js_path: &Path) -> Result<(), String> {
     let content = fs::read_to_string(js_path)
         .map_err(|e| format!("Failed to read {}: {}", js_path.display(), e))?;
 
@@ -157,8 +142,8 @@ fn patch_wasm_js_glue(p: &Printer, js_path: &Path) -> Result<(), String> {
 
     eprintln!(
         "  {} Patching JS glue: replacing {} import with inline stubs",
-        p.dim.apply_to("•"),
-        p.cyan.apply_to("'env'")
+        console::style("•").dim(),
+        console::style("'env'").cyan().bold()
     );
 
     let stub = "const __wbg_star0 = {\n    \
@@ -340,19 +325,19 @@ fn find_tree_sitter_wasm_headers() -> Option<String> {
 }
 
 /// Build a friendly, colorful error message for a missing tool.
-fn missing_tool_error(p: &Printer, tool: &str, install_hints: &[(&str, &str)]) -> String {
+fn missing_tool_error(tool: &str, install_hints: &[(&str, &str)]) -> String {
     let mut msg = format!(
         "\n  {} {} not found\n\n  {} Install it using one of:\n",
-        p.red.apply_to("✘"),
-        p.bold.apply_to(tool),
-        p.yellow.apply_to("hint:"),
+        console::style("✘").red().bold(),
+        console::style(tool).bold(),
+        console::style("hint:").yellow(),
     );
     for (platform, command) in install_hints {
         msg.push_str(&format!(
             "\n    {} {:<16} {}",
-            p.dim.apply_to("▸"),
-            p.dim.apply_to(platform),
-            p.cyan.apply_to(command),
+            console::style("▸").dim(),
+            console::style(platform).dim(),
+            console::style(command).cyan().bold(),
         ));
     }
     msg.push('\n');

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -9,11 +9,9 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use crate::util::{collect_child_dirs, display_name, Printer};
+use crate::util::{collect_child_dirs, display_name};
 
 pub fn run(app: Option<&str>) -> ExitCode {
-    let p = Printer::new();
-
     let Some(app_name) = app else {
         eprintln!(
             "Usage: cargo xtask dev <app>\n\nAvailable apps: {}",
@@ -34,15 +32,15 @@ pub fn run(app: Option<&str>) -> ExitCode {
 
     eprintln!(
         "{} dev mode for {} (Ctrl+C to stop)",
-        p.cyan.apply_to("▸"),
-        p.bold.apply_to(app_name),
+        console::style("▸").cyan().bold(),
+        console::style(app_name).bold(),
     );
 
-    let mut server = match spawn_child("server", "pnpm", &["start:server"], &app_dir, &p) {
+    let mut server = match spawn_child("server", "pnpm", &["start:server"], &app_dir) {
         Some(c) => c,
         None => return ExitCode::FAILURE,
     };
-    let mut client = match spawn_child("client", "pnpm", &["start:client"], &app_dir, &p) {
+    let mut client = match spawn_child("client", "pnpm", &["start:client"], &app_dir) {
         Some(c) => c,
         None => {
             let _ = server.kill();
@@ -66,7 +64,7 @@ pub fn run(app: Option<&str>) -> ExitCode {
             let _ = client.kill();
             let _ = server.wait();
             let _ = client.wait();
-            eprintln!("\n  {} stopped", p.green.apply_to("✔"));
+            eprintln!("\n  {} stopped", console::style("✔").green());
             return ExitCode::SUCCESS;
         }
 
@@ -84,13 +82,13 @@ pub fn run(app: Option<&str>) -> ExitCode {
             let c = client.wait().map(|s| s.code().unwrap_or(1)).unwrap_or(1);
 
             if ctrlc.load(Ordering::SeqCst) {
-                eprintln!("\n  {} stopped", p.green.apply_to("✔"));
+                eprintln!("\n  {} stopped", console::style("✔").green());
                 return ExitCode::SUCCESS;
             }
 
             eprintln!(
                 "  {} dev processes exited (server={}, client={})",
-                p.red.apply_to("✘"),
+                console::style("✘").red().bold(),
                 s,
                 c,
             );
@@ -101,11 +99,11 @@ pub fn run(app: Option<&str>) -> ExitCode {
     }
 }
 
-fn spawn_child(label: &str, cmd: &str, args: &[&str], cwd: &Path, p: &Printer) -> Option<Child> {
+fn spawn_child(label: &str, cmd: &str, args: &[&str], cwd: &Path) -> Option<Child> {
     eprintln!(
         "  {} starting {}",
-        p.dim.apply_to("→"),
-        p.cyan.apply_to(label),
+        console::style("→").dim(),
+        console::style(label).cyan().bold(),
     );
 
     match Command::new(cmd)
@@ -118,7 +116,12 @@ fn spawn_child(label: &str, cmd: &str, args: &[&str], cwd: &Path, p: &Printer) -
     {
         Ok(child) => Some(child),
         Err(e) => {
-            eprintln!("  [{}] failed to start: {}", label, e);
+            eprintln!(
+                "  {} [{}] failed to start: {}",
+                console::style("✘").red().bold(),
+                label,
+                e
+            );
             None
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,7 +4,7 @@ mod dev;
 mod util;
 
 use std::process::ExitCode;
-use util::{run_command, workspace_root};
+use util::{ensure_cargo_install, ensure_rustup_component, run_command, workspace_root};
 
 fn main() -> ExitCode {
     let workspace_root = match workspace_root() {
@@ -65,7 +65,7 @@ fn usage() -> ExitCode {
            docs    Build the documentation site\n  \
            dev <app>  Run example app in dev mode (server + client watch concurrently)"
     );
-    ExitCode::FAILURE
+    ExitCode::SUCCESS
 }
 
 fn check() -> ExitCode {
@@ -91,11 +91,15 @@ struct Step {
 impl Step {
     const FMT: Self = Self {
         name: "fmt",
-        run: || run_command("cargo", &["fmt", "--all", "--check"], None),
+        run: || {
+            ensure_rustup_component("rustfmt")?;
+            run_command("cargo", &["fmt", "--all", "--check"], None)
+        },
     };
     const CLIPPY: Self = Self {
         name: "clippy",
         run: || {
+            ensure_rustup_component("clippy")?;
             run_command(
                 "cargo",
                 &["clippy", "--workspace", "--", "-D", "warnings"],
@@ -105,7 +109,10 @@ impl Step {
     };
     const DENY: Self = Self {
         name: "deny",
-        run: || run_command("cargo", &["deny", "check"], None),
+        run: || {
+            ensure_cargo_install("cargo-deny", "cargo-deny")?;
+            run_command("cargo", &["deny", "check"], None)
+        },
     };
     const TEST: Self = Self {
         name: "test",
@@ -140,16 +147,21 @@ impl Step {
 
 fn run_steps(steps: &[Step]) -> ExitCode {
     for step in steps {
-        eprintln!("\n▸ {}", step.name);
+        eprintln!("\n{} {}", console::style("▸").cyan().bold(), step.name);
         match (step.run)() {
-            Ok(()) => eprintln!("  ✔ {}", step.name),
+            Ok(()) => eprintln!("  {} {}", console::style("✔").green(), step.name),
             Err(message) => {
-                eprintln!("  ✘ {}", step.name);
-                eprintln!("  ✘ {} — {}", step.name, message);
+                eprintln!("  {} {}", console::style("✘").red().bold(), step.name);
+                eprintln!(
+                    "  {} {} — {}",
+                    console::style("✘").red().bold(),
+                    step.name,
+                    message
+                );
                 return ExitCode::FAILURE;
             }
         }
     }
-    eprintln!("\n✨ All checks passed\n");
+    eprintln!("\n{} All checks passed\n", console::style("✨").green());
     ExitCode::SUCCESS
 }

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,6 +1,5 @@
 //! Shared utilities for xtask commands.
 
-use console::Style;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -18,30 +17,6 @@ pub fn workspace_root() -> Result<PathBuf, String> {
         ));
     };
     Ok(root.to_path_buf())
-}
-
-// ── Styled output (matches webui-cli output.rs) ─────────────────────────
-
-pub struct Printer {
-    pub cyan: Style,
-    pub green: Style,
-    pub red: Style,
-    pub yellow: Style,
-    pub dim: Style,
-    pub bold: Style,
-}
-
-impl Printer {
-    pub fn new() -> Self {
-        Self {
-            cyan: Style::new().cyan().bold(),
-            green: Style::new().green(),
-            red: Style::new().red().bold(),
-            yellow: Style::new().yellow(),
-            dim: Style::new().dim(),
-            bold: Style::new().bold(),
-        }
-    }
 }
 
 /// Run a command and return Ok if it exits with status 0.
@@ -92,6 +67,71 @@ pub fn which_exists(cmd: &str) -> bool {
         .stderr(std::process::Stdio::null())
         .status()
         .is_ok()
+}
+
+/// Ensure a tool installed via `cargo install` is available, installing it
+/// automatically if missing.
+///
+/// `crate_name` is the crate to install (e.g. `"cargo-deny"`, `"wasm-pack"`).
+/// `binary` is the executable name to probe on PATH (e.g. `"cargo-deny"`,
+/// `"wasm-pack"`).
+pub fn ensure_cargo_install(crate_name: &str, binary: &str) -> Result<(), String> {
+    if which_exists(binary) {
+        return Ok(());
+    }
+
+    eprintln!(
+        "    {} not found — installing…",
+        console::style(crate_name).yellow()
+    );
+    run_command("cargo", &["install", crate_name], None)
+        .map_err(|e| format!("failed to install {crate_name}: {e}"))
+}
+
+/// Ensure a rustup component (e.g. `clippy`, `rustfmt`) is available,
+/// adding it automatically if missing.
+pub fn ensure_rustup_component(component: &str) -> Result<(), String> {
+    let output = Command::new("rustup")
+        .args(["component", "list", "--installed"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to run rustup: {e}"))?;
+
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if installed.lines().any(|line| line.starts_with(component)) {
+        return Ok(());
+    }
+
+    eprintln!(
+        "    rustup component '{}' not found — adding…",
+        console::style(component).yellow()
+    );
+    run_command("rustup", &["component", "add", component], None)
+        .map_err(|e| format!("failed to add rustup component {component}: {e}"))
+}
+
+/// Ensure a rustup target (e.g. `wasm32-unknown-unknown`) is installed,
+/// adding it automatically if missing.
+pub fn ensure_rustup_target(target: &str) -> Result<(), String> {
+    let output = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to run rustup: {e}"))?;
+
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if installed.lines().any(|line| line == target) {
+        return Ok(());
+    }
+
+    eprintln!(
+        "    rustup target '{}' not found — adding…",
+        console::style(target).yellow()
+    );
+    run_command("rustup", &["target", "add", target], None)
+        .map_err(|e| format!("failed to add rustup target {target}: {e}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add ensure_cargo_install, ensure_rustup_component, and ensure_rustup_target helpers in xtask/src/util.rs to auto-install missing Rust tools (cargo-deny, wasm-pack, clippy, rustfmt, wasm32-unknown-unknown target) on first run of cargo xtask check.
- Replace Printer structs in both xtask and webui-cli with console::style() free functions for consistent terminal colors.
- Style all previously plain eprintln! output (step runner, build examples, dev mode, file watcher) with colored symbols.
- Make cargo xtask and webui with no subcommand exit 0 instead of failing.
- Enable clap color feature for colored help output.
- Update copilot-instructions.md with terminal styling and auto-install conventions.
- Update quality-gate SKILL.md to document auto-install behavior.