### PR TITLE
perf: make handler render take &self for concurrent throughput

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -376,8 +376,8 @@ Injects FAST-HTML hydration comment markers for client-side re-hydration:
 
 **Usage:**
 ```rust
-let mut handler = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
-handler.handle(&protocol, &state, &mut writer)?;
+let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
+handler.handle(&protocol, &state, &options, &mut writer)?;
 ```
 ### Fragment Processing
 - **Raw fragments:** Write value directly to output

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -427,8 +427,8 @@ fn build_and_render(
 
     // Render to memory
     let mut writer = MemoryWriter::with_capacity(4096);
-    let mut handler = match config.app_args.plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new())),
+    let handler = match config.app_args.plugin.as_deref() {
+        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
         _ => WebUIHandler::new(),
     };
     handler.handle(
@@ -539,8 +539,8 @@ async fn render_page_response(
     };
 
     let mut writer = MemoryWriter::with_capacity(4096);
-    let mut handler = match plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new())),
+    let handler = match plugin.as_deref() {
+        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
         _ => WebUIHandler::new(),
     };
 

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn webui_handler_create_with_plugin(plugin_id: *const c_ch
         WebUIHandler::new()
     } else {
         match CStr::from_ptr(plugin_id).to_str() {
-            Ok("fast") => WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new())),
+            Ok("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
             Ok(unknown) => {
                 set_last_error(format!("unknown plugin: {unknown}"));
                 return std::ptr::null_mut();
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn webui_handler_render(
     }
 
     // SAFETY: caller guarantees handler_ptr is valid and exclusively owned.
-    let context = &mut *(handler_ptr as *mut HandlerContext);
+    let context = &*(handler_ptr as *const HandlerContext);
 
     // SAFETY: caller guarantees protocol_data points to protocol_len valid bytes.
     let protocol_bytes = std::slice::from_raw_parts(protocol_data, protocol_len);
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn webui_render(
     };
 
     // --- Render --------------------------------------------------------------
-    let mut handler = WebUIHandler::new();
+    let handler = WebUIHandler::new();
     let mut writer = StringResponseWriter::new();
 
     match handler.render(

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -158,7 +158,7 @@ fn handler_plugin_fast_bench(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(baseline_writer.len() as u64));
 
     group.bench_function(BenchmarkId::new("render", "without_plugin"), |b| {
-        let mut handler = WebUIHandler::new();
+        let handler = WebUIHandler::new();
         let mut writer = BenchWriter::new(16 * 1024);
 
         b.iter(|| {
@@ -175,7 +175,7 @@ fn handler_plugin_fast_bench(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("render", "with_fast_plugin"), |b| {
-        let mut handler = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
+        let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
         let mut writer = BenchWriter::new(24 * 1024);
 
         b.iter(|| {
@@ -202,7 +202,7 @@ fn handler_loop_scaling_bench(c: &mut Criterion) {
         let state = build_state(count);
 
         // Pre-render to measure output size for throughput
-        let mut handler = WebUIHandler::new();
+        let handler = WebUIHandler::new();
         let mut writer = BenchWriter::new(count * 80 + 1024);
         handler
             .handle(
@@ -311,7 +311,7 @@ fn handler_condition_variety_bench(c: &mut Criterion) {
     let protocol = build_condition_protocol();
 
     let state_true = build_condition_state();
-    let mut handler = WebUIHandler::new();
+    let handler = WebUIHandler::new();
     let mut writer = BenchWriter::new(1024);
     handler
         .handle(
@@ -424,7 +424,7 @@ fn handler_nested_components_bench(c: &mut Criterion) {
     let protocol = build_nested_component_protocol();
     let state = build_state(50);
 
-    let mut handler = WebUIHandler::new();
+    let handler = WebUIHandler::new();
     let mut writer = BenchWriter::new(8 * 1024);
     handler
         .handle(

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -77,8 +77,11 @@ impl<'a> RenderOptions<'a> {
 }
 
 /// The main WebUI handler that processes protocols and renders them.
+///
+/// The handler is stateless: plugin instances are created per-render from
+/// the stored factory function, allowing concurrent renders with `&self`.
 pub struct WebUIHandler {
-    plugin: Option<Box<dyn HandlerPlugin>>,
+    plugin_factory: Option<fn() -> Box<dyn HandlerPlugin>>,
 }
 
 /// Context object for processing WebUI fragments
@@ -95,6 +98,8 @@ struct WebUIProcessContext<'a> {
     request_path: String,
     /// Component names visited during rendering (for selective f-template emission).
     rendered_components: HashSet<String>,
+    /// Per-render plugin instance created from the handler's factory.
+    plugin: Option<Box<dyn HandlerPlugin>>,
 }
 
 /// Convert hyphenated name to camelCase (e.g., "data-title" → "dataTitle").
@@ -229,13 +234,18 @@ fn find_best_route_match(fragments: &[WebUIFragment], request_path: &str) -> Opt
 impl WebUIHandler {
     /// Create a new WebUI handler with no plugin.
     pub fn new() -> Self {
-        Self { plugin: None }
+        Self {
+            plugin_factory: None,
+        }
     }
 
-    /// Create a new WebUI handler with a plugin.
-    pub fn with_plugin(plugin: Box<dyn HandlerPlugin>) -> Self {
+    /// Create a new WebUI handler with a plugin factory.
+    ///
+    /// Each render call creates a fresh plugin instance from the factory,
+    /// enabling concurrent renders with `&self`.
+    pub fn with_plugin(factory: fn() -> Box<dyn HandlerPlugin>) -> Self {
         Self {
-            plugin: Some(plugin),
+            plugin_factory: Some(factory),
         }
     }
 
@@ -244,7 +254,7 @@ impl WebUIHandler {
     /// `options.entry_id` selects the fragment to start rendering from.
     /// `options.request_path` controls server-side route matching.
     pub fn handle(
-        &mut self,
+        &self,
         protocol: &WebUIProtocol,
         state: &Value,
         options: &RenderOptions<'_>,
@@ -263,6 +273,7 @@ impl WebUIHandler {
             component_attrs: HashMap::new(),
             request_path: options.request_path.to_string(),
             rendered_components: HashSet::new(),
+            plugin: self.plugin_factory.map(|f| f()),
         };
         self.process_fragment_id(options.entry_id, &mut context)?;
 
@@ -278,7 +289,7 @@ impl WebUIHandler {
     /// normal page render flow (e.g., re-rendering a route component with
     /// modified state).
     pub fn handle_as_component(
-        &mut self,
+        &self,
         protocol: &WebUIProtocol,
         state: &Value,
         entry_id: &str,
@@ -286,10 +297,6 @@ impl WebUIHandler {
     ) -> Result<()> {
         if !protocol.fragments.contains_key(entry_id) {
             return Err(HandlerError::MissingFragment(entry_id.to_string()));
-        }
-
-        if let Some(p) = &mut self.plugin {
-            p.push_scope();
         }
 
         let mut context = WebUIProcessContext {
@@ -301,10 +308,16 @@ impl WebUIHandler {
             component_attrs: HashMap::new(),
             request_path: String::new(),
             rendered_components: HashSet::new(),
+            plugin: self.plugin_factory.map(|f| f()),
         };
+
+        if let Some(p) = &mut context.plugin {
+            p.push_scope();
+        }
+
         self.process_fragment_id(entry_id, &mut context)?;
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.pop_scope();
         }
 
@@ -318,7 +331,7 @@ impl WebUIHandler {
     /// The `context` parameter contains scope-local variables that are accessible during rendering,
     /// such as loop iteration variables. This is separate from the global `state`.
     fn process_fragment_id(
-        &mut self,
+        &self,
         fragment_id: &str,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -334,7 +347,7 @@ impl WebUIHandler {
     /// The `context` maintains scope-specific variables that can be accessed by fragments
     /// during rendering, while `state` contains the global application state.
     fn process_fragment(
-        &mut self,
+        &self,
         fragments: &[WebUIFragment],
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -363,7 +376,7 @@ impl WebUIHandler {
                     self.process_attribute(attr, context)?;
                 }
                 Some(Fragment::Plugin(plugin_frag)) => {
-                    if let Some(p) = &mut self.plugin {
+                    if let Some(p) = &mut context.plugin {
                         p.on_plugin_data(&plugin_frag.data, context.writer)?;
                     }
                 }
@@ -437,7 +450,7 @@ impl WebUIHandler {
 
     /// Process a component fragment.
     fn process_component(
-        &mut self,
+        &self,
         component: &webui_protocol::WebUIFragmentComponent,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -453,13 +466,13 @@ impl WebUIHandler {
         // Component gets accumulated attrs as its local vars
         context.local_vars = saved_component_attrs;
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.push_scope();
         }
 
         self.process_fragment_id(&component.fragment_id, context)?;
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.pop_scope();
         }
 
@@ -526,7 +539,7 @@ impl WebUIHandler {
     /// This allows nested templates to access both the loop variable and any parent context.
     /// Example: `for item in items` makes "item" available in the loop body.
     fn process_for_loop(
-        &mut self,
+        &self,
         for_loop: &webui_protocol::WebUIFragmentFor,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -545,13 +558,13 @@ impl WebUIHandler {
             None => Vec::new(),
         };
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_start(&for_loop.fragment_id, context.writer)?;
         }
 
         let item_name = &for_loop.item;
         for (i, item) in items.into_iter().enumerate() {
-            if let Some(p) = &mut self.plugin {
+            if let Some(p) = &mut context.plugin {
                 p.on_repeat_item_start(i, context.writer)?;
                 p.push_scope();
             }
@@ -568,13 +581,13 @@ impl WebUIHandler {
                 }
             }
 
-            if let Some(p) = &mut self.plugin {
+            if let Some(p) = &mut context.plugin {
                 p.pop_scope();
                 p.on_repeat_item_end(i, context.writer)?;
             }
         }
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_end(&for_loop.fragment_id, context.writer)?;
         }
 
@@ -587,13 +600,13 @@ impl WebUIHandler {
     /// This prioritization allows local variables (like loop items) to override global state.
     /// If the value is not found in either scope, an empty string is returned.
     fn process_signal(
-        &mut self,
+        &self,
         signal: &webui_protocol::WebUIFragmentSignal,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
         // Hook: emit plugin content (e.g., f-templates) before body_end
         if signal.raw && signal.value == "body_end" {
-            if let Some(p) = &mut self.plugin {
+            if let Some(p) = &mut context.plugin {
                 p.on_render_complete(
                     context.protocol,
                     &context.rendered_components,
@@ -602,7 +615,7 @@ impl WebUIHandler {
             }
         }
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_start(&signal.value, context.writer)?;
         }
 
@@ -610,7 +623,7 @@ impl WebUIHandler {
             self.write_signal_value(&value, signal.raw, context.writer)?;
         }
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_end(&signal.value, context.writer)?;
         }
         Ok(())
@@ -642,7 +655,7 @@ impl WebUIHandler {
 
     /// Process an if condition fragment.
     fn process_if(
-        &mut self,
+        &self,
         if_cond: &webui_protocol::WebUIFragmentIf,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -652,23 +665,23 @@ impl WebUIHandler {
             .ok_or_else(|| HandlerError::Rendering("If fragment missing condition".to_string()))?;
         let condition_met = self.evaluate_condition(condition, context)?;
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_start(&if_cond.fragment_id, context.writer)?;
         }
 
         if condition_met {
-            if let Some(p) = &mut self.plugin {
+            if let Some(p) = &mut context.plugin {
                 p.push_scope();
             }
 
             self.process_fragment_id(&if_cond.fragment_id, context)?;
 
-            if let Some(p) = &mut self.plugin {
+            if let Some(p) = &mut context.plugin {
                 p.pop_scope();
             }
         }
 
-        if let Some(p) = &mut self.plugin {
+        if let Some(p) = &mut context.plugin {
             p.on_binding_end(&if_cond.fragment_id, context.writer)?;
         }
 
@@ -677,7 +690,7 @@ impl WebUIHandler {
 
     /// Process an attribute fragment by rendering the attribute name/value pair.
     fn process_attribute(
-        &mut self,
+        &self,
         attr: &webui_protocol::WebUIFragmentAttribute,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
@@ -771,7 +784,7 @@ impl WebUIHandler {
 
     /// Render a template attribute's fragments into a raw (unescaped) string.
     fn render_template_attr_value(
-        &mut self,
+        &self,
         template_id: &str,
         context: &WebUIProcessContext,
     ) -> Result<String> {
@@ -802,7 +815,7 @@ impl WebUIHandler {
     ///
     /// Like `handle()` but does not call `writer.end()`.
     pub fn render(
-        &mut self,
+        &self,
         protocol: &WebUIProtocol,
         state: &Value,
         options: &RenderOptions<'_>,
@@ -817,6 +830,7 @@ impl WebUIHandler {
             component_attrs: HashMap::new(),
             request_path: options.request_path.to_string(),
             rendered_components: HashSet::new(),
+            plugin: self.plugin_factory.map(|f| f()),
         };
 
         self.process_fragment_id(options.entry_id, &mut context)?;
@@ -848,7 +862,7 @@ pub fn handle(
     options: &RenderOptions<'_>,
     writer: &mut dyn ResponseWriter,
 ) -> Result<()> {
-    let mut handler = WebUIHandler::new();
+    let handler = WebUIHandler::new();
     handler.handle(protocol, state, options, writer)
 }
 

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -419,10 +419,10 @@ mod tests {
     fn render_with_plugin(
         protocol: &WebUIProtocol,
         state: &serde_json::Value,
-        plugin: Box<dyn HandlerPlugin>,
+        factory: fn() -> Box<dyn HandlerPlugin>,
     ) -> String {
         let mut writer = TestWriter::new();
-        let mut handler = WebUIHandler::with_plugin(plugin);
+        let handler = WebUIHandler::with_plugin(factory);
         handler
             .handle(
                 protocol,
@@ -436,7 +436,7 @@ mod tests {
 
     fn render_no_plugin(protocol: &WebUIProtocol, state: &serde_json::Value) -> String {
         let mut writer = TestWriter::new();
-        let mut handler = WebUIHandler::new();
+        let handler = WebUIHandler::new();
         handler
             .handle(
                 protocol,
@@ -483,7 +483,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "Alice"});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Root scope is disabled — no markers at root level
         assert_eq!(output, "<p>Alice</p>");
     }
@@ -505,7 +505,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": ["a", "b"]});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no for-loop binding or repeat item markers
         assert!(!output.contains("$$for-1$$"));
         assert!(!output.contains("fe-repeat"));
@@ -536,13 +536,13 @@ mod tests {
 
         // True case — root scope disabled, no markers; content still rendered
         let state = test_json!({"show": true});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         assert!(output.contains("<p>Visible</p>"));
         assert!(!output.contains("fe-b"));
 
         // False case — no content, no markers
         let state = test_json!({"show": false});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         assert!(!output.contains("<p>Visible</p>"));
         assert!(!output.contains("fe-b"));
     }
@@ -568,7 +568,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"before": "B", "inner": "I", "after": "A"});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no markers for root-level signals
         assert!(!output.contains("$$before$$"));
         assert!(!output.contains("$$after$$"));
@@ -594,7 +594,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"itemId": "42", "itemTitle": "Hello"});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Root scope disabled — no plugin data markers
         assert!(!output.contains("data-fe-c"));
         assert!(output.contains("id=\"42\""));
@@ -648,7 +648,7 @@ mod tests {
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": "World", "content": "CONTENT"});
 
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
 
         // Hydration markers should exist in the output (around component content)
         assert!(
@@ -783,7 +783,7 @@ mod tests {
             ]
         });
 
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
 
         let expected = "\
             <div>\
@@ -860,7 +860,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Hydration comments must be emitted even when signal is not found in state
         assert!(
             output.contains("<!--fe-b$$start$$0$$missing_field$$fe-b-->"),
@@ -903,7 +903,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         // Hydration comments must be emitted even when collection is missing from state
         assert!(
             output.contains("<!--fe-b$$start$$0$$loop-body$$fe-b-->"),
@@ -936,7 +936,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"name": ""});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         assert!(
             output.contains("<!--fe-b$$start$$0$$name$$fe-b-->"),
             "Expected binding start marker for empty string signal, got: {output}"
@@ -975,7 +975,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
         let state = test_json!({"items": []});
-        let output = render_with_plugin(&protocol, &state, Box::new(FastHydrationPlugin::new()));
+        let output = render_with_plugin(&protocol, &state, || Box::new(FastHydrationPlugin::new()));
         assert!(
             output.contains("<!--fe-b$$start$$0$$loop-body$$fe-b-->"),
             "Expected binding start marker for empty collection, got: {output}"

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -192,8 +192,8 @@ pub fn render(
         .map_err(|e| NapiError::from_reason(format!("State JSON error: {e}")))?;
 
     let mut writer = CallbackWriter::new(&on_chunk);
-    let mut handler = match plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new())),
+    let handler = match plugin.as_deref() {
+        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
         Some(unknown) => {
             return Err(NapiError::from_reason(format!("Unknown plugin: {unknown}")));
         }
@@ -235,7 +235,7 @@ mod tests {
         let state: Value = serde_json::from_str(state_json).map_err(|e| e.to_string())?;
 
         let mut output = String::with_capacity(1024);
-        let mut handler = WebUIHandler::new();
+        let handler = WebUIHandler::new();
 
         struct StringWriter<'a> {
             output: &'a mut String,

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -120,9 +120,9 @@ fn build_protocol_inner(
 /// Create a handler with an optional plugin.
 fn create_handler(plugin: Option<&str>) -> Result<WebUIHandler, BuildError> {
     match plugin {
-        Some("fast") => Ok(WebUIHandler::with_plugin(Box::new(
-            FastHydrationPlugin::new(),
-        ))),
+        Some("fast") => Ok(WebUIHandler::with_plugin(|| {
+            Box::new(FastHydrationPlugin::new())
+        })),
         Some(unknown) => Err(BuildError::Render(format!("Unknown plugin: {unknown}"))),
         None => Ok(WebUIHandler::new()),
     }
@@ -141,7 +141,7 @@ fn render_inner(
         serde_json::from_str(state_json).map_err(|e| BuildError::State(e.to_string()))?;
 
     let mut writer = StringWriter::with_capacity(1024);
-    let mut handler = create_handler(plugin)?;
+    let handler = create_handler(plugin)?;
     handler
         .render(
             &protocol,
@@ -167,7 +167,7 @@ pub(crate) fn build_and_render_inner(
         serde_json::from_str(state_json).map_err(|e| BuildError::State(e.to_string()))?;
 
     let mut writer = StringWriter::with_capacity(1024);
-    let mut handler = create_handler(None)?;
+    let handler = create_handler(None)?;
     handler
         .render(
             &protocol,

--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -315,7 +315,7 @@ fn handler_rendering_bench(c: &mut Criterion) {
 
     for (count, state) in &fixture.states {
         // Pre-render to measure output size for throughput calculation
-        let mut handler = WebUIHandler::new();
+        let handler = WebUIHandler::new();
         let mut warmup_writer = BenchWriter::new(count * BYTES_PER_CONTACT + BASE_HTML_BYTES);
         handler
             .handle(
@@ -328,7 +328,7 @@ fn handler_rendering_bench(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(warmup_writer.len() as u64));
 
         group.bench_with_input(BenchmarkId::new("contacts", count), state, |b, state| {
-            let mut h = WebUIHandler::new();
+            let h = WebUIHandler::new();
             let mut w = BenchWriter::new(warmup_writer.len() + WRITER_HEADROOM);
 
             b.iter(|| {
@@ -357,7 +357,7 @@ fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
     group.measurement_time(MEASUREMENT_TIME);
 
     for (count, state) in &fixture.states {
-        let mut handler = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
+        let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
         let mut warmup_writer =
             BenchWriter::new(count * BYTES_PER_CONTACT_WITH_PLUGIN + BASE_HTML_BYTES_WITH_PLUGIN);
         handler
@@ -373,7 +373,7 @@ fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(warmup_writer.len() as u64));
 
         group.bench_with_input(BenchmarkId::new("contacts", count), state, |b, state| {
-            let mut h = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
+            let h = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
             let mut w = BenchWriter::new(warmup_writer.len() + WRITER_HEADROOM);
 
             b.iter(|| {
@@ -500,8 +500,8 @@ fn collect_render_samples(
     use_plugin: bool,
 ) -> SummaryRow {
     // Warm up — also measures output size
-    let mut handler = if use_plugin {
-        WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()))
+    let handler = if use_plugin {
+        WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()))
     } else {
         WebUIHandler::new()
     };

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -41,8 +41,8 @@ When `--plugin=fast` is specified:
 use webui_handler::plugin::FastHydrationPlugin;
 use webui::WebUIHandler;
 
-let mut handler = WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new()));
-handler.handle(&protocol, &state, &mut writer)?;
+let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
+handler.handle(&protocol, &state, &options, &mut writer)?;
 ```
 
 ```js [Node.js]

--- a/examples/integration/rust/src/main.rs
+++ b/examples/integration/rust/src/main.rs
@@ -56,8 +56,8 @@ fn main() -> Result<()> {
     let state: serde_json::Value =
         serde_json::from_str(&state_json).context("Failed to parse state JSON")?;
 
-    let mut handler = match plugin_name {
-        Some("fast") => WebUIHandler::with_plugin(Box::new(FastHydrationPlugin::new())),
+    let handler = match plugin_name {
+        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
         Some(unknown) => anyhow::bail!("Unknown plugin: {unknown}"),
         None => WebUIHandler::new(),
     };

--- a/examples/integration/ssr-performance-showdown/src/main.rs
+++ b/examples/integration/ssr-performance-showdown/src/main.rs
@@ -99,7 +99,7 @@ async fn handle_index(protocol: web::Data<WebUIProtocol>) -> HttpResponse {
     let state = serde_json::Value::Object(state_map);
 
     let mut writer = MemoryWriter::with_capacity(256 * 1024);
-    let mut handler = WebUIHandler::new();
+    let handler = WebUIHandler::new();
 
     if let Err(e) = handler.handle(
         &protocol,


### PR DESCRIPTION
Replace plugin instance with plugin factory (fn() -> Box<dyn HandlerPlugin>) so each render creates per-call plugin state in the process context. This makes handle(), handle_as_component(), and render() take &self instead of &mut self, enabling WebUIHandler to be Send + Sync with zero contention across threads.

```

============================= WebUI Contact Book — Performance Summary =============================
Story                     Iters   Avg(ms)       Min       Max   Dev%       P50       P90       P99       IQR     Bytes
----------------------------------------------------------------------------------------------------
ProtocolParse            133790      0.02      0.02      0.21  10.2%      0.02      0.02      0.02      0.00     28538
Render/10                 78755      0.04      0.03      0.32   7.7%      0.04      0.04      0.05      0.00     25960
Render/100                13693      0.22      0.19      1.91   8.5%      0.22      0.23      0.26      0.01     56397
Render/1000                1449      2.07      1.88      2.43   3.4%      2.06      2.14      2.37      0.04    362930
RenderFAST/10             72408      0.04      0.04      0.12   7.5%      0.04      0.04      0.05      0.00     31052
RenderFAST/100            13233      0.23      0.19      1.88  10.4%      0.22      0.24      0.27      0.01     68149
RenderFAST/1000            1414      2.12      1.91      4.79   5.5%      2.11      2.22      2.44      0.06    443082
====================================================================================================
IQR = P75 − P25 (lower means more consistent)
All times in milliseconds
====================================================================================================
```



