### PR TITLE
feat(routing): add @microsoft/webui-router client-side routing package

### DIFF
--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@microsoft/webui-router",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Lightweight client-side router for WebUI apps. Intercepts navigation, matches routes locally or via server route-data, and hydrates components.",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --platform=browser && tsc --emitDeclarationOnly",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "esbuild": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/webui-router/src/index.ts
+++ b/packages/webui-router/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @microsoft/webui-router — DOM-native client-side router for WebUI apps.
+ *
+ * Routes are `<webui-route>` custom elements (transformed from `<route>` at build time).
+ * The router uses the Navigation API to intercept navigations and show/hide matching routes.
+ *
+ * @example
+ * ```ts
+ * import { Router } from '@microsoft/webui-router';
+ * Router.start();
+ * Router.navigate('/contacts/42');
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { Router, WebUIRouter, WebUIRouteElement } from './router.js';
+export type { RouterConfig, NavigationEvent } from './types.js';
+export { matchPath, parseTemplate, specificity } from './matcher.js';
+export type { Segment, PathMatch } from './matcher.js';

--- a/packages/webui-router/src/matcher.ts
+++ b/packages/webui-router/src/matcher.ts
@@ -1,0 +1,99 @@
+/**
+ * Iterative path template matching — no regex.
+ *
+ * Supports `:param`, `:param?` (optional), and `*splat` segments.
+ */
+
+/** A single parsed segment from a path template. */
+export type Segment =
+  | { type: 'literal'; value: string }
+  | { type: 'param'; name: string }
+  | { type: 'optional'; name: string }
+  | { type: 'splat'; name: string };
+
+/** Result of a successful path match. */
+export interface PathMatch {
+  params: Record<string, string>;
+}
+
+/** Parse a path template string into typed segments. */
+export function parseTemplate(path: string): Segment[] {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .map((seg): Segment => {
+      if (seg.startsWith(':')) {
+        const raw = seg.slice(1);
+        if (raw.endsWith('?')) {
+          return { type: 'optional', name: raw.slice(0, -1) };
+        }
+        return { type: 'param', name: raw };
+      }
+      if (seg.startsWith('*')) {
+        return { type: 'splat', name: seg.slice(1) || 'rest' };
+      }
+      return { type: 'literal', value: seg };
+    });
+}
+
+// Module-level cache: template strings are static, avoid re-parsing.
+const templateCache = new Map<string, Segment[]>();
+
+function getCachedSegments(template: string): Segment[] {
+  let segs = templateCache.get(template);
+  if (!segs) {
+    segs = parseTemplate(template);
+    templateCache.set(template, segs);
+  }
+  return segs;
+}
+
+/**
+ * Try to match a request path against a single route template.
+ *
+ * Returns bound parameters on success, `null` on failure.
+ */
+export function matchPath(
+  template: string,
+  requestPath: string,
+  exact: boolean,
+): PathMatch | null {
+  const segs = getCachedSegments(template);
+  const parts = requestPath.split('/').filter(Boolean);
+  const params: Record<string, string> = {};
+  let pi = 0;
+
+  for (let si = 0; si < segs.length; si++) {
+    const seg = segs[si];
+    switch (seg.type) {
+      case 'literal':
+        if (pi >= parts.length || parts[pi] !== seg.value) return null;
+        pi++;
+        break;
+      case 'param':
+        if (pi >= parts.length) return null;
+        params[seg.name] = decodeURIComponent(parts[pi++]);
+        break;
+      case 'optional':
+        if (pi < parts.length) {
+          params[seg.name] = decodeURIComponent(parts[pi++]);
+        }
+        break;
+      case 'splat':
+        params[seg.name] = parts.slice(pi).map(decodeURIComponent).join('/');
+        pi = parts.length;
+        break;
+    }
+  }
+
+  if (exact && pi < parts.length) return null;
+  return { params };
+}
+
+/**
+ * Count the number of literal (non-param) segments in a template.
+ * Used to rank matches by specificity.
+ */
+export function specificity(template: string): number {
+  return getCachedSegments(template).filter(s => s.type === 'literal').length;
+}

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -1,0 +1,370 @@
+/**
+ * Core router — uses the Navigation API to intercept navigations and
+ * activates/deactivates `<webui-route>` elements in the DOM tree.
+ *
+ * For routes with a `component` attribute, the router fetches a JSON
+ * partial from the server (state + f-templates), registers any new
+ * templates, instantiates the component, and mounts it into the route.
+ */
+
+import { matchPath, specificity } from './matcher.js';
+import type { RouterConfig, NavigationEvent } from './types.js';
+
+const ROUTE_SELECTOR = 'webui-route';
+
+// ── Route element helpers ────────────────────────────────────────
+
+function routePath(el: Element): string {
+  return el.getAttribute('path') ?? '';
+}
+
+function routeName(el: Element): string {
+  return el.getAttribute('name') ?? '';
+}
+
+function isExact(el: Element): boolean {
+  return el.hasAttribute('exact');
+}
+
+function routeComponent(el: Element): string {
+  return el.getAttribute('component') ?? '';
+}
+
+function activateRoute(el: HTMLElement, params: Record<string, string>): void {
+  (el as any)._routeParams = params;
+  el.setAttribute('active', '');
+  el.style.display = '';
+}
+
+function deactivateRoute(el: HTMLElement): void {
+  (el as any)._routeParams = {};
+  el.removeAttribute('active');
+  el.style.display = 'none';
+}
+
+function getRouteParams(el: Element): Record<string, string> {
+  return (el as any)._routeParams ?? {};
+}
+
+// ── WebUIRouteElement custom element ─────────────────────────────
+
+/** Custom element backing `<webui-route>`. Self-registers with the Router. */
+export class WebUIRouteElement extends HTMLElement {
+  get path(): string { return this.getAttribute('path') ?? ''; }
+  get routeName(): string { return this.getAttribute('name') ?? ''; }
+  get exact(): boolean { return this.hasAttribute('exact'); }
+  get component(): string { return this.getAttribute('component') ?? ''; }
+  get isActive(): boolean { return this.hasAttribute('active'); }
+  get params(): Record<string, string> { return (this as any)._routeParams ?? {}; }
+
+  connectedCallback(): void {
+    routeRegistry.add(this);
+  }
+
+  disconnectedCallback(): void {
+    routeRegistry.delete(this);
+  }
+
+  activate(params: Record<string, string> = {}): void {
+    (this as any)._routeParams = params;
+    this.setAttribute('active', '');
+    this.style.display = '';
+  }
+
+  deactivate(): void {
+    (this as any)._routeParams = {};
+    this.removeAttribute('active');
+    this.style.display = 'none';
+  }
+}
+
+/** Global registry — route elements self-register via connectedCallback. */
+const routeRegistry = new Set<WebUIRouteElement>();
+
+// ── Router ───────────────────────────────────────────────────────
+
+/** JSON partial response from the server. */
+interface PartialResponse {
+  state: Record<string, unknown>;
+  templates: string[];
+  path: string;
+}
+
+export class WebUIRouter {
+  private config: RouterConfig = {};
+  private started = false;
+  private cleanupFns: Array<() => void> = [];
+  private isInitialNavigation = true;
+  /** Hex string tracking which component templates are loaded. */
+  private inventory = '';
+  /** Opt-in lazy loaders: component tag → async import function. */
+  private loaders: Record<string, () => Promise<unknown>> = {};
+  /** Deduplication cache for in-flight / completed loader promises. */
+  private loaderPromises = new Map<string, Promise<void>>();
+
+  /** The name of the currently active leaf route. */
+  get activeRouteName(): string {
+    const el = this.findActiveLeaf();
+    return el ? routeName(el) : '';
+  }
+
+  /** The bound params of the currently active leaf route. */
+  get activeParams(): Record<string, string> {
+    const el = this.findActiveLeaf();
+    return el ? getRouteParams(el) : {};
+  }
+
+  /** Start the router. Lazily registers the `<webui-route>` custom element. */
+  start(config: RouterConfig = {}): void {
+    if (this.started) return;
+    this.started = true;
+    this.config = config;
+    this.loaders = config.loaders ?? {};
+
+    if (!customElements.get('webui-route')) {
+      customElements.define('webui-route', WebUIRouteElement);
+    }
+
+    this.inventory = this.buildInventoryFromDOM();
+
+    const nav = (window as any).navigation;
+    const handler = (event: any) => {
+      if (!event.canIntercept || event.hashChange) return;
+      const url = new URL(event.destination.url);
+      if (url.origin !== location.origin) return;
+      event.intercept({
+        handler: async () => {
+          await this.handleNavigation(this.stripBase(url.pathname));
+        },
+      });
+    };
+    nav.addEventListener('navigate', handler);
+    this.cleanupFns.push(() => nav.removeEventListener('navigate', handler));
+
+    this.handleNavigation(this.currentPath());
+  }
+
+  /** Navigate to a new path. */
+  navigate(path: string): void {
+    const fullPath = (this.config.basePath ?? '') + path;
+    (window as any).navigation.navigate(fullPath);
+  }
+
+  /** Navigate back. */
+  back(): void {
+    (window as any).navigation.back();
+  }
+
+  /** Tear down. */
+  destroy(): void {
+    this.loaderPromises.clear();
+    this.loaders = {};
+    for (const fn of this.cleanupFns) fn();
+    this.cleanupFns = [];
+    this.started = false;
+  }
+
+  // ── Route matching ──────────────────────────────────────────────
+
+  private async handleNavigation(pathname: string): Promise<void> {
+    const topRoutes = this.discoverTopRoutes();
+
+    if (topRoutes.length > 0) {
+      if (!this.isInitialNavigation) {
+        this.deactivateAll();
+      }
+      const matched = await this.activateMatching(topRoutes, pathname);
+      if (!matched && !this.isInitialNavigation) {
+        // No client route matched — fall through to server
+        window.location.href = (this.config.basePath ?? '') + pathname;
+        return;
+      }
+    }
+
+    this.isInitialNavigation = false;
+
+    const active = this.findActiveLeaf();
+    const detail: NavigationEvent = {
+      routeName: active ? routeName(active) : '',
+      params: active ? getRouteParams(active) : {},
+      path: pathname,
+    };
+    window.dispatchEvent(new CustomEvent('webui:route:navigated', { detail }));
+  }
+
+  private async activateMatching(routes: HTMLElement[], pathname: string): Promise<boolean> {
+    let best: { el: HTMLElement; params: Record<string, string>; score: number } | null = null;
+
+    for (const el of routes) {
+      const m = matchPath(routePath(el), pathname, isExact(el));
+      if (m) {
+        const score = specificity(routePath(el));
+        if (!best || score > best.score) {
+          best = { el, params: m.params, score };
+        }
+      }
+    }
+
+    if (!best) return false;
+
+    const comp = routeComponent(best.el);
+    if (comp) {
+      const existing = best.el.querySelector(comp);
+      const isSSRd = existing && existing.shadowRoot;
+
+      if (isSSRd && this.isInitialNavigation) {
+        // SSR'd content is already correct — don't load the component JS
+        // (which would trigger FAST hydration and wipe the SSR'd DOM).
+      } else if (!isSSRd) {
+        await this.ensureComponentLoaded(comp);
+        await this.fetchAndMount(best.el, comp, pathname, best.params);
+      } else if (typeof (existing as any).setInitialState === 'function') {
+        await this.ensureComponentLoaded(comp);
+        const fullPath = (this.config.basePath ?? '') + pathname;
+        const headers: Record<string, string> = { 'Accept': 'application/json' };
+        if (this.inventory) headers['X-WebUI-Inventory'] = this.inventory;
+        const resp = await fetch(fullPath, { headers });
+        if (resp.ok) {
+          const data = await resp.json();
+          (existing as any).setInitialState(data.state, best.params);
+        }
+      }
+    }
+
+    activateRoute(best.el, best.params);
+    return true;
+  }
+
+  // ── Fetch + Mount ──────────────────────────────────────────────
+
+  private async fetchAndMount(
+    routeEl: HTMLElement,
+    componentTag: string,
+    pathname: string,
+    params: Record<string, string> = {},
+  ): Promise<void> {
+    const fullPath = (this.config.basePath ?? '') + pathname;
+    const headers: Record<string, string> = { 'Accept': 'application/json' };
+    if (this.inventory) headers['X-WebUI-Inventory'] = this.inventory;
+    const resp = await fetch(fullPath, { headers });
+
+    if (!resp.ok) return;
+
+    const data = await resp.json() as PartialResponse & { inventory?: string };
+
+    if (data.inventory) {
+      this.updateInventory(data.inventory);
+    }
+
+    for (const tmpl of data.templates) {
+      const container = document.createElement('div');
+      container.innerHTML = tmpl;
+      while (container.firstChild) {
+        document.body.appendChild(container.firstChild);
+      }
+    }
+
+    const component = document.createElement(componentTag);
+    routeEl.textContent = '';
+    routeEl.appendChild(component);
+
+    // Ensure the component's JS module is loaded (lazy loader or already eager)
+    await this.ensureComponentLoaded(componentTag);
+    await customElements.whenDefined(componentTag);
+    if (typeof (component as any).setInitialState === 'function') {
+      (component as any).setInitialState(data.state, params);
+    }
+  }
+
+  // ── Lazy Loading ────────────────────────────────────────────────
+
+  /**
+   * Ensure a component's JS module is loaded. If a lazy loader is
+   * configured for this tag and the element isn't already registered,
+   * invoke the loader. The promise is cached so each loader runs at
+   * most once.
+   */
+  private async ensureComponentLoaded(tag: string): Promise<void> {
+    if (customElements.get(tag)) return;
+
+    const loader = this.loaders[tag];
+    if (!loader) return;
+
+    let promise = this.loaderPromises.get(tag);
+    if (!promise) {
+      promise = loader().then(() => {});
+      this.loaderPromises.set(tag, promise);
+    }
+    await promise;
+  }
+
+  // ── Discovery ───────────────────────────────────────────────────
+
+  private discoverTopRoutes(): HTMLElement[] {
+    const results: HTMLElement[] = [];
+    for (const el of routeRegistry) {
+      if (!el.parentElement?.closest(ROUTE_SELECTOR)) {
+        results.push(el);
+      }
+    }
+    return results;
+  }
+
+  private deactivateAll(): void {
+    for (const el of routeRegistry) {
+      if (el.hasAttribute('active')) {
+        deactivateRoute(el);
+      }
+    }
+  }
+
+  private findActiveLeaf(): HTMLElement | null {
+    let last: HTMLElement | null = null;
+    for (const el of routeRegistry) {
+      if (el.hasAttribute('active')) {
+        last = el;
+      }
+    }
+    return last;
+  }
+
+  private currentPath(): string {
+    return this.stripBase(window.location.pathname);
+  }
+
+  private stripBase(path: string): string {
+    const base = this.config.basePath ?? '';
+    if (base && path.startsWith(base)) return path.slice(base.length) || '/';
+    return path;
+  }
+
+  // ── Component Inventory ────────────────────────────────────────
+
+  private static componentBitPosition(name: string): number {
+    let hash = 0x811c9dc5 | 0;
+    for (let i = 0; i < name.length; i++) {
+      hash ^= name.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return ((hash >>> 0) % 256);
+  }
+
+  private buildInventoryFromDOM(): string {
+    const inv = new Uint8Array(32);
+    for (const tmpl of document.querySelectorAll('f-template[name]')) {
+      const name = tmpl.getAttribute('name');
+      if (name) {
+        const bit = WebUIRouter.componentBitPosition(name);
+        inv[bit >> 3] |= 1 << (bit & 7);
+      }
+    }
+    return Array.from(inv, b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  private updateInventory(serverInventory: string): void {
+    this.inventory = serverInventory;
+  }
+}
+
+/** Singleton router instance. */
+export const Router = new WebUIRouter();

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Public type definitions for @microsoft/webui-router.
+ */
+
+/** Configuration passed to `Router.start()`. */
+export interface RouterConfig {
+  /**
+   * Base path prepended to all route URLs.
+   * @default ""
+   */
+  basePath?: string;
+
+  /**
+   * Optional lazy-loading map: component tag → async loader function.
+   *
+   * When a route's `component` attribute matches a key in this map, the
+   * loader is called before the component is mounted. The loader should
+   * dynamically import the component's JS module (which registers the
+   * custom element via `defineAsync`).
+   *
+   * Components NOT in this map are assumed to be eagerly loaded (existing
+   * behavior). Each loader runs at most once — the promise is cached.
+   *
+   * @example
+   * ```ts
+   * Router.start({
+   *   loaders: {
+   *     'user-detail': () => import('./pages/user-detail.js'),
+   *     'user-settings': () => import('./pages/user-settings.js'),
+   *   },
+   * });
+   * ```
+   */
+  loaders?: Record<string, () => Promise<unknown>>;
+}
+
+/** Detail payload of the `webui:route:navigated` CustomEvent. */
+export interface NavigationEvent {
+  routeName: string;
+  params: Record<string, string>;
+  path: string;
+}

--- a/packages/webui-router/tsconfig.json
+++ b/packages/webui-router/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,24 @@ importers:
 
   examples/integration/node: {}
 
+  examples/server/dotnet/bin/Debug/net10.0:
+    devDependencies:
+      '@microsoft/fast-element':
+        specifier: 'catalog:'
+        version: 2.10.1
+      '@microsoft/fast-html':
+        specifier: 'catalog:'
+        version: 1.0.0-alpha.38(@microsoft/fast-element@2.10.1)
+      '@microsoft/webui-router':
+        specifier: workspace:*
+        version: link:../../../../../../packages/webui-router
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/webui:
     devDependencies:
       '@types/node':
@@ -210,6 +228,15 @@ importers:
   packages/webui-linux-arm64: {}
 
   packages/webui-linux-x64: {}
+
+  packages/webui-router:
+    devDependencies:
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/webui-win32-arm64: {}
 


### PR DESCRIPTION
### Why

The server renders the correct page on initial load (PR3), but after that the 
user is stuck with full page reloads. A client-side router lets users navigate 
between routes instantly — the shell (nav, sidebar) stays in place and only the 
route content changes. This is what makes a WebUI app feel like a single-page 
application while keeping the SSR-first architecture.

### What

A new `@microsoft/webui-router` TypeScript package that bridges the gap between 
server-rendered pages and client-side navigation:

- **Navigation API interception** — clicks on `<a>` tags are intercepted via the 
  browser's Navigation API. The router fetches a JSON partial from the server 
  (state + templates) instead of reloading the entire page.
- **Self-registering `<webui-route>` element** — each route element registers 
  itself via `connectedCallback`, eliminating DOM scanning entirely. Works 
  across shadow DOM boundaries without MutationObservers or `querySelectorAll('*')`.
- **Opt-in lazy loading** — a `loaders` config maps component tags to dynamic 
  `import()` calls. Components not in the map are assumed eagerly loaded. Each 
  loader fires at most once (promise is cached). On SSR'd initial load, the 
  loader is skipped to preserve the server-rendered DOM.
- **Iterative path matching** — supports `:param`, `:param?`, and `*splat` with 
  specificity ranking. Parsed templates are cached in a module-level `Map` to 
  avoid re-parsing on every navigation.
- **SSR-safe** — on page refresh, the router detects that the matched route's 
  component already has a declarative shadow root and preserves it instead of 
  loading JS that would trigger FAST re-hydration with empty state.

### How

The package is a single ESM bundle (`esbuild`) with TypeScript declarations. 
Three modules: `types.ts` (RouterConfig, NavigationEvent), `matcher.ts` 
(parseTemplate, matchPath, specificity with template cache), and `router.ts` 
(WebUIRouteElement custom element, WebUIRouter class, singleton Router instance). 
The router starts after FAST-HTML hydration completes and registers a Navigation 
API listener for all subsequent navigations.