### PR TITLE
fix: correct repository URL in @microsoft/webui package.json

### DIFF
--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -36,7 +36,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nicolo-ribaudo/nicolo-nicolo.git"
+    "url": "https://github.com/microsoft/webui.git"
   },
   "scripts": {
     "build": "esbuild src/index.ts src/platform.ts src/install.ts --outdir=dist --format=esm --platform=node && tsc --emitDeclarationOnly",


### PR DESCRIPTION
Closes #135

The repository URL in packages/webui/package.json was pointing to an incorrect repo (nicolo-ribaudo/nicolo-nicolo). Updated to the correct microsoft/webui URL.