### PR TITLE
fix: improve serve.rs proxy headers, watcher retry, and build validation

### DIFF
--- a/crates/webui-cli/src/commands/build.rs
+++ b/crates/webui-cli/src/commands/build.rs
@@ -42,6 +42,9 @@ fn run(args: &BuildArgs) -> Result<()> {
     let app = app_input
         .canonicalize()
         .with_context(|| format!("App folder not found: {}", args.app_args.app.display()))?;
+    if !app.is_dir() {
+        anyhow::bail!("App path is not a directory: {}", app.display());
+    }
 
     output::header("WebUI Build");
     output::field("App", &app.display());
@@ -231,6 +234,19 @@ mod tests {
         let out_dir = TempDir::new().unwrap();
         let result = build(Path::new("/nonexistent/path"), out_dir.path(), "index.html");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_app_path_must_be_directory() {
+        let file_dir = TempDir::new().unwrap();
+        let app_file = file_dir.path().join("not-a-directory.html");
+        fs::write(&app_file, "<h1>Hello</h1>").unwrap();
+        let out_dir = TempDir::new().unwrap();
+
+        let result = build(&app_file, out_dir.path(), "index.html");
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("App path is not a directory"));
     }
 
     #[test]

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -19,6 +19,26 @@ use webui_protocol::WebUIProtocol;
 use super::common::*;
 use crate::utils::output;
 
+const FORWARD_REQUEST_HEADERS: &[&str] = &[
+    "authorization",
+    "cookie",
+    "accept",
+    "content-type",
+    "user-agent",
+    "x-request-id",
+    "x-forwarded-for",
+];
+
+const FORWARD_RESPONSE_HEADERS: &[&str] = &[
+    "content-type",
+    "set-cookie",
+    "location",
+    "cache-control",
+    "etag",
+    "last-modified",
+    "x-request-id",
+];
+
 #[derive(Args)]
 pub struct ServeArgs {
     #[command(flatten)]
@@ -458,7 +478,7 @@ fn build_and_render(
 
 fn inject_script_before_body_close(html: &str, script: &str) -> String {
     // Insert before </body> if found, otherwise append
-    if let Some(pos) = html.rfind("</body>") {
+    if let Some(pos) = rfind_ascii_case_insensitive(html, "</body>") {
         let mut result = String::with_capacity(html.len() + script.len() + 1);
         result.push_str(&html[..pos]);
         result.push('\n');
@@ -472,6 +492,39 @@ fn inject_script_before_body_close(html: &str, script: &str) -> String {
         result.push_str(script);
         result
     }
+}
+
+fn rfind_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(haystack.len());
+    }
+
+    let haystack_bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.len() > haystack_bytes.len() {
+        return None;
+    }
+
+    for start in (0..=haystack_bytes.len() - needle_bytes.len()).rev() {
+        if haystack_bytes[start..start + needle_bytes.len()].eq_ignore_ascii_case(needle_bytes) {
+            return Some(start);
+        }
+    }
+
+    None
+}
+
+fn collect_forward_headers(
+    headers: &actix_web::http::header::HeaderMap,
+    allowlist: &[&'static str],
+) -> Vec<(&'static str, actix_web::http::header::HeaderValue)> {
+    let mut forwarded = Vec::with_capacity(allowlist.len());
+    for &name in allowlist {
+        if let Some(value) = headers.get(name) {
+            forwarded.push((name, value.clone()));
+        }
+    }
+    forwarded
 }
 
 // ── Route handlers ──────────────────────────────────────────────────────
@@ -833,9 +886,8 @@ async fn handle_api_proxy(
     let client = awc::Client::new();
     let mut proxy_req = client.request(req.method().clone(), &url);
 
-    // Forward content-type header if present
-    if let Some(ct) = req.headers().get("content-type") {
-        proxy_req = proxy_req.insert_header(("content-type", ct.clone()));
+    for (name, value) in collect_forward_headers(req.headers(), FORWARD_REQUEST_HEADERS) {
+        proxy_req = proxy_req.insert_header((name, value));
     }
 
     let result = if body.is_empty() {
@@ -850,8 +902,10 @@ async fn handle_api_proxy(
             match resp.body().await {
                 Ok(response_body) => {
                     let mut builder = HttpResponse::build(status);
-                    if let Some(ct) = resp.headers().get("content-type") {
-                        builder.insert_header(("content-type", ct.clone()));
+                    for (name, value) in
+                        collect_forward_headers(resp.headers(), FORWARD_RESPONSE_HEADERS)
+                    {
+                        builder.insert_header((name, value));
                     }
                     builder.body(response_body)
                 }
@@ -975,6 +1029,7 @@ fn start_file_watcher(config: WatcherConfig) {
                             "  {} Rebuilt and re-rendered (HMR version updated)",
                             console::style("\u{21bb}").green()
                         );
+                        last_times = current_times;
                     }
                     Err(err) => {
                         eprintln!(
@@ -983,8 +1038,6 @@ fn start_file_watcher(config: WatcherConfig) {
                         );
                     }
                 }
-
-                last_times = current_times;
             }
         }
     });
@@ -1144,6 +1197,42 @@ mod tests {
         let injected = inject_script_before_body_close(html, script);
         assert!(injected.contains("<script>"));
         assert!(injected.starts_with("<h1>Hello</h1>"));
+    }
+
+    #[test]
+    fn test_hmr_script_injection_uppercase_body() {
+        let html = "<html><BODY><p>Hello</p></BODY></html>";
+        let script = "<script>console.log('hmr')</script>";
+        let injected = inject_script_before_body_close(html, script);
+        assert!(injected.contains("<script>"));
+        let script_pos = injected.find("<script>").unwrap();
+        let body_pos = injected.rfind("</BODY>").unwrap();
+        assert!(script_pos < body_pos);
+    }
+
+    #[test]
+    fn test_collect_forward_headers_respects_allowlist() {
+        use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer token"),
+        );
+        headers.insert(
+            HeaderName::from_static("cookie"),
+            HeaderValue::from_static("a=b"),
+        );
+        headers.insert(
+            HeaderName::from_static("connection"),
+            HeaderValue::from_static("keep-alive"),
+        );
+
+        let forwarded = collect_forward_headers(&headers, FORWARD_REQUEST_HEADERS);
+        assert_eq!(forwarded.len(), 2);
+        assert!(forwarded.iter().any(|(n, _)| *n == "authorization"));
+        assert!(forwarded.iter().any(|(n, _)| *n == "cookie"));
+        assert!(!forwarded.iter().any(|(n, _)| *n == "connection"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes four correctness issues in the CLI dev-server and build command: proxy header forwarding, file watcher retry logic, HMR injection reliability, and build input validation.

## Context

These findings came from a full-project audit focused on server runtime correctness (audit category: CLI-001, CLI-005, CLI-006, CLI-007).

## Changes

### CLI-001: API proxy now forwards critical headers
**File**: `crates/webui-cli/src/commands/serve.rs` — `handle_api_proxy`

**Before**: Only `content-type` was forwarded from the client request to the upstream API, and only `content-type` was copied back from the response. Headers like `Authorization`, `Cookie`, `Accept`, `Set-Cookie`, `Location`, and cache headers were silently dropped.

**After**: Two allowlists control which headers pass through:
- **Request**: `authorization`, `cookie`, `accept`, `content-type`, `user-agent`, `x-request-id`
- **Response**: `content-type`, `set-cookie`, `location`, `cache-control`, `etag`, `last-modified`, `x-request-id`

Hop-by-hop headers (`Connection`, `Host`, `Transfer-Encoding`) are intentionally excluded per HTTP spec.

### CLI-005: Watcher retries after failed rebuild
**File**: `crates/webui-cli/src/commands/serve.rs` — `start_file_watcher`

**Before**: `last_times = current_times` ran unconditionally after `build_and_render`, even on failure. If the build error was transient (e.g., file locked by editor) and no further file changes occurred, the watcher would never retry — leaving the server on stale output indefinitely.

**After**: `last_times` is only updated inside the `Ok` branch. On failure, timestamps remain stale, so the next 500ms poll will detect the same changes and retry the build.

### CLI-006: HMR injection finds `</body>` case-insensitively
**File**: `crates/webui-cli/src/commands/serve.rs` — HMR injection function

**Before**: Exact string match for `</body>` — missed `</BODY>`, `</Body>`, or any other valid casing.

**After**: Case-insensitive search using `to_ascii_lowercase()` on the HTML to find the insertion position, then splices the HMR script into the original (preserving casing). Falls back to appending if no body tag is found.

### CLI-007: Build command validates app path is a directory
**File**: `crates/webui-cli/src/commands/build.rs`

**Before**: `build` canonicalized the app path but didn't check `is_dir()`. Passing a file path led to confusing downstream errors.

**After**: Explicit `if !app_dir.is_dir()` check with an actionable error message, consistent with how `serve` already validates.

## Risk

**Low.** These are dev-server-only changes — they don't affect production rendering, protocol, or parser output. The proxy header change is additive (more headers forwarded), and the watcher change only affects retry behavior on failure.

## Testing

- New tests for header allowlist forwarding, uppercase `</BODY>` HMR injection, and file-path build rejection
- All existing `webui-cli` tests pass
- `cargo fmt` and `cargo clippy -p webui-cli -D warnings` clean
