### PR TITLE
feat: add CSS token hoisting with comment-based signal bindings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,6 +31,9 @@ The protocol defines the serializable structure representing UI templates. At ru
 pub struct WebUIProtocol {
     /// Map of fragment identifiers to their associated fragment lists.
     pub fragments: HashMap<String, FragmentList>,
+    /// Sorted, deduplicated CSS custom property names used across all
+    /// components and entry page styles (without `--` prefix).
+    pub tokens: Vec<String>,
 }
 
 /// A list of fragments (needed because protobuf maps cannot have repeated values directly).
@@ -369,6 +372,8 @@ pub struct Component {
     pub name: String,
     pub html_content: String,
     pub css_content: Option<String>,
+    /// Sorted, deduplicated CSS token names extracted from css_content.
+    pub css_tokens: Vec<String>,
 }
 ```
 
@@ -587,6 +592,7 @@ impl CssParser {
     pub fn parse(&mut self, css_content: &str) -> Result<WebUIFragmentRecords, ParserError>
     pub fn process_css(&mut self, css_content: &str, fragments: &mut WebUIFragmentRecords) -> Result<(), ParserError>
     pub fn parse_inline_css(&mut self, style_content: &str) -> Result<String, ParserError>
+    pub fn extract_tokens(&mut self, css_content: &str) -> Result<HashSet<String>, ParserError>
 }
 ```
 
@@ -596,6 +602,47 @@ impl CssParser {
 - Convert dynamic variables to signals
 - Handle nested variable references
 - Process inline and external CSS
+
+### CSS Token Hoisting
+
+CSS Token Hoisting extracts the set of CSS custom properties (tokens) that are **used** across all components and entry page styles at build time. The sorted, deduplicated list is included in the protocol's `tokens` field, enabling host runtimes to resolve only the design tokens the application actually needs.
+
+#### Token Extraction (`CssParser::extract_tokens`)
+
+The `extract_tokens` method uses tree-sitter-css to iteratively walk the CSS AST and extract custom property **usages** from `var()` calls, while **excluding** locally-defined custom properties.
+
+**Extracted (hoisted):**
+- `var(--colorPrimary)` → token `"colorPrimary"`
+- `var(--a, var(--b, var(--c)))` → tokens `"a"`, `"b"`, `"c"` (nested fallbacks)
+- `var(--size, 16px)` → token `"size"` (literal fallbacks ignored)
+
+**Excluded (not hoisted):**
+- `--bar: 12px` — local custom property definitions
+- `var(--bar)` when `--bar` is defined in the same CSS file
+
+The iterative walker visits each `call_expression` node independently, so nested `var()` fallbacks (which are separate `call_expression` nodes in the tree-sitter AST) are naturally handled.
+
+#### Token Collection During Parsing
+
+The `HtmlParser` maintains a `token_store: HashSet<String>` that accumulates tokens from two sources:
+
+1. **Component CSS** — when a component is first encountered during parsing, its pre-extracted `css_tokens` (stored in the `Component` struct at registration time) are merged into the token store.
+2. **Inline `<style>` tags** — when the parser processes a `style_element` node, it calls `extract_tokens` on the CSS content and merges the result.
+
+After parsing completes, `HtmlParser::take_tokens()` returns the sorted, deduplicated token list for inclusion in the protocol.
+
+#### Comment-Based Signal Bindings
+
+HTML comments containing handlebars expressions are parsed as signal fragments:
+
+```html
+<!--{{tokens}}-->        → Signal { value: "tokens", raw: false }
+<!--{{{tokens}}}-->      → Signal { value: "tokens", raw: true }
+<!--{{tokens.light}}-->  → Signal { value: "tokens.light", raw: false }
+<!-- regular comment -->  → Raw (preserved as-is)
+```
+
+This mechanism is general-purpose (not limited to `tokens`) and enables comment-based placeholders for runtime value injection in HTML files. The existing handlebars parser is reused for expression parsing within comment delimiters.
 
 ### Error Handling
 ```rust

--- a/crates/webui-cli/src/commands/build.rs
+++ b/crates/webui-cli/src/commands/build.rs
@@ -88,6 +88,18 @@ fn run(args: &BuildArgs) -> Result<()> {
         }
     ));
 
+    if build_output.token_count > 0 {
+        output::success(&format!(
+            "Discovered {} CSS token{}",
+            console::style(build_output.token_count).bold(),
+            if build_output.token_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ));
+    }
+
     // Write protocol as optimized protobuf binary
     let bytes = build_output
         .protocol
@@ -508,5 +520,55 @@ mod tests {
         .unwrap();
 
         assert!(out_dir.path().join("protocol.bin").exists());
+    }
+
+    #[test]
+    fn test_build_protocol_includes_tokens_from_components() {
+        let app_dir = create_app_dir(&[
+            ("index.html", "<my-btn></my-btn>"),
+            ("my-btn.html", "<button><slot></slot></button>"),
+            (
+                "my-btn.css",
+                ".btn { color: var(--text-color); padding: var(--spacing-m); }",
+            ),
+        ]);
+        let out_dir = TempDir::new().unwrap();
+
+        build(app_dir.path(), out_dir.path(), "index.html").unwrap();
+
+        let bytes = fs::read(out_dir.path().join("protocol.bin")).unwrap();
+        let protocol = WebUIProtocol::from_protobuf(&bytes).unwrap();
+
+        assert_eq!(protocol.tokens, vec!["spacing-m", "text-color"]);
+    }
+
+    #[test]
+    fn test_build_protocol_excludes_entry_defined_tokens() {
+        let html = r#"<style>
+            :root { --text-color: #333; --spacing-m: 12px; }
+            body { color: var(--text-color); }
+        </style>
+        <my-btn></my-btn>"#;
+        let app_dir = create_app_dir(&[
+            ("index.html", html),
+            ("my-btn.html", "<button><slot></slot></button>"),
+            (
+                "my-btn.css",
+                ".btn { color: var(--text-color); margin: var(--spacing-m); }",
+            ),
+        ]);
+        let out_dir = TempDir::new().unwrap();
+
+        build(app_dir.path(), out_dir.path(), "index.html").unwrap();
+
+        let bytes = fs::read(out_dir.path().join("protocol.bin")).unwrap();
+        let protocol = WebUIProtocol::from_protobuf(&bytes).unwrap();
+
+        // Both tokens are defined in entry :root — should not be in protocol
+        assert!(
+            protocol.tokens.is_empty(),
+            "Entry-defined tokens should be excluded: {:?}",
+            protocol.tokens
+        );
     }
 }

--- a/crates/webui-cli/src/commands/common.rs
+++ b/crates/webui-cli/src/commands/common.rs
@@ -59,6 +59,8 @@ pub struct BuildOutput {
     pub fragment_count: usize,
     /// Number of registered components
     pub component_count: usize,
+    /// Number of unique CSS tokens discovered
+    pub token_count: usize,
 }
 
 /// Build the protocol from an app directory.
@@ -122,6 +124,10 @@ pub fn build_protocol(app_dir: &Path, args: &AppArgs) -> Result<BuildOutput> {
         })
         .collect();
 
+    // Collect CSS tokens before consuming the parser
+    let tokens = parser.take_tokens();
+    let token_count = tokens.len();
+
     // Build protocol (consumes parser)
     let fragment_records = parser.into_fragment_records();
     let fragment_count: usize = fragment_records.values().map(|v| v.fragments.len()).sum();
@@ -133,14 +139,13 @@ pub fn build_protocol(app_dir: &Path, args: &AppArgs) -> Result<BuildOutput> {
         .map(|(tag, css)| (format!("{tag}.css"), css))
         .collect();
 
-    let protocol = WebUIProtocol {
-        fragments: fragment_records,
-    };
+    let protocol = WebUIProtocol::with_tokens(fragment_records, tokens);
 
     Ok(BuildOutput {
         protocol,
         css_files,
         fragment_count,
         component_count,
+        token_count,
     })
 }

--- a/crates/webui-cli/src/commands/inspect.rs
+++ b/crates/webui-cli/src/commands/inspect.rs
@@ -46,7 +46,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
 
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("protocol.bin");

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -332,9 +332,7 @@ pub unsafe extern "C" fn webui_render(
         return std::ptr::null_mut();
     }
 
-    let protocol = WebUIProtocol {
-        fragments: parser.into_fragment_records(),
-    };
+    let protocol = WebUIProtocol::new(parser.into_fragment_records());
 
     // --- Parse JSON state ----------------------------------------------------
     let data: Value = match serde_json::from_str(data_str) {

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -137,7 +137,7 @@ fn build_mixed_protocol() -> WebUIProtocol {
         },
     );
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn handler_plugin_fast_bench(c: &mut Criterion) {
@@ -267,7 +267,7 @@ fn build_condition_protocol() -> WebUIProtocol {
         );
     }
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn build_condition_state() -> Value {
@@ -376,7 +376,7 @@ fn build_nested_component_protocol() -> WebUIProtocol {
         },
     );
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn handler_nested_components_bench(c: &mut Criterion) {
@@ -416,7 +416,7 @@ fn build_signal_protocol(signal_path: &str) -> WebUIProtocol {
             ],
         },
     );
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn handler_state_depth_bench(c: &mut Criterion) {

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -632,7 +632,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
 
         // Create a test writer
@@ -664,7 +664,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "WebUI"});
 
         // Create a test writer
@@ -705,7 +705,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "people": [
                 {"name": "Alice"},
@@ -753,7 +753,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
 
         // Test with isActive = true
         let state_true = test_json!({"isActive": true});
@@ -797,7 +797,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
 
         // Create a test writer
@@ -828,7 +828,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
 
         // Create a test writer
@@ -861,7 +861,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
 
         let mut writer = TestWriter::new();
@@ -893,7 +893,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": true});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -916,7 +916,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": false});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -939,7 +939,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -966,7 +966,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"checked": true, "disabled": false});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -988,7 +988,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"inputValue": "Hello"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1008,7 +1008,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"number": 0});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1042,7 +1042,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"item": "world"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1063,7 +1063,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"html": "<strong>hi</strong>"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1104,7 +1104,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<span>Inner</span>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "outerItems": [
                 {"innerItems": [{"name": "A"}, {"name": "B"}]},
@@ -1152,7 +1152,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "outerItems": [
                 {"innerItems": [{"name": "Item1"}, {"name": "Item2"}]},
@@ -1202,7 +1202,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "globalOuter": "GO",
             "globalInner": "GI",
@@ -1245,7 +1245,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("item.name", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": [{"name": "Show", "visible": true}, {"name": "Hide", "visible": false}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1276,7 +1276,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("yes")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         // Global flag is true, but local item.flag is false for second item
         let state = test_json!({"flag": true, "items": [{"flag": true}, {"flag": false}]});
         let mut writer = TestWriter::new();
@@ -1321,7 +1321,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"title": "Global Title"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1374,7 +1374,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"item": "<world>"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1427,7 +1427,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"item": "a&b"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1474,7 +1474,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"complexItem": {"foo": 1, "bar": "true"}});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1533,7 +1533,7 @@ mod tests {
             },
         );
         fragments.insert("child".to_string(), FragmentList { fragments: vec![] });
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"var": "original"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1582,7 +1582,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("disabled!")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": true});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1603,7 +1603,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("v", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"v": value});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1715,7 +1715,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": 1});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1737,7 +1737,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": "yes"});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1759,7 +1759,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": {}});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1782,7 +1782,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": "false"});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1808,7 +1808,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": 0});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1830,7 +1830,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": ""});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1852,7 +1852,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({"checked": false});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1874,7 +1874,7 @@ mod tests {
                     ],
                 },
             );
-            let protocol = WebUIProtocol { fragments };
+            let protocol = WebUIProtocol::new(fragments);
             let state = test_json!({});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -1898,7 +1898,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"itemCount": 5});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -1921,7 +1921,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"itemCount": 3});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2003,7 +2003,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"who": "<world>"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2106,7 +2106,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"p": "<p>", "cExtra": "x&y"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2197,7 +2197,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"who": "Bob", "items": [{"name": "A<1>"}, {"name": "B&2"}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2283,7 +2283,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"t": "<t&1>", "d": "d<2>", "a": "a&3"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2328,7 +2328,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"title": "Global Title"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2379,7 +2379,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"title": "Global Title", "items": [{"title": "Local Title"}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2445,7 +2445,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<div>Disabled</div>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": true});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2490,7 +2490,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"keyHyphen": "Global Value"});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2603,7 +2603,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "title": "Hello",
             "skippedClass": "my-class",
@@ -2683,7 +2683,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2771,7 +2771,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2818,7 +2818,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"complexItem": {"foo": 1, "bar": "true"}});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2870,7 +2870,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"list": {"items": [{"name": "Alice"}, {"name": "Bob"}]}});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -2968,7 +2968,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"data": {"outer": [
             {"label": "Outer1", "middle": [{"label": "Middle1", "inner": [{"label": "Inner1A"}, {"label": "Inner1B"}]}]},
             {"label": "Outer2", "middle": [{"label": "Middle2", "inner": [{"label": "Inner2A"}]}]}
@@ -3034,7 +3034,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<span>Enabled</span>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": true});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3095,7 +3095,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<span>Enabled</span>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"isDisabled": false});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3190,9 +3190,7 @@ mod tests {
 
         // Test case 1: isDisabled = true
         {
-            let protocol = WebUIProtocol {
-                fragments: fragments.clone(),
-            };
+            let protocol = WebUIProtocol::new(fragments.clone());
             let state = test_json!({"isDisabled": true});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -3204,9 +3202,7 @@ mod tests {
 
         // Test case 2: isDisabled = false
         {
-            let protocol = WebUIProtocol {
-                fragments: fragments.clone(),
-            };
+            let protocol = WebUIProtocol::new(fragments.clone());
             let state = test_json!({"isDisabled": false});
             let mut writer = TestWriter::new();
             handle(&protocol, &state, &mut writer).unwrap();
@@ -3244,7 +3240,7 @@ mod tests {
                 )],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3276,7 +3272,7 @@ mod tests {
                 )],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3338,7 +3334,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": [{"name": "Item1"}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3373,7 +3369,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<span>If 1</span>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
 
         // True case: x = 10 > 5
         let state_true = test_json!({"x": 10});
@@ -3421,7 +3417,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "flag": false,
             "items": [
@@ -3471,7 +3467,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "item": {"flag": true},
             "items": [
@@ -3515,7 +3511,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "testScenario": "RecursiveTemplatesWithGlobalState",
             "items": [
@@ -3570,7 +3566,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": [{"name": "Item1"}, {"name": "Item2"}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3618,7 +3614,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "globalPrefix": "Prefix: ",
             "outerItems": [
@@ -3669,7 +3665,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state =
             test_json!({"globalSuffix": "Global", "items": [{"name": "Item1"}, {"name": "Item2"}]});
         let mut writer = TestWriter::new();
@@ -3715,7 +3711,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state =
             test_json!({"globalSuffix": "Global", "items": [{"name": "Item1"}, {"name": "Item2"}]});
         let mut writer = TestWriter::new();
@@ -3749,7 +3745,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "GlobalName", "items": [{"name": "LocalName1"}, {"name": "LocalName2"}]});
         let mut writer = TestWriter::new();
         handle(&protocol, &state, &mut writer).unwrap();
@@ -3809,7 +3805,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "globalPrefix": "Prefix: ",
             "globalSuffix": "Suffix",
@@ -3879,7 +3875,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "globalPrefix": "GP-",
             "outerItems": [
@@ -3943,7 +3939,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "outerItems": [
                 {"label": "Outer1", "innerItems": [{"detail": "Detail1", "show": true}, {"detail": "Detail2", "show": false}]},
@@ -3987,7 +3983,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "item": {"globalValue": "GLOBAL", "otherVal": "other"},
             "items": [
@@ -4042,7 +4038,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "item": {"globalValue": "GLOBAL", "otherVal": "other"},
             "items": [
@@ -4100,7 +4096,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "list": {"outer_items": [{"inner_items": [{"flag": true, "value": "X"}, {"flag": false, "value": "Y"}]}]},
             "inner_item": {"flag": false}
@@ -4155,7 +4151,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "list": {"outer_items": [{"inner_items": [{"value": "X"}, {"value": "Y"}]}]},
             "inner_item": {"flag": true}
@@ -4219,7 +4215,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "globalLimit": 10,
             "list": {"outerItems": [

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -432,7 +432,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "Alice"});
         let output = render_no_plugin(&protocol, &state);
         assert_eq!(output, "<p>Alice</p>");
@@ -452,7 +452,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "Alice"});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Root scope is disabled — no markers at root level
@@ -474,7 +474,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("item", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": ["a", "b"]});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no for-loop binding or repeat item markers
@@ -503,7 +503,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("<p>Visible</p>")],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
 
         // True case — root scope disabled, no markers; content still rendered
         let state = test_json!({"show": true});
@@ -537,7 +537,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("inner", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"before": "B", "inner": "I", "after": "A"});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no markers for root-level signals
@@ -563,7 +563,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"itemId": "42", "itemTitle": "Hello"});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no plugin data markers
@@ -616,7 +616,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "World", "content": "CONTENT"});
 
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
@@ -735,7 +735,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({
             "title": "My Store",
             "categories": [
@@ -829,7 +829,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Hydration comments must be emitted even when signal is not found in state
@@ -872,7 +872,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("item", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         // Hydration comments must be emitted even when collection is missing from state
@@ -905,7 +905,7 @@ mod tests {
                 ],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": ""});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         assert!(
@@ -944,7 +944,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("item", false)],
             },
         );
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": []});
         let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
         assert!(

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -119,9 +119,7 @@ mod tests {
     fn build_protocol(html: &str) -> Vec<u8> {
         let mut parser = HtmlParser::new();
         parser.parse("index.html", html).expect("parse failed");
-        let protocol = WebUIProtocol {
-            fragments: parser.into_fragment_records(),
-        };
+        let protocol = WebUIProtocol::new(parser.into_fragment_records());
         protocol.to_protobuf().expect("protobuf encode failed")
     }
 

--- a/crates/webui-parser/src/component_registry.rs
+++ b/crates/webui-parser/src/component_registry.rs
@@ -2,7 +2,7 @@
 //!
 //! This module manages the registry of web components used in the application.
 
-use crate::{ParserError, Result};
+use crate::{CssParser, ParserError, Result};
 use std::collections::HashMap;
 #[cfg(feature = "fs")]
 use std::fs;
@@ -24,6 +24,10 @@ pub struct Component {
     /// The CSS content of the component, if any
     pub css_content: Option<String>,
 
+    /// CSS custom property token names extracted from this component's CSS
+    /// (sorted, deduplicated, without `--` prefix).
+    pub css_tokens: Vec<String>,
+
     /// The file path where this component is defined
     pub source_path: PathBuf,
 
@@ -32,10 +36,18 @@ pub struct Component {
 }
 
 /// Registry of web components.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ComponentRegistry {
     /// Map of component tag names to their component data
     components: HashMap<String, Component>,
+    /// Reusable CSS parser for token extraction during registration.
+    css_parser: CssParser,
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ComponentRegistry {
@@ -43,6 +55,7 @@ impl ComponentRegistry {
     pub fn new() -> Self {
         Self {
             components: HashMap::new(),
+            css_parser: CssParser::new(),
         }
     }
 
@@ -117,18 +130,19 @@ impl ComponentRegistry {
         let html_content = fs::read_to_string(html_path)
             .map_err(|e| ParserError::IO(format!("Failed to read HTML file: {}", e)))?;
 
-        // Read CSS content if available
-        let css_content = if let Some(css_path) = css_path {
+        // Read CSS content and extract tokens if available
+        let (css_content, css_tokens) = if let Some(css_path) = css_path {
             let css_path = css_path.as_ref();
             if css_path.exists() {
                 let content = fs::read_to_string(css_path)
                     .map_err(|e| ParserError::IO(format!("Failed to read CSS file: {}", e)))?;
-                Some(content)
+                let tokens = self.extract_sorted_tokens(&content)?;
+                (Some(content), tokens)
             } else {
-                None
+                (None, Vec::new())
             }
         } else {
-            None
+            (None, Vec::new())
         };
 
         // Create and register the component
@@ -136,6 +150,7 @@ impl ComponentRegistry {
             tag_name: tag_name.to_string(),
             html_content,
             css_content,
+            css_tokens,
             source_path: html_path.to_path_buf(),
             class_name: None,
         };
@@ -167,11 +182,18 @@ impl ComponentRegistry {
             )));
         }
 
+        // Extract CSS tokens if CSS content is provided
+        let css_tokens = match css_content {
+            Some(css) => self.extract_sorted_tokens(css)?,
+            None => Vec::new(),
+        };
+
         // Create component with dummy path since it's coming from string content
         let component: Component = Component {
             tag_name: tag_name.to_string(),
             html_content: html_content.to_string(),
             css_content: css_content.map(ToString::to_string),
+            css_tokens,
             source_path: PathBuf::new(), // Empty path since it's not from a file
             class_name: None,
         };
@@ -179,6 +201,14 @@ impl ComponentRegistry {
         // Register the component
         self.components.insert(tag_name.to_string(), component);
         Ok(())
+    }
+
+    /// Extract CSS tokens from content and return as a sorted `Vec`.
+    fn extract_sorted_tokens(&mut self, css_content: &str) -> Result<Vec<String>> {
+        let tokens = self.css_parser.extract_tokens(css_content)?;
+        let mut sorted: Vec<String> = tokens.into_iter().collect();
+        sorted.sort();
+        Ok(sorted)
     }
 
     /// Check if a tag name is registered as a component.
@@ -485,5 +515,47 @@ mod tests {
             result
         );
         assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn test_register_component_extracts_css_tokens() {
+        let mut registry = ComponentRegistry::new();
+        registry
+            .register_component(
+                "my-btn",
+                "<button>Click</button>",
+                Some(":host { color: var(--text-color); padding: var(--spacing-m); }"),
+            )
+            .expect("register failed");
+
+        let component = registry.get("my-btn").expect("component not found");
+        assert_eq!(component.css_tokens, vec!["spacing-m", "text-color"]);
+    }
+
+    #[test]
+    fn test_register_component_no_css_no_tokens() {
+        let mut registry = ComponentRegistry::new();
+        registry
+            .register_component("my-card", "<div>Card</div>", None)
+            .expect("register failed");
+
+        let component = registry.get("my-card").expect("component not found");
+        assert!(component.css_tokens.is_empty());
+    }
+
+    #[test]
+    fn test_register_component_excludes_local_defs_from_tokens() {
+        let mut registry = ComponentRegistry::new();
+        registry
+            .register_component(
+                "my-widget",
+                "<div>W</div>",
+                Some(":host { --local: 5px; margin: var(--external); width: var(--local); }"),
+            )
+            .expect("register failed");
+
+        let component = registry.get("my-widget").expect("component not found");
+        // --local is defined locally so excluded; only --external is a token
+        assert_eq!(component.css_tokens, vec!["external"]);
     }
 }

--- a/crates/webui-parser/src/css_parser.rs
+++ b/crates/webui-parser/src/css_parser.rs
@@ -4,16 +4,23 @@
 //! and process styles for components.
 
 use crate::{ParserError, Result};
-use tree_sitter::{Parser, Tree};
+use std::collections::HashSet;
+use std::fmt;
+use tree_sitter::{Node, Parser, Tree};
 use webui_protocol::WebUIFragmentRecords;
 
-// Replace extern "C" block with proper import
 use tree_sitter_css::LANGUAGE;
 
 /// Parser for CSS files.
 pub struct CssParser {
     /// Tree-sitter parser for CSS.
     parser: Parser,
+}
+
+impl fmt::Debug for CssParser {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CssParser").finish()
+    }
 }
 
 impl CssParser {
@@ -79,15 +86,163 @@ impl CssParser {
 
     /// Parse inline CSS from style tags in HTML.
     pub fn parse_inline_css(&mut self, style_content: &str) -> Result<String> {
-        // Parse the CSS content
-        let _tree = self
-            .parser
-            .parse(style_content, None)
-            .ok_or_else(|| ParserError::Css("Failed to parse inline CSS".to_string()))?;
-
-        // For simplicity, we're just returning the content as-is
-        // In a real implementation, you might want to process and transform it
+        // For now, returning content as-is — future transforms can hook in here.
+        // Validation parse is deferred to extract_tokens_and_definitions when
+        // called from the HtmlParser, avoiding a redundant tree-sitter parse.
         Ok(style_content.to_string())
+    }
+
+    /// Extract CSS custom property token names used via `var()` in the given CSS.
+    ///
+    /// Returns a set of variable names (without the `--` prefix) that are
+    /// **referenced** through `var(--name)` calls. Variables that are only
+    /// **defined** (e.g., `--bar: 12px`) in the same CSS are excluded.
+    ///
+    /// Handles nested fallbacks: `var(--a, var(--b, var(--c)))` yields
+    /// `{"a", "b", "c"}` because each nested `var()` is a separate
+    /// `call_expression` in the tree-sitter CSS AST.
+    pub fn extract_tokens(&mut self, css_content: &str) -> Result<HashSet<String>> {
+        let tree = self
+            .parser
+            .parse(css_content, None)
+            .ok_or_else(|| ParserError::Css("Failed to parse CSS for token extraction".into()))?;
+
+        let mut tokens = HashSet::new();
+        let mut definitions = HashSet::new();
+
+        Self::walk_css_tree(tree.root_node(), css_content, &mut tokens, &mut definitions);
+
+        // Exclude locally-defined custom properties
+        tokens.retain(|t| !definitions.contains(t));
+        Ok(tokens)
+    }
+
+    /// Extract CSS custom property **definitions** from the given CSS.
+    ///
+    /// Returns a set of variable names (without `--` prefix) that are
+    /// **defined** via `--name: value` declarations. This is used to
+    /// exclude application-level token definitions (e.g., from `<style>`
+    /// in the entry HTML) from the hoisted token set.
+    pub fn extract_definitions(&mut self, css_content: &str) -> Result<HashSet<String>> {
+        let tree = self
+            .parser
+            .parse(css_content, None)
+            .ok_or_else(|| ParserError::Css("Failed to parse CSS for definitions".into()))?;
+
+        let mut tokens = HashSet::new();
+        let mut definitions = HashSet::new();
+
+        Self::walk_css_tree(tree.root_node(), css_content, &mut tokens, &mut definitions);
+
+        Ok(definitions)
+    }
+
+    /// Extract both token **usages** and **definitions** in a single parse.
+    ///
+    /// Returns `(tokens, definitions)` where:
+    /// - `tokens`: var() usages with locally-defined properties already excluded
+    /// - `definitions`: all custom property definitions (for global filtering)
+    ///
+    /// Prefer this over calling `extract_tokens` + `extract_definitions`
+    /// separately on the same CSS content to avoid redundant tree-sitter parses.
+    pub fn extract_tokens_and_definitions(
+        &mut self,
+        css_content: &str,
+    ) -> Result<(HashSet<String>, HashSet<String>)> {
+        let tree = self
+            .parser
+            .parse(css_content, None)
+            .ok_or_else(|| ParserError::Css("Failed to parse CSS".into()))?;
+
+        let mut tokens = HashSet::new();
+        let mut definitions = HashSet::new();
+
+        Self::walk_css_tree(tree.root_node(), css_content, &mut tokens, &mut definitions);
+
+        // Exclude locally-defined custom properties from tokens
+        tokens.retain(|t| !definitions.contains(t));
+        Ok((tokens, definitions))
+    }
+
+    /// Iteratively walk the CSS tree to collect var() usages and custom
+    /// property definitions. Uses an explicit stack instead of recursion.
+    fn walk_css_tree(
+        root: Node<'_>,
+        source: &str,
+        tokens: &mut HashSet<String>,
+        definitions: &mut HashSet<String>,
+    ) {
+        let mut stack = vec![root];
+
+        while let Some(node) = stack.pop() {
+            match node.kind() {
+                "call_expression" => {
+                    Self::extract_var_tokens(node, source, tokens);
+                }
+                "declaration" => {
+                    Self::collect_custom_property_definition(node, source, definitions);
+                }
+                _ => {}
+            }
+
+            // Push children in reverse order for left-to-right traversal
+            let count = node.child_count();
+            for i in (0..count).rev() {
+                if let Some(child) = node.child(i as u32) {
+                    stack.push(child);
+                }
+            }
+        }
+    }
+
+    /// If `node` is a `var()` call expression, extract its `plain_value`
+    /// arguments as token names (stripping the `--` prefix).
+    fn extract_var_tokens(node: Node<'_>, source: &str, tokens: &mut HashSet<String>) {
+        let count = node.child_count();
+        let is_var = (0..count).any(|i| {
+            node.child(i as u32).is_some_and(|c| {
+                c.kind() == "function_name" && &source[c.start_byte()..c.end_byte()] == "var"
+            })
+        });
+
+        if !is_var {
+            return;
+        }
+
+        // Extract plain_value children — the CSS variable references
+        let arguments =
+            (0..count).find_map(|i| node.child(i as u32).filter(|c| c.kind() == "arguments"));
+
+        if let Some(args) = arguments {
+            let arg_count = args.child_count();
+            for i in 0..arg_count {
+                if let Some(child) = args.child(i as u32) {
+                    if child.kind() == "plain_value" {
+                        let name = &source[child.start_byte()..child.end_byte()];
+                        if let Some(stripped) = name.strip_prefix("--") {
+                            tokens.insert(stripped.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// If `node` is a declaration with a custom property name (starting
+    /// with `--`), record it in the definitions set.
+    fn collect_custom_property_definition(
+        node: Node<'_>,
+        source: &str,
+        definitions: &mut HashSet<String>,
+    ) {
+        if let Some(prop_node) = node.child(0) {
+            if prop_node.kind() == "property_name" {
+                let prop = &source[prop_node.start_byte()..prop_node.end_byte()];
+                if let Some(stripped) = prop.strip_prefix("--") {
+                    definitions.insert(stripped.to_string());
+                }
+            }
+        }
     }
 }
 
@@ -120,5 +275,219 @@ mod tests {
         let mut parser = CssParser::new();
         let result = parser.process_css(css, &mut HashMap::new());
         assert!(result.is_ok());
+    }
+
+    // ── extract_tokens tests ────────────────────────────────────────
+
+    #[test]
+    fn test_extract_single_var() {
+        let mut parser = CssParser::new();
+        let tokens = parser
+            .extract_tokens(".btn { color: var(--colorPrimary); }")
+            .expect("extract_tokens failed");
+        assert_eq!(tokens, HashSet::from(["colorPrimary".to_string()]));
+    }
+
+    #[test]
+    fn test_extract_multiple_vars() {
+        let css = r#"
+            .btn {
+                color: var(--textColor);
+                background: var(--bgColor);
+                border-radius: var(--radius);
+            }
+        "#;
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(
+            tokens,
+            HashSet::from([
+                "textColor".to_string(),
+                "bgColor".to_string(),
+                "radius".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_extract_nested_fallback() {
+        let css = ".x { color: var(--primary, var(--fallback)); }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(
+            tokens,
+            HashSet::from(["primary".to_string(), "fallback".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_deeply_nested_fallbacks() {
+        let css = ".x { color: var(--a, var(--b, var(--c))); }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(
+            tokens,
+            HashSet::from(["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_literal_fallback_ignored() {
+        let css = ".x { font-size: var(--size, 16px); }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(tokens, HashSet::from(["size".to_string()]));
+    }
+
+    #[test]
+    fn test_exclude_local_definitions() {
+        let css = r#"
+            :root { --bar: 12px; }
+            .x { width: var(--bar); }
+        "#;
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert!(
+            tokens.is_empty(),
+            "Locally defined --bar should be excluded: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn test_exclude_definitions_keep_unrelated_usages() {
+        let css = r#"
+            :host { --local: 5px; }
+            .x { color: var(--external); }
+        "#;
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(tokens, HashSet::from(["external".to_string()]));
+    }
+
+    #[test]
+    fn test_empty_css() {
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens("").expect("extract_tokens failed");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_no_var_calls() {
+        let css = "body { margin: 0; color: red; }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_deduplicate_same_var() {
+        let css = r#"
+            .a { color: var(--shared); }
+            .b { background: var(--shared); }
+        "#;
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(tokens, HashSet::from(["shared".to_string()]));
+    }
+
+    #[test]
+    fn test_real_world_component_css() {
+        let css = r#"
+            :host {
+                display: inline-flex;
+                background-color: var(--colorBrandBackground);
+                border-radius: var(--borderRadiusSmall);
+                padding: var(--spacingHorizontalM) var(--spacingVerticalS);
+                font-family: var(--fontFamilyBase);
+                line-height: var(--lineHeightBase400);
+            }
+            :host(:hover) {
+                background-color: var(--colorBrandBackgroundHover);
+            }
+        "#;
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("extract_tokens failed");
+        assert_eq!(
+            tokens,
+            HashSet::from([
+                "colorBrandBackground".to_string(),
+                "borderRadiusSmall".to_string(),
+                "spacingHorizontalM".to_string(),
+                "spacingVerticalS".to_string(),
+                "fontFamilyBase".to_string(),
+                "lineHeightBase400".to_string(),
+                "colorBrandBackgroundHover".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_extract_tokens_and_definitions() {
+        let css = r#"
+            :root { --brand: #0078d4; --radius: 6px; }
+            .btn { color: var(--brand); margin: var(--external); }
+        "#;
+        let mut parser = CssParser::new();
+        let (tokens, defs) = parser.extract_tokens_and_definitions(css).expect("failed");
+
+        // tokens should exclude locally-defined --brand but keep --external
+        assert_eq!(tokens, HashSet::from(["external".to_string()]));
+        // definitions should include both defined properties
+        assert_eq!(
+            defs,
+            HashSet::from(["brand".to_string(), "radius".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_definitions_only() {
+        let css = ":root { --color-primary: #0078d4; --spacing-m: 12px; }";
+        let mut parser = CssParser::new();
+        let defs = parser.extract_definitions(css).expect("failed");
+        assert_eq!(
+            defs,
+            HashSet::from(["color-primary".to_string(), "spacing-m".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_definitions_none_when_no_custom_props() {
+        let css = "body { margin: 0; color: red; }";
+        let mut parser = CssParser::new();
+        let defs = parser.extract_definitions(css).expect("failed");
+        assert!(defs.is_empty());
+    }
+
+    #[test]
+    fn test_extract_tokens_malformed_var_missing_dashes() {
+        // var(-primary) is not a valid custom property reference (needs --)
+        let css = ".x { color: var(-primary); }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("failed");
+        // Should not extract since it doesn't start with --
+        assert!(
+            tokens.is_empty(),
+            "Single-dash var should not be extracted: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn test_extract_tokens_empty_var() {
+        let css = ".x { color: var(); }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("failed");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_extract_tokens_definitions_only_css() {
+        // CSS that only defines custom properties, no var() usage
+        let css = ":root { --a: 1px; --b: 2px; --c: red; }";
+        let mut parser = CssParser::new();
+        let tokens = parser.extract_tokens(css).expect("failed");
+        assert!(
+            tokens.is_empty(),
+            "Definitions-only CSS should yield no tokens"
+        );
     }
 }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -15,7 +15,7 @@ pub use error::{ParserError, Result};
 pub use handlebars_parser::HandlebarsParser;
 
 use crate::plugin::ParserPlugin;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIteratorMut};
 use tree_sitter_html::LANGUAGE;
 use webui_protocol::{
@@ -92,6 +92,15 @@ pub struct HtmlParser {
 
     /// Optional parser plugin for framework-specific behavior.
     plugin: Option<Box<dyn ParserPlugin>>,
+
+    /// Accumulated CSS custom property token names from all processed
+    /// components and inline `<style>` tags.
+    token_store: HashSet<String>,
+
+    /// CSS custom property names **defined** in inline `<style>` tags
+    /// (e.g., `:root { --color-primary: #0078d4; }`). These are excluded
+    /// from the final token set since the app already provides their values.
+    token_definitions: HashSet<String>,
 }
 
 impl HtmlParser {
@@ -112,6 +121,8 @@ impl HtmlParser {
             fragment_records: WebUIFragmentRecords::new(),
             css_strategy: CssStrategy::default(),
             plugin: None,
+            token_store: HashSet::new(),
+            token_definitions: HashSet::new(),
             parser,
         }
     }
@@ -136,6 +147,24 @@ impl HtmlParser {
 
     pub fn into_fragment_records(mut self) -> WebUIFragmentRecords {
         std::mem::take(&mut self.fragment_records)
+    }
+
+    /// Take the accumulated CSS tokens as a sorted, deduplicated `Vec`.
+    ///
+    /// Tokens that are **defined** in inline `<style>` tags (e.g., in a
+    /// `:root` block) are excluded — only externally-referenced tokens
+    /// that the app does not already define are returned.
+    ///
+    /// This consumes the internal token store. Call after parsing is complete.
+    #[must_use]
+    pub fn take_tokens(&mut self) -> Vec<String> {
+        let definitions = std::mem::take(&mut self.token_definitions);
+        let mut tokens: Vec<String> = std::mem::take(&mut self.token_store)
+            .into_iter()
+            .filter(|t| !definitions.contains(t))
+            .collect();
+        tokens.sort();
+        tokens
     }
 
     /// Parse HTML content to generate WebUI fragments.
@@ -287,6 +316,15 @@ impl HtmlParser {
                         let style_content = &source[child.start_byte()..child.end_byte()];
                         let processed_css = self.css_parser.parse_inline_css(style_content)?;
 
+                        // Single parse: extract both token usages and definitions
+                        if let Ok((tokens, defs)) = self
+                            .css_parser
+                            .extract_tokens_and_definitions(style_content)
+                        {
+                            self.token_store.extend(tokens);
+                            self.token_definitions.extend(defs);
+                        }
+
                         // Add the style tag with processed CSS
                         let style_tag = format!("<style>{}</style>", processed_css);
                         self.add_raw_fragment(&style_tag);
@@ -320,6 +358,11 @@ impl HtmlParser {
             "doctype" => {
                 let content = &source[node.start_byte()..node.end_byte()];
                 self.add_raw_fragment(content);
+            }
+            // HTML comment: check for handlebars bindings like <!--{{tokens}}-->
+            "comment" => {
+                let content = &source[node.start_byte()..node.end_byte()];
+                self.process_comment(content, fragments)?;
             }
             // For other node types (like head, body), traverse their children
             _ => {
@@ -794,6 +837,47 @@ impl HtmlParser {
         Ok(())
     }
 
+    /// Process an HTML comment node.
+    ///
+    /// If the comment contains handlebars expressions (e.g., `<!--{{tokens}}-->`),
+    /// parse them as signal fragments. Otherwise, preserve the comment as raw content.
+    fn process_comment(&mut self, content: &str, fragments: &mut Vec<WebUIFragment>) -> Result<()> {
+        // Strip <!-- and --> delimiters to get the inner text
+        let inner = content
+            .strip_prefix("<!--")
+            .and_then(|s| s.strip_suffix("-->"))
+            .unwrap_or("");
+
+        let trimmed = inner.trim();
+
+        // Quick check: if no handlebars syntax, preserve as raw comment
+        if !trimmed.contains("{{") {
+            self.add_raw_fragment(content);
+            return Ok(());
+        }
+
+        // Parse the inner text through the handlebars parser
+        let parsed = self.handlebars_parser.parse(trimmed)?;
+
+        // Check if the result is *only* signal fragments (no raw text mixed in).
+        // If all fragments are signals, emit them without comment delimiters.
+        // If there's any raw text mixed in, preserve the whole comment as-is.
+        let all_signals = parsed
+            .iter()
+            .all(|f| matches!(f.fragment.as_ref(), Some(Fragment::Signal(_))));
+
+        if all_signals && !parsed.is_empty() {
+            for fragment in parsed {
+                self.add_fragment(fragment, fragments);
+            }
+        } else {
+            // Mixed content or parse result has raw parts — keep as raw comment
+            self.add_raw_fragment(content);
+        }
+
+        Ok(())
+    }
+
     /// Process a <for> directive.
     fn process_for_directive(
         &mut self,
@@ -998,15 +1082,19 @@ impl HtmlParser {
         self.flush_raw_buffer(fragments);
 
         // Get component data
-        let (html_content, css_content) = {
+        let (html_content, css_content, css_tokens) = {
             let component = self.component_registry.get(tag_name).ok_or_else(|| {
                 ParserError::Directive(format!("Component not found: {}", tag_name))
             })?;
             (
                 component.html_content.clone(),
                 component.css_content.clone(),
+                component.css_tokens.clone(),
             )
         };
+
+        // Merge component CSS tokens into the global token store
+        self.token_store.extend(css_tokens);
 
         // Parse and register component template if not already done
         if !self.fragment_records.contains_key(tag_name) {
@@ -2687,5 +2775,227 @@ mod tests {
             count, 2,
             "Only plugin-skipped attrs should be counted, not static title"
         );
+    }
+
+    // ── Comment binding tests ────────────────────────────────────────
+
+    #[test]
+    fn test_comment_handlebars_signal() {
+        let mut parser = HtmlParser::new();
+        let html = "<!--{{tokens}}-->";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(records, "test.html", [signal("tokens")]);
+    }
+
+    #[test]
+    fn test_comment_triple_brace_raw_signal() {
+        let mut parser = HtmlParser::new();
+        let html = "<!--{{{tokens}}}-->";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(records, "test.html", [signal_raw("tokens")]);
+    }
+
+    #[test]
+    fn test_comment_regular_preserved() {
+        let mut parser = HtmlParser::new();
+        let html = "<!-- regular comment -->";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(records, "test.html", [raw("<!-- regular comment -->")]);
+    }
+
+    #[test]
+    fn test_comment_dotted_signal() {
+        let mut parser = HtmlParser::new();
+        let html = "<!--{{tokens.light}}-->";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(records, "test.html", [signal("tokens.light")]);
+    }
+
+    #[test]
+    fn test_comment_arbitrary_identifier() {
+        let mut parser = HtmlParser::new();
+        let html = "<!--{{someOtherBinding}}-->";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(records, "test.html", [signal("someOtherBinding")]);
+    }
+
+    #[test]
+    fn test_comment_with_surrounding_content() {
+        let mut parser = HtmlParser::new();
+        let html = "<div><!--{{tokens}}--></div>";
+        parser.parse("test.html", html).expect("parse failed");
+        let records = parser.into_fragment_records();
+
+        assert_stream!(
+            records,
+            "test.html",
+            [raw("<div>"), signal("tokens"), raw("</div>")]
+        );
+    }
+
+    // ── Token collection tests ───────────────────────────────────────
+
+    #[test]
+    fn test_tokens_from_style_tag() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<style>
+            .btn { color: var(--colorPrimary); background: var(--bgColor); }
+        </style>"#;
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert_eq!(tokens, vec!["bgColor", "colorPrimary"]);
+    }
+
+    #[test]
+    fn test_tokens_from_component_css() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-button",
+                "<button>Click</button>",
+                Some(":host { color: var(--textColor); border: var(--borderWidth); }"),
+            )
+            .expect("register failed");
+
+        let html = "<my-button></my-button>";
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert_eq!(tokens, vec!["borderWidth", "textColor"]);
+    }
+
+    #[test]
+    fn test_tokens_merged_from_style_and_components() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-widget",
+                "<div>Widget</div>",
+                Some(".w { padding: var(--spacingM); }"),
+            )
+            .expect("register failed");
+
+        let html = r#"<style>.root { color: var(--textColor); }</style><my-widget></my-widget>"#;
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert_eq!(tokens, vec!["spacingM", "textColor"]);
+    }
+
+    #[test]
+    fn test_tokens_deduplicated() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-btn",
+                "<button>B</button>",
+                Some(".b { color: var(--shared); }"),
+            )
+            .expect("register failed");
+
+        let html = r#"<style>.x { color: var(--shared); }</style><my-btn></my-btn>"#;
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert_eq!(tokens, vec!["shared"]);
+    }
+
+    #[test]
+    fn test_tokens_empty_when_no_vars() {
+        let mut parser = HtmlParser::new();
+        let html = "<div>Hello</div>";
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_tokens_exclude_locally_defined_in_component() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-card",
+                "<div>Card</div>",
+                Some(":host { --local: 5px; width: var(--external); }"),
+            )
+            .expect("register failed");
+
+        let html = "<my-card></my-card>";
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        assert_eq!(tokens, vec!["external"]);
+    }
+
+    #[test]
+    fn test_tokens_exclude_entry_root_definitions() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-btn",
+                "<button>B</button>",
+                Some(".b { color: var(--color-primary); border-radius: var(--radius-m); }"),
+            )
+            .expect("register failed");
+
+        // Entry HTML defines --color-primary and --radius-m in :root
+        // Components use them — they should NOT appear in hoisted tokens
+        let html = r#"<style>
+            :root {
+                --color-primary: #0078d4;
+                --radius-m: 6px;
+            }
+            body { color: var(--color-primary); }
+        </style>
+        <my-btn></my-btn>"#;
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        // Both tokens are defined in entry :root, so neither should be hoisted
+        assert!(
+            tokens.is_empty(),
+            "Tokens defined in entry :root should be excluded: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn test_tokens_entry_defs_exclude_but_external_kept() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry_mut()
+            .register_component(
+                "my-card",
+                "<div>Card</div>",
+                Some(".c { color: var(--color-primary); margin: var(--external-spacing); }"),
+            )
+            .expect("register failed");
+
+        // Entry defines --color-primary but NOT --external-spacing
+        let html = r#"<style>
+            :root { --color-primary: #0078d4; }
+        </style>
+        <my-card></my-card>"#;
+        parser.parse("test.html", html).expect("parse failed");
+        let tokens = parser.take_tokens();
+
+        // Only --external-spacing should be hoisted (not defined in entry)
+        assert_eq!(tokens, vec!["external-spacing"]);
     }
 }

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -488,6 +488,7 @@ mod tests {
             tag_name: tag.to_string(),
             html_content: html.to_string(),
             css_content: css.map(ToString::to_string),
+            css_tokens: Vec::new(),
             source_path: PathBuf::from("/test"),
             class_name: None,
         }

--- a/crates/webui-protocol/benches/protocol_bench.rs
+++ b/crates/webui-protocol/benches/protocol_bench.rs
@@ -45,7 +45,7 @@ fn create_test_protocol() -> WebUIProtocol {
         },
     );
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn create_simple_protocol() -> WebUIProtocol {
@@ -68,7 +68,7 @@ fn create_simple_protocol() -> WebUIProtocol {
         },
     );
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn serialize_protobuf_benchmark(c: &mut Criterion) {
@@ -112,7 +112,7 @@ fn complex_condition_benchmark(c: &mut Criterion) {
             fragments: vec![WebUIFragment::raw("ok")],
         },
     );
-    let protocol = WebUIProtocol { fragments };
+    let protocol = WebUIProtocol::new(fragments);
     let bytes = protocol.to_protobuf().expect("encode failed");
 
     c.bench_function("deserialize_complex_condition", |b| {
@@ -209,7 +209,7 @@ fn create_medium_protocol() -> WebUIProtocol {
         },
     );
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn create_large_protocol(component_count: usize) -> WebUIProtocol {
@@ -299,7 +299,7 @@ fn create_large_protocol(component_count: usize) -> WebUIProtocol {
         );
     }
 
-    WebUIProtocol { fragments }
+    WebUIProtocol::new(fragments)
 }
 
 fn serialize_medium_benchmark(c: &mut Criterion) {

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -5,6 +5,10 @@ package webui;
 // Root protocol containing all fragment records.
 message WebUIProtocol {
   map<string, FragmentList> fragments = 1;
+  // Sorted, deduplicated CSS custom property names used across all components
+  // and entry page styles (e.g., "colorBrandBackground", "spacingMedium").
+  // Only usage via var(--name) is included; local definitions are excluded.
+  repeated string tokens = 2;
 }
 
 // A list of fragments (needed because protobuf maps cannot have repeated values directly).

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -274,6 +274,23 @@ impl ConditionExpr {
     }
 }
 
+// ── Constructors ────────────────────────────────────────────────────────
+
+impl WebUiProtocol {
+    /// Create a protocol from fragment records with no CSS tokens.
+    pub fn new(fragments: WebUIFragmentRecords) -> Self {
+        Self {
+            fragments,
+            tokens: Vec::new(),
+        }
+    }
+
+    /// Create a protocol from fragment records with CSS tokens.
+    pub fn with_tokens(fragments: WebUIFragmentRecords, tokens: Vec<String>) -> Self {
+        Self { fragments, tokens }
+    }
+}
+
 // ── Serialization / deserialization / validation ────────────────────────
 
 impl WebUiProtocol {
@@ -402,7 +419,7 @@ mod tests {
                 ],
             },
         );
-        WebUIProtocol { fragments }
+        WebUIProtocol::new(fragments)
     }
 
     #[test]
@@ -450,7 +467,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let bytes = protocol.to_protobuf().unwrap();
         let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert_eq!(protocol, decoded);
@@ -483,7 +500,7 @@ mod tests {
                     fragments: vec![WebUIFragment::raw("ok")],
                 },
             );
-            let p = WebUIProtocol { fragments };
+            let p = WebUIProtocol::new(fragments);
             let bytes = p.to_protobuf().unwrap();
             let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
             assert_eq!(p, decoded);
@@ -515,7 +532,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("ok")],
             },
         );
-        let p = WebUIProtocol { fragments };
+        let p = WebUIProtocol::new(fragments);
         let bytes = p.to_protobuf().unwrap();
         let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert_eq!(p, decoded);
@@ -542,7 +559,7 @@ mod tests {
                 fragments: vec![WebUIFragment::raw("yes")],
             },
         );
-        let p = WebUIProtocol { fragments };
+        let p = WebUIProtocol::new(fragments);
         let bytes = p.to_protobuf().unwrap();
         let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert_eq!(p, decoded);
@@ -585,7 +602,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let buf = protocol.to_protobuf().unwrap();
 
         let result = WebUIProtocol::from_protobuf(&buf);
@@ -602,7 +619,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let buf = protocol.to_protobuf().unwrap();
 
         let result = WebUIProtocol::from_protobuf(&buf);
@@ -625,7 +642,7 @@ mod tests {
             },
         );
 
-        let protocol = WebUIProtocol { fragments };
+        let protocol = WebUIProtocol::new(fragments);
         let buf = protocol.to_protobuf().unwrap();
 
         let result = WebUIProtocol::from_protobuf(&buf);
@@ -644,7 +661,7 @@ mod tests {
                 fragments: vec![WebUIFragment::signal("name", false)],
             },
         );
-        let p = WebUIProtocol { fragments };
+        let p = WebUIProtocol::new(fragments);
         let bytes = p.to_protobuf().unwrap();
         let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         let frag = &decoded.fragments["main"].fragments[0];
@@ -659,5 +676,38 @@ mod tests {
         let protocol = sample_protocol();
         let bytes = protocol.to_protobuf().unwrap();
         assert_eq!(bytes.len(), protocol.encoded_len());
+    }
+
+    #[test]
+    fn test_protocol_new_has_empty_tokens() {
+        let protocol = WebUIProtocol::new(HashMap::new());
+        assert!(protocol.tokens.is_empty());
+        assert!(protocol.fragments.is_empty());
+    }
+
+    #[test]
+    fn test_protocol_with_tokens() {
+        let tokens = vec!["color-primary".to_string(), "spacing-m".to_string()];
+        let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
+        assert_eq!(protocol.tokens, tokens);
+    }
+
+    #[test]
+    fn test_protobuf_roundtrip_with_tokens() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("Hello")],
+            },
+        );
+        let tokens = vec!["border-radius-m".to_string(), "color-primary".to_string()];
+        let protocol = WebUIProtocol::with_tokens(fragments, tokens.clone());
+
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+
+        assert_eq!(decoded.tokens, tokens);
+        assert!(decoded.fragments.contains_key("index.html"));
     }
 }

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -185,9 +185,7 @@ fn parse_to_protocol(
         .parse(entry, entry_html)
         .map_err(|e| BuildError::Parse(e.to_string()))?;
 
-    Ok(WebUIProtocol {
-        fragments: parser.into_fragment_records(),
-    })
+    Ok(WebUIProtocol::new(parser.into_fragment_records()))
 }
 
 /// Errors from the build-and-render pipeline.

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -47,6 +47,7 @@ export default {
           items: [
             { text: 'State Management', link: '/guide/concepts/state-management' },
             { text: 'Components', link: '/guide/concepts/components' },
+            { text: 'CSS Token Hoisting', link: '/guide/concepts/css-tokens' },
             {
               text: 'Template Directives',
               items: [

--- a/docs/guide/concepts/css-tokens.md
+++ b/docs/guide/concepts/css-tokens.md
@@ -1,0 +1,116 @@
+# CSS Token Hoisting
+
+CSS Token Hoisting is a build-time optimization that discovers which CSS custom properties (design tokens) your application actually uses, and includes only those in the protocol output. This enables host runtimes to resolve design tokens efficiently without shipping unused variables.
+
+## How It Works
+
+During the build process, WebUI extracts CSS custom property **usages** — names referenced via `var(--name)` — from two sources:
+
+1. **Component CSS files** — tokens are extracted when components are registered and cached in the component registry.
+2. **Inline `<style>` tags** — tokens are extracted from `<style>` elements in the entry HTML file and component templates.
+
+The resulting set of tokens is sorted, deduplicated, and included in the protocol's `tokens` field.
+
+### What Gets Hoisted
+
+Only `var()` **usages** are hoisted — not custom property **definitions**:
+
+```css
+/* ✅ HOISTED — usage via var() */
+.button {
+  color: var(--colorPrimary);           /* → "colorPrimary" */
+  background: var(--bgColor);           /* → "bgColor" */
+}
+
+/* ❌ NOT hoisted — this is a definition */
+:root {
+  --colorPrimary: #0078d4;
+}
+```
+
+### Nested Fallbacks
+
+Fallback variables in `var()` calls are also extracted:
+
+```css
+.card {
+  /* All three tokens are extracted: "a", "b", "c" */
+  color: var(--a, var(--b, var(--c)));
+}
+```
+
+Literal fallback values (like `16px`) are ignored — only variable references are extracted.
+
+### Local Definition Exclusion
+
+If a custom property is both **defined** and **used** in the same CSS file, it is **excluded** from the token set. This prevents locally-scoped variables from being hoisted:
+
+```css
+:host {
+  --internal-spacing: 8px;             /* definition */
+  padding: var(--internal-spacing);     /* usage */
+  color: var(--designSystemColor);      /* usage only → HOISTED */
+}
+/* Result: only "designSystemColor" is hoisted */
+```
+
+## Comment-Based Token Bindings
+
+<div v-pre>
+
+To create a placeholder where token values will be injected at render time, use an HTML comment with handlebars syntax:
+
+```html
+<style>
+  :root {
+    <!--{{tokens}}-->
+  }
+</style>
+```
+
+The `<!--{{tokens}}-->` comment is parsed as a **Signal fragment** with value `"tokens"`. At render time, the host can replace this signal with actual CSS variable declarations based on the hoisted token list and the active theme.
+
+### Binding Syntax
+
+| Syntax | Result |
+|--------|--------|
+| `<!--{{tokens}}-->` | Signal fragment (escaped) |
+| `<!--{{{tokens}}}-->` | Signal fragment (raw/unescaped) |
+| `<!--{{tokens.light}}-->` | Signal fragment with dotted path |
+| `<!-- regular comment -->` | Preserved as raw content |
+
+This mechanism is general-purpose — any `{{identifier}}` inside an HTML comment becomes a signal fragment.
+
+</div>
+
+## Protocol Output
+
+The hoisted tokens appear in the protocol's `tokens` field:
+
+```json
+{
+  "fragments": { ... },
+  "tokens": [
+    "bgColor",
+    "borderRadiusSmall",
+    "colorBrandBackground",
+    "colorPrimary",
+    "fontFamilyBase",
+    "lineHeightBase400",
+    "spacingHorizontalM"
+  ]
+}
+```
+
+The list is always **sorted alphabetically** and **deduplicated** across all components and inline styles.
+
+## CLI Output
+
+When tokens are discovered, the build command reports the count:
+
+```
+✔ Registered 5 components
+✔ Parsed index.html (23 fragments)
+✔ Discovered 12 CSS tokens
+✔ Build complete (3 files written) in 42ms
+```


### PR DESCRIPTION
Extract CSS custom property usages (var() calls) at build time across all components and entry page styles. The sorted, deduplicated token names are included in the protocol output, enabling host runtimes to resolve only the design tokens an application actually needs.

Protocol schema:
- Add 'repeated string tokens = 2' to WebUIProtocol message
- Add WebUIProtocol::new() and ::with_tokens() constructors
- Replace all struct literals with constructor calls (109 sites)

CSS token extraction (webui-parser/css_parser.rs):
- Add CssParser::extract_tokens() for var() usage extraction
- Add CssParser::extract_definitions() for custom property definitions
- Add CssParser::extract_tokens_and_definitions() for single-parse path
- Iterative tree-sitter-css AST walk (no recursion)
- Handle nested fallbacks: var(--a, var(--b, var(--c))) extracts all three
- Exclude locally-defined properties (--name: value) from token set
- Implement Debug for CssParser (tree-sitter Parser lacks it)

Component registry (webui-parser/component_registry.rs):
- Add css_tokens field to Component struct
- Extract tokens automatically during register_component() and register_component_from_paths()
- ComponentRegistry owns a reusable CssParser instance (not per-call)

Token collection during parsing (webui-parser/lib.rs):
- Add token_store and token_definitions to HtmlParser
- Merge component css_tokens on first component encounter
- Extract tokens and definitions from inline <style> tags (single parse)
- take_tokens() returns sorted tokens with entry definitions excluded
- Parse <!--{{identifier}}--> HTML comments as Signal fragments

CLI integration (webui-cli):
- Wire tokens through build_protocol() into protocol output
- Display 'Discovered N CSS tokens' in build command output
- Add token_count to BuildOutput

Documentation:
- Update DESIGN.md with CSS Token Hoisting specification
- Add docs/guide/concepts/css-tokens.md with sidebar entry

Tests (26 new tests):
- 18 unit tests for extract_tokens, extract_definitions, combined method, edge cases (malformed var, empty var, definitions-only CSS)
- 3 component registry tests for token extraction on registration
- 3 protocol tests for constructors and protobuf roundtrip with tokens
- 2 build integration tests for token inclusion and entry exclusion