### PR TITLE
feat(parser): Add full condition expression support for boolean attributes

### DIFF
--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -829,9 +829,12 @@ impl HtmlParser {
         fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         if let Some(val) = value {
-            if let Some(signal_name) = Self::extract_single_handlebars(val) {
-                // Valid boolean attribute — emit as attribute fragment with conditionTree
-                let condition = ConditionExpr::identifier(&signal_name);
+            if let Some(expr_str) = Self::extract_single_handlebars(val) {
+                // Parse as a full condition expression (supports predicates like page == 'dashboard')
+                let condition = self
+                    .condition_parser
+                    .parse(&expr_str)
+                    .unwrap_or_else(|_| ConditionExpr::identifier(&expr_str));
                 self.add_fragment(WebUIFragment::attribute_boolean(name, condition), fragments);
                 return Ok(());
             }
@@ -2136,6 +2139,65 @@ mod tests {
 
         // Boolean attribute is silently dropped
         assert_fragments!(fragments, [raw("<button>Click</button>"),]);
+    }
+
+    #[test]
+    fn test_attribute_boolean_predicate_equal() {
+        // Boolean attribute with == predicate expression
+        let (fragments, _) =
+            parse_and_get_fragments(r#"<div ?data-active="{{page == 'dashboard'}}">X</div>"#);
+        assert_fragments!(
+            fragments,
+            [
+                raw("<div"),
+                bool_attr_predicate("data-active", "page", 3, "'dashboard'"),
+                raw(">X</div>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_attribute_boolean_predicate_greater_than() {
+        // Boolean attribute with > predicate expression
+        let (fragments, _) = parse_and_get_fragments(r#"<span ?hidden="{{num > 9}}">X</span>"#);
+        assert_fragments!(
+            fragments,
+            [
+                raw("<span"),
+                bool_attr_predicate("hidden", "num", 1, "9"),
+                raw(">X</span>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_attribute_boolean_predicate_not_equal() {
+        // Boolean attribute with != predicate expression
+        let (fragments, _) =
+            parse_and_get_fragments(r#"<a ?data-active="{{status != 'inactive'}}">X</a>"#);
+        assert_fragments!(
+            fragments,
+            [
+                raw("<a"),
+                bool_attr_predicate("data-active", "status", 4, "'inactive'"),
+                raw(">X</a>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_attribute_boolean_negation() {
+        // Boolean attribute with negated expression
+        let (fragments, _) =
+            parse_and_get_fragments(r#"<button ?disabled="{{!isReady}}">X</button>"#);
+        assert_fragments!(
+            fragments,
+            [
+                raw("<button"),
+                bool_attr_not("disabled", "isReady"),
+                raw(">X</button>"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/webui-test-utils/src/lib.rs
+++ b/crates/webui-test-utils/src/lib.rs
@@ -87,6 +87,10 @@ pub struct AttrMatcher {
     pub attr_skip: bool,
     pub raw_value: bool,
     pub bool_signal: Option<String>,
+    /// Match a boolean attribute with a predicate condition (left, op, right).
+    pub bool_predicate: Option<(String, i32, String)>,
+    /// Match a boolean attribute with a negation condition (inner identifier).
+    pub bool_not: Option<String>,
 }
 
 // ── Matcher constructors ────────────────────────────────────────────
@@ -166,6 +170,24 @@ pub fn bool_attr_start(name: &str, signal: &str) -> FragmentMatcher {
         name: name.to_string(),
         bool_signal: Some(signal.to_string()),
         attr_start: true,
+        ..Default::default()
+    })
+}
+
+/// Match a boolean attribute with a predicate condition (e.g., `?disabled={{count > 5}}`).
+pub fn bool_attr_predicate(name: &str, left: &str, op: i32, right: &str) -> FragmentMatcher {
+    FragmentMatcher::Attribute(AttrMatcher {
+        name: name.to_string(),
+        bool_predicate: Some((left.to_string(), op, right.to_string())),
+        ..Default::default()
+    })
+}
+
+/// Match a boolean attribute with a negated condition (e.g., `?disabled={{!isReady}}`).
+pub fn bool_attr_not(name: &str, inner: &str) -> FragmentMatcher {
+    FragmentMatcher::Attribute(AttrMatcher {
+        name: name.to_string(),
+        bool_not: Some(inner.to_string()),
         ..Default::default()
     })
 }
@@ -304,6 +326,62 @@ pub fn assert_fragment_list(
                             "Fragment[{}]: expected identifier condition, got {:?}",
                             i, other
                         ),
+                    }
+                }
+                if let Some((ref left, op, ref right)) = m.bool_predicate {
+                    let cond = a
+                        .condition_tree
+                        .as_ref()
+                        .unwrap_or_else(|| panic!("Fragment[{}]: expected condition_tree", i));
+                    match cond.expr.as_ref() {
+                        Some(webui_protocol::condition_expr::Expr::Predicate(pred)) => {
+                            assert_eq!(
+                                pred.left, *left,
+                                "Fragment[{}]: predicate left mismatch",
+                                i
+                            );
+                            assert_eq!(
+                                pred.operator, op,
+                                "Fragment[{}]: predicate operator mismatch",
+                                i
+                            );
+                            assert_eq!(
+                                pred.right, *right,
+                                "Fragment[{}]: predicate right mismatch",
+                                i
+                            );
+                        }
+                        other => panic!(
+                            "Fragment[{}]: expected predicate condition, got {:?}",
+                            i, other
+                        ),
+                    }
+                }
+                if let Some(ref inner) = m.bool_not {
+                    let cond = a
+                        .condition_tree
+                        .as_ref()
+                        .unwrap_or_else(|| panic!("Fragment[{}]: expected condition_tree", i));
+                    match cond.expr.as_ref() {
+                        Some(webui_protocol::condition_expr::Expr::Not(not_cond)) => {
+                            let inner_cond = not_cond.condition.as_ref().unwrap_or_else(|| {
+                                panic!("Fragment[{}]: not condition missing inner", i)
+                            });
+                            match inner_cond.expr.as_ref() {
+                                Some(webui_protocol::condition_expr::Expr::Identifier(id)) => {
+                                    assert_eq!(
+                                        id.value, *inner,
+                                        "Fragment[{}]: not inner identifier mismatch",
+                                        i
+                                    );
+                                }
+                                other => panic!(
+                                    "Fragment[{}]: expected identifier inside not, got {:?}",
+                                    i, other
+                                ),
+                            }
+                        }
+                        other => panic!("Fragment[{}]: expected not condition, got {:?}", i, other),
                     }
                 }
             }


### PR DESCRIPTION
Upgrade boolean attribute parsing from simple identifier extraction to full condition expression parsing via the existing condition_parser. This attribute values, falling back to a plain identifier when parsing fails.

Add comprehensive test coverage in webui-parser for:
- Predicate expressions: `?data-active="{{page == 'dashboard'}}"`
- Greater-than comparisons: `?hidden="{{num > 9}}"`
- Not-equal predicates: `?data-active="{{status != 'inactive'}}"`

Extend webui-test-utils with `bool_attr_predicate` and `bool_attr_not` matchers and their corresponding assertion logic for predicate and negation condition trees.