### PR TITLE
fix: rename start to serve in example package.json scripts

### DIFF
--- a/crates/webui-cli/src/commands/common.rs
+++ b/crates/webui-cli/src/commands/common.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use std::path::PathBuf;
 pub use webui::CssStrategy;
 
-/// Shared CLI arguments used by both `build` and `start` commands.
+/// Shared CLI arguments used by both `build` and `serve` commands.
 #[derive(Args, Clone)]
 pub struct AppArgs {
     /// Path to the app folder (defaults to current directory)

--- a/examples/app/calculator/package.json
+++ b/examples/app/calculator/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
-    "start:server": "cargo run -p webui-cli -- start ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
+    "start:server": "cargo run -p webui-cli -- serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
     "start": "cargo xtask dev calculator"
   },
   "devDependencies": {

--- a/examples/app/contact-book-manager/package.json
+++ b/examples/app/contact-book-manager/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
-    "start:server": "cargo run -p webui-cli -- start ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
+    "start:server": "cargo run -p webui-cli -- serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
     "start": "cargo xtask dev contact-book-manager"
    },
   "devDependencies": {

--- a/examples/app/hello-world/package.json
+++ b/examples/app/hello-world/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
-    "start:server": "cargo run -p webui-cli -- start ./src --state ./data/state.json --servedir ./dist --port 3001 --watch",
+    "start:server": "cargo run -p webui-cli -- serve ./src --state ./data/state.json --servedir ./dist --port 3001 --watch",
     "start": "cargo xtask dev hello-world"
   },
   "devDependencies": {

--- a/examples/app/todo-fast/package.json
+++ b/examples/app/todo-fast/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
-    "start:server": "cargo run -p webui-cli -- start ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
+    "start:server": "cargo run -p webui-cli -- serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 3001 --watch",
     "start": "cargo xtask dev todo-fast"
   },
   "devDependencies": {


### PR DESCRIPTION
The CLI command was renamed from `start` to `serve`, but the example app `package.json` files and a doc comment still referenced the old `start` subcommand. This caused `pnpm start` to fail in any example app because the `start:server` script invoked a non-existent CLI subcommand.

### Changes

- **examples/app/calculator/package.json**  update `start:server` script from `start` to `serve`
- **examples/app/contact-book-manager/package.json**  same fix
- **examples/app/hello-world/package.json**  same fix
- **examples/app/todo-fast/package.json**  same fix
- **crates/webui-cli/src/commands/common.rs**  update doc comment to reference `serve` instead of `start`