### PR TITLE
fix: remove unnecessary git credentials from CD

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -1,11 +1,10 @@
 trigger: none
 pr: none
 
-parameters:
+variables:
 - name: releaseTag
   displayName: GitHub Release Tag (e.g. v0.0.1)
-  type: string
-  default: ''
+  value: ''
 
 # The `resources` specify the location and version of the 1ES PT.
 resources:
@@ -52,15 +51,15 @@ extends:
           # GitHub release produced by the publish.yml GitHub Actions workflow.
           - script: |
               mkdir -p publish_artifacts_npm publish_artifacts_crates publish_artifacts_nuget
-              gh release download "${{ parameters.releaseTag }}" \
+              gh release download "$(releaseTag)" \
                 --repo microsoft/webui \
                 --pattern "*.tgz" \
                 --dir publish_artifacts_npm/
-              gh release download "${{ parameters.releaseTag }}" \
+              gh release download "$(releaseTag)" \
                 --repo microsoft/webui \
                 --pattern "*.crate" \
                 --dir publish_artifacts_crates/
-              gh release download "${{ parameters.releaseTag }}" \
+              gh release download "$(releaseTag)" \
                 --repo microsoft/webui \
                 --pattern "*.nupkg" \
                 --dir publish_artifacts_nuget/


### PR DESCRIPTION
This was left in by mistake, there is no github token and it is not necessary since now the task simply takes the release files from github.