### PR TITLE
feat(routing): add route fragment and route registry to schema

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -193,6 +193,10 @@ impl WebUIHandler {
                         p.on_plugin_data(&plugin_frag.data, context.writer)?;
                     }
                 }
+                Some(Fragment::Route(_)) => {
+                    // Route fragments are handled by the route-aware render path.
+                    // When no route matching is active, route fragments are skipped.
+                }
                 None => {}
             }
         }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -7,6 +7,7 @@ mod css_parser;
 mod error;
 mod handlebars_parser;
 pub mod plugin;
+mod route_parser;
 
 pub use component_registry::{Component, ComponentRegistry};
 pub use condition_parser::ConditionParser;
@@ -19,15 +20,15 @@ use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIteratorMut};
 use tree_sitter_html::LANGUAGE;
 use webui_protocol::{
-    web_ui_fragment, web_ui_fragment::Fragment, ConditionExpr, FragmentList, WebUIFragment,
-    WebUIFragmentAttribute, WebUIFragmentRecords,
+    web_ui_fragment, web_ui_fragment::Fragment, ConditionExpr, FragmentList, RouteRecord,
+    WebUIFragment, WebUIFragmentAttribute, WebUIFragmentRecords, WebUiFragmentRoute,
 };
 
 /// Strategy for how component CSS is delivered in rendered output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum CssStrategy {
-    /// Emit `<link rel="stylesheet" href="./component.css">` tags (default).
+    /// Emit `<link rel="stylesheet" href="/component.css">` tags (default).
     #[default]
     Link,
     /// Embed CSS content in `<style>` tags within the shadow DOM template.
@@ -102,6 +103,12 @@ pub struct HtmlParser {
     /// (e.g., `:root { --color-primary: #0078d4; }`). These are excluded
     /// from the final token set since the app already provides their values.
     token_definitions: HashSet<String>,
+
+    /// Collected route fragments for the top-level registry.
+    route_fragments: Vec<WebUiFragmentRoute>,
+
+    /// Route name uniqueness tracker.
+    route_name_registry: route_parser::RouteNameRegistry,
 }
 
 impl HtmlParser {
@@ -124,6 +131,8 @@ impl HtmlParser {
             plugin: None,
             token_store: HashSet::new(),
             token_definitions: HashSet::new(),
+            route_fragments: Vec::new(),
+            route_name_registry: route_parser::RouteNameRegistry::new(),
             parser,
         }
     }
@@ -150,6 +159,17 @@ impl HtmlParser {
         std::mem::take(&mut self.fragment_records)
     }
 
+    /// Take the parser plugin. Call before `into_fragment_records()` if you need
+    /// access to plugin state (e.g., component templates).
+    pub fn take_plugin(&mut self) -> Option<Box<dyn ParserPlugin>> {
+        self.plugin.take()
+    }
+
+    /// Get a mutable reference to the parser plugin.
+    pub fn plugin_mut(&mut self) -> Option<&mut dyn ParserPlugin> {
+        self.plugin.as_deref_mut()
+    }
+
     /// Take the accumulated CSS tokens as a sorted, deduplicated `Vec`.
     ///
     /// Tokens that are **defined** in inline `<style>` tags (e.g., in a
@@ -166,6 +186,15 @@ impl HtmlParser {
             .collect();
         tokens.sort();
         tokens
+    }
+
+    /// Take the collected route registry as a map keyed by route name (or fragment ID).
+    ///
+    /// Call after parsing is complete.
+    #[must_use]
+    pub fn take_routes(&mut self) -> HashMap<String, RouteRecord> {
+        let routes = std::mem::take(&mut self.route_fragments);
+        route_parser::collect_route_registry(&routes)
     }
 
     /// Parse HTML content to generate WebUI fragments.
@@ -293,6 +322,7 @@ impl HtmlParser {
                     "for" => return self.process_for_directive(node, source, fragments),
                     "if" => return self.process_if_directive(node, source, fragments),
                     "body" => return self.process_body_element(node, source, fragments),
+                    "route" => return self.process_route_directive(node, source, fragments),
                     _ => {
                         if self.component_registry.contains(tag_name.as_str()) {
                             return self.process_component_directive(
@@ -332,7 +362,7 @@ impl HtmlParser {
                     }
                 }
             }
-            "text" => {
+            "text" | "raw_text" => {
                 let content = &source[node.start_byte()..node.end_byte()];
                 if !content.trim().is_empty() {
                     let handlebars_result = self.handlebars_parser.parse(content);
@@ -450,6 +480,53 @@ impl HtmlParser {
         }
 
         Ok(None)
+    }
+
+    /// Check whether a boolean attribute (no value) exists on an element.
+    /// Returns `true` for `<el attr>` or `<el attr="...">`.
+    fn has_element_attribute(&self, node: Node, attr_name: &str, source: &str) -> Result<bool> {
+        // First check for valued attributes
+        if self
+            .get_element_attribute(node, attr_name, source)?
+            .is_some()
+        {
+            return Ok(true);
+        }
+
+        // Check for boolean (valueless) attributes via tree-sitter query
+        let query_str = r#"
+            (element
+              [
+                (start_tag
+                  (attribute
+                    (attribute_name) @name))
+                (self_closing_tag
+                  (attribute
+                    (attribute_name) @name))
+              ]
+            )
+        "#;
+
+        let query = Query::new(&LANGUAGE.into(), query_str)
+            .map_err(|e| ParserError::Html(format!("Failed to create attribute query: {:?}", e)))?;
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, node, source.as_bytes());
+        while let Some(m) = matches.next_mut() {
+            for capture in m.captures.iter() {
+                let capture_name = query.capture_names()[capture.index as usize];
+                if capture_name == "name" {
+                    let name_text = capture.node.utf8_text(source.as_bytes()).map_err(|_| {
+                        ParserError::Html("Invalid UTF-8 for attribute name".to_string())
+                    })?;
+                    if name_text == attr_name {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        Ok(false)
     }
 
     /// Find the start_tag or self_closing_tag child of an element node.
@@ -1029,6 +1106,107 @@ impl HtmlParser {
         Ok(())
     }
 
+    /// Process a `<route>` directive.
+    ///
+    /// Emits a `Fragment::Route` protocol fragment. The handler renders
+    /// `<webui-route>` elements with server-side route matching — matched
+    /// routes get `active` + component content, non-matched get `display:none`.
+    fn process_route_directive(
+        &mut self,
+        node: Node,
+        source: &str,
+        fragments: &mut Vec<WebUIFragment>,
+    ) -> Result<()> {
+        // Extract route attributes
+        let path = self
+            .get_element_attribute(node, "path", source)?
+            .unwrap_or_default();
+
+        let component = self
+            .get_element_attribute(node, "component", source)?
+            .unwrap_or_default();
+
+        let name = self
+            .get_element_attribute(node, "name", source)?
+            .unwrap_or_default();
+
+        let exact = self.has_element_attribute(node, "exact", source)?;
+
+        let attrs = route_parser::RouteAttributes {
+            path: path.clone(),
+            component: component.clone(),
+            name: name.clone(),
+            exact,
+        };
+
+        // Validate attributes (component is required)
+        route_parser::validate_attributes(&attrs)?;
+
+        // Register route name for uniqueness
+        self.route_name_registry.register(&name)?;
+
+        // Extract params from path template (validation only)
+        route_parser::extract_params(&path)?;
+
+        // Ensure the component's template is parsed and registered
+        if !component.is_empty()
+            && self.component_registry.contains(&component)
+            && !self.fragment_records.contains_key(&component)
+        {
+            if let Some(ref mut p) = self.plugin {
+                if let Some(comp) = self.component_registry.get(&component) {
+                    p.on_parse_component(&component, comp)?;
+                }
+            }
+            let (html_content, css_content, css_tokens) = {
+                let comp = self.component_registry.get(&component).ok_or_else(|| {
+                    crate::error::ParserError::Directive(format!(
+                        "Component not found: {component}"
+                    ))
+                })?;
+                (
+                    comp.html_content.clone(),
+                    comp.css_content.clone(),
+                    comp.css_tokens.clone(),
+                )
+            };
+            self.token_store.extend(css_tokens);
+            let css_injection = match self.css_strategy {
+                CssStrategy::Link => {
+                    if css_content.is_some() {
+                        Some(format!(
+                            "<link rel=\"stylesheet\" href=\"/{component}.css\">"
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                CssStrategy::Style => css_content
+                    .as_ref()
+                    .map(|css| format!("<style>{}</style>", css.trim())),
+            };
+            let processed =
+                self.process_component_template(&html_content, css_injection.as_deref());
+            let saved_buffer = std::mem::take(&mut self.raw_buffer);
+            self.parse(&component, &processed)?;
+            self.raw_buffer = saved_buffer;
+        }
+
+        // Flush any pending raw content before the route fragment
+        self.flush_raw_buffer(fragments);
+
+        // Build route metadata for the registry
+        let route_fragment = route_parser::build_route_fragment(&attrs, component.clone());
+
+        // Emit Fragment::Route — the handler renders it as <webui-route>
+        fragments.push(WebUIFragment::route_from(route_fragment.clone()));
+
+        // Track for registry
+        self.route_fragments.push(route_fragment);
+
+        Ok(())
+    }
+
     /// Skipped attribute names for components.
     const SKIPPED_ATTRIBUTES: &[&str] = &["class", "style", "role"];
     /// Skipped attribute prefixes for components.
@@ -1110,7 +1288,7 @@ impl HtmlParser {
                 CssStrategy::Link => {
                     if css_content.is_some() {
                         Some(format!(
-                            "<link rel=\"stylesheet\" href=\"./{}.css\">",
+                            "<link rel=\"stylesheet\" href=\"/{}.css\">",
                             tag_name
                         ))
                     } else {
@@ -1461,7 +1639,7 @@ mod tests {
             records,
             "custom-element",
             [raw(
-                r#"<template foo="bar"><link rel="stylesheet" href="./custom-element.css"><slot></slot></template>"#
+                r#"<template foo="bar"><link rel="stylesheet" href="/custom-element.css"><slot></slot></template>"#
             ),]
         );
     }
@@ -2447,7 +2625,7 @@ mod tests {
             })
             .collect();
         assert!(
-            raw_text.contains(r#"<link rel="stylesheet" href="./my-card.css">"#),
+            raw_text.contains(r#"<link rel="stylesheet" href="/my-card.css">"#),
             "Expected external <link> tag in: {}",
             raw_text
         );
@@ -2640,6 +2818,14 @@ mod tests {
             } else {
                 None
             }
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
         }
     }
 
@@ -2998,5 +3184,105 @@ mod tests {
 
         // Only --external-spacing should be hoisted (not defined in entry)
         assert_eq!(tokens, vec!["external-spacing"]);
+    }
+
+    // ── Route parsing tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_simple_route() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/profile" component="profile-page" name="profile" exact />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        // Routes are emitted as Fragment::Route
+        let records = parser.into_fragment_records();
+        let frags = &records["test.html"].fragments;
+        assert_eq!(frags.len(), 1);
+        match frags[0].fragment.as_ref() {
+            Some(web_ui_fragment::Fragment::Route(r)) => {
+                assert_eq!(r.path, "/profile");
+                assert_eq!(r.name, "profile");
+                assert_eq!(r.fragment_id, "profile-page");
+                assert!(r.exact);
+            }
+            other => panic!("expected Fragment::Route, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_route_with_params() {
+        let mut parser = HtmlParser::new();
+        let html =
+            r#"<route path="/profile/:id/view/:section" component="detail" name="detail" />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        // Route is registered in the route registry
+        let routes = parser.take_routes();
+        assert_eq!(routes["detail"].path, "/profile/:id/view/:section");
+    }
+
+    #[test]
+    fn test_parse_route_requires_component() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/old" />"#;
+        let result = parser.parse("test.html", html);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_multiple_routes() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/" name="app" component="app-layout" />
+            <route path="/dashboard" name="dashboard" component="dash-page" exact />
+            <route path="/contacts" name="contacts" component="contacts-page" exact />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        let routes = parser.take_routes();
+        // Should have 3 routes
+        assert_eq!(routes.len(), 3);
+        assert!(routes.contains_key("app"));
+        assert!(routes.contains_key("dashboard"));
+        assert!(routes.contains_key("contacts"));
+
+        // App has correct path
+        let app = &routes["app"];
+        assert_eq!(app.path, "/");
+    }
+
+    #[test]
+    fn test_parse_route_duplicate_name_error() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/a" name="home" component="a" />
+            <route path="/b" name="home" component="b" />"#;
+        let result = parser.parse("test.html", html);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_route_requires_component_with_body() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/error" name="error-page">
+            <div class="error"><h1>Not Found</h1></div>
+        </route>"#;
+        let result = parser.parse("test.html", html);
+        assert!(
+            result.is_err(),
+            "Route without component attribute should fail"
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_routes_with_registry() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/" name="home" component="home-page" exact />
+            <route path="/about" name="about" component="about-page" exact />
+            <route path="/contact/:id" name="contact" component="contact-page" />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        let routes = parser.take_routes();
+        assert_eq!(routes.len(), 3);
+        assert_eq!(routes["home"].path, "/");
+        assert_eq!(routes["about"].path, "/about");
+        assert_eq!(routes["contact"].path, "/contact/:id");
     }
 }

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -35,6 +35,26 @@ impl FastParserPlugin {
             components: Vec::new(),
         }
     }
+
+    /// Take the individual component f-template strings, keyed by tag name.
+    ///
+    /// Each value is a complete `<f-template name="tag-name">...</f-template>` string
+    /// ready to be appended to a document. This is used by the JSON partial render
+    /// endpoint to send only the templates the client needs.
+    #[must_use]
+    pub fn take_component_templates(&self) -> Vec<(String, String)> {
+        self.components
+            .iter()
+            .map(|comp| {
+                let tmpl = generate_f_template(
+                    &comp.tag_name,
+                    &comp.html_content,
+                    comp.css_content.as_deref(),
+                );
+                (comp.tag_name.clone(), tmpl)
+            })
+            .collect()
+    }
 }
 
 impl Default for FastParserPlugin {
@@ -74,48 +94,62 @@ impl ParserPlugin for FastParserPlugin {
     }
 
     fn on_body_end(&mut self) -> Option<String> {
-        if self.components.is_empty() {
-            return None;
-        }
-
-        let mut output = String::with_capacity(self.components.len() * 256);
-
-        for comp in &self.components {
-            output.push_str("<f-template name=\"");
-            output.push_str(&comp.tag_name);
-            output.push_str("\">\n");
-
-            let converted = convert_btr_to_fast(&comp.html_content);
-            let trimmed = minify_inter_tag_whitespace(converted.trim());
-
-            if trimmed.starts_with("<template") {
-                if let Some(close_pos) = trimmed.find('>') {
-                    output.push_str(&trimmed[..=close_pos]);
-                    if comp.css_content.is_some() {
-                        output.push_str("<link rel=\"stylesheet\" href=\"./");
-                        output.push_str(&comp.tag_name);
-                        output.push_str(".css\">");
-                    }
-                    output.push_str(&trimmed[close_pos + 1..]);
-                } else {
-                    output.push_str(&trimmed);
-                }
-            } else {
-                output.push_str("<template>");
-                if comp.css_content.is_some() {
-                    output.push_str("<link rel=\"stylesheet\" href=\"./");
-                    output.push_str(&comp.tag_name);
-                    output.push_str(".css\">");
-                }
-                output.push_str(&trimmed);
-                output.push_str("</template>");
-            }
-
-            output.push_str("\n</f-template>\n");
-        }
-
-        Some(output)
+        // f-templates are stored in protocol.component_templates and emitted
+        // selectively by the handler based on which components were rendered.
+        None
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+/// Generate a single f-template HTML string from component data.
+///
+/// Used by the server to generate templates on demand for route components
+/// that weren't encountered during initial parsing.
+pub fn generate_f_template(
+    tag_name: &str,
+    html_content: &str,
+    css_content: Option<&str>,
+) -> String {
+    let mut output = String::with_capacity(256);
+    output.push_str("<f-template name=\"");
+    output.push_str(tag_name);
+    output.push_str("\">\n");
+
+    let converted = convert_btr_to_fast(html_content);
+    let trimmed = minify_inter_tag_whitespace(converted.trim());
+
+    if trimmed.starts_with("<template") {
+        if let Some(close_pos) = trimmed.find('>') {
+            output.push_str(&trimmed[..=close_pos]);
+            if css_content.is_some() {
+                output.push_str("<link rel=\"stylesheet\" href=\"/");
+                output.push_str(tag_name);
+                output.push_str(".css\">");
+            }
+            output.push_str(&trimmed[close_pos + 1..]);
+        } else {
+            output.push_str(&trimmed);
+        }
+    } else {
+        output.push_str("<template>");
+        if css_content.is_some() {
+            output.push_str("<link rel=\"stylesheet\" href=\"/");
+            output.push_str(tag_name);
+            output.push_str(".css\">");
+        }
+        output.push_str(&trimmed);
+        output.push_str("</template>");
+    }
+
+    output.push_str("\n</f-template>\n");
+    output
 }
 
 /// Convert WebUI Framework template syntax to FAST syntax in HTML content.
@@ -167,6 +201,11 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
         result.push_str("</f-repeat>");
         return Some(6);
     }
+    // <route> in f-templates becomes empty <webui-route> (client router mounts components)
+    if remaining.starts_with("</route>") {
+        result.push_str("</webui-route>");
+        return Some(8);
+    }
 
     // Check for <if condition="...">
     if starts_with_tag_name(remaining, "if") {
@@ -178,6 +217,13 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
     // Check for <for each="...">
     if starts_with_tag_name(remaining, "for") {
         if let Some(consumed) = convert_for_tag(remaining, result) {
+            return Some(consumed);
+        }
+    }
+
+    // Check for <route ...> → <webui-route ...> in f-templates
+    if starts_with_tag_name(remaining, "route") {
+        if let Some(consumed) = convert_route_tag(remaining, result) {
             return Some(consumed);
         }
     }
@@ -245,6 +291,53 @@ fn convert_for_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     result.push_str("<f-repeat value=\"{");
     result.push_str(attr_value);
     result.push_str("}\">");
+
+    Some(close + 1)
+}
+
+/// Convert `<route ...>` to `<webui-route ...>` in f-templates.
+/// Self-closing routes become `<webui-route ...></webui-route>` (empty).
+/// The component attribute is preserved for the client router.
+fn convert_route_tag(tag_str: &str, result: &mut String) -> Option<usize> {
+    let close = tag_str.find('>')?;
+    let is_self_closing = tag_str[..=close].ends_with("/>");
+    let tag = &tag_str[..=close];
+
+    result.push_str("<webui-route");
+
+    if let Some(v) = extract_attribute_value(tag, "path") {
+        result.push_str(" path=\"");
+        result.push_str(v);
+        result.push('"');
+    }
+    if let Some(v) = extract_attribute_value(tag, "name") {
+        result.push_str(" name=\"");
+        result.push_str(v);
+        result.push('"');
+    }
+    if let Some(v) = extract_attribute_value(tag, "component") {
+        result.push_str(" component=\"");
+        result.push_str(v);
+        result.push('"');
+    }
+    if let Some(v) = extract_attribute_value(tag, "redirectTo") {
+        result.push_str(" redirectto=\"");
+        result.push_str(v);
+        result.push('"');
+    }
+    if tag.contains(" exact") {
+        result.push_str(" exact");
+    }
+    if tag.contains(" layout") {
+        result.push_str(" layout");
+    }
+    result.push_str(" style=\"display:none\"");
+
+    if is_self_closing {
+        result.push_str("></webui-route>");
+    } else {
+        result.push('>');
+    }
 
     Some(close + 1)
 }
@@ -567,56 +660,60 @@ mod tests {
     }
 
     #[test]
-    fn body_end_simple_component() {
+    fn component_template_simple_component() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component("my-comp", "<div>hello</div>", Some("div { color: red; }"));
         plugin.on_parse_component("my-comp", &comp).unwrap();
 
-        let output = plugin.on_body_end();
-        assert!(output.is_some());
-        let html = output.unwrap_or_default();
-
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (name, html) = &templates[0];
+        assert_eq!(name, "my-comp");
         assert!(html.contains("<f-template name=\"my-comp\">"));
         assert!(html.contains("</f-template>"));
         assert!(html.contains("<template>"));
         assert!(html.contains("</template>"));
-        assert!(html.contains("<link rel=\"stylesheet\" href=\"./my-comp.css\">"));
+        assert!(html.contains("<link rel=\"stylesheet\" href=\"/my-comp.css\">"));
         assert!(html.contains("<div>hello</div>"));
     }
 
     #[test]
-    fn body_end_component_without_css() {
+    fn component_template_without_css() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component("no-css", "<span>text</span>", None);
         plugin.on_parse_component("no-css", &comp).unwrap();
 
-        let output = plugin.on_body_end();
-        assert!(output.is_some());
-        let html = output.unwrap_or_default();
-
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (name, html) = &templates[0];
+        assert_eq!(name, "no-css");
         assert!(html.contains("<f-template name=\"no-css\">"));
         assert!(!html.contains("<link rel=\"stylesheet\""));
         assert!(html.contains("<span>text</span>"));
     }
 
     #[test]
-    fn body_end_multiple_components() {
+    fn component_template_multiple_components() {
         let mut plugin = FastParserPlugin::new();
         let comp1 = make_component("comp-a", "<div>A</div>", None);
         let comp2 = make_component("comp-b", "<div>B</div>", Some("b { }"));
         plugin.on_parse_component("comp-a", &comp1).unwrap();
         plugin.on_parse_component("comp-b", &comp2).unwrap();
 
-        let output = plugin.on_body_end();
-        assert!(output.is_some());
-        let html = output.unwrap_or_default();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 2);
 
-        assert!(html.contains("<f-template name=\"comp-a\">"));
-        assert!(html.contains("<f-template name=\"comp-b\">"));
+        let names: Vec<&str> = templates.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"comp-a"));
+        assert!(names.contains(&"comp-b"));
+
+        for (_, html) in &templates {
+            assert!(html.contains("<f-template name="));
+        }
     }
 
     #[test]
-    fn body_end_deduplicates_same_component() {
+    fn component_template_deduplicates_same_component() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component(
             "my-button",
@@ -630,16 +727,18 @@ mod tests {
         plugin.on_parse_component("my-button", &comp).unwrap();
         plugin.on_parse_component("my-button", &comp).unwrap();
 
-        let output = plugin.on_body_end().unwrap();
-        let count = output.matches("<f-template name=\"my-button\">").count();
+        let templates = plugin.take_component_templates();
         assert_eq!(
-            count, 1,
-            "Expected exactly 1 <f-template> for my-button, got {count}"
+            templates.len(),
+            1,
+            "Expected exactly 1 template for my-button, got {}",
+            templates.len()
         );
+        assert_eq!(templates[0].0, "my-button");
     }
 
     #[test]
-    fn body_end_deduplicates_mixed_components() {
+    fn component_template_deduplicates_mixed_components() {
         let mut plugin = FastParserPlugin::new();
         let btn = make_component("my-button", "<button><slot></slot></button>", None);
         let card = make_component("my-card", "<div><slot></slot></div>", Some(".card{}"));
@@ -649,10 +748,13 @@ mod tests {
         plugin.on_parse_component("my-card", &card).unwrap();
         plugin.on_parse_component("my-button", &btn).unwrap();
 
-        let output = plugin.on_body_end().unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 2);
 
-        assert_eq!(output.matches("<f-template name=\"my-button\">").count(), 1);
-        assert_eq!(output.matches("<f-template name=\"my-card\">").count(), 1);
+        let button_count = templates.iter().filter(|(n, _)| n == "my-button").count();
+        let card_count = templates.iter().filter(|(n, _)| n == "my-card").count();
+        assert_eq!(button_count, 1);
+        assert_eq!(card_count, 1);
     }
 
     // --- FAST syntax conversion ---
@@ -718,15 +820,16 @@ mod tests {
     }
 
     #[test]
-    fn body_end_with_btr_conversion() {
+    fn component_template_with_btr_conversion() {
         let mut plugin = FastParserPlugin::new();
         let html = r#"<div><if condition="visible"><span>hi</span></if></div>"#;
         let comp = make_component("my-widget", html, None);
         plugin.on_parse_component("my-widget", &comp).unwrap();
 
-        let output = plugin.on_body_end();
-        assert!(output.is_some());
-        let result = output.unwrap_or_default();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (name, result) = &templates[0];
+        assert_eq!(name, "my-widget");
 
         assert!(result.contains("<f-when value=\"{visible}\">"));
         assert!(result.contains("</f-when>"));
@@ -766,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn body_end_strips_shadowrootmode_from_f_template() {
+    fn component_template_strips_shadowrootmode_from_f_template() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component(
             "my-comp",
@@ -774,13 +877,16 @@ mod tests {
             Some("div { color: red; }"),
         );
         plugin.on_parse_component("my-comp", &comp).unwrap();
-        let output = plugin.on_body_end().unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (name, html) = &templates[0];
+        assert_eq!(name, "my-comp");
         // f-template content should NOT have shadowrootmode
-        assert!(!output.contains("shadowrootmode"));
+        assert!(!html.contains("shadowrootmode"));
         // But should keep @click (framework attr kept in f-template mode)
-        assert!(output.contains("@click"));
+        assert!(html.contains("@click"));
         // Should have the converted content
-        assert!(output.contains("{{title}}"));
+        assert!(html.contains("{{title}}"));
     }
 
     #[test]
@@ -820,12 +926,36 @@ mod tests {
         let comp = make_component("parent-comp", html, None);
         plugin.on_parse_component("parent-comp", &comp).unwrap();
 
-        let output = plugin.on_body_end().unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (name, output) = &templates[0];
+        assert_eq!(name, "parent-comp");
 
         assert!(output.contains("<f-template name=\"parent-comp\">"));
         // shadowrootmode must be stripped from the inner non-JS component's template
         assert!(!output.contains("shadowrootmode"));
         // The inner template structure should be preserved (without shadowrootmode)
         assert!(output.contains("<child-comp><template><p>inner</p></template></child-comp>"));
+    }
+
+    #[test]
+    fn route_tags_converted_to_f_route() {
+        let input = r#"<route path="/home" name="home" exact><span>Home</span></route>"#;
+        let output = convert_btr_to_fast(input);
+        assert!(output.starts_with("<webui-route"));
+        assert!(output.contains(r#"path="/home""#));
+        assert!(output.contains(r#"name="home""#));
+        assert!(output.contains(" exact"));
+        assert!(output.contains("style=\"display:none\""));
+        assert!(output.contains("<span>Home</span>"));
+        assert!(output.ends_with("</webui-route>"));
+    }
+
+    #[test]
+    fn f_route_tags_pass_through() {
+        // <webui-route> tags emitted by the parser should pass through unchanged
+        let input = r#"<webui-route path="/" name="dashboard" component="cb-page-dashboard" exact style="display:none"></webui-route>"#;
+        let output = convert_btr_to_fast(input);
+        assert_eq!(output, input);
     }
 }

--- a/crates/webui-parser/src/plugin/mod.rs
+++ b/crates/webui-parser/src/plugin/mod.rs
@@ -7,10 +7,12 @@
 
 pub mod fast;
 
+pub use fast::generate_f_template;
 pub use fast::FastParserPlugin;
 
 use crate::component_registry::Component;
 use crate::Result;
+use std::any::Any;
 
 /// A parser plugin that can customize template parsing behavior.
 ///
@@ -21,7 +23,7 @@ use crate::Result;
 /// - **Element completion**: `on_element_parsed` after attributes are processed
 ///
 /// WebUI calls these hooks during parsing; plugins decide what (if anything) to do.
-pub trait ParserPlugin {
+pub trait ParserPlugin: Any {
     /// Called when a component element is encountered during parsing.
     /// Use to track components for later template generation.
     fn on_parse_component(&mut self, tag_name: &str, component: &Component) -> Result<()>;
@@ -40,4 +42,10 @@ pub trait ParserPlugin {
     /// `binding_attribute_count` is the number of dynamic attribute bindings found.
     /// Returns optional opaque bytes to emit as a `Plugin` protocol fragment.
     fn on_element_parsed(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
+
+    /// Downcast to `Any` for plugin-specific access.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Downcast to mutable `Any` for plugin-specific access.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/crates/webui-parser/src/route_parser.rs
+++ b/crates/webui-parser/src/route_parser.rs
@@ -1,0 +1,298 @@
+//! Route element parsing for `<route>` directives.
+//!
+//! Parses `<route path="..." component="..." ...>` elements into
+//! `WebUIFragmentRoute` protocol fragments and builds a top-level
+//! route registry (`HashMap<String, RouteRecord>`).
+
+use std::collections::{HashMap, HashSet};
+
+use webui_protocol::{RouteRecord, WebUiFragmentRoute};
+
+use crate::error::{ParserError, Result};
+
+/// Maximum number of path parameters allowed per route.
+const MAX_PARAMS_PER_ROUTE: usize = 20;
+
+/// Parsed attributes from a single `<route>` element.
+#[derive(Debug, Default)]
+pub(crate) struct RouteAttributes {
+    pub path: String,
+    pub component: String,
+    pub name: String,
+    pub exact: bool,
+}
+
+/// Iteratively extract `:param` and `*splat` tokens from a path template.
+///
+/// Returns param names without the `:` or `*` prefix.
+/// Validates the path template for correctness.
+pub(crate) fn extract_params(path: &str) -> Result<Vec<String>> {
+    let mut params = Vec::new();
+    let mut seen = HashSet::new();
+
+    for segment in path.split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+
+        // :param or :param? (optional)
+        if let Some(rest) = segment.strip_prefix(':') {
+            let name = rest.trim_end_matches('?');
+            if name.is_empty() {
+                return Err(ParserError::Directive(format!(
+                    "Empty parameter name in path: {path}"
+                )));
+            }
+            if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                return Err(ParserError::Directive(format!(
+                    "Invalid parameter name '{name}' in path: {path}"
+                )));
+            }
+            if !seen.insert(name.to_string()) {
+                return Err(ParserError::Directive(format!(
+                    "Duplicate parameter name '{name}' in path: {path}"
+                )));
+            }
+            params.push(name.to_string());
+        }
+        // *splat
+        else if let Some(rest) = segment.strip_prefix('*') {
+            let name = if rest.is_empty() { "rest" } else { rest };
+            if !seen.insert(name.to_string()) {
+                return Err(ParserError::Directive(format!(
+                    "Duplicate splat name '{name}' in path: {path}"
+                )));
+            }
+            params.push(name.to_string());
+        }
+    }
+
+    if params.len() > MAX_PARAMS_PER_ROUTE {
+        return Err(ParserError::Directive(format!(
+            "Too many parameters ({}) in path: {path} (max {MAX_PARAMS_PER_ROUTE})",
+            params.len()
+        )));
+    }
+
+    Ok(params)
+}
+
+/// Validate route attributes for consistency.
+pub(crate) fn validate_attributes(attrs: &RouteAttributes) -> Result<()> {
+    // component is required
+    if attrs.component.is_empty() {
+        return Err(ParserError::Directive(format!(
+            "Route '{}' must have a 'component' attribute",
+            attrs.path
+        )));
+    }
+
+    Ok(())
+}
+
+/// Build a `WebUiFragmentRoute` from parsed attributes.
+pub(crate) fn build_route_fragment(
+    attrs: &RouteAttributes,
+    fragment_id: String,
+) -> WebUiFragmentRoute {
+    WebUiFragmentRoute {
+        path: attrs.path.clone(),
+        fragment_id,
+        exact: attrs.exact,
+        name: attrs.name.clone(),
+    }
+}
+
+/// Build a `RouteRecord` from a route fragment for the top-level registry.
+pub(crate) fn build_route_record(route: &WebUiFragmentRoute) -> RouteRecord {
+    RouteRecord {
+        name: route.name.clone(),
+        path: route.path.clone(),
+        fragment_id: route.fragment_id.clone(),
+        exact: route.exact,
+    }
+}
+
+/// Route name uniqueness tracker.
+pub(crate) struct RouteNameRegistry {
+    names: HashSet<String>,
+}
+
+impl RouteNameRegistry {
+    pub fn new() -> Self {
+        Self {
+            names: HashSet::new(),
+        }
+    }
+
+    /// Register a route name, returning an error if it's a duplicate.
+    pub fn register(&mut self, name: &str) -> Result<()> {
+        if name.is_empty() {
+            return Ok(());
+        }
+        if !self.names.insert(name.to_string()) {
+            return Err(ParserError::Directive(format!(
+                "Duplicate route name: '{name}'"
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Collect all route records into a map keyed by route name.
+/// Routes without names are keyed by their fragment ID.
+pub(crate) fn collect_route_registry(
+    routes: &[WebUiFragmentRoute],
+) -> HashMap<String, RouteRecord> {
+    let mut registry = HashMap::with_capacity(routes.len());
+    for route in routes {
+        let key = if route.name.is_empty() {
+            route.fragment_id.clone()
+        } else {
+            route.name.clone()
+        };
+        registry.insert(key, build_route_record(route));
+    }
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_params_simple() {
+        let params = extract_params("/profile/:id").unwrap();
+        assert_eq!(params, vec!["id"]);
+    }
+
+    #[test]
+    fn test_extract_params_multiple() {
+        let params = extract_params("/profile/:id/view/:section").unwrap();
+        assert_eq!(params, vec!["id", "section"]);
+    }
+
+    #[test]
+    fn test_extract_params_optional() {
+        let params = extract_params("/profile/:id?").unwrap();
+        assert_eq!(params, vec!["id"]);
+    }
+
+    #[test]
+    fn test_extract_params_splat() {
+        let params = extract_params("/files/*rest").unwrap();
+        assert_eq!(params, vec!["rest"]);
+    }
+
+    #[test]
+    fn test_extract_params_splat_unnamed() {
+        let params = extract_params("/files/*").unwrap();
+        assert_eq!(params, vec!["rest"]);
+    }
+
+    #[test]
+    fn test_extract_params_empty_path() {
+        let params = extract_params("/").unwrap();
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_extract_params_no_params() {
+        let params = extract_params("/contacts/add").unwrap();
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_extract_params_duplicate_error() {
+        let result = extract_params("/profile/:id/other/:id");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_params_invalid_name() {
+        let result = extract_params("/profile/:id-with-dash");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_params_empty_name() {
+        let result = extract_params("/profile/:");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_attributes_valid() {
+        let attrs = RouteAttributes {
+            path: "/profile".to_string(),
+            component: "profile-page".to_string(),
+            ..Default::default()
+        };
+        assert!(validate_attributes(&attrs).is_ok());
+    }
+
+    #[test]
+    fn test_validate_missing_component() {
+        let attrs = RouteAttributes {
+            path: "/page".to_string(),
+            ..Default::default()
+        };
+        assert!(validate_attributes(&attrs).is_err());
+    }
+
+    #[test]
+    fn test_route_name_registry_unique() {
+        let mut reg = RouteNameRegistry::new();
+        assert!(reg.register("home").is_ok());
+        assert!(reg.register("profile").is_ok());
+    }
+
+    #[test]
+    fn test_route_name_registry_duplicate() {
+        let mut reg = RouteNameRegistry::new();
+        assert!(reg.register("home").is_ok());
+        assert!(reg.register("home").is_err());
+    }
+
+    #[test]
+    fn test_route_name_registry_empty_ok() {
+        let mut reg = RouteNameRegistry::new();
+        assert!(reg.register("").is_ok());
+        assert!(reg.register("").is_ok());
+    }
+
+    #[test]
+    fn test_build_route_record() {
+        let route = WebUiFragmentRoute {
+            path: "/users/:id".to_string(),
+            fragment_id: "users-page".to_string(),
+            name: "user-detail".to_string(),
+            exact: true,
+        };
+        let record = build_route_record(&route);
+        assert_eq!(record.name, "user-detail");
+        assert_eq!(record.path, "/users/:id");
+        assert!(record.exact);
+    }
+
+    #[test]
+    fn test_collect_route_registry() {
+        let routes = vec![
+            WebUiFragmentRoute {
+                name: "home".to_string(),
+                path: "/".to_string(),
+                fragment_id: "home-page".to_string(),
+                ..Default::default()
+            },
+            WebUiFragmentRoute {
+                name: "".to_string(),
+                path: "/unnamed".to_string(),
+                fragment_id: "unnamed-page".to_string(),
+                ..Default::default()
+            },
+        ];
+        let registry = collect_route_registry(&routes);
+        assert_eq!(registry.len(), 2);
+        assert!(registry.contains_key("home"));
+        assert!(registry.contains_key("unnamed-page"));
+    }
+}

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -9,6 +9,12 @@ message WebUIProtocol {
   // and entry page styles (e.g., "colorBrandBackground", "spacingMedium").
   // Only usage via var(--name) is included; local definitions are excluded.
   repeated string tokens = 2;
+  // Top-level route registry keyed by route name.
+  map<string, RouteRecord> routes = 3;
+  // Component f-template HTML strings keyed by tag name.
+  // Populated by the FAST parser plugin at build time. Used by servers
+  // to send f-templates to the client during navigation (JSON partials).
+  map<string, string> component_templates = 4;
 }
 
 // A list of fragments (needed because protobuf maps cannot have repeated values directly).
@@ -26,7 +32,30 @@ message WebUIFragment {
     WebUIFragmentIf if_cond = 5;
     WebUIFragmentAttribute attribute = 6;
     WebUIFragmentPlugin plugin = 7;
+    WebUIFragmentRoute route = 8;
   }
+}
+
+// Declarative route definition linking a URL path template to a fragment.
+message WebUIFragmentRoute {
+  string path = 1;
+  string fragment_id = 2;
+  // Fields 3-4 reserved (removed: redirect_to, error_fragment_id).
+  reserved 3, 4;
+  bool exact = 5;
+  string name = 6;
+  // Fields 7-11 reserved (removed: params, children, outlets, layout, tokens).
+  reserved 7, 8, 9, 10, 11;
+}
+
+// Entry in the top-level route registry (WebUIProtocol.routes).
+message RouteRecord {
+  string name = 1;
+  string path = 2;
+  string fragment_id = 3;
+  bool exact = 4;
+  // Fields 5-8 reserved (removed: params, children, outlets, layout).
+  reserved 5, 6, 7, 8;
 }
 
 // Opaque plugin-specific data passed from parser plugin to handler plugin.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -30,6 +30,7 @@ pub type WebUIFragmentSignal = WebUiFragmentSignal;
 pub type WebUIFragmentIf = WebUiFragmentIf;
 pub type WebUIFragmentAttribute = WebUiFragmentAttribute;
 pub type WebUIFragmentPlugin = WebUiFragmentPlugin;
+pub type WebUIFragmentRoute = WebUiFragmentRoute;
 
 /// A mapping of unique fragment identifiers to their corresponding fragment lists.
 pub type WebUIFragmentRecords = HashMap<String, FragmentList>;
@@ -224,6 +225,24 @@ impl WebUiFragment {
             })),
         }
     }
+
+    /// Create a route fragment linking a URL path template to a fragment.
+    pub fn route(path: impl Into<String>, fragment_id: impl Into<String>) -> Self {
+        Self {
+            fragment: Some(web_ui_fragment::Fragment::Route(WebUiFragmentRoute {
+                path: path.into(),
+                fragment_id: fragment_id.into(),
+                ..Default::default()
+            })),
+        }
+    }
+
+    /// Create a route fragment from a pre-built `WebUiFragmentRoute`.
+    pub fn route_from(route: WebUiFragmentRoute) -> Self {
+        Self {
+            fragment: Some(web_ui_fragment::Fragment::Route(route)),
+        }
+    }
 }
 
 impl ConditionExpr {
@@ -277,17 +296,38 @@ impl ConditionExpr {
 // ── Constructors ────────────────────────────────────────────────────────
 
 impl WebUiProtocol {
-    /// Create a protocol from fragment records with no CSS tokens.
+    /// Create a protocol from fragment records with no CSS tokens or routes.
     pub fn new(fragments: WebUIFragmentRecords) -> Self {
         Self {
             fragments,
             tokens: Vec::new(),
+            routes: HashMap::new(),
+            component_templates: HashMap::new(),
         }
     }
 
     /// Create a protocol from fragment records with CSS tokens.
     pub fn with_tokens(fragments: WebUIFragmentRecords, tokens: Vec<String>) -> Self {
-        Self { fragments, tokens }
+        Self {
+            fragments,
+            tokens,
+            routes: HashMap::new(),
+            component_templates: HashMap::new(),
+        }
+    }
+
+    /// Create a protocol from fragment records, CSS tokens, and a route registry.
+    pub fn with_routes(
+        fragments: WebUIFragmentRecords,
+        tokens: Vec<String>,
+        routes: HashMap<String, RouteRecord>,
+    ) -> Self {
+        Self {
+            fragments,
+            tokens,
+            routes,
+            component_templates: HashMap::new(),
+        }
     }
 }
 
@@ -334,6 +374,17 @@ impl WebUiProtocol {
                             "Attribute references non-existent template fragment ID: {}",
                             attr.template
                         )))
+                    }
+                    Some(web_ui_fragment::Fragment::Route(route)) => {
+                        if !route.fragment_id.is_empty()
+                            && !fragments.contains_key(&route.fragment_id)
+                        {
+                            return Some(ProtocolError::Validation(format!(
+                                "Route references non-existent fragment ID: {}",
+                                route.fragment_id
+                            )));
+                        }
+                        None
                     }
                     _ => None,
                 })
@@ -690,6 +741,159 @@ mod tests {
         let tokens = vec!["color-primary".to_string(), "spacing-m".to_string()];
         let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
         assert_eq!(protocol.tokens, tokens);
+        assert!(protocol.routes.is_empty());
+    }
+
+    #[test]
+    fn test_protobuf_route_fragment_roundtrip() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "main".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route("/profile/:id", "profile-page")],
+            },
+        );
+        fragments.insert(
+            "profile-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>Profile</h1>")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+        assert_eq!(protocol, decoded);
+
+        let frag = &decoded.fragments["main"].fragments[0];
+        match frag.fragment.as_ref() {
+            Some(web_ui_fragment::Fragment::Route(r)) => {
+                assert_eq!(r.path, "/profile/:id");
+                assert_eq!(r.fragment_id, "profile-page");
+            }
+            _ => panic!("expected route fragment"),
+        }
+    }
+
+    #[test]
+    fn test_protobuf_route_fragment_all_fields() {
+        let mut fragments = HashMap::new();
+        let route_frag = WebUiFragment {
+            fragment: Some(web_ui_fragment::Fragment::Route(WebUiFragmentRoute {
+                path: "/users/:id/posts/:postId".to_string(),
+                fragment_id: "user-posts".to_string(),
+                exact: true,
+                name: "user-posts".to_string(),
+            })),
+        };
+        fragments.insert(
+            "main".to_string(),
+            FragmentList {
+                fragments: vec![route_frag],
+            },
+        );
+        fragments.insert(
+            "user-posts".into(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("posts")],
+            },
+        );
+
+        let protocol = WebUIProtocol::new(fragments);
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+        assert_eq!(protocol, decoded);
+    }
+
+    #[test]
+    fn test_protobuf_route_registry_roundtrip() {
+        let mut routes = HashMap::new();
+        routes.insert(
+            "home".to_string(),
+            RouteRecord {
+                name: "home".to_string(),
+                path: "/".to_string(),
+                fragment_id: "home-page".to_string(),
+                exact: true,
+            },
+        );
+        routes.insert(
+            "profile".to_string(),
+            RouteRecord {
+                name: "profile".to_string(),
+                path: "/profile/:id".to_string(),
+                fragment_id: "profile-page".to_string(),
+                exact: false,
+            },
+        );
+
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "home-page".into(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("home")],
+            },
+        );
+        fragments.insert(
+            "profile-page".into(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("profile")],
+            },
+        );
+
+        let protocol = WebUIProtocol::with_routes(fragments, Vec::new(), routes);
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+        assert_eq!(protocol.routes.len(), decoded.routes.len());
+        assert_eq!(decoded.routes["home"].path, "/");
+        assert_eq!(decoded.routes["profile"].path, "/profile/:id");
+    }
+
+    #[test]
+    fn test_protobuf_route_validation_missing_fragment() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "main".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route("/test", "missing-fragment")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let buf = protocol.to_protobuf().expect("encode failed");
+        let result = WebUIProtocol::from_protobuf(&buf);
+        assert!(result.is_err());
+        if let Err(ProtocolError::Validation(msg)) = result {
+            assert!(msg.contains("missing-fragment"));
+        }
+    }
+
+    #[test]
+    fn test_protobuf_route_no_fragment_id_roundtrip() {
+        let mut fragments = HashMap::new();
+        let route_frag = WebUiFragment {
+            fragment: Some(web_ui_fragment::Fragment::Route(WebUiFragmentRoute {
+                path: "/old-path".to_string(),
+                ..Default::default()
+            })),
+        };
+        fragments.insert(
+            "main".to_string(),
+            FragmentList {
+                fragments: vec![route_frag],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+        assert_eq!(protocol, decoded);
+    }
+
+    #[test]
+    fn test_protobuf_backward_compat_no_routes() {
+        // Protocol without routes field should decode successfully with empty routes map
+        let protocol = WebUIProtocol::new(HashMap::new());
+        let bytes = protocol.to_protobuf().expect("encode failed");
+        let decoded = WebUIProtocol::from_protobuf(&bytes).expect("decode failed");
+        assert!(decoded.routes.is_empty());
     }
 
     #[test]

--- a/crates/webui-test-utils/src/lib.rs
+++ b/crates/webui-test-utils/src/lib.rs
@@ -365,6 +365,10 @@ fn format_fragment(frag: &webui_protocol::WebUIFragment) -> String {
         ),
         Some(Fragment::IfCond(i)) => format!("if(template={:?})", i.fragment_id),
         Some(Fragment::Plugin(p)) => format!("plugin(data={:?})", p.data),
+        Some(Fragment::Route(r)) => format!(
+            "route(path={:?}, fragment={:?}, name={:?})",
+            r.path, r.fragment_id, r.name
+        ),
         None => "None".to_string(),
     }
 }


### PR DESCRIPTION
### Why

WebUI needs server-side route matching so that when a request hits `/users/42`, 
the server knows which component to render without client JavaScript. Routes also 
need to be part of the compiled protocol so any host language (Rust, C#, Go, Python) 
can match routes and render the correct page — not just Node.js.

### What

Routes are now first-class citizens in the WebUI protocol:

- **Route fragments** — a new `WebUIFragmentRoute` message (path template, component 
  reference, exact flag, name) sits alongside existing fragment types. The server 
  walks the fragment graph, finds route fragments, and renders only the matched one.
- **Route registry** — a top-level `map<string, RouteRecord>` in the protocol gives 
  servers O(1) access to all declared routes without walking the fragment tree.
- **Component template map** — `map<string, string>` stores pre-built f-template HTML 
  keyed by tag name. During client navigation, the server sends only the templates 
  the client doesn't already have (tracked via an inventory bitmask).

### How

The HTML parser extracts `<route>` elements during build, converting them to 
`<webui-route>` custom elements in the FAST output. A new `route_parser` module 
walks the parsed HTML to build `RouteRecord` entries. The parser plugin trait gains 
`as_any()` downcasting so the build pipeline can extract FAST-specific data (f-templates) 
without coupling to concrete plugin types. The duplicated f-template generation logic 
in `take_component_templates()` was consolidated into a single `generate_f_template()` 
function.

The handler gets a no-op `Fragment::Route(_)` match arm so it compiles — full route 
rendering logic follows in next iteration in #92 
