### PR TITLE
chore: add missing metadata needed for publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 authors = ["Microsoft Edge"]
 license = "MIT"
 repository = "https://github.com/microsoft/webui"
+homepage = "https://microsoft.github.io/webui"
 
 [workspace.dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
 description = "CLI tool for building WebUI applications"
+keywords = ["webui", "cli", "build-tool", "ssr", "tooling"]
+categories = ["command-line-utilities", "development-tools", "web-programming"]
 
 [[bin]]
 name = "webui"

--- a/crates/webui-discovery/Cargo.toml
+++ b/crates/webui-discovery/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "discovery", "components", "ssr", "tooling"]
+categories = ["web-programming", "development-tools"]
 
 [lib]
 name = "webui_discovery"

--- a/crates/webui-discovery/README.md
+++ b/crates/webui-discovery/README.md
@@ -1,0 +1,11 @@
+# microsoft-webui-discovery
+
+External component discovery for the [WebUI](https://github.com/microsoft/webui) framework. Resolves web component definitions from npm packages and local paths for use during the build step.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "expressions", "evaluation", "templates", "ssr"]
+categories = ["web-programming", "parser-implementations"]
 
 [lib]
 name = "webui_expressions"

--- a/crates/webui-expressions/README.md
+++ b/crates/webui-expressions/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-expressions
+
+Expression evaluator for the [WebUI](https://github.com/microsoft/webui) framework. Evaluates template binding expressions against JSON state at render time.
+
+## Overview
+
+`microsoft-webui-expressions` provides a fast, allocation-conscious expression engine for resolving data bindings, conditional expressions, and loop iterators inside WebUI templates.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "ffi", "c-api", "bindings", "ssr"]
+categories = ["api-bindings", "web-programming"]
 
 [lib]
 name = "webui_ffi"

--- a/crates/webui-ffi/README.md
+++ b/crates/webui-ffi/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-ffi
+
+C-compatible FFI boundary for the [WebUI](https://github.com/microsoft/webui) framework. Exposes the WebUI renderer to any host language via a stable C ABI.
+
+## Overview
+
+`microsoft-webui-ffi` compiles to a `cdylib` (`libwebui_ffi.so` / `webui_ffi.dll` / `libwebui_ffi.dylib`) that host language bindings (e.g. .NET, Node.js) load at runtime. The generated C header (`webui_ffi.h`) describes the full public API.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and integration examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "rendering", "ssr", "templates", "server-side"]
+categories = ["web-programming", "template-engine"]
 
 [lib]
 name = "webui_handler"

--- a/crates/webui-handler/README.md
+++ b/crates/webui-handler/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-handler
+
+High-performance template renderer for the [WebUI](https://github.com/microsoft/webui) framework. Consumes the compiled binary protocol and produces HTML output at request time.
+
+## Overview
+
+`microsoft-webui-handler` evaluates expressions, resolves state bindings, and renders full or partial HTML responses from pre-compiled WebUI protocol buffers — with no JavaScript runtime required.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "nodejs", "napi", "ssr", "rendering"]
+categories = ["api-bindings", "web-programming"]
 
 [lib]
 name = "webui_node"

--- a/crates/webui-node/README.md
+++ b/crates/webui-node/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-node
+
+Node.js native addon for the [WebUI](https://github.com/microsoft/webui) framework, built with [napi-rs](https://napi.rs).
+
+## Overview
+
+`microsoft-webui-node` compiles to a platform-specific `.node` addon that exposes WebUI's rendering API to Node.js hosts (e.g. Express, Fastify) without spawning a subprocess.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "parser", "html", "templates", "ssr"]
+categories = ["parser-implementations", "template-engine", "web-programming"]
 
 [lib]
 name = "webui_parser"

--- a/crates/webui-parser/README.md
+++ b/crates/webui-parser/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-parser
+
+HTML/CSS template parser for the [WebUI](https://github.com/microsoft/webui) framework. Transforms WebUI template markup into the binary protocol consumed by the handler at runtime.
+
+## Overview
+
+`microsoft-webui-parser` uses tree-sitter to parse HTML and CSS, extracting static and dynamic fragments, component slots, directives (`<for>`, `<if>`), and CSS token bindings into a compact protobuf protocol.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-protocol/Cargo.toml
+++ b/crates/webui-protocol/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "protocol", "protobuf", "binary", "serialization"]
+categories = ["encoding", "web-programming"]
 
 [lib]
 name = "webui_protocol"

--- a/crates/webui-protocol/README.md
+++ b/crates/webui-protocol/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-protocol
+
+Protobuf protocol definitions and serialization for the [WebUI](https://github.com/microsoft/webui) framework. Defines the binary format that carries compiled template data from the build step to the renderer.
+
+## Overview
+
+`microsoft-webui-protocol` uses `prost` for zero-copy protobuf encoding and decoding. It defines the `WebUIProtocol` message and all fragment types that flow between the parser and handler.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "state", "ssr", "rendering", "templates"]
+categories = ["web-programming"]
 
 [lib]
 name = "webui_state"

--- a/crates/webui-state/README.md
+++ b/crates/webui-state/README.md
@@ -1,0 +1,11 @@
+# microsoft-webui-state
+
+State management for the [WebUI](https://github.com/microsoft/webui) framework. Provides the scoped JSON state store used by the expression evaluator and renderer during a render pass.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "testing", "test-utils", "ssr", "mocking"]
+categories = ["development-tools::testing", "web-programming"]
 
 [lib]
 name = "webui_test_utils"

--- a/crates/webui-test-utils/README.md
+++ b/crates/webui-test-utils/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-test-utils
+
+Shared test helpers, builders, and fixtures for the [WebUI](https://github.com/microsoft/webui) framework.
+
+## Overview
+
+`microsoft-webui-test-utils` provides common utilities for writing tests against WebUI crates, including mock builders, protocol fixtures, and assertion helpers.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license-file = "../../LICENSE"
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "wasm", "webassembly", "ssr", "rendering"]
+categories = ["wasm", "web-programming"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/crates/webui-wasm/README.md
+++ b/crates/webui-wasm/README.md
@@ -1,0 +1,15 @@
+# microsoft-webui-wasm
+
+WebAssembly bindings for the [WebUI](https://github.com/microsoft/webui) framework, built with `wasm-bindgen`. Powers the online WebUI playground.
+
+## Overview
+
+`microsoft-webui-wasm` exposes WebUI's parser and handler to the browser via a WASM module, enabling live template preview without a server.
+
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
+## License
+
+MIT — Copyright (c) Microsoft Corporation.

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["webui", "ssr", "rendering", "templates", "server-side"]
+categories = ["web-programming", "template-engine"]
 
 [lib]
 name = "webui"


### PR DESCRIPTION
See https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate

Some of these fields are required and have been included with this change.