### PR TITLE
fix: split publish-stage into native-only and pack-only phases

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
 
   build-macos:
     name: Build (macOS)
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     needs: lint
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,14 +38,15 @@ jobs:
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-  # ── Step 2: Build and stage all artifacts (3 runners, 2 targets each) ─
+  # ── Step 2: Build and stage native artifacts (3 runners, 2 targets each) ─
   #
-  # Each runner builds native + cross targets, then runs full publish-stage
-  # to produce a complete publish/ folder for its platforms.
+  # Each runner builds native + cross targets, then stages only the native files
+  # for its platforms into package/runtime directories. The release job later
+  # merges those staged files and packs npm/NuGet/crates/WASM once on Linux.
   #
-  #   ubuntu-latest  (x64) → linux-x64   + linux-arm64
-  #   macos-latest   (arm) → darwin-arm64 + darwin-x64
-  #   windows-latest (x64) → win32-x64   + win32-arm64
+  #   ubuntu-latest  (x64) → linux-x64    + linux-arm64
+  #   macos-latest-large   (arm) → darwin-arm64 + darwin-x64
+  #   windows-latest (x64) → win32-x64    + win32-arm64
 
   build-linux:
     name: Build (Linux x64 + arm64)
@@ -58,7 +59,6 @@ jobs:
         with:
           shared-cache-key: publish-linux
           rust-targets: x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu
-          dotnet: '8.0.x'
           skip-build: 'true'
 
       - name: Install cross-compilation tools (arm64 linker)
@@ -82,28 +82,32 @@ jobs:
           -p microsoft-webui-ffi
           -p microsoft-webui-node
 
-      - name: Stage all artifacts
-        run: cargo xtask publish-stage --target all --profile release
+      - name: Stage native artifacts
+        run: cargo xtask publish-stage --target all --profile release --native-only
 
-      - name: Upload publish folder
+      - name: Upload staged native assets
         uses: actions/upload-artifact@v4
         with:
-          name: publish-linux
-          path: publish/
+          name: stage-linux
+          path: |
+            publish/native/
+            packages/webui-linux-x64/
+            packages/webui-linux-arm64/
+            dotnet/runtimes/linux-x64/
+            dotnet/runtimes/linux-arm64/
           retention-days: 1
 
   build-macos:
     name: Build (macOS arm64 + x64)
     needs: check-version
     if: needs.check-version.outputs.should_publish == 'true'
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
         with:
           shared-cache-key: publish-macos
           rust-targets: aarch64-apple-darwin, x86_64-apple-darwin
-          dotnet: '8.0.x'
           skip-build: 'true'
 
       - name: Build arm64 (native)
@@ -122,14 +126,19 @@ jobs:
           -p microsoft-webui-ffi
           -p microsoft-webui-node
 
-      - name: Stage all artifacts
-        run: cargo xtask publish-stage --target all --profile release
+      - name: Stage native artifacts
+        run: cargo xtask publish-stage --target all --profile release --native-only
 
-      - name: Upload publish folder
+      - name: Upload staged native assets
         uses: actions/upload-artifact@v4
         with:
-          name: publish-macos
-          path: publish/
+          name: stage-macos
+          path: |
+            publish/native/
+            packages/webui-darwin-arm64/
+            packages/webui-darwin-x64/
+            dotnet/runtimes/osx-arm64/
+            dotnet/runtimes/osx-x64/
           retention-days: 1
 
   build-windows:
@@ -143,7 +152,6 @@ jobs:
         with:
           shared-cache-key: publish-windows
           rust-targets: x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
-          dotnet: '8.0.x'
           skip-build: 'true'
 
       - name: Build x64 (native)
@@ -162,17 +170,22 @@ jobs:
           -p microsoft-webui-ffi
           -p microsoft-webui-node
 
-      - name: Stage all artifacts
-        run: cargo xtask publish-stage --target all --profile release
+      - name: Stage native artifacts
+        run: cargo xtask publish-stage --target all --profile release --native-only
 
-      - name: Upload publish folder
+      - name: Upload staged native assets
         uses: actions/upload-artifact@v4
         with:
-          name: publish-windows
-          path: publish/
+          name: stage-windows
+          path: |
+            publish/native/
+            packages/webui-win32-x64/
+            packages/webui-win32-arm64/
+            dotnet/runtimes/win-x64/
+            dotnet/runtimes/win-arm64/
           retention-days: 1
 
-  # ── Step 3: Merge artifacts, tag, and create release ──────────────────
+  # ── Step 3: Merge native assets, pack once, tag, and create release ───
   release:
     name: Create Release
     needs: [check-version, build-linux, build-macos, build-windows]
@@ -182,13 +195,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Download and merge all publish/ folders from the 3 runners
-      - name: Download all publish artifacts
+      - uses: ./.github/actions/build
+        with:
+          shared-cache-key: publish-release
+          dotnet: '8.0.x'
+          skip-build: 'true'
+
+      # Download and merge all staged native assets from the 3 runners
+      - name: Download staged native artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: publish-*
-          path: publish/
+          pattern: stage-*
+          path: .
           merge-multiple: true
+
+      - name: Setup WASM C headers
+        shell: bash
+        run: |
+          cargo fetch
+          WASM_HEADERS=$(find $HOME/.cargo/registry/src -path "*/tree-sitter-language-*/wasm/include" -type d | head -1)
+          if [ -n "$WASM_HEADERS" ]; then
+            echo "WASI_INCLUDE=$WASM_HEADERS" >> $GITHUB_ENV
+          else
+            echo "::error::Could not find tree-sitter-language WASM headers after cargo fetch"
+            exit 1
+          fi
+
+      - name: Pack unified release artifacts
+        run: cargo xtask publish-stage --pack-only --profile release
 
       # List all artifacts for verification
       - name: List publish artifacts

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All development tasks go through `cargo xtask`:
 | `cargo xtask bench <crate>` | Run benchmarks (parser, handler, protocol, expressions, state, all) |
 | `cargo xtask dev <app>` | Run example app in dev mode |
 | `cargo xtask version <semver>` | Update version across all Cargo.toml and package.json files |
-| `cargo xtask publish-stage` | Stage all release artifacts into `publish/` (npm, NuGet, crates, WASM, native binaries) |
+| `cargo xtask publish-stage` | Stage release artifacts into `publish/` (supports `--native-only` and `--pack-only`) |
 
 ### CI Pipelines
 
@@ -91,7 +91,7 @@ graph LR
     buildL["Build Linux<br/><small>x64 + arm64 (cross)</small>"]
     buildM["Build macOS<br/><small>arm64 + x64 (cross)</small>"]
     buildW["Build Windows<br/><small>x64 + arm64 (cross)</small>"]
-    release["Release<br/><small>merge → tag → GitHub Release</small>"]
+    release["Release<br/><small>merge staged natives → pack → tag → GitHub Release</small>"]
 
     ver --> buildL
     ver --> buildM
@@ -101,7 +101,14 @@ graph LR
     buildW --> release
 ```
 
-Each build runner produces a complete `publish/` folder containing:
+Each build runner uploads only the platform-native inputs it produced:
+
+- `publish/native/` direct-download CLI binaries
+- `packages/webui-*` directories populated with the platform CLI + Node addon
+- `dotnet/runtimes/*` directories populated with the platform FFI library
+
+The release job merges those staged files and then runs `cargo xtask publish-stage --pack-only`
+once on Linux to build the final `publish/` folder:
 
 | Subfolder | Contents | Target registry |
 |-----------|----------|-----------------|

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -115,7 +115,7 @@ fn usage() -> ExitCode {
            e2e [--update-snapshots]  Run Playwright E2E tests for all example apps\n  \
            e2e-approve [run-id]  Download CI screenshot baselines and apply locally\n  \
            version <semver>  Update version across all Cargo.toml and package.json files\n  \
-           publish-stage [--target <triple|all>] [--profile release]  Stage all release artifacts into publish/\n  \
+           publish-stage [--target <triple|all>] [--profile release] [--native-only|--pack-only]  Stage release artifacts into publish/\n  \
            license-headers [--fix]  Check (or fix) license headers in source files"
     );
     ExitCode::SUCCESS

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -91,11 +91,25 @@ const PLATFORMS: &[PlatformEntry] = &[
 /// Subdirectories created inside `publish/`.
 const PUBLISH_SUBDIRS: &[&str] = &["native", "npm", "nuget", "crates", "wasm"];
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StageMode {
+    Full,
+    NativeOnly,
+    PackOnly,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct StageOptions {
+    target_triple: Option<String>,
+    profile: String,
+    mode: StageMode,
+}
+
 // ── Public entry point ──────────────────────────────────────────────────
 
 /// Stage release artifacts into `publish/` and package directories.
 ///
-/// Usage: `cargo xtask publish-stage [--target <triple|all>] [--profile release]`
+/// Usage: `cargo xtask publish-stage [--target <triple|all>] [--profile release] [--native-only|--pack-only]`
 ///
 /// Pass `--target all` to stage every platform whose build artifacts exist.
 /// If `--target` is omitted, detects the current host platform.
@@ -119,27 +133,13 @@ pub fn run_stage(args: &[String]) -> ExitCode {
         }
     };
 
-    let mut target_triple: Option<&str> = None;
-    let mut profile = "release";
-    let mut i = 0;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--target" => {
-                i += 1;
-                if i < args.len() {
-                    target_triple = Some(args[i].as_str());
-                }
-            }
-            "--profile" => {
-                i += 1;
-                if i < args.len() {
-                    profile = args[i].as_str();
-                }
-            }
-            _ => {}
+    let options = match parse_stage_options(args) {
+        Ok(options) => options,
+        Err(e) => {
+            eprintln!("  {} {}", console::style("✘").red().bold(), e,);
+            return ExitCode::FAILURE;
         }
-        i += 1;
-    }
+    };
 
     // Read workspace version
     let ver = match version::read_version() {
@@ -160,7 +160,7 @@ pub fn run_stage(args: &[String]) -> ExitCode {
     );
 
     // Create publish/ directory tree
-    if let Err(e) = create_publish_dirs(&root) {
+    if let Err(e) = prepare_publish_dirs(&root, options.mode) {
         eprintln!(
             "  {} Failed to create publish/ directories: {e}",
             console::style("✘").red().bold(),
@@ -169,22 +169,33 @@ pub fn run_stage(args: &[String]) -> ExitCode {
     }
 
     // Phase 1: Stage native binaries (existing behavior + publish/native/)
-    let stage_result = match target_triple {
-        Some("all") => stage_all_platforms(&root, profile),
-        Some(triple) => stage_one_platform(&root, triple, profile),
-        None => {
-            let host = detect_host_triple();
-            eprintln!(
-                "  {} No --target specified, using host: {}",
-                console::style("▸").cyan().bold(),
-                console::style(&host).bold(),
-            );
-            stage_one_platform(&root, &host, profile)
-        }
-    };
+    if options.mode != StageMode::PackOnly {
+        let stage_result = match options.target_triple.as_deref() {
+            Some("all") => stage_all_platforms(&root, &options.profile),
+            Some(triple) => stage_one_platform(&root, triple, &options.profile),
+            None => {
+                let host = detect_host_triple();
+                eprintln!(
+                    "  {} No --target specified, using host: {}",
+                    console::style("▸").cyan().bold(),
+                    console::style(&host).bold(),
+                );
+                stage_one_platform(&root, &host, &options.profile)
+            }
+        };
 
-    if stage_result != ExitCode::SUCCESS {
-        return stage_result;
+        if stage_result != ExitCode::SUCCESS {
+            return stage_result;
+        }
+
+        if options.mode == StageMode::NativeOnly {
+            eprintln!(
+                "\n{} Native artifacts staged in {}\n",
+                console::style("✨").green(),
+                console::style("publish/native").bold(),
+            );
+            return ExitCode::SUCCESS;
+        }
     }
 
     // Phase 2: Pack npm tarballs
@@ -252,19 +263,86 @@ pub fn run_stage(args: &[String]) -> ExitCode {
 // ── Publish directory setup ─────────────────────────────────────────────
 
 /// Create the `publish/` directory tree, cleaning it first if it exists.
-fn create_publish_dirs(root: &Path) -> Result<(), String> {
+fn prepare_publish_dirs(root: &Path, mode: StageMode) -> Result<(), String> {
     let publish_dir = root.join("publish");
 
-    if publish_dir.exists() {
-        fs::remove_dir_all(&publish_dir).map_err(|e| format!("failed to clean publish/: {e}"))?;
-    }
+    match mode {
+        StageMode::Full | StageMode::NativeOnly => {
+            if publish_dir.exists() {
+                fs::remove_dir_all(&publish_dir)
+                    .map_err(|e| format!("failed to clean publish/: {e}"))?;
+            }
 
-    for subdir in PUBLISH_SUBDIRS {
-        fs::create_dir_all(publish_dir.join(subdir))
-            .map_err(|e| format!("failed to create publish/{subdir}: {e}"))?;
+            for subdir in PUBLISH_SUBDIRS {
+                fs::create_dir_all(publish_dir.join(subdir))
+                    .map_err(|e| format!("failed to create publish/{subdir}: {e}"))?;
+            }
+        }
+        StageMode::PackOnly => {
+            fs::create_dir_all(publish_dir.join("native"))
+                .map_err(|e| format!("failed to create publish/native: {e}"))?;
+
+            for subdir in ["npm", "nuget", "crates", "wasm"] {
+                let path = publish_dir.join(subdir);
+                if path.exists() {
+                    fs::remove_dir_all(&path)
+                        .map_err(|e| format!("failed to clean publish/{subdir}: {e}"))?;
+                }
+                fs::create_dir_all(&path)
+                    .map_err(|e| format!("failed to create publish/{subdir}: {e}"))?;
+            }
+        }
     }
 
     Ok(())
+}
+
+fn parse_stage_options(args: &[String]) -> Result<StageOptions, String> {
+    let mut target_triple = None;
+    let mut profile = String::from("release");
+    let mut mode = StageMode::Full;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--target" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("missing value for --target".to_string());
+                }
+                target_triple = Some(args[i].clone());
+            }
+            "--profile" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("missing value for --profile".to_string());
+                }
+                profile = args[i].clone();
+            }
+            "--native-only" => {
+                mode = set_stage_mode(mode, StageMode::NativeOnly)?;
+            }
+            "--pack-only" => {
+                mode = set_stage_mode(mode, StageMode::PackOnly)?;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    Ok(StageOptions {
+        target_triple,
+        profile,
+        mode,
+    })
+}
+
+fn set_stage_mode(current: StageMode, requested: StageMode) -> Result<StageMode, String> {
+    if current != StageMode::Full && current != requested {
+        return Err("cannot combine --native-only and --pack-only".to_string());
+    }
+
+    Ok(requested)
 }
 
 // ── Phase 1: Native binary staging ──────────────────────────────────────
@@ -825,6 +903,38 @@ fn copy_files_with_extension(src_dir: &Path, dest_dir: &Path, ext: &str) -> Resu
 mod tests {
     use super::*;
 
+    fn parse(args: &[&str]) -> Result<StageOptions, String> {
+        let args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        parse_stage_options(&args)
+    }
+
+    #[test]
+    fn parse_stage_options_defaults_to_full_mode() {
+        let options = parse(&[]).expect("default options should parse");
+
+        assert_eq!(options.target_triple, None);
+        assert_eq!(options.profile, "release");
+        assert_eq!(options.mode, StageMode::Full);
+    }
+
+    #[test]
+    fn parse_stage_options_supports_pack_only_mode() {
+        let options = parse(&["--target", "all", "--profile", "debug", "--pack-only"])
+            .expect("pack-only options should parse");
+
+        assert_eq!(options.target_triple.as_deref(), Some("all"));
+        assert_eq!(options.profile, "debug");
+        assert_eq!(options.mode, StageMode::PackOnly);
+    }
+
+    #[test]
+    fn parse_stage_options_rejects_conflicting_modes() {
+        let error =
+            parse(&["--native-only", "--pack-only"]).expect_err("conflicting modes should fail");
+
+        assert!(error.contains("cannot combine"));
+    }
+
     #[test]
     fn test_native_binary_name_unix() {
         let p = PlatformEntry {
@@ -856,7 +966,7 @@ mod tests {
     #[test]
     fn test_create_publish_dirs() {
         let dir = tempfile::TempDir::new().unwrap();
-        create_publish_dirs(dir.path()).unwrap();
+        prepare_publish_dirs(dir.path(), StageMode::Full).unwrap();
 
         for subdir in PUBLISH_SUBDIRS {
             assert!(
@@ -873,12 +983,33 @@ mod tests {
         fs::create_dir_all(publish.join("stale")).unwrap();
         fs::write(publish.join("stale").join("old.txt"), "old").unwrap();
 
-        create_publish_dirs(dir.path()).unwrap();
+        prepare_publish_dirs(dir.path(), StageMode::Full).unwrap();
 
         assert!(!publish.join("stale").exists(), "stale/ should be removed");
         for subdir in PUBLISH_SUBDIRS {
             assert!(publish.join(subdir).is_dir());
         }
+    }
+
+    #[test]
+    fn test_pack_only_preserves_native_outputs() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let publish = dir.path().join("publish");
+        let native = publish.join("native");
+        let npm = publish.join("npm");
+
+        fs::create_dir_all(&native).unwrap();
+        fs::create_dir_all(&npm).unwrap();
+        fs::write(native.join("webui-win32-x64.exe"), "bin").unwrap();
+        fs::write(npm.join("stale.tgz"), "stale").unwrap();
+
+        prepare_publish_dirs(dir.path(), StageMode::PackOnly).unwrap();
+
+        assert!(native.join("webui-win32-x64.exe").exists());
+        assert!(!npm.join("stale.tgz").exists());
+        assert!(publish.join("nuget").is_dir());
+        assert!(publish.join("crates").is_dir());
+        assert!(publish.join("wasm").is_dir());
     }
 
     #[test]


### PR DESCRIPTION
The macOS publish runner failed building WASM during publish-stage because tree-sitter-html cannot compile to wasm32-unknown-unknown without LLVM on that runner. Additionally, each runner was packing all platform npm/NuGet artifacts before native binaries from other runners were merged, risking incomplete release packages.

Split publish-stage into two modes:
- --native-only: each platform runner stages only its native binaries
- --pack-only: the release job merges staged natives, then packs npm/NuGet/crates/WASM once on Linux where LLVM is available

Update publish.yml so platform runners upload only their native outputs, and the release job downloads+merges them before running pack-only with WASM C headers set up via cargo fetch.