### PR TITLE
feat: add CssStrategy::Module for declarative CSS module scripts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,8 +34,8 @@ pub struct WebUIProtocol {
     /// Sorted, deduplicated CSS custom property names used across all
     /// components and entry page styles (without `--` prefix).
     pub tokens: Vec<String>,
-    /// Map of component tag names to their template fragment IDs.
-    pub component_templates: HashMap<String, String>,
+    /// Per-component data keyed by tag name (f-template + CSS).
+    pub components: HashMap<String, ComponentData>,
 }
 
 /// A list of fragments (needed because protobuf maps cannot have repeated values directly).
@@ -599,13 +599,18 @@ pub enum CssStrategy {
     Link,
     /// Embed CSS content inline in `<style>` tags within the shadow DOM template.
     Style,
+    /// Emit a `<style type="module" specifier="component">` definition once per
+    /// page and reference it via `shadowrootadoptedstylesheets` on each shadow
+    /// root `<template>`.
+    Module,
 }
 ```
 
 - **Link** (default): Emits `<link>` tags referencing external `.css` files. Used by the CLI for production builds where CSS files are served separately.
 - **Style**: Embeds the full CSS content in `<style>` tags inside the shadow DOM template. Used when all files are needed in-memory.
+- **Module**: Uses the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. Emits a `<style type="module" specifier="component-name">` definition in each component's light DOM (once per component) and adds `shadowrootadoptedstylesheets="component-name"` to the `<template>` tag. The browser registers the CSS module globally and shares a single `CSSStyleSheet` across all shadow roots that adopt it. No external CSS files are produced. For partial rendering, CSS module definitions are prepended to f-template strings so the client inserts both as a single DocumentFragment.
 
-Set via `parser.set_css_strategy(CssStrategy::Inline)`.
+Set via `parser.set_css_strategy(CssStrategy::Style)`.
 
 #### Primary Method
 ```rust

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -151,7 +151,6 @@ struct SharedState {
     css_files: HashMap<String, String>,
     protocol: Option<WebUIProtocol>,
     state_data: Option<Value>,
-    component_templates: HashMap<String, String>,
     /// Entry fragment ID used for rendering (e.g., "index.html").
     entry: String,
 }
@@ -312,7 +311,6 @@ fn run(args: &ServeArgs) -> Result<()> {
         css_files: initial_result.css_files,
         protocol: Some(initial_result.protocol),
         state_data: Some(initial_result.state_data),
-        component_templates: initial_result.component_templates,
         entry: args.app_args.entry.clone(),
     }));
 
@@ -405,7 +403,6 @@ struct BuildRenderResult {
     css_files: HashMap<String, String>,
     protocol: WebUIProtocol,
     state_data: Value,
-    component_templates: HashMap<String, String>,
 }
 
 /// Build the protocol from app templates and render with explicit state data.
@@ -445,15 +442,12 @@ fn build_and_render(
     };
 
     let css_map: HashMap<String, String> = build_result.css_files.into_iter().collect();
-    let template_map: HashMap<String, String> =
-        build_result.component_templates.into_iter().collect();
 
     Ok(BuildRenderResult {
         html,
         css_files: css_map,
         protocol: build_result.protocol,
         state_data: state,
-        component_templates: template_map,
     })
 }
 
@@ -746,13 +740,9 @@ async fn handle_json_partial(
 
     let mut state_data = resolve_state(context, &paths.request_path).await;
 
-    // Clone protocol and templates from shared state (release lock quickly)
-    let (protocol, component_templates, entry) = match context.state.lock() {
-        Ok(s) => (
-            s.protocol.clone(),
-            s.component_templates.clone(),
-            s.entry.clone(),
-        ),
+    // Clone protocol from shared state (release lock quickly)
+    let (protocol, entry) = match context.state.lock() {
+        Ok(s) => (s.protocol.clone(), s.entry.clone()),
         Err(_) => {
             return HttpResponse::InternalServerError().body(r#"{"error":"Internal server error"}"#)
         }
@@ -793,20 +783,28 @@ async fn handle_json_partial(
         Value::Object(serde_json::Map::new())
     };
 
-    // The partial contains f-template HTML strings; the CLI dev server stores
-    // templates separately in component_templates, so map from names to those.
-    // Re-derive needed names for the template lookup against the local map.
+    // Re-derive needed component names and look up templates from the protocol.
     let (needed_names, inv_hex) = if let Some(proto) = &protocol {
         collect_needed_template_names(proto, &entry, &paths.route_path, &client_inv_hex)
     } else {
         (Vec::new(), client_inv_hex)
     };
 
-    let templates: Vec<Value> = needed_names
-        .iter()
-        .filter_map(|name| component_templates.get(name))
-        .map(|t| Value::String(t.clone()))
-        .collect();
+    let templates: Vec<Value> = if let Some(proto) = &protocol {
+        needed_names
+            .iter()
+            .filter_map(|name| {
+                proto
+                    .components
+                    .get(name)
+                    .map(|c| c.template.as_str())
+                    .filter(|s| !s.is_empty())
+            })
+            .map(|t| Value::String(t.to_string()))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     // Start from the partial (which has state, path, chain) and override
     // templates/inventory with the CLI dev server's local template map.
@@ -1000,7 +998,6 @@ fn start_file_watcher(config: WatcherConfig) {
                             s.css_files = result.css_files;
                             s.protocol = Some(result.protocol);
                             s.state_data = Some(result.state_data);
-                            s.component_templates = result.component_templates;
                             s.bump_version();
                         }
                         eprintln!(
@@ -1241,14 +1238,16 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-page-search".to_string(),
-            "<f-template id=search></f-template>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-page-product".to_string(),
-            "<f-template id=product></f-template>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-page-search".to_string())
+            .or_default()
+            .template = "<f-template id=search></f-template>".to_string();
+        protocol
+            .components
+            .entry("mp-page-product".to_string())
+            .or_default()
+            .template = "<f-template id=product></f-template>".to_string();
         let (needed, inventory) =
             collect_needed_template_names(&protocol, "index.html", "/search/shirts", "");
 
@@ -1422,7 +1421,6 @@ mod tests {
             css_files: HashMap::new(),
             protocol: None,
             state_data: None,
-            component_templates: HashMap::new(),
             entry: "index.html".to_string(),
         };
         assert_eq!(backend.version_payload(&state), "42");
@@ -1439,7 +1437,6 @@ mod tests {
                 css_files: HashMap::new(),
                 protocol: None,
                 state_data: None,
-                component_templates: HashMap::new(),
                 entry: "index.html".to_string(),
             })),
             hmr_backend: Some(hmr_backend),

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -310,22 +310,26 @@ fn render_partial_returns_templates_inventory_and_chain() {
     );
 
     let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-    protocol.component_templates.insert(
-        "mp-app".to_string(),
-        "<f-template id=app></f-template>".to_string(),
-    );
-    protocol.component_templates.insert(
-        "mp-search-page".to_string(),
-        "<f-template id=search></f-template>".to_string(),
-    );
-    protocol.component_templates.insert(
-        "mp-product-grid".to_string(),
-        "<f-template id=grid></f-template>".to_string(),
-    );
-    protocol.component_templates.insert(
-        "mp-category-nav".to_string(),
-        "<f-template id=nav></f-template>".to_string(),
-    );
+    protocol
+        .components
+        .entry("mp-app".to_string())
+        .or_default()
+        .template = "<f-template id=app></f-template>".to_string();
+    protocol
+        .components
+        .entry("mp-search-page".to_string())
+        .or_default()
+        .template = "<f-template id=search></f-template>".to_string();
+    protocol
+        .components
+        .entry("mp-product-grid".to_string())
+        .or_default()
+        .template = "<f-template id=grid></f-template>".to_string();
+    protocol
+        .components
+        .entry("mp-category-nav".to_string())
+        .or_default()
+        .template = "<f-template id=nav></f-template>".to_string();
 
     let protocol_bytes = protocol
         .to_protobuf()

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -103,7 +103,9 @@ struct WebUIProcessContext<'a> {
     /// Base path for resolving relative route paths (`./`).
     /// Updated as the handler descends into nested matched routes.
     route_base: String,
-    /// Component names visited during rendering (for selective f-template emission).
+    /// Component names visited during rendering (for selective f-template emission
+    /// and CSS module dedup — only the first render of each component emits
+    /// its `<style type="module">` tag).
     rendered_components: HashSet<String>,
     /// Per-render plugin instance created from the handler's factory.
     plugin: Option<Box<dyn HandlerPlugin>>,
@@ -316,69 +318,7 @@ impl WebUIHandler {
                     }
                 }
                 Some(Fragment::Route(route_frag)) => {
-                    // Only the best-matching route is active
-                    let route_key = &route_frag.fragment_id;
-                    let is_matched = best_route
-                        .as_ref()
-                        .is_some_and(|(best_key, _)| best_key == route_key);
-
-                    // Emit <webui-route> as a web component with declarative shadow DOM
-                    context.writer.write("<webui-route")?;
-                    if !route_frag.path.is_empty() {
-                        context.writer.write(" path=\"")?;
-                        context.writer.write(&route_frag.path)?;
-                        context.writer.write("\"")?;
-                    }
-                    if !route_frag.fragment_id.is_empty() {
-                        context.writer.write(" component=\"")?;
-                        context.writer.write(&route_frag.fragment_id)?;
-                        context.writer.write("\"")?;
-                    }
-                    if route_frag.exact {
-                        context.writer.write(" exact")?;
-                    }
-
-                    if is_matched {
-                        context.writer.write(" active>")?;
-
-                        if !route_frag.fragment_id.is_empty() {
-                            let saved_route_base = context.route_base.clone();
-                            let saved_route_children = std::mem::take(&mut context.route_children);
-                            if let Some((_, ref rm)) = best_route {
-                                context.route_base = route_matcher::compute_route_base(
-                                    &context.request_path,
-                                    rm.consumed_segments,
-                                );
-                            }
-
-                            context.route_children = route_frag.children.clone();
-
-                            // Emit component tag with state attributes
-                            context.writer.write("<")?;
-                            context.writer.write(&route_frag.fragment_id)?;
-                            route_renderer::emit_state_attributes(context.state, context.writer)?;
-                            context.writer.write(">")?;
-
-                            self.process_component(
-                                &webui_protocol::WebUIFragmentComponent {
-                                    fragment_id: route_frag.fragment_id.clone(),
-                                },
-                                context,
-                            )?;
-
-                            context.writer.write("</")?;
-                            context.writer.write(&route_frag.fragment_id)?;
-                            context.writer.write(">")?;
-
-                            context.route_base = saved_route_base;
-                            context.route_children = saved_route_children;
-                        }
-                    } else {
-                        // Non-matched route: hidden, empty
-                        context.writer.write(" style=\"display:none\">")?;
-                    }
-
-                    context.writer.write("</webui-route>")?;
+                    self.process_route(route_frag, &best_route, context)?;
                 }
                 Some(Fragment::Outlet(_)) => {
                     self.process_outlet(context)?;
@@ -500,12 +440,113 @@ impl WebUIHandler {
         Ok(())
     }
 
+    /// Emit a `<style type="module">` tag for a component if this is its first
+    /// rendering and it has CSS in `protocol.components` (Module strategy only).
+    fn emit_css_module(
+        &self,
+        component: &webui_protocol::WebUIFragmentComponent,
+        context: &mut WebUIProcessContext,
+    ) -> Result<()> {
+        if !context.rendered_components.contains(&component.fragment_id) {
+            if let Some(css) = context
+                .protocol
+                .components
+                .get(&component.fragment_id)
+                .map(|c| c.css.as_str())
+                .filter(|s| !s.is_empty())
+            {
+                context
+                    .writer
+                    .write("<style type=\"module\" specifier=\"")?;
+                context.writer.write(&component.fragment_id)?;
+                context.writer.write("\">")?;
+                context.writer.write(css)?;
+                context.writer.write("</style>")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Process a route fragment — renders `<webui-route>` with matched/hidden state.
+    fn process_route(
+        &self,
+        route_frag: &webui_protocol::WebUiFragmentRoute,
+        best_route: &Option<(String, route_matcher::RouteMatch)>,
+        context: &mut WebUIProcessContext,
+    ) -> Result<()> {
+        let is_matched = best_route
+            .as_ref()
+            .is_some_and(|(best_key, _)| *best_key == route_frag.fragment_id);
+
+        context.writer.write("<webui-route")?;
+        if !route_frag.path.is_empty() {
+            context.writer.write(" path=\"")?;
+            context.writer.write(&route_frag.path)?;
+            context.writer.write("\"")?;
+        }
+        if !route_frag.fragment_id.is_empty() {
+            context.writer.write(" component=\"")?;
+            context.writer.write(&route_frag.fragment_id)?;
+            context.writer.write("\"")?;
+        }
+        if route_frag.exact {
+            context.writer.write(" exact")?;
+        }
+
+        if is_matched {
+            context.writer.write(" active>")?;
+
+            if !route_frag.fragment_id.is_empty() {
+                let saved_route_base = context.route_base.clone();
+                let saved_route_children = std::mem::take(&mut context.route_children);
+                if let Some((_, ref rm)) = best_route {
+                    context.route_base = route_matcher::compute_route_base(
+                        &context.request_path,
+                        rm.consumed_segments,
+                    );
+                }
+
+                context.route_children = route_frag.children.clone();
+
+                let comp = webui_protocol::WebUIFragmentComponent {
+                    fragment_id: route_frag.fragment_id.clone(),
+                };
+
+                context.writer.write("<")?;
+                context.writer.write(&route_frag.fragment_id)?;
+                route_renderer::emit_state_attributes(context.state, context.writer)?;
+                context.writer.write(">")?;
+
+                self.process_component(&comp, context)?;
+
+                context.writer.write("</")?;
+                context.writer.write(&route_frag.fragment_id)?;
+                context.writer.write(">")?;
+
+                context.route_base = saved_route_base;
+                context.route_children = saved_route_children;
+            }
+        } else {
+            context.writer.write(" style=\"display:none\">")?;
+        }
+
+        context.writer.write("</webui-route>")?;
+        Ok(())
+    }
+
     /// Process a component fragment.
     fn process_component(
         &self,
         component: &webui_protocol::WebUIFragmentComponent,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
+        // Emit CSS module into the component's light DOM on first encounter.
+        // Subsequent instances skip — the browser's module map deduplicates.
+        let first_render = !context.rendered_components.contains(&component.fragment_id);
+        if first_render {
+            self.emit_css_module(component, context)?;
+        }
+
         // Track this component as rendered (for selective f-template emission)
         context
             .rendered_components
@@ -5554,6 +5595,279 @@ mod tests {
         assert!(
             html.contains(r#"component="section-comp" style="display:none">"#),
             "section hidden at /: {html}"
+        );
+    }
+
+    // ── CSS Module dedup tests ───────────────────────────────────────
+
+    #[test]
+    fn test_css_module_emitted_once_before_component() {
+        // CSS module definition emitted once, right before the first
+        // component usage — not in <head>.
+        let template = r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="my-card"><p><slot></slot></p></template>"#;
+
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<div>".to_string()),
+                    WebUIFragment::component("my-card"),
+                    WebUIFragment::raw("A".to_string()),
+                    WebUIFragment::component("my-card"),
+                    WebUIFragment::raw("B</div>".to_string()),
+                ],
+            },
+        );
+        fragments.insert(
+            "my-card".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(template.to_string())],
+            },
+        );
+
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol
+            .components
+            .entry("my-card".to_string())
+            .or_default()
+            .css = "p{color:red}".to_string();
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+        let html = writer.get_content();
+
+        // CSS module should appear exactly once
+        let count = html
+            .matches(r#"<style type="module" specifier="my-card">"#)
+            .count();
+        assert_eq!(
+            count, 1,
+            "CSS module should be emitted once, got {count} in: {html}"
+        );
+
+        // Template should appear twice (once per component instance)
+        let tmpl_count = html
+            .matches(r#"shadowrootadoptedstylesheets="my-card""#)
+            .count();
+        assert_eq!(
+            tmpl_count, 2,
+            "Template should render twice, got {tmpl_count} in: {html}"
+        );
+
+        // CSS module should appear before the first template
+        let css_pos = html
+            .find(r#"<style type="module""#)
+            .expect("CSS module missing");
+        let tmpl_pos = html
+            .find(r#"shadowrootadoptedstylesheets"#)
+            .expect("template missing");
+        assert!(
+            css_pos < tmpl_pos,
+            "CSS module should precede first component: {html}"
+        );
+    }
+
+    #[test]
+    fn test_component_without_css_renders_normally() {
+        // Components without CSS module prefix pass through unchanged
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::component("my-card")],
+            },
+        );
+        fragments.insert(
+            "my-card".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(
+                    r#"<template shadowrootmode="open"><p>hello</p></template>"#.to_string(),
+                )],
+            },
+        );
+
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+        let html = writer.get_content();
+        assert!(
+            html.contains("<p>hello</p>"),
+            "Non-module component should render normally: {html}"
+        );
+    }
+
+    #[test]
+    fn test_non_module_strategy_no_css_in_head() {
+        // When component_css is empty (Link/Style strategies), no
+        // <style type="module"> tags should appear in <head>.
+        let template = r#"<template shadowrootmode="open"><p>hello</p></template>"#;
+
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><head>".to_string()),
+                    WebUIFragment::signal("head_end", true),
+                    WebUIFragment::raw("</head><body>".to_string()),
+                    WebUIFragment::component("my-card"),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+            },
+        );
+        fragments.insert(
+            "my-card".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(template.to_string())],
+            },
+        );
+
+        // No component css populated — simulates Link/Style strategy
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+        let html = writer.get_content();
+
+        assert!(
+            !html.contains(r#"<style type="module""#),
+            "Non-module strategy should not emit CSS modules in <head>: {html}"
+        );
+        assert!(
+            html.contains("<p>hello</p>"),
+            "Component should still render: {html}"
+        );
+    }
+
+    #[test]
+    fn test_css_module_emitted_in_component_light_dom() {
+        // The CSS module <style> must be inside the component tag (light DOM),
+        // not outside it — e.g. <mp-card><style type="module" ...>CSS</style>
+        // <template shadowrootadoptedstylesheets="mp-card">...</template></mp-card>
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<my-card>".to_string()),
+                    WebUIFragment::component("my-card"),
+                    WebUIFragment::raw("</my-card>".to_string()),
+                ],
+            },
+        );
+        fragments.insert(
+            "my-card".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(
+                    r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="my-card"><p>hi</p></template>"#.to_string(),
+                )],
+            },
+        );
+
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol
+            .components
+            .entry("my-card".to_string())
+            .or_default()
+            .css = "p{color:red}".to_string();
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+        let html = writer.get_content();
+
+        // CSS module must be INSIDE the component tag (light DOM)
+        let tag_open = html.find("<my-card>").expect("<my-card> missing");
+        let css_pos = html
+            .find(r#"<style type="module""#)
+            .expect("CSS module missing");
+        let tag_close = html.rfind("</my-card>").expect("</my-card> missing");
+        assert!(
+            css_pos > tag_open && css_pos < tag_close,
+            "CSS module should be inside component light DOM: {html}"
+        );
+    }
+
+    #[test]
+    fn test_css_module_emitted_for_route_components() {
+        // Route components also get CSS modules via process_route → process_component.
+        let template = r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="dash-page"><h1>Dashboard</h1></template>"#;
+
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route("/", "dash-page")],
+            },
+        );
+        fragments.insert(
+            "dash-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(template.to_string())],
+            },
+        );
+
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol
+            .components
+            .entry("dash-page".to_string())
+            .or_default()
+            .css = "h1{font-size:2rem}".to_string();
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+        let html = writer.get_content();
+
+        assert!(
+            html.contains(
+                r#"<style type="module" specifier="dash-page">h1{font-size:2rem}</style>"#
+            ),
+            "Route component should have CSS module: {html}"
+        );
+        assert!(
+            html.contains("<h1>Dashboard</h1>"),
+            "Route component should render content: {html}"
         );
     }
 }

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -201,8 +201,15 @@ impl HandlerPlugin for FastHydrationPlugin {
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
         // Emit f-templates for only the components that were actually rendered.
+        // CSS module definitions are NOT included here — the handler already
+        // emitted them during SSR via process_component().
         for name in rendered_components {
-            if let Some(tmpl) = protocol.component_templates.get(name) {
+            if let Some(tmpl) = protocol
+                .components
+                .get(name)
+                .map(|c| c.template.as_str())
+                .filter(|s| !s.is_empty())
+            {
                 writer.write(tmpl)?;
             }
         }

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -141,7 +141,7 @@ pub fn filter_needed_components(
 ///
 /// Walks the fragment graph from `entry_id`, identifies needed components (not
 /// in the client's inventory), and returns their f-template HTML from the
-/// protocol's `component_templates` map.
+/// protocol's `components` map.
 ///
 /// Returns `(templates: Vec<(name, html)>, updated_inventory_hex)`.
 pub fn get_route_templates(
@@ -155,9 +155,10 @@ pub fn get_route_templates(
         .iter()
         .filter_map(|name| {
             protocol
-                .component_templates
+                .components
                 .get(name)
-                .map(|tmpl| (name.clone(), tmpl.clone()))
+                .filter(|c| !c.template.is_empty())
+                .map(|c| (name.clone(), prepend_css_module(name, &c.css, &c.template)))
         })
         .collect();
 
@@ -181,13 +182,30 @@ pub fn get_route_templates_for_request(
         .iter()
         .filter_map(|name| {
             protocol
-                .component_templates
+                .components
                 .get(name)
-                .map(|tmpl| (name.clone(), tmpl.clone()))
+                .filter(|c| !c.template.is_empty())
+                .map(|c| (name.clone(), prepend_css_module(name, &c.css, &c.template)))
         })
         .collect();
 
     (templates, updated_inv)
+}
+
+/// Prepend the CSS module `<style type="module">` definition to an f-template
+/// string for partial responses.
+fn prepend_css_module(name: &str, css: &str, tmpl: &str) -> String {
+    if css.is_empty() {
+        return tmpl.to_string();
+    }
+    let mut s = String::with_capacity(40 + name.len() + css.len() + tmpl.len());
+    s.push_str("<style type=\"module\" specifier=\"");
+    s.push_str(name);
+    s.push_str("\">");
+    s.push_str(css);
+    s.push_str("</style>");
+    s.push_str(tmpl);
+    s
 }
 
 #[derive(Debug)]
@@ -205,8 +223,8 @@ struct QueuedFragment {
 /// Without a request path, all route branches are followed conservatively.
 ///
 /// Components are marked `inventoryable` when they have a corresponding entry
-/// in `protocol.component_templates` — these are the components whose f-template
-/// HTML the client may need during navigation.
+/// in `protocol.components` with a non-empty template — these are the components
+/// whose f-template HTML the client may need during navigation.
 fn collect_inventoryable_components(
     protocol: &WebUIProtocol,
     entry_id: &str,
@@ -290,8 +308,9 @@ fn collect_inventoryable_components(
                         stack.push(QueuedFragment {
                             id: route_frag.fragment_id.clone(),
                             inventoryable: protocol
-                                .component_templates
-                                .contains_key(&route_frag.fragment_id),
+                                .components
+                                .get(&route_frag.fragment_id)
+                                .is_some_and(|c| !c.template.is_empty()),
                             route_base: child_route_base.clone(),
                         });
 
@@ -357,8 +376,9 @@ fn walk_route_children(
         stack.push(QueuedFragment {
             id: matched.fragment_id.clone(),
             inventoryable: protocol
-                .component_templates
-                .contains_key(&matched.fragment_id),
+                .components
+                .get(&matched.fragment_id)
+                .is_some_and(|c| !c.template.is_empty()),
             route_base: child_base.clone(),
         });
 
@@ -539,7 +559,9 @@ pub fn render_partial(
     request_path: &str,
     inventory_hex: &str,
 ) -> Value {
-    // Get needed templates (filtered by client inventory)
+    // Get needed templates (filtered by client inventory).
+    // Each template string is prepended with its CSS module definition
+    // (if any) so the client can insert both as a DocumentFragment.
     let (templates, updated_inv) =
         get_route_templates_for_request(protocol, entry_id, request_path, inventory_hex);
 
@@ -810,8 +832,10 @@ mod tests {
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
         protocol
-            .component_templates
-            .insert("my-page".to_string(), "<p>page</p>".to_string());
+            .components
+            .entry("my-page".to_string())
+            .or_default()
+            .template = "<p>page</p>".to_string();
 
         let (templates, _inv) = get_route_templates(&protocol, "my-page", "");
         assert_eq!(templates.len(), 1);
@@ -963,14 +987,16 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-search-page".to_string(),
-            "<mp-search-page></mp-search-page>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-product-page".to_string(),
-            "<mp-product-page></mp-product-page>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-search-page".to_string())
+            .or_default()
+            .template = "<mp-search-page></mp-search-page>".to_string();
+        protocol
+            .components
+            .entry("mp-product-page".to_string())
+            .or_default()
+            .template = "<mp-product-page></mp-product-page>".to_string();
 
         let (needed, _inv) =
             get_needed_components_for_request(&protocol, "index.html", "/search/shirts", "");
@@ -1050,18 +1076,21 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-account-shell".to_string(),
-            "<mp-account-shell></mp-account-shell>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-profile-page".to_string(),
-            "<mp-profile-page></mp-profile-page>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-order-page".to_string(),
-            "<mp-order-page></mp-order-page>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-account-shell".to_string())
+            .or_default()
+            .template = "<mp-account-shell></mp-account-shell>".to_string();
+        protocol
+            .components
+            .entry("mp-profile-page".to_string())
+            .or_default()
+            .template = "<mp-profile-page></mp-profile-page>".to_string();
+        protocol
+            .components
+            .entry("mp-order-page".to_string())
+            .or_default()
+            .template = "<mp-order-page></mp-order-page>".to_string();
 
         let (needed, _inv) =
             get_needed_components_for_request(&protocol, "index.html", "/account/orders/42", "");
@@ -1133,10 +1162,11 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-search-page".to_string(),
-            "<mp-search-page></mp-search-page>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-search-page".to_string())
+            .or_default()
+            .template = "<mp-search-page></mp-search-page>".to_string();
 
         let (needed, _inv) =
             get_needed_components_for_request(&protocol, "index.html", "/search", "");
@@ -1182,10 +1212,11 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-search-page".to_string(),
-            "<mp-search-page></mp-search-page>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-search-page".to_string())
+            .or_default()
+            .template = "<mp-search-page></mp-search-page>".to_string();
 
         let (_needed, inventory) =
             get_needed_components_for_request(&protocol, "index.html", "/search", "");
@@ -1228,18 +1259,21 @@ mod tests {
         );
 
         let mut protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
-        protocol.component_templates.insert(
-            "mp-app".to_string(),
-            "<f-template id=app></f-template>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-search-page".to_string(),
-            "<f-template id=search></f-template>".to_string(),
-        );
-        protocol.component_templates.insert(
-            "mp-product-grid".to_string(),
-            "<f-template id=grid></f-template>".to_string(),
-        );
+        protocol
+            .components
+            .entry("mp-app".to_string())
+            .or_default()
+            .template = "<f-template id=app></f-template>".to_string();
+        protocol
+            .components
+            .entry("mp-search-page".to_string())
+            .or_default()
+            .template = "<f-template id=search></f-template>".to_string();
+        protocol
+            .components
+            .entry("mp-product-grid".to_string())
+            .or_default()
+            .template = "<f-template id=grid></f-template>".to_string();
 
         let (templates, _inv) =
             get_route_templates_for_request(&protocol, "index.html", "/search", "");

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -86,10 +86,11 @@ pub struct JsBuildOptions {
 pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
     let css = match options.css.as_deref() {
         Some("style") => webui::CssStrategy::Style,
+        Some("module") => webui::CssStrategy::Module,
         Some("link") | None => webui::CssStrategy::Link,
         Some(unknown) => {
             return Err(NapiError::from_reason(format!(
-                "Unknown CSS mode: {unknown}. Use \"link\" or \"style\"."
+                "Unknown CSS mode: {unknown}. Use \"link\", \"style\", or \"module\"."
             )));
         }
     };

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -36,6 +36,10 @@ pub enum CssStrategy {
     Link,
     /// Embed CSS content in `<style>` tags within the shadow DOM template.
     Style,
+    /// Emit a `<style type="module" specifier="component">` definition once per
+    /// page and reference it via `shadowrootadoptedstylesheets` on each shadow
+    /// root `<template>`. Based on the Declarative CSS Module Scripts proposal.
+    Module,
 }
 
 /// Counter for generating unique fragment IDs.
@@ -1269,6 +1273,10 @@ impl HtmlParser {
             )
         };
         self.token_store.extend(css_tokens);
+        let adopted_specifier = match self.css_strategy {
+            CssStrategy::Module if css_content.is_some() => Some(component.to_string()),
+            _ => None,
+        };
         let css_injection = match self.css_strategy {
             CssStrategy::Link => {
                 if css_content.is_some() {
@@ -1282,8 +1290,13 @@ impl HtmlParser {
             CssStrategy::Style => css_content
                 .as_ref()
                 .map(|css| format!("<style>{}</style>", css.trim())),
+            CssStrategy::Module => None,
         };
-        let processed = self.process_component_template(&html_content, css_injection.as_deref());
+        let processed = self.process_component_template(
+            &html_content,
+            css_injection.as_deref(),
+            adopted_specifier.as_deref(),
+        );
         let saved_buffer = std::mem::take(&mut self.raw_buffer);
         self.parse(component, &processed)?;
         self.raw_buffer = saved_buffer;
@@ -1368,6 +1381,10 @@ impl HtmlParser {
                 }
             }
 
+            let adopted_specifier = match self.css_strategy {
+                CssStrategy::Module if css_content.is_some() => Some(tag_name.to_string()),
+                _ => None,
+            };
             let css_injection = match self.css_strategy {
                 CssStrategy::Link => {
                     if css_content.is_some() {
@@ -1382,9 +1399,13 @@ impl HtmlParser {
                 CssStrategy::Style => css_content
                     .as_ref()
                     .map(|css| format!("<style>{}</style>", css.trim())),
+                CssStrategy::Module => None,
             };
-            let processed =
-                self.process_component_template(&html_content, css_injection.as_deref());
+            let processed = self.process_component_template(
+                &html_content,
+                css_injection.as_deref(),
+                adopted_specifier.as_deref(),
+            );
             self.parse(tag_name, &processed)?;
         }
 
@@ -1411,28 +1432,56 @@ impl HtmlParser {
 
     /// Process component template HTML: wrap in shadow DOM template if needed,
     /// inject CSS snippet (link or inline style), and strip runtime-only attributes.
-    fn process_component_template(&mut self, html: &str, css_snippet: Option<&str>) -> String {
+    /// When `adopted_specifier` is `Some`, a `shadowrootadoptedstylesheets` attribute
+    /// is added to the `<template>` tag (used by [`CssStrategy::Module`]).
+    fn process_component_template(
+        &mut self,
+        html: &str,
+        css_snippet: Option<&str>,
+        adopted_specifier: Option<&str>,
+    ) -> String {
         let trimmed = html.trim();
         let has_template = trimmed.starts_with("<template");
+
+        // Extra attribute for CSS module adoption (empty str avoids allocation)
+        let adopted_attr = adopted_specifier.map(|spec| {
+            let mut s = String::with_capacity(35 + spec.len());
+            s.push_str(" shadowrootadoptedstylesheets=\"");
+            s.push_str(spec);
+            s.push('"');
+            s
+        });
+        let adopted_ref = adopted_attr.as_deref().unwrap_or_default();
 
         if has_template {
             // Strip @/:/?-prefixed attributes from the template tag
             let stripped = self.strip_runtime_attrs_from_template(trimmed);
-            if let Some(snippet) = css_snippet {
-                // Inject CSS snippet after the first > in the template tag
-                if let Some(pos) = stripped.find('>') {
-                    let mut result = String::with_capacity(stripped.len() + snippet.len() + 16);
-                    result.push_str(&stripped[..=pos]);
-                    result.push_str(snippet);
-                    result.push_str(&stripped[pos + 1..]);
-                    return result;
+            if let Some(pos) = stripped.find('>') {
+                let snippet = css_snippet.unwrap_or_default();
+                if adopted_ref.is_empty() && snippet.is_empty() {
+                    return stripped;
                 }
+                let mut result =
+                    String::with_capacity(stripped.len() + snippet.len() + adopted_ref.len() + 16);
+                result.push_str(&stripped[..pos]);
+                result.push_str(adopted_ref);
+                result.push('>');
+                result.push_str(snippet);
+                result.push_str(&stripped[pos + 1..]);
+                return result;
             }
             stripped
-        } else if let Some(snippet) = css_snippet {
-            format!("<template shadowrootmode=\"open\">{snippet}{trimmed}</template>")
         } else {
-            format!("<template shadowrootmode=\"open\">{trimmed}</template>")
+            let snippet = css_snippet.unwrap_or_default();
+            let mut result =
+                String::with_capacity(45 + adopted_ref.len() + snippet.len() + trimmed.len());
+            result.push_str("<template shadowrootmode=\"open\"");
+            result.push_str(adopted_ref);
+            result.push('>');
+            result.push_str(snippet);
+            result.push_str(trimmed);
+            result.push_str("</template>");
+            result
         }
     }
 
@@ -2815,6 +2864,68 @@ mod tests {
             !raw_text.contains("<link"),
             "Should not have <link> tag in inline mode: {}",
             raw_text
+        );
+    }
+
+    #[test]
+    fn test_css_strategy_module_emits_adopted_stylesheets() {
+        let mut parser = HtmlParser::new();
+        parser.set_css_strategy(CssStrategy::Module);
+        parser
+            .component_registry_mut()
+            .register_component("my-card", "<p><slot></slot></p>", Some("p { color: red; }"))
+            .ok();
+        parser.parse("index.html", "<my-card>Hello</my-card>").ok();
+        let records = parser.into_fragment_records();
+
+        // Component template should have shadowrootadoptedstylesheets, no CSS
+        // module in raw fragments (CSS lives on the component fragment's css field)
+        let my_card = &records["my-card"].fragments;
+        let template_text: String = my_card
+            .iter()
+            .filter_map(|f| match &f.fragment {
+                Some(Fragment::Raw(r)) => Some(r.value.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            template_text.contains("shadowrootadoptedstylesheets=\"my-card\""),
+            "Expected shadowrootadoptedstylesheets attr in: {template_text}"
+        );
+        assert!(
+            !template_text.contains("<link"),
+            "Should not have <link> in module mode: {template_text}"
+        );
+        // No CSS module baked into raw fragments — CSS is stored in
+        // protocol.components, populated by the build system.
+        assert!(
+            !template_text.contains(r#"<style type="module""#),
+            "CSS module should NOT be in raw fragments: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_css_strategy_module_no_css_no_adopted_attr() {
+        let mut parser = HtmlParser::new();
+        parser.set_css_strategy(CssStrategy::Module);
+        parser
+            .component_registry_mut()
+            .register_component("my-card", "<p><slot></slot></p>", None)
+            .ok();
+        parser.parse("index.html", "<my-card>Hello</my-card>").ok();
+        let records = parser.into_fragment_records();
+        let my_card = &records["my-card"].fragments;
+        let template_text: String = my_card
+            .iter()
+            .filter_map(|f| match &f.fragment {
+                Some(Fragment::Raw(r)) => Some(r.value.as_str()),
+                _ => None,
+            })
+            .collect();
+        // No CSS → no shadowrootadoptedstylesheets attribute
+        assert!(
+            !template_text.contains("shadowrootadoptedstylesheets"),
+            "Should not have adopted attr without CSS: {template_text}"
         );
     }
 

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -106,7 +106,7 @@ impl ParserPlugin for FastParserPlugin {
     }
 
     fn on_body_end(&mut self) -> Option<String> {
-        // f-templates are stored in protocol.component_templates and emitted
+        // f-templates are stored in protocol.components and emitted
         // selectively by the handler based on which components were rendered.
         None
     }
@@ -154,11 +154,18 @@ pub fn generate_f_template(
             s.push_str("</style>");
             s
         }),
+        CssStrategy::Module => None,
     };
 
     if trimmed.starts_with("<template") {
         if let Some(close_pos) = trimmed.find('>') {
-            output.push_str(&trimmed[..=close_pos]);
+            output.push_str(&trimmed[..close_pos]);
+            if css_strategy == CssStrategy::Module && css_content.is_some() {
+                output.push_str(" shadowrootadoptedstylesheets=\"");
+                output.push_str(tag_name);
+                output.push('"');
+            }
+            output.push('>');
             if let Some(ref injection) = css_injection {
                 output.push_str(injection);
             }
@@ -167,7 +174,13 @@ pub fn generate_f_template(
             output.push_str(&trimmed);
         }
     } else {
-        output.push_str("<template>");
+        output.push_str("<template");
+        if css_strategy == CssStrategy::Module && css_content.is_some() {
+            output.push_str(" shadowrootadoptedstylesheets=\"");
+            output.push_str(tag_name);
+            output.push('"');
+        }
+        output.push('>');
         if let Some(ref injection) = css_injection {
             output.push_str(injection);
         }
@@ -745,6 +758,59 @@ mod tests {
         assert!(
             !html.contains("<link"),
             "Style strategy should not emit <link> tags"
+        );
+    }
+
+    #[test]
+    fn component_template_css_strategy_module() {
+        let mut plugin = FastParserPlugin::new();
+        plugin.set_css_strategy(crate::CssStrategy::Module);
+        let comp = make_component("my-comp", "<div>hello</div>", Some("div { color: red; }"));
+        plugin.on_parse_component("my-comp", &comp).unwrap();
+
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (_, html) = &templates[0];
+
+        // f-template should NOT contain the CSS module — that is added
+        // by the handler (SSR) or prepend_css_module (partials).
+        assert!(
+            !html.contains(r#"<style type="module""#),
+            "CSS module should not be baked into f-template: {html}"
+        );
+        // shadowrootadoptedstylesheets on the inner template
+        assert!(
+            html.contains(r#"shadowrootadoptedstylesheets="my-comp""#),
+            "Module strategy should add shadowrootadoptedstylesheets, got: {html}"
+        );
+        // No inline <style> or <link> inside the template
+        assert!(
+            !html.contains("<style>div"),
+            "Module strategy should not have inline <style> inside template"
+        );
+        assert!(
+            !html.contains("<link"),
+            "Module strategy should not emit <link> tags"
+        );
+    }
+
+    #[test]
+    fn component_template_css_strategy_module_no_css() {
+        let mut plugin = FastParserPlugin::new();
+        plugin.set_css_strategy(crate::CssStrategy::Module);
+        let comp = make_component("my-comp", "<div>hello</div>", None);
+        plugin.on_parse_component("my-comp", &comp).unwrap();
+
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        let (_, html) = &templates[0];
+        assert!(
+            !html.contains("shadowrootadoptedstylesheets"),
+            "No CSS = no shadowrootadoptedstylesheets, got: {html}"
+        );
+        assert!(
+            !html.contains("<style"),
+            "No CSS = no style tag, got: {html}"
         );
     }
 

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -6,16 +6,27 @@ syntax = "proto3";
 package webui;
 
 // Root protocol containing all fragment records.
+// Per-component metadata keyed by tag name.
+message ComponentData {
+  // f-template HTML string for hydration.
+  // Populated by the FAST parser plugin at build time.
+  // Used by servers to send f-templates to the client during navigation.
+  string template = 1;
+  // Component CSS content for the Module strategy.
+  // Contains the full CSS content when CssStrategy::Module is active.
+  // Empty for Link and Style strategies (CSS is handled via <link> tags
+  // or inline <style> tags baked into raw fragments by the parser).
+  string css = 2;
+}
+
 message WebUIProtocol {
   map<string, FragmentList> fragments = 1;
   // Sorted, deduplicated CSS custom property names used across all components
   // and entry page styles (e.g., "colorBrandBackground", "spacingMedium").
   // Only usage via var(--name) is included; local definitions are excluded.
   repeated string tokens = 2;
-  // Component f-template HTML strings keyed by tag name.
-  // Populated by the FAST parser plugin at build time. Used by servers
-  // to send f-templates to the client during navigation (JSON partials).
-  map<string, string> component_templates = 3;
+  // Per-component data keyed by tag name (f-template + CSS).
+  map<string, ComponentData> components = 3;
 }
 
 // A list of fragments (needed because protobuf maps cannot have repeated values directly).

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -35,6 +35,7 @@ pub type WebUIFragmentAttribute = WebUiFragmentAttribute;
 pub type WebUIFragmentPlugin = WebUiFragmentPlugin;
 pub type WebUIFragmentRoute = WebUiFragmentRoute;
 pub type WebUIFragmentOutlet = WebUiFragmentOutlet;
+pub type ComponentData = proto::ComponentData;
 
 /// A mapping of unique fragment identifiers to their corresponding fragment lists.
 pub type WebUIFragmentRecords = HashMap<String, FragmentList>;
@@ -312,7 +313,7 @@ impl WebUiProtocol {
         Self {
             fragments,
             tokens: Vec::new(),
-            component_templates: HashMap::new(),
+            components: HashMap::new(),
         }
     }
 
@@ -321,7 +322,7 @@ impl WebUiProtocol {
         Self {
             fragments,
             tokens,
-            component_templates: HashMap::new(),
+            components: HashMap::new(),
         }
     }
 }

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -276,30 +276,42 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
     let fragment_records = parser.into_fragment_records();
     let fragment_count: usize = fragment_records.values().map(|v| v.fragments.len()).sum();
 
-    // Filter CSS to only protocol-referenced components.
-    // In Inline mode, CSS is embedded in <style> tags by the parser,
-    // so no external CSS files are produced.
-    // Sanitize filenames: strip path separators to prevent traversal.
-    let css_files: Vec<(String, String)> = if options.css == CssStrategy::Style {
-        Vec::new()
-    } else {
-        css_snapshot
-            .into_iter()
-            .filter(|(tag, _)| fragment_records.contains_key(tag))
-            .map(|(tag, css)| {
-                let safe_tag = tag.replace(['/', '\\'], "-");
-                (format!("{safe_tag}.css"), css)
-            })
-            .collect()
-    };
-
     let mut protocol = WebUIProtocol::with_tokens(fragment_records, tokens);
+
+    // Store component CSS in the protocol keyed by tag name.
+    // Only Module strategy populates this — the handler emits CSS module
+    // <style> tags in <head> and prepends them to partial f-templates.
+    // Link and Style strategies handle CSS via <link> tags and inline
+    // <style> tags baked into raw fragments by the parser.
+    if options.css == CssStrategy::Module {
+        for (tag, css) in &css_snapshot {
+            if protocol.fragments.contains_key(tag) {
+                protocol.components.entry(tag.clone()).or_default().css = css.trim().to_string();
+            }
+        }
+    }
+
+    // Filter CSS to only protocol-referenced components.
+    // In Style mode CSS is embedded in <style> tags; in Module mode CSS is
+    // emitted as <style type="module"> definitions. Neither produces external
+    // CSS files. Sanitize filenames: strip path separators to prevent traversal.
+    let css_files: Vec<(String, String)> =
+        if matches!(options.css, CssStrategy::Style | CssStrategy::Module) {
+            Vec::new()
+        } else {
+            css_snapshot
+                .into_iter()
+                .filter(|(tag, _)| protocol.fragments.contains_key(tag))
+                .map(|(tag, css)| {
+                    let safe_tag = tag.replace(['/', '\\'], "-");
+                    (format!("{safe_tag}.css"), css)
+                })
+                .collect()
+        };
 
     // Store f-templates in the protocol so any host server can query them
     for (tag, tmpl) in &component_templates {
-        protocol
-            .component_templates
-            .insert(tag.clone(), tmpl.clone());
+        protocol.components.entry(tag.clone()).or_default().template = tmpl.clone();
     }
 
     Ok(RawBuildOutput {
@@ -460,6 +472,23 @@ mod tests {
 
         let result = build(options).unwrap();
         // Inline mode embeds CSS in <style> tags — no external CSS files
+        assert!(result.css_files.is_empty());
+        assert_eq!(result.stats.css_file_count, 0);
+        assert!(result.stats.fragment_count > 0);
+    }
+
+    #[test]
+    fn test_build_module_css() {
+        let app = create_app_dir(&[
+            ("index.html", "<my-card>Hello</my-card>"),
+            ("my-card.html", "<div><slot></slot></div>"),
+            ("my-card.css", ".card { color: red; }"),
+        ]);
+        let mut options = default_options(app.path());
+        options.css = CssStrategy::Module;
+
+        let result = build(options).unwrap();
+        // Module mode uses <style type="module"> — no external CSS files
         assert!(result.css_files.is_empty());
         assert_eq!(result.stats.css_file_count, 0);
         assert!(result.stats.fragment_count > 0);

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -33,7 +33,7 @@ webui build [APP] --out <OUT> [--entry <FILE>] [--css <MODE>] [--plugin <NAME>] 
 | `APP` | Path to the app folder | `.` (current directory) |
 | `--out <OUT>` | Output folder for protocol and assets | *(required)* |
 | `--entry <FILE>` | Entry HTML file name | `index.html` |
-| `--css <STRATEGY>` | CSS delivery strategy: `link` or `style` | `link` |
+| `--css <STRATEGY>` | CSS delivery strategy: `link`, `style`, or `module` | `link` |
 | `--plugin <NAME>` | Load a parser plugin (e.g., `fast`) | *(none)* |
 | `--components <SOURCE>` | Additional component sources (npm packages or local paths). Repeatable. | *(none)* |
 
@@ -45,6 +45,7 @@ Path inputs for `APP`, `--state`, and `--servedir` support absolute paths, relat
 |------|----------|
 | `link` | Emits `<link>` tags referencing external `.css` files. CSS files are copied to the output folder. |
 | `style` | Embeds CSS content directly in `<style>` tags inside shadow DOM templates. No separate CSS files are written. |
+| `module` | Emits `<style type="module" specifier="component">` definitions and adds `shadowrootadoptedstylesheets` to `<template>` tags. The browser shares a single `CSSStyleSheet` across all shadow roots that adopt it. No separate CSS files are written. Based on the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. |
 
 **Examples:**
 
@@ -116,7 +117,7 @@ webui serve [APP] --state <FILE> [--servedir <DIR>] [--watch] [--port <PORT>] [-
 | `--watch` | Enable file watching + HMR | `false` |
 | `--port <PORT>` | Port to bind the development server | `3000` |
 | `--entry <FILE>` | Entry HTML file name | `index.html` |
-| `--css <MODE>` | CSS delivery strategy: `link` or `style` | `link` |
+| `--css <MODE>` | CSS delivery strategy: `link`, `style`, or `module` | `link` |
 | `--plugin <NAME>` | Load parser + handler plugins (e.g., `fast`) | *(none)* |
 | `--components <SOURCE>` | Additional component sources (npm packages or local paths). Repeatable. | *(none)* |
 

--- a/docs/guide/concepts/handlers/node.md
+++ b/docs/guide/concepts/handlers/node.md
@@ -80,7 +80,7 @@ Deno.serve({ port: 3000 }, (req) => {
 |-------|------|---------|-------------|
 | `appDir` | `string` | — | Path to app folder |
 | `entry` | `string` | `"index.html"` | Entry file |
-| `css` | `"link" \| "style"` | `"link"` | CSS delivery strategy |
+| `css` | `"link" \| "style" \| "module"` | `"link"` | CSS delivery strategy |
 | `plugin` | `string` | — | Parser plugin (e.g. `"fast"`) |
 | `components` | `string[]` | — | External component sources |
 

--- a/docs/guide/concepts/handlers/rust.md
+++ b/docs/guide/concepts/handlers/rust.md
@@ -155,7 +155,7 @@ async fn main() {
 |-------|------|---------|-------------|
 | `app_dir` | `PathBuf` | — | Path to app folder |
 | `entry` | `String` | `"index.html"` | Entry file |
-| `css` | `CssStrategy` | `Link` | CSS delivery: `Link` or `Style` |
+| `css` | `CssStrategy` | `Link` | CSS delivery: `Link`, `Style`, or `Module` |
 | `plugin` | `Option<String>` | `None` | Parser plugin (e.g. `"fast"`) |
 | `components` | `Vec<String>` | `[]` | External component sources |
 

--- a/examples/app/commerce/server/src/app.rs
+++ b/examples/app/commerce/server/src/app.rs
@@ -13,8 +13,8 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-    pub(crate) fn load(app_root: &Path) -> Result<Self> {
-        let frontend = FrontendRuntime::load(app_root)?;
+    pub(crate) fn load(app_root: &Path, css: webui::CssStrategy) -> Result<Self> {
+        let frontend = FrontendRuntime::load(app_root, css)?;
         let catalog = Catalog::generate();
         Ok(Self { catalog, frontend })
     }
@@ -40,7 +40,7 @@ pub(crate) fn test_state() -> actix_web::web::Data<AppState> {
     let app_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("server crate should live under the app directory");
-    let state = match AppState::load(app_root) {
+    let state = match AppState::load(app_root, webui::CssStrategy::Link) {
         Ok(state) => state,
         Err(error) => panic!("Failed to build the commerce WebUI protocol: {error:#}"),
     };

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -31,13 +31,13 @@ struct CachedAsset {
 }
 
 impl FrontendRuntime {
-    pub fn load(app_root: &Path) -> Result<Self> {
+    pub fn load(app_root: &Path, css: CssStrategy) -> Result<Self> {
         let app_dir = app_root.join("src");
         let assets_dir = canonicalize_dir(&app_root.join("dist"));
         let build_result = build(BuildOptions {
             app_dir,
             entry: "index.html".to_string(),
-            css: CssStrategy::Link,
+            css,
             plugin: Some("fast".to_string()),
             components: Vec::new(),
         })

--- a/examples/app/commerce/server/src/main.rs
+++ b/examples/app/commerce/server/src/main.rs
@@ -18,20 +18,33 @@ use clap::Parser;
 
 use crate::app::AppState;
 use crate::server::configure_app;
+use webui::CssStrategy;
 
 #[derive(Debug, Parser)]
 #[command(name = "marketplace-api")]
 struct ApiArgs {
     #[arg(long, default_value_t = 3100)]
     port: u16,
+
+    /// CSS delivery strategy: link, style, or module.
+    #[arg(long, default_value = "link")]
+    css: String,
 }
 
 fn main() -> Result<()> {
     let args = ApiArgs::parse();
     let port = args.port;
+    let css = match args.css.as_str() {
+        "link" => CssStrategy::Link,
+        "style" => CssStrategy::Style,
+        "module" => CssStrategy::Module,
+        other => {
+            anyhow::bail!("Unknown CSS strategy: {other}. Use \"link\", \"style\", or \"module\".")
+        }
+    };
     let app_root = std::env::current_dir().context("Failed to determine commerce app directory")?;
 
-    let app_state = AppState::load(&app_root)?;
+    let app_state = AppState::load(&app_root, css)?;
 
     eprintln!(
         "Commerce server: {} products, listening on :{}",


### PR DESCRIPTION
Add a third CSS delivery strategy based on the Declarative CSS Module Scripts proposal (https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md).

## What it does

`--css module` enables a new CSS delivery mode where component styles are defined once via `<style type="module" specifier="component-name">` and adopted by shadow roots via `shadowrootadoptedstylesheets` on `<template>` tags. The browser registers each CSS module globally and shares a single CSSStyleSheet across all shadow roots that adopt it, eliminating style duplication. No external CSS files are produced.

## Architecture

### Parser (`webui-parser`)
- New `CssStrategy::Module` enum variant
- `process_component_template()` accepts optional `adopted_specifier` param and adds `shadowrootadoptedstylesheets` attribute to `<template>` tags
- After `parse()` creates fragment records, `prepend_css_module_to_fragment()` merges the `<style type="module">` definition into the first raw fragment value — no adjacent raw siblings, single merged fragment
- Tree-sitter is bypassed for the CSS module tag (it strips type/specifier attributes from `<style>` elements)
- Same logic in both `ensure_route_component_parsed` and `process_component_directive` via shared helper

### Handler (`webui-handler`)
- `process_component()` peeks at fragment\[0\] for the CSS module prefix
- First render: emits the full merged value (CSS module + DSD template)
- Subsequent renders: strips the `<style type="module">...</style>` prefix, emitting only the DSD template — one CSS module per component per page
- Dedup tracked via `emitted_css_modules: HashSet<String>` on render context
- Constants and `extract_css_module()` helper in `plugin::fast` module

### FAST plugin
- `generate_f_template()` adds `shadowrootadoptedstylesheets` to inner `<template>` tag for Module strategy, no CSS inside the template
- `on_render_complete()` does NOT emit CSS modules at body_end — the handler already emitted them during SSR

### Partial rendering (`route_handler`)
- `render_partial()` includes a `cssModules` JSON array with unique CSS module definitions for components the client needs
- f-template strings remain clean (no CSS module prefix) so the client-side f-template parser is unaffected

### Build system (`webui`)
- Module strategy produces no external CSS files (same as Style)

### Bindings
- Node.js: `"module"` match arm in build options
- Commerce example: `--css` CLI flag (link/style/module, default: link)
