### PR TITLE
feat: add end-to-end benchmark for contact-book-manager app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
 name = "webui"
 version = "0.0.1"
 dependencies = [
+ "criterion",
  "serde_json",
  "tempfile",
  "thiserror",

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -20,3 +20,11 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+criterion = { workspace = true }
+serde_json = { workspace = true }
+webui-handler = { path = "../webui-handler" }
+webui-protocol = { path = "../webui-protocol" }
+
+[[bench]]
+name = "contact_book_bench"
+harness = false

--- a/crates/webui/benches/README.md
+++ b/crates/webui/benches/README.md
@@ -1,0 +1,149 @@
+# Contact Book Benchmark
+
+End-to-end performance benchmark for the WebUI framework, using the
+**contact-book-manager** example application as a realistic workload.
+
+## What it measures
+
+| Benchmark Group | What it does |
+|---|---|
+| **`contact_book_protocol_parse`** | Deserializes the compiled protocol binary (`WebUIProtocol::from_protobuf`) — measures the cost of loading a protocol at startup. |
+| **`contact_book_render`** | Renders the full contact-book dashboard (protocol + state → HTML) without any hydration plugin, at 10 / 100 / 1,000 contacts. |
+| **`contact_book_render_fast_plugin`** | Same rendering with the `FastHydrationPlugin` enabled, which injects FAST-HTML hydration markers. |
+
+### Why it stays up to date
+
+The protocol is **compiled from live source** at benchmark time via
+`webui::build()` against `examples/app/contact-book-manager/src/`. There is no
+cached binary — any change to the contact-book-manager templates is
+automatically reflected in the next benchmark run.
+
+## Running the benchmark
+
+### Quick validation (no measurements)
+
+```bash
+cargo bench -p webui --bench contact_book_bench -- --test
+```
+
+Compiles in release mode and runs each benchmark once to verify correctness.
+Takes ~1 minute (mostly compile time).
+
+### Full benchmark
+
+```bash
+cargo bench -p webui --bench contact_book_bench
+```
+
+Runs all benchmark groups with 30-second measurement windows. Produces:
+
+1. **Criterion output** — per-benchmark timing, throughput (MiB/s), and change
+   detection printed inline.
+2. **Summary table** — a compact table printed at the end with Iters, Avg, Min,
+   Max, Dev%, P50, P90, P99, IQR, and output Bytes for every scenario.
+3. **HTML reports** — detailed charts saved to `target/criterion/report/index.html`.
+
+### Run a single group
+
+```bash
+# Only protocol parsing
+cargo bench -p webui --bench contact_book_bench -- "contact_book_protocol_parse"
+
+# Only rendering at 100 contacts
+cargo bench -p webui --bench contact_book_bench -- "contact_book_render/contacts/100"
+
+# Only FAST plugin benchmarks
+cargo bench -p webui --bench contact_book_bench -- "contact_book_render_fast_plugin"
+```
+
+## Reading the results
+
+### Inline output
+
+Criterion prints results as each benchmark completes:
+
+```
+contact_book_render/contacts/100
+                        time:   [5.05 ms 5.09 ms 5.12 ms]
+                        thrpt:  [10.5 MiB/s 10.6 MiB/s 10.6 MiB/s]
+```
+
+- **time** — [lower bound, estimate, upper bound] at 95% confidence.
+- **thrpt** — throughput in MiB/s based on HTML output size.
+
+### Summary table
+
+Printed at the end of a full run:
+
+```
+===================== WebUI Contact Book — Performance Summary =====================
+Story                  Iters   Avg(ms)     Min       Max   Dev%     P50     P90     P99     IQR   Bytes
+-------------------------------------------------------------------------------------
+ProtocolParse          55000      0.05    0.04      0.37  12.0%    0.05    0.05    0.08    0.00   28538
+Render/10               4600      0.65    0.61     10.34  28.2%    0.63    0.66    1.22    0.02   25960
+Render/100               600      4.94    4.70      9.03   9.4%    4.80    5.21    7.43    0.11   56397
+Render/1000               53     57.50   53.78     67.33   4.6%   57.20   60.90   62.28    4.31  362930
+RenderFAST/10           4600      0.65    0.61      1.83  13.7%    0.63    0.66    1.19    0.02   31052
+RenderFAST/100           600      5.02    4.72      9.86  14.1%    4.81    5.26    9.09    0.11   68149
+RenderFAST/1000           51     59.53   53.19     72.35   7.2%   58.64   64.56   72.35    4.83  443082
+=====================================================================================
+```
+
+| Column | Meaning |
+|---|---|
+| **Iters** | Total iterations completed during the sampling window. |
+| **Avg(ms)** | Mean time per iteration. |
+| **Min / Max** | Fastest and slowest observed iteration. |
+| **Dev%** | Standard deviation as a percentage of the mean. |
+| **P50 / P90 / P99** | Percentile latencies (P50 = median). |
+| **IQR** | Interquartile range (P75 − P25) — lower means more consistent. |
+| **Bytes** | Output size in bytes (protocol size for parse, HTML size for render). |
+
+## Detecting regressions and improvements
+
+### Automatic change detection
+
+When you run the benchmark a second time, criterion compares against the
+previous baseline and reports the delta:
+
+```
+contact_book_render/contacts/100
+                        time:   [5.05 ms 5.09 ms 5.12 ms]
+                 change:
+                        time:   [+2.60% +3.37% +4.20%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+```
+
+- **Performance has improved** — the change is statistically significant and
+  faster.
+- **Performance has regressed** — the change is statistically significant and
+  slower.
+- **No change in performance** — the difference is within noise.
+
+### HTML reports
+
+Open `target/criterion/report/index.html` in a browser. Each benchmark has:
+
+- **PDF/CDF plots** of iteration times.
+- **Before/after violin plots** when a baseline exists.
+- **Regression analysis** with confidence intervals.
+
+### Tips for reliable measurements
+
+- **Close other applications** — CPU-intensive background work adds noise.
+- **Run on the same machine** — cross-machine comparisons are not meaningful.
+- **Use release mode** — `cargo bench` always compiles with optimizations;
+  debug builds are not representative.
+- **Compare P50 over Avg** — the median is more robust to outliers than the
+  mean, especially on machines with thermal throttling or background activity.
+- **Watch IQR and Dev%** — high values indicate noisy measurements. Re-run if
+  Dev% exceeds ~15% for the larger benchmarks.
+
+### Resetting the baseline
+
+To discard previous results and start fresh:
+
+```bash
+rm -rf target/criterion
+cargo bench -p webui --bench contact_book_bench
+```

--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -1,0 +1,602 @@
+//! End-to-end benchmark for the contact-book-manager example application.
+//!
+//! Compiles the real contact-book-manager templates into a protocol binary at
+//! benchmark time, then measures protocol parsing and handler rendering at
+//! different data scales (10 / 100 / 1,000 contacts).
+//!
+//! Run with: `cargo bench -p webui --bench contact_book_bench`
+
+use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use serde_json::{json, Value};
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use webui::{build, BuildOptions, CssStrategy, ResponseWriter, WebUIHandler};
+use webui_handler::plugin::FastHydrationPlugin;
+use webui_protocol::WebUIProtocol;
+
+/// Contact counts to benchmark.
+const CONTACT_COUNTS: &[usize] = &[10, 100, 1000];
+
+/// Measurement time per benchmark — 30 s gives criterion enough samples for
+/// stable statistics even at the 1,000-contact scale.
+const MEASUREMENT_TIME: Duration = Duration::from_secs(30);
+
+/// Minimum time to spend collecting samples for the summary table.
+const SUMMARY_MIN_TIME: Duration = Duration::from_secs(3);
+
+/// Estimated bytes of HTML output per contact (without plugin).
+/// Used to pre-allocate the writer buffer: `count * BYTES_PER_CONTACT + BASE_HTML_BYTES`.
+const BYTES_PER_CONTACT: usize = 512;
+
+/// Estimated bytes of HTML output per contact with the hydration plugin.
+/// Plugin adds binding markers per signal/loop, increasing output ~50%.
+const BYTES_PER_CONTACT_WITH_PLUGIN: usize = 768;
+
+/// Approximate size of the static HTML shell (head, header, sidebar, chrome)
+/// that is independent of the contact count.
+const BASE_HTML_BYTES: usize = 8_192;
+
+/// Same as [`BASE_HTML_BYTES`] but for plugin output which includes extra
+/// hydration scaffolding in the shell.
+const BASE_HTML_BYTES_WITH_PLUGIN: usize = 16_384;
+
+/// Extra headroom added to the bench writer beyond the warmup-measured size,
+/// so the buffer is never reallocated during timed iterations.
+const WRITER_HEADROOM: usize = 1_024;
+
+/// Initial capacity for the summary writer. 64 KiB is enough for the largest
+/// render (1,000 contacts with plugin produces ~443 KiB, but the summary pass
+/// reuses the same writer via `clear()`).
+const SUMMARY_WRITER_CAPACITY: usize = 64 * 1024;
+
+/// Expected upper bound of samples collected per summary scenario.
+/// Used only for `Vec::with_capacity` — does not limit collection.
+const EXPECTED_SUMMARY_SAMPLES: usize = 500;
+
+/// Number of warmup iterations before collecting parse samples.
+const PARSE_WARMUP_ITERATIONS: usize = 10;
+
+/// Number of warmup iterations before collecting render samples.
+const RENDER_WARMUP_ITERATIONS: usize = 3;
+
+/// Maximum number of recent contacts shown on the dashboard page.
+const MAX_RECENT_CONTACTS: usize = 5;
+
+// ---------------------------------------------------------------------------
+// Bench writer — captures rendered HTML into a pre-allocated buffer
+// ---------------------------------------------------------------------------
+
+struct BenchWriter {
+    output: String,
+}
+
+impl BenchWriter {
+    fn new(capacity: usize) -> Self {
+        Self {
+            output: String::with_capacity(capacity),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.output.clear();
+    }
+
+    fn len(&self) -> usize {
+        self.output.len()
+    }
+}
+
+impl ResponseWriter for BenchWriter {
+    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+        self.output.push_str(content);
+        Ok(())
+    }
+
+    fn end(&mut self) -> webui_handler::Result<()> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Realistic contact state generators
+// ---------------------------------------------------------------------------
+
+const FIRST_NAMES: &[&str] = &[
+    "Sarah", "Marcus", "Yuki", "Priya", "James", "Amara", "Luis", "Emma", "David", "Fatima",
+    "Carlos", "Aisha", "Ryan", "Sofia", "Kenji", "Olivia", "Mateo", "Ava", "Noah", "Mia",
+];
+
+const LAST_NAMES: &[&str] = &[
+    "Chen",
+    "Johnson",
+    "Tanaka",
+    "Sharma",
+    "O'Brien",
+    "Okafor",
+    "Ramirez",
+    "Lindström",
+    "Kim",
+    "Al-Hassan",
+    "Mendoza",
+    "Patel",
+    "Mitchell",
+    "Andersson",
+    "Watanabe",
+    "Garcia",
+    "Smith",
+    "Williams",
+    "Brown",
+    "Jones",
+];
+
+const COMPANIES: &[&str] = &[
+    "Contoso Ltd",
+    "Fabrikam Inc",
+    "Northwind Traders",
+    "Adventure Works",
+    "Ramirez Photography",
+    "Patel & Associates",
+    "Watanabe Martial Arts",
+    "",
+];
+
+const GROUPS: &[&str] = &["Family", "Work", "Friends", "Other"];
+
+const AVATAR_COLORS: &[&str] = &[
+    "#4A90D9", "#E67E22", "#2ECC71", "#9B59B6", "#3498DB", "#E74C3C", "#1ABC9C", "#F39C12",
+    "#8E44AD", "#16A085", "#D35400", "#2980B9", "#27AE60", "#C0392B", "#7F8C8D",
+];
+
+const CITIES: &[&str] = &[
+    "Seattle, WA 98101",
+    "Portland, OR 97201",
+    "San Francisco, CA 94103",
+    "Austin, TX 78701",
+    "Boston, MA 02108",
+    "Atlanta, GA 30301",
+    "Miami, FL 33101",
+    "New York, NY 10007",
+    "Chicago, IL 60601",
+    "Denver, CO 80201",
+];
+
+fn generate_contact(idx: usize) -> Value {
+    let first = FIRST_NAMES[idx % FIRST_NAMES.len()];
+    let last = LAST_NAMES[idx % LAST_NAMES.len()];
+    let initials = format!("{}{}", &first[..1], &last.chars().next().unwrap_or('?'));
+    let company = COMPANIES[idx % COMPANIES.len()];
+    let group = GROUPS[idx % GROUPS.len()];
+    let color = AVATAR_COLORS[idx % AVATAR_COLORS.len()];
+    let city = CITIES[idx % CITIES.len()];
+    let favorite = idx % 3 == 0;
+
+    json!({
+        "id": (idx + 1).to_string(),
+        "firstName": first,
+        "lastName": last,
+        "email": format!("{}.{}@example.com", first.to_lowercase(), last.to_lowercase()),
+        "phone": format!("+1 (555) {:03}-{:04}", (idx * 111) % 1000, (idx * 1234) % 10000),
+        "company": company,
+        "group": group,
+        "favorite": favorite,
+        "initials": initials,
+        "avatarColor": color,
+        "notes": if idx % 2 == 0 { format!("Contact note for {} {}", first, last) } else { String::new() },
+        "address": format!("{} {} St, {}", (idx + 1) * 100, first, city),
+    })
+}
+
+fn build_contact_state(contact_count: usize) -> Value {
+    let contacts: Vec<Value> = (0..contact_count).map(generate_contact).collect();
+
+    let favorites: Vec<Value> = contacts
+        .iter()
+        .filter(|c| c["favorite"] == json!(true))
+        .cloned()
+        .collect();
+    let favorite_count = favorites.len();
+
+    let recent_count = std::cmp::min(MAX_RECENT_CONTACTS, contact_count);
+    let recent: Vec<Value> = contacts[contact_count.saturating_sub(recent_count)..].to_vec();
+
+    json!({
+        "page": "dashboard",
+        "searchQuery": "",
+        "activeGroup": "all",
+        "groups": GROUPS,
+        "totalContacts": contact_count,
+        "totalFavorites": favorite_count,
+        "totalGroups": GROUPS.len(),
+        "contacts": contacts,
+        "filteredContacts": contacts,
+        "recentContacts": recent,
+        "favoriteContacts": favorites,
+        "selectedContact": null
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Build protocol from the contact-book-manager example app
+// ---------------------------------------------------------------------------
+
+fn contact_book_app_dir() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .join("..")
+        .join("..")
+        .join("examples")
+        .join("app")
+        .join("contact-book-manager")
+        .join("src")
+}
+
+/// Builds the protocol binary from the live contact-book-manager source.
+///
+/// This compiles the real templates at benchmark time — there is no cached
+/// `.pb` file. Any change to `examples/app/contact-book-manager/src/` is
+/// automatically reflected in the next benchmark run, making regressions and
+/// improvements traceable to specific template changes.
+fn build_contact_book_protocol() -> (WebUIProtocol, Vec<u8>) {
+    let app_dir = contact_book_app_dir();
+    assert!(
+        app_dir.join("index.html").exists(),
+        "contact-book-manager source not found at {}",
+        app_dir.display()
+    );
+
+    let result = build(BuildOptions {
+        app_dir,
+        entry: "index.html".to_string(),
+        css: CssStrategy::Style,
+        plugin: None,
+        components: Vec::new(),
+    })
+    .expect("failed to build contact-book-manager protocol");
+
+    let bytes = result.protocol_bytes.clone();
+    (result.protocol, bytes)
+}
+
+// ---------------------------------------------------------------------------
+// One-time setup: build protocol + generate all state sizes up-front
+// ---------------------------------------------------------------------------
+
+struct BenchFixture {
+    protocol: WebUIProtocol,
+    protocol_bytes: Vec<u8>,
+    states: Vec<(usize, Value)>,
+}
+
+fn setup() -> BenchFixture {
+    let (protocol, protocol_bytes) = build_contact_book_protocol();
+    let states = CONTACT_COUNTS
+        .iter()
+        .map(|&n| (n, build_contact_state(n)))
+        .collect();
+    BenchFixture {
+        protocol,
+        protocol_bytes,
+        states,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Protocol deserialization
+// ---------------------------------------------------------------------------
+
+fn protocol_deserialization_bench(c: &mut Criterion) {
+    let fixture = setup();
+    let mut group = c.benchmark_group("contact_book_protocol_parse");
+    group.measurement_time(MEASUREMENT_TIME);
+
+    group.throughput(Throughput::Bytes(fixture.protocol_bytes.len() as u64));
+
+    group.bench_function("from_protobuf", |b| {
+        b.iter(|| {
+            let protocol = WebUIProtocol::from_protobuf(black_box(&fixture.protocol_bytes))
+                .expect("protocol deserialization failed");
+            black_box(&protocol);
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Handler rendering (no plugin) at different contact counts
+// ---------------------------------------------------------------------------
+
+fn handler_rendering_bench(c: &mut Criterion) {
+    let fixture = setup();
+    let mut group = c.benchmark_group("contact_book_render");
+    group.measurement_time(MEASUREMENT_TIME);
+
+    for (count, state) in &fixture.states {
+        // Pre-render to measure output size for throughput calculation
+        let mut handler = WebUIHandler::new();
+        let mut warmup_writer = BenchWriter::new(count * BYTES_PER_CONTACT + BASE_HTML_BYTES);
+        handler
+            .handle(&fixture.protocol, state, &mut warmup_writer)
+            .unwrap_or_else(|e| panic!("warmup render failed for {count} contacts: {e}"));
+        group.throughput(Throughput::Bytes(warmup_writer.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("contacts", count), state, |b, state| {
+            let mut h = WebUIHandler::new();
+            let mut w = BenchWriter::new(warmup_writer.len() + WRITER_HEADROOM);
+
+            b.iter(|| {
+                w.clear();
+                h.handle(black_box(&fixture.protocol), black_box(state), &mut w)
+                    .unwrap_or_else(|e| panic!("render failed for {count} contacts: {e}"));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Handler rendering with FastHydration plugin
+// ---------------------------------------------------------------------------
+
+fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
+    let fixture = setup();
+    let mut group = c.benchmark_group("contact_book_render_fast_plugin");
+    group.measurement_time(MEASUREMENT_TIME);
+
+    for (count, state) in &fixture.states {
+        let mut handler = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
+        let mut warmup_writer =
+            BenchWriter::new(count * BYTES_PER_CONTACT_WITH_PLUGIN + BASE_HTML_BYTES_WITH_PLUGIN);
+        handler
+            .handle(&fixture.protocol, state, &mut warmup_writer)
+            .unwrap_or_else(|e| {
+                panic!("warmup render with plugin failed for {count} contacts: {e}")
+            });
+        group.throughput(Throughput::Bytes(warmup_writer.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("contacts", count), state, |b, state| {
+            let mut h = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
+            let mut w = BenchWriter::new(warmup_writer.len() + WRITER_HEADROOM);
+
+            b.iter(|| {
+                w.clear();
+                h.handle(black_box(&fixture.protocol), black_box(state), &mut w)
+                    .unwrap_or_else(|e| {
+                        panic!("render with plugin failed for {count} contacts: {e}")
+                    });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Criterion harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    protocol_deserialization_bench,
+    handler_rendering_bench,
+    handler_rendering_with_plugin_bench,
+);
+
+// ---------------------------------------------------------------------------
+// Summary table — performance report printed after criterion finishes
+// ---------------------------------------------------------------------------
+
+struct SummaryRow {
+    name: String,
+    iterations: usize,
+    samples_ms: Vec<f64>,
+    output_bytes: usize,
+}
+
+impl SummaryRow {
+    fn avg(&self) -> f64 {
+        self.samples_ms.iter().sum::<f64>() / self.samples_ms.len() as f64
+    }
+
+    fn min(&self) -> f64 {
+        self.samples_ms
+            .iter()
+            .cloned()
+            .reduce(f64::min)
+            .unwrap_or(0.0)
+    }
+
+    fn max(&self) -> f64 {
+        self.samples_ms
+            .iter()
+            .cloned()
+            .reduce(f64::max)
+            .unwrap_or(0.0)
+    }
+
+    fn percentile(&self, p: f64) -> f64 {
+        if self.samples_ms.is_empty() {
+            return 0.0;
+        }
+        let mut sorted = self.samples_ms.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let idx = (p / 100.0 * (sorted.len() - 1) as f64).round() as usize;
+        sorted[idx.min(sorted.len() - 1)]
+    }
+
+    fn iqr(&self) -> f64 {
+        self.percentile(75.0) - self.percentile(25.0)
+    }
+
+    fn std_dev(&self) -> f64 {
+        let avg = self.avg();
+        let variance = self
+            .samples_ms
+            .iter()
+            .map(|s| (s - avg).powi(2))
+            .sum::<f64>()
+            / self.samples_ms.len() as f64;
+        variance.sqrt()
+    }
+
+    fn dev_pct(&self) -> f64 {
+        let avg = self.avg();
+        if avg == 0.0 {
+            return 0.0;
+        }
+        (self.std_dev() / avg) * 100.0
+    }
+}
+
+fn collect_parse_samples(name: &str, bytes: &[u8]) -> SummaryRow {
+    for _ in 0..PARSE_WARMUP_ITERATIONS {
+        let _ = WebUIProtocol::from_protobuf(black_box(bytes));
+    }
+
+    let mut samples = Vec::with_capacity(EXPECTED_SUMMARY_SAMPLES);
+    let deadline = Instant::now() + SUMMARY_MIN_TIME;
+
+    while Instant::now() < deadline {
+        let start = Instant::now();
+        let protocol =
+            WebUIProtocol::from_protobuf(black_box(bytes)).expect("parse failed in summary pass");
+        black_box(&protocol);
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    SummaryRow {
+        name: name.to_string(),
+        iterations: samples.len(),
+        samples_ms: samples,
+        output_bytes: bytes.len(),
+    }
+}
+
+fn collect_render_samples(
+    name: &str,
+    protocol: &WebUIProtocol,
+    state: &Value,
+    use_plugin: bool,
+) -> SummaryRow {
+    // Warm up — also measures output size
+    let mut handler = if use_plugin {
+        WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()))
+    } else {
+        WebUIHandler::new()
+    };
+    let mut writer = BenchWriter::new(SUMMARY_WRITER_CAPACITY);
+    for _ in 0..RENDER_WARMUP_ITERATIONS {
+        writer.clear();
+        handler
+            .handle(protocol, state, &mut writer)
+            .expect("warmup failed in summary pass");
+    }
+    let output_bytes = writer.len();
+
+    // Collect timing samples
+    let mut samples = Vec::with_capacity(EXPECTED_SUMMARY_SAMPLES);
+    let deadline = Instant::now() + SUMMARY_MIN_TIME;
+
+    while Instant::now() < deadline {
+        writer.clear();
+        let start = Instant::now();
+        handler
+            .handle(black_box(protocol), black_box(state), &mut writer)
+            .expect("render failed in summary pass");
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    SummaryRow {
+        name: name.to_string(),
+        iterations: samples.len(),
+        samples_ms: samples,
+        output_bytes,
+    }
+}
+
+fn print_summary(rows: &[SummaryRow]) {
+    let width = 100;
+    let border = "=".repeat(width);
+    let dash = "-".repeat(width);
+
+    eprintln!();
+    eprintln!(
+        "{:=^width$}",
+        " WebUI Contact Book — Performance Summary ",
+        width = width
+    );
+    eprintln!(
+        "{:<24} {:>6} {:>9} {:>9} {:>9} {:>6} {:>9} {:>9} {:>9} {:>9} {:>9}",
+        "Story", "Iters", "Avg(ms)", "Min", "Max", "Dev%", "P50", "P90", "P99", "IQR", "Bytes"
+    );
+    eprintln!("{dash}");
+
+    for row in rows {
+        eprintln!(
+            "{:<24} {:>6} {:>9.2} {:>9.2} {:>9.2} {:>5.1}% {:>9.2} {:>9.2} {:>9.2} {:>9.2} {:>9}",
+            row.name,
+            row.iterations,
+            row.avg(),
+            row.min(),
+            row.max(),
+            row.dev_pct(),
+            row.percentile(50.0),
+            row.percentile(90.0),
+            row.percentile(99.0),
+            row.iqr(),
+            row.output_bytes,
+        );
+    }
+
+    eprintln!("{border}");
+    eprintln!("IQR = P75 − P25 (lower means more consistent)");
+    eprintln!("All times in milliseconds");
+    eprintln!("{border}");
+}
+
+fn run_summary_pass(fixture: &BenchFixture) {
+    let mut rows = Vec::new();
+
+    rows.push(collect_parse_samples(
+        "ProtocolParse",
+        &fixture.protocol_bytes,
+    ));
+
+    for (count, state) in &fixture.states {
+        rows.push(collect_render_samples(
+            &format!("Render/{count}"),
+            &fixture.protocol,
+            state,
+            false,
+        ));
+    }
+
+    for (count, state) in &fixture.states {
+        rows.push(collect_render_samples(
+            &format!("RenderFAST/{count}"),
+            &fixture.protocol,
+            state,
+            true,
+        ));
+    }
+
+    print_summary(&rows);
+}
+
+// ---------------------------------------------------------------------------
+// Custom main — runs criterion then prints the summary table
+// ---------------------------------------------------------------------------
+
+fn main() {
+    // Run criterion benchmarks (handles --test, filters, etc.)
+    benches();
+
+    // Print summary table unless running in --test mode
+    let is_test_mode = std::env::args().any(|a| a == "--test");
+    if !is_test_mode {
+        let fixture = setup();
+        run_summary_pass(&fixture);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,7 +65,7 @@ fn usage() -> ExitCode {
     eprintln!(
         "Usage: cargo xtask <COMMAND>\n\n\
          Commands:\n  \
-           check   Run all checks (fmt, clippy, deny, test, build, docs)\n  \
+           check   Run all checks (fmt, clippy, deny, test, build, bench validate, docs)\n  \
            fmt     Check formatting\n  \
            clippy  Run clippy lints\n  \
            deny    Run cargo-deny license/advisory checks\n  \
@@ -74,7 +74,7 @@ fn usage() -> ExitCode {
            build-examples  Build all example integrations and apps\n  \
            build-wasm  Build WASM playground module\n  \
            docs    Build the documentation site\n  \
-           bench <name> [-- <criterion args>]  Run benchmarks for a target crate (parser, handler, protocol, expressions, state, all)\n  \
+           bench <name> [-- <criterion args>]  Run benchmarks for a target crate (parser, handler, protocol, expressions, state, webui, all)\n  \
            dev <app>  Run example app in dev mode (server + client watch concurrently)\n  \
            version <semver>  Update version across all Cargo.toml and package.json files"
     );
@@ -100,11 +100,14 @@ fn bench(target: Option<&str>, extra_args: &[&str]) -> ExitCode {
         Some("state") | Some("webui-state") => {
             args.extend(["-p", "webui-state"]);
         }
+        Some("webui") | Some("contact-book") => {
+            args.extend(["-p", "webui", "--bench", "contact_book_bench"]);
+        }
         Some("all") | None => {
             args.extend(["--workspace"]);
         }
         Some(other) => {
-            eprintln!("Unknown bench target '{other}'. Supported targets: parser, handler, protocol, expressions, state, all");
+            eprintln!("Unknown bench target '{other}'. Supported targets: parser, handler, protocol, expressions, state, webui, all");
             return ExitCode::FAILURE;
         }
     }
@@ -129,6 +132,7 @@ fn check() -> ExitCode {
         Step::BUILD,
         Step::BUILD_EXAMPLES,
         Step::BUILD_WASM,
+        Step::BENCH_VALIDATE,
         Step::DOCS,
     ])
 }
@@ -194,6 +198,24 @@ impl Step {
     const DOCS: Self = Self {
         name: "docs",
         run: || run_command("pnpm", &["--filter", "@webui/docs", "build"], None),
+    };
+    const BENCH_VALIDATE: Self = Self {
+        name: "bench (validate)",
+        run: || {
+            run_command(
+                "cargo",
+                &[
+                    "bench",
+                    "-p",
+                    "webui",
+                    "--bench",
+                    "contact_book_bench",
+                    "--",
+                    "--test",
+                ],
+                None,
+            )
+        },
     };
 }
 


### PR DESCRIPTION
Add a criterion-based end-to-end benchmark that compiles the real contact-book-manager templates into a protocol binary and measures performance across three areas:

- **Protocol deserialization**  measures `WebUIProtocol::from_protobuf()` throughput
- **Handler rendering** (no plugin)  renders the dashboard page at 10 / 100 / 1,000 contacts
- **Handler rendering** (FastHydration plugin)  same with hydration markers enabled

### Key design choices

- **Always fresh protocol**  templates are compiled via `webui::build()` at benchmark time from `examples/app/contact-book-manager/src/`. No cached binary  template changes are automatically reflected in the next run.
- **Realistic state**  contacts are generated with names, emails, phones, companies, groups, favorites, and addresses matching the app's `state.json` schema.
- **Summary table**  a compact performance report (Iters, Avg, Min, Max, Dev%, P50, P90, P99, IQR, Bytes) is printed after criterion finishes for easy sharing.

### Quality gate integration

- `cargo xtask check` now includes a **bench (validate)** step that runs `--test` mode (compile + one iteration per benchmark) to catch breakage early.
- `cargo xtask bench webui` runs the full contact-book benchmark with measurements.

### Files changed

| File | Change |
|------|--------|
| `crates/webui/benches/contact_book_bench.rs` | New benchmark file (602 lines) |
| `crates/webui/benches/README.md` | Usage docs, result interpretation, regression detection |
| `crates/webui/Cargo.toml` | Add criterion, webui-handler, webui-protocol dev-deps + `[[bench]]` |
| `xtask/src/main.rs` | Add bench validate step to check, add `webui` bench target |
| `Cargo.lock` | Lockfile update |

### Running

```bash
# Quick validation
cargo bench -p webui --bench contact_book_bench -- --test

# Full benchmark
cargo bench -p webui --bench contact_book_bench

# Via xtask
cargo xtask bench webui
```
