### PR TITLE
refactor: unify plugin architecture for extensibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ version = "0.0.2"
 dependencies = [
  "clap",
  "criterion",
+ "html-escape",
  "microsoft-webui-expressions",
  "microsoft-webui-protocol",
  "microsoft-webui-test-utils",

--- a/crates/webui-cli/src/commands/common.rs
+++ b/crates/webui-cli/src/commands/common.rs
@@ -20,7 +20,7 @@ pub struct AppArgs {
     #[arg(long, value_enum, default_value_t = CssStrategy::Link)]
     pub css: CssStrategy,
 
-    /// Parser plugin to load (e.g., "fast" for FAST-HTML hydration support)
+    /// Framework plugin to load
     #[arg(long)]
     pub plugin: Option<String>,
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime};
 use webui::WebUIHandler;
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter};
 use webui_protocol::WebUIProtocol;
 

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -31,7 +31,7 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_parser::HtmlParser;
 use webui_protocol::WebUIProtocol;

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::hint::black_box;
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_protocol::{
     ComparisonOperator, ConditionExpr, FragmentList, LogicalOperator, WebUIFragment, WebUIProtocol,

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -25,6 +25,9 @@ pub enum HandlerError {
     #[error("Rendering error: {0}")]
     Rendering(String),
 
+    #[error("Rendering invariant error: {0}")]
+    Invariant(String),
+
     #[error("Missing fragment: {0}")]
     MissingFragment(String),
 
@@ -45,6 +48,9 @@ pub enum HandlerError {
 
     #[error("Writer error: {0}")]
     Writer(String),
+
+    #[error("Plugin data error: {0}")]
+    PluginData(String),
 }
 
 pub type Result<T> = std::result::Result<T, HandlerError>;
@@ -314,7 +320,7 @@ impl WebUIHandler {
                 }
                 Some(Fragment::Plugin(plugin_frag)) => {
                     if let Some(p) = &mut context.plugin {
-                        p.on_plugin_data(&plugin_frag.data, context.writer)?;
+                        p.on_element_data(&plugin_frag.data, context.writer)?;
                     }
                 }
                 Some(Fragment::Route(route_frag)) => {
@@ -399,7 +405,9 @@ impl WebUIHandler {
 
                 context.writer.write("<")?;
                 context.writer.write(comp)?;
-                route_renderer::emit_state_attributes(context.state, context.writer)?;
+                if let Some(p) = &context.plugin {
+                    p.write_route_component_state(context.state, context.writer)?;
+                }
                 context.writer.write(">")?;
 
                 self.process_component(
@@ -514,7 +522,9 @@ impl WebUIHandler {
 
                 context.writer.write("<")?;
                 context.writer.write(&route_frag.fragment_id)?;
-                route_renderer::emit_state_attributes(context.state, context.writer)?;
+                if let Some(p) = &context.plugin {
+                    p.write_route_component_state(context.state, context.writer)?;
+                }
                 context.writer.write(">")?;
 
                 self.process_component(&comp, context)?;
@@ -712,15 +722,13 @@ impl WebUIHandler {
             context.writer.write("\">")?;
         }
 
-        // Hook: emit plugin content (e.g., f-templates) before body_end
-        if signal.raw && signal.value == "body_end" {
-            if let Some(p) = &mut context.plugin {
-                p.on_render_complete(
-                    context.protocol,
-                    &context.rendered_components,
-                    context.writer,
-                )?;
-            }
+        // Hook: emit rendered component templates before body_end when hydration is enabled
+        if signal.raw && signal.value == "body_end" && context.plugin.is_some() {
+            crate::plugin::emit_rendered_component_templates(
+                context.protocol,
+                &context.rendered_components,
+                context.writer,
+            )?;
         }
 
         if let Some(p) = &mut context.plugin {
@@ -5142,6 +5150,63 @@ mod tests {
         WebUIProtocol::new(fragments)
     }
 
+    fn make_nested_route_protocol() -> WebUIProtocol {
+        use webui_protocol::WebUiFragmentRoute;
+
+        let mut fragments = HashMap::new();
+
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![WebUiFragmentRoute {
+                        path: "sections/:id".into(),
+                        fragment_id: "section-comp".into(),
+                        exact: false,
+                        children: vec![WebUiFragmentRoute {
+                            path: "topics/:topicId".into(),
+                            fragment_id: "topic-comp".into(),
+                            exact: true,
+                            children: vec![],
+                        }],
+                    }],
+                })],
+            },
+        );
+
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<h1>Shell</h1>"),
+                    WebUIFragment::outlet(),
+                ],
+            },
+        );
+
+        fragments.insert(
+            "section-comp".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<h2>Section</h2>"),
+                    WebUIFragment::outlet(),
+                ],
+            },
+        );
+
+        fragments.insert(
+            "topic-comp".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Topic content</p>")],
+            },
+        );
+
+        WebUIProtocol::new(fragments)
+    }
+
     #[test]
     fn test_route_renders_shell_always() {
         let protocol = make_route_protocol();
@@ -5321,10 +5386,10 @@ mod tests {
     }
 
     #[test]
-    fn test_route_state_attributes_escape_scalars_and_data_state() {
+    fn test_no_plugin_no_state_attributes() {
         let protocol = make_route_protocol();
         let state = test_json!({
-            "title": "Fish & Chips <\"special\">",
+            "title": "Fish & Chips",
             "cartOpen": true,
             "items": [{"name": "A&B"}]
         });
@@ -5339,82 +5404,15 @@ mod tests {
         .unwrap();
 
         let html = writer.get_content();
+        // Without a plugin, no state attributes at all
         assert!(
-            html.contains(r#"title="Fish &amp; Chips &lt;&quot;special&quot;&gt;""#),
-            "escaped title should be emitted: {html}"
-        );
-        assert!(
-            html.contains(r#"cart-open="true""#),
-            "bool attrs should render: {html}"
+            !html.contains("data-state"),
+            "no data-state without plugin: {html}"
         );
         assert!(
-            html.contains(r#"data-state=""#),
-            "complex state should be emitted as data-state: {html}"
+            !html.contains(r#"title="Fish"#),
+            "no scalar attrs without plugin: {html}"
         );
-        assert!(
-            html.contains(r#"&quot;name&quot;:&quot;A&amp;B&quot;"#),
-            "complex state values should be escaped inside data-state: {html}"
-        );
-    }
-
-    // ── Nested route + outlet rendering tests ─────────────────────────
-
-    /// Build a protocol with nested routes and outlet-based components.
-    fn make_nested_route_protocol() -> WebUIProtocol {
-        use webui_protocol::WebUiFragmentRoute;
-
-        let mut fragments = HashMap::new();
-
-        fragments.insert(
-            "index.html".to_string(),
-            FragmentList {
-                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
-                    path: "/".into(),
-                    fragment_id: "app-shell".into(),
-                    exact: false,
-                    children: vec![WebUiFragmentRoute {
-                        path: "sections/:id".into(),
-                        fragment_id: "section-comp".into(),
-                        exact: false,
-                        children: vec![WebUiFragmentRoute {
-                            path: "topics/:topicId".into(),
-                            fragment_id: "topic-comp".into(),
-                            exact: true,
-                            children: vec![],
-                        }],
-                    }],
-                })],
-            },
-        );
-
-        fragments.insert(
-            "app-shell".to_string(),
-            FragmentList {
-                fragments: vec![
-                    WebUIFragment::raw("<h1>Shell</h1>"),
-                    WebUIFragment::outlet(),
-                ],
-            },
-        );
-
-        fragments.insert(
-            "section-comp".to_string(),
-            FragmentList {
-                fragments: vec![
-                    WebUIFragment::raw("<h2>Section</h2>"),
-                    WebUIFragment::outlet(),
-                ],
-            },
-        );
-
-        fragments.insert(
-            "topic-comp".to_string(),
-            FragmentList {
-                fragments: vec![WebUIFragment::raw("<p>Topic content</p>")],
-            },
-        );
-
-        WebUIProtocol::new(fragments)
     }
 
     #[test]

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -21,8 +21,10 @@
 //! binding counter starting from 0. This matches the C++ prototype behavior.
 
 use super::HandlerPlugin;
-use crate::{ResponseWriter, Result};
+use crate::{HandlerError, ResponseWriter, Result};
+use serde_json::Value;
 use std::fmt::Write;
+use webui_protocol::FastElementData;
 
 // Comment format constants
 const BINDING_START_PREFIX: &str = "<!--fe-b$$start$$";
@@ -178,41 +180,61 @@ impl HandlerPlugin for FastHydrationPlugin {
         writer.write(&self.buffer)
     }
 
-    fn on_plugin_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()> {
+    fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()> {
         if !self.is_active() {
             return Ok(());
         }
-        // FAST hydration protocol: data is a u32 LE attribute count
-        if data.len() >= 4 {
-            let count = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
-            if count > 0 {
-                let binding_index = self.next_index_n(count);
-                self.build_attribute_marker(binding_index, count);
-                writer.write(&self.buffer)?;
-            }
+        let decoded = FastElementData::decode(data).map_err(|error| {
+            HandlerError::PluginData(format!(
+                "FAST hydration plugin expected 4 bytes of element data: {error}"
+            ))
+        })?;
+        if decoded.binding_count > 0 {
+            let binding_index = self.next_index_n(decoded.binding_count);
+            self.build_attribute_marker(binding_index, decoded.binding_count);
+            writer.write(&self.buffer)?;
         }
         Ok(())
     }
 
-    fn on_render_complete(
-        &mut self,
-        protocol: &webui_protocol::WebUIProtocol,
-        rendered_components: &std::collections::HashSet<String>,
+    /// FAST emits scalar attributes + `data-state` JSON on route component elements.
+    /// Components read these via `@attr` and `prepare()`.
+    fn write_route_component_state(
+        &self,
+        state: &Value,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
-        // Emit f-templates for only the components that were actually rendered.
-        // CSS module definitions are NOT included here — the handler already
-        // emitted them during SSR via process_component().
-        for name in rendered_components {
-            if let Some(tmpl) = protocol
-                .components
-                .get(name)
-                .map(|c| c.template.as_str())
-                .filter(|s| !s.is_empty())
-            {
-                writer.write(tmpl)?;
-            }
+        let map = match state.as_object() {
+            Some(m) => m,
+            None => return Ok(()),
+        };
+
+        // Emit scalar values as individual kebab-case attributes
+        for (key, value) in map {
+            let val_str = match value {
+                Value::String(s) => std::borrow::Cow::Borrowed(s.as_str()),
+                Value::Number(n) => std::borrow::Cow::Owned(n.to_string()),
+                Value::Bool(true) => std::borrow::Cow::Borrowed("true"),
+                Value::Bool(false) => std::borrow::Cow::Borrowed("false"),
+                _ => continue,
+            };
+            let attr_name = crate::camel_to_kebab(key);
+            writer.write(" ")?;
+            writer.write(&attr_name)?;
+            writer.write("=\"")?;
+            crate::route_renderer::write_escaped_state_attr(writer, val_str.as_ref())?;
+            writer.write("\"")?;
         }
+
+        // Emit data-state JSON for complex values (arrays, objects)
+        let has_complex = map.values().any(|v| v.is_array() || v.is_object());
+        if has_complex {
+            let json_str = state.to_string();
+            writer.write(" data-state=\"")?;
+            crate::route_renderer::write_escaped_state_attr(writer, &json_str)?;
+            writer.write("\"")?;
+        }
+
         Ok(())
     }
 }
@@ -253,7 +275,7 @@ mod tests {
         plugin.on_repeat_item_start(0, &mut writer).unwrap();
         plugin.on_repeat_item_end(0, &mut writer).unwrap();
         let data = 3u32.to_le_bytes();
-        plugin.on_plugin_data(&data, &mut writer).unwrap();
+        plugin.on_element_data(&data, &mut writer).unwrap();
         assert_eq!(writer.output, "");
     }
 
@@ -329,7 +351,7 @@ mod tests {
         plugin.push_scope();
         let mut writer = TestWriter::new();
         let data = 1u32.to_le_bytes();
-        plugin.on_plugin_data(&data, &mut writer).unwrap();
+        plugin.on_element_data(&data, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-b-0");
     }
 
@@ -339,7 +361,7 @@ mod tests {
         plugin.push_scope();
         let mut writer = TestWriter::new();
         let data = 3u32.to_le_bytes();
-        plugin.on_plugin_data(&data, &mut writer).unwrap();
+        plugin.on_element_data(&data, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-c-0-3");
     }
 
@@ -349,7 +371,7 @@ mod tests {
         plugin.push_scope();
         let mut writer = TestWriter::new();
         let data = 0u32.to_le_bytes();
-        plugin.on_plugin_data(&data, &mut writer).unwrap();
+        plugin.on_element_data(&data, &mut writer).unwrap();
         assert_eq!(writer.output, "");
     }
 
@@ -360,7 +382,7 @@ mod tests {
         let mut writer = TestWriter::new();
         // 3 attributes → counter goes from 0 to 3
         let data = 3u32.to_le_bytes();
-        plugin.on_plugin_data(&data, &mut writer).unwrap();
+        plugin.on_element_data(&data, &mut writer).unwrap();
         // Next binding should be at index 3
         writer.output.clear();
         plugin.on_binding_start("x", &mut writer).unwrap();
@@ -398,21 +420,54 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_plugin_data_ignored() {
+    fn test_empty_element_data_returns_error() {
         let mut plugin = FastHydrationPlugin::new();
         plugin.push_scope();
         let mut writer = TestWriter::new();
-        plugin.on_plugin_data(&[], &mut writer).unwrap();
+        let result = plugin.on_element_data(&[], &mut writer);
+        assert!(
+            matches!(result, Err(crate::HandlerError::PluginData(ref msg)) if msg.contains("expected 4 bytes")),
+            "invalid payload length should produce a plugin-data error: {result:?}"
+        );
         assert_eq!(writer.output, "");
     }
 
     #[test]
-    fn test_short_plugin_data_ignored() {
+    fn test_short_element_data_returns_error() {
         let mut plugin = FastHydrationPlugin::new();
         plugin.push_scope();
         let mut writer = TestWriter::new();
-        plugin.on_plugin_data(&[1, 2], &mut writer).unwrap();
+        let result = plugin.on_element_data(&[1, 2], &mut writer);
+        assert!(
+            matches!(result, Err(crate::HandlerError::PluginData(ref msg)) if msg.contains("expected 4 bytes")),
+            "invalid payload length should produce a plugin-data error: {result:?}"
+        );
         assert_eq!(writer.output, "");
+    }
+
+    #[test]
+    fn test_write_route_component_state_emits_data_state() {
+        let plugin = FastHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        let state = serde_json::json!({
+            "title": "Hello",
+            "items": [{"name": "A&B"}]
+        });
+
+        plugin
+            .write_route_component_state(&state, &mut writer)
+            .unwrap();
+
+        assert!(
+            writer.output.contains("data-state="),
+            "FAST plugin should emit data-state: {}",
+            writer.output
+        );
+        assert!(
+            writer.output.contains(r#"title="Hello""#),
+            "FAST plugin should still emit scalar attrs: {}",
+            writer.output
+        );
     }
 
     // ── Integration tests (full render cycles with WebUIHandler) ────────

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -3,15 +3,14 @@
 
 //! Handler plugin trait and built-in plugin implementations.
 //!
-//! The plugin system is framework-agnostic — WebUI provides lifecycle hooks
-//! and plugins decide what (if anything) to write. Different frameworks
-//! (FAST, LIT, etc.) implement `HandlerPlugin` with their own marker formats.
+//! Handler plugins write framework-specific hydration markers while shared
+//! completion work, such as component template emission, stays in handler core.
 
-mod fast;
-
-pub use fast::FastHydrationPlugin;
+pub mod fast;
 
 use crate::{ResponseWriter, Result};
+use std::collections::HashSet;
+use webui_protocol::WebUIProtocol;
 
 /// A handler plugin that can inject additional content during rendering.
 ///
@@ -19,7 +18,8 @@ use crate::{ResponseWriter, Result};
 /// - **Scope management**: `push_scope` / `pop_scope` for component and loop boundaries
 /// - **Binding lifecycle**: `on_binding_start` / `on_binding_end` around signals, for-loops, if-conditions
 /// - **Repeat items**: `on_repeat_item_start` / `on_repeat_item_end` per for-loop item
-/// - **Plugin data**: `on_plugin_data` for opaque data from parser plugins
+/// - **Element data**: `on_element_data` for parser-produced hydration metadata
+/// - **Route state**: `write_route_component_state` for framework-specific opening-tag attributes
 ///
 /// WebUI does not interpret what plugins write — it just calls the hooks.
 /// Each framework defines its own marker format.
@@ -44,17 +44,37 @@ pub trait HandlerPlugin {
     /// Called after rendering a repeat item.
     fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
 
-    /// Called when a plugin-specific protocol fragment is encountered.
-    /// The data is opaque bytes from the parser plugin — interpretation is plugin-defined.
-    fn on_plugin_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
+    /// Called when parser-produced element metadata is encountered.
+    fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
 
-    /// Called after all fragments have been rendered.
-    fn on_render_complete(
-        &mut self,
-        _protocol: &webui_protocol::WebUIProtocol,
-        _rendered_components: &std::collections::HashSet<String>,
+    /// Called when emitting a matched route component's opening tag.
+    /// Plugins can write framework-specific attributes before the closing `>`.
+    /// The default is a no-op.
+    fn write_route_component_state(
+        &self,
+        _state: &serde_json::Value,
         _writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
         Ok(())
     }
+}
+
+/// Emit client component templates for only the components rendered in this response.
+pub(crate) fn emit_rendered_component_templates(
+    protocol: &WebUIProtocol,
+    rendered_components: &HashSet<String>,
+    writer: &mut dyn ResponseWriter,
+) -> Result<()> {
+    for name in rendered_components {
+        if let Some(template) = protocol
+            .components
+            .get(name)
+            .map(|component| component.template.as_str())
+            .filter(|template| !template.is_empty())
+        {
+            writer.write(template)?;
+        }
+    }
+
+    Ok(())
 }

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -140,7 +140,7 @@ pub fn filter_needed_components(
 /// already have.
 ///
 /// Walks the fragment graph from `entry_id`, identifies needed components (not
-/// in the client's inventory), and returns their f-template HTML from the
+/// in the client's inventory), and returns their client template HTML from the
 /// protocol's `components` map.
 ///
 /// Returns `(templates: Vec<(name, html)>, updated_inventory_hex)`.
@@ -165,8 +165,8 @@ pub fn get_route_templates(
     (templates, updated_inv)
 }
 
-/// Get the f-template HTML strings needed for the active route chain rooted at
-/// `entry_id` for the current `request_path`.
+/// Get the client template HTML strings needed for the active route chain
+/// rooted at `entry_id` for the current `request_path`.
 ///
 /// Returns `(templates: Vec<(name, html)>, updated_inventory_hex)`.
 pub fn get_route_templates_for_request(
@@ -192,7 +192,7 @@ pub fn get_route_templates_for_request(
     (templates, updated_inv)
 }
 
-/// Prepend the CSS module `<style type="module">` definition to an f-template
+/// Prepend the CSS module `<style type="module">` definition to a client template
 /// string for partial responses.
 fn prepend_css_module(name: &str, css: &str, tmpl: &str) -> String {
     if css.is_empty() {

--- a/crates/webui-handler/src/route_renderer.rs
+++ b/crates/webui-handler/src/route_renderer.rs
@@ -3,57 +3,12 @@
 
 //! Route and outlet rendering helpers.
 //!
-//! Free functions for emitting state attributes on route component elements,
-//! escaping HTML attribute values, and selecting the best matching route
-//! among sibling route fragments.
+//! Free functions for escaping HTML attribute values and selecting the best
+//! matching route among sibling route fragments.
 
 use crate::route_matcher;
 use crate::{ResponseWriter, Result};
-use serde_json::Value;
 use webui_protocol::{web_ui_fragment::Fragment, WebUIFragment};
-
-/// Emit top-level state values as HTML attributes on a route component element.
-///
-/// This ensures FAST hydration reads the correct values from DOM attributes
-/// instead of using the component's default `@attr` values.
-///
-/// Scalar values (string, number, bool) are emitted as individual kebab-case
-/// attributes. The full state (including arrays/objects) is also emitted as a
-/// `data-state` JSON attribute so components can read complex state during hydration.
-pub(crate) fn emit_state_attributes(state: &Value, writer: &mut dyn ResponseWriter) -> Result<()> {
-    let map = match state.as_object() {
-        Some(m) => m,
-        None => return Ok(()),
-    };
-
-    // Emit scalar values as individual attributes
-    for (key, value) in map {
-        let val_str = match value {
-            Value::String(s) => std::borrow::Cow::Borrowed(s.as_str()),
-            Value::Number(n) => std::borrow::Cow::Owned(n.to_string()),
-            Value::Bool(true) => std::borrow::Cow::Borrowed("true"),
-            Value::Bool(false) => std::borrow::Cow::Borrowed("false"),
-            _ => continue,
-        };
-        let attr_name = super::camel_to_kebab(key);
-        writer.write(" ")?;
-        writer.write(&attr_name)?;
-        writer.write("=\"")?;
-        write_escaped_state_attr(writer, val_str.as_ref())?;
-        writer.write("\"")?;
-    }
-
-    // Emit full state as data-state for complex values (arrays, objects)
-    let has_complex = map.values().any(|v| v.is_array() || v.is_object());
-    if has_complex {
-        let json_str = state.to_string();
-        writer.write(" data-state=\"")?;
-        write_escaped_state_attr(writer, &json_str)?;
-        writer.write("\"")?;
-    }
-
-    Ok(())
-}
 
 /// Escape HTML special characters in an attribute value and write directly to the writer.
 ///

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -32,7 +32,7 @@ use napi::bindgen_prelude::{Buffer, Function};
 use napi::Error as NapiError;
 use napi_derive::napi;
 use serde_json::Value;
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_protocol::WebUIProtocol;
 

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -29,6 +29,7 @@ tree-sitter = { workspace = true }
 tree-sitter-language = { workspace = true }
 tree-sitter-html = { workspace = true }
 tree-sitter-css = { workspace = true }
+html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 

--- a/crates/webui-parser/benches/parser_bench.rs
+++ b/crates/webui-parser/benches/parser_bench.rs
@@ -3,7 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::hint::black_box;
-use webui_parser::{plugin::FastParserPlugin, CssStrategy, HtmlParser};
+use webui_parser::{plugin::fast::FastParserPlugin, CssStrategy, HtmlParser};
 
 fn build_simple_template() -> String {
     let mut html = String::with_capacity(256);

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -18,7 +18,7 @@ pub use css_parser::CssParser;
 pub use error::{ParserError, Result};
 pub use handlebars_parser::HandlebarsParser;
 
-use crate::plugin::ParserPlugin;
+use crate::plugin::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, Parser, Query, QueryCursor, StreamingIteratorMut};
 use tree_sitter_html::LANGUAGE;
@@ -163,15 +163,14 @@ impl HtmlParser {
         self.fragment_records.contains_key(fragment_id)
     }
 
-    /// Take the parser plugin. Call before `into_fragment_records()` if you need
-    /// access to plugin state (e.g., component templates).
-    pub fn take_plugin(&mut self) -> Option<Box<dyn ParserPlugin>> {
-        self.plugin.take()
-    }
-
-    /// Get a mutable reference to the parser plugin.
-    pub fn plugin_mut(&mut self) -> Option<&mut dyn ParserPlugin> {
-        self.plugin.as_deref_mut()
+    /// Take any post-parse artifacts captured by the parser plugin.
+    #[must_use]
+    pub fn take_plugin_artifacts(&mut self) -> ParserPluginArtifacts {
+        self.plugin
+            .take()
+            .map_or(ParserPluginArtifacts::None, |plugin| {
+                plugin.into_artifacts()
+            })
     }
 
     /// Take the accumulated CSS tokens as a sorted, deduplicated `Vec`.
@@ -196,6 +195,9 @@ impl HtmlParser {
     pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<()> {
         // Reset sub-fragments for new parse
         self.raw_buffer.clear();
+        if let Some(ref mut plugin) = self.plugin {
+            plugin.start_fragment(fragment_id);
+        }
 
         // Parse HTML
         let tree = self
@@ -265,6 +267,77 @@ impl HtmlParser {
         }
     }
 
+    /// Returns true when a text node should be emitted into the fragment stream.
+    ///
+    /// Pure formatting nodes that contain line breaks are still dropped, but
+    /// inline whitespace-only separators such as the spaces around `&gt;` in
+    /// `{{sectionName}} &gt; {{topicName}}` must be preserved. Tree-sitter can
+    /// split those separators into standalone text nodes.
+    fn should_emit_text_content(content: &str) -> bool {
+        if content.is_empty() {
+            return false;
+        }
+
+        if !content.trim().is_empty() {
+            return true;
+        }
+
+        content.chars().all(char::is_whitespace)
+            && !content.contains('\n')
+            && !content.contains('\r')
+    }
+
+    /// Process child nodes while preserving raw source gaps between them.
+    ///
+    /// Tree-sitter HTML treats some authored whitespace as extras rather than
+    /// concrete child nodes. Reconstructing the byte gaps between children keeps
+    /// inline separators like `{{a}} &gt; {{b}}` intact.
+    fn process_children_with_source_gaps(
+        &mut self,
+        node: Node,
+        source: &str,
+        fragments: &mut Vec<WebUIFragment>,
+        skip_structural_tags: bool,
+    ) -> Result<()> {
+        let mut cursor = node.walk();
+        let mut last_end = node.start_byte();
+
+        for child in node.children(&mut cursor) {
+            if child.start_byte() > last_end {
+                let gap = &source[last_end..child.start_byte()];
+                if Self::should_emit_text_content(gap) {
+                    self.add_raw_fragment(gap);
+                }
+            }
+
+            let kind = child.kind();
+            if !skip_structural_tags || (kind != "start_tag" && kind != "end_tag") {
+                self.process_child_node(child, source, fragments)?;
+            }
+
+            last_end = child.end_byte();
+        }
+
+        if node.end_byte() > last_end {
+            let gap = &source[last_end..node.end_byte()];
+            if Self::should_emit_text_content(gap) {
+                self.add_raw_fragment(gap);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process all non-structural child nodes inside an element-like container.
+    fn process_content_children(
+        &mut self,
+        node: Node,
+        source: &str,
+        fragments: &mut Vec<WebUIFragment>,
+    ) -> Result<()> {
+        self.process_children_with_source_gaps(node, source, fragments, true)
+    }
+
     /// Process an HTML node to generate WebUI fragments.
     fn process_html_node(
         &mut self,
@@ -272,27 +345,12 @@ impl HtmlParser {
         source: &str,
         fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
-        let mut cursor = node.walk();
-
         if node.kind() == "document" || node.kind() == "fragment" || node.kind() == "element" {
-            // Process children
-            if cursor.goto_first_child() {
-                loop {
-                    let child = cursor.node();
-
-                    // Process child node
-                    self.process_child_node(child, source, fragments)?;
-
-                    if !cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
-                cursor.goto_parent();
-            }
+            self.process_children_with_source_gaps(node, source, fragments, false)?;
         } else {
             // Add text content as raw fragment
             let content = &source[node.start_byte()..node.end_byte()];
-            if !content.trim().is_empty() {
+            if Self::should_emit_text_content(content) {
                 self.add_raw_fragment(content);
             }
         }
@@ -365,7 +423,7 @@ impl HtmlParser {
             }
             "text" | "raw_text" => {
                 let content = &source[node.start_byte()..node.end_byte()];
-                if !content.trim().is_empty() {
+                if Self::should_emit_text_content(content) {
                     let handlebars_result = self.handlebars_parser.parse(content);
                     match handlebars_result {
                         Ok(parsed_fragments) => {
@@ -604,7 +662,7 @@ impl HtmlParser {
             // Process attributes on the tag
             let binding_count = self.process_tag_attributes(tag_node, source, fragments, false)?;
             if let Some(ref mut p) = self.plugin {
-                if let Some(data) = p.on_element_parsed(binding_count) {
+                if let Some(data) = p.finish_element(binding_count) {
                     self.add_fragment(WebUIFragment::plugin(data), fragments);
                 }
             }
@@ -623,13 +681,7 @@ impl HtmlParser {
             } else {
                 self.add_raw_fragment(">");
 
-                // Process children (skip start_tag and end_tag nodes)
-                for child in node.named_children(&mut node.walk()) {
-                    let kind = child.kind();
-                    if kind != "start_tag" && kind != "end_tag" && kind != "self_closing_tag" {
-                        self.process_child_node(child, source, fragments)?;
-                    }
-                }
+                self.process_content_children(node, source, fragments)?;
 
                 // Add closing tag
                 self.add_raw_fragment(&format!("</{}>", tag_name));
@@ -663,12 +715,14 @@ impl HtmlParser {
 
             let attr_name = self.get_attr_name(child, source)?;
 
-            // Let plugin skip framework-specific attributes (but still count them
-            // for binding attribute tracking — FAST-HTML creates factories for these)
-            if let Some(ref p) = self.plugin {
-                if p.should_skip_attribute(&attr_name) {
-                    binding_count += 1;
-                    continue;
+            if let Some(ref mut p) = self.plugin {
+                match p.classify_attribute(&attr_name) {
+                    AttributeAction::Keep => {}
+                    AttributeAction::Skip => continue,
+                    AttributeAction::SkipAndCountBinding => {
+                        binding_count += 1;
+                        continue;
+                    }
                 }
             }
 
@@ -677,19 +731,19 @@ impl HtmlParser {
             if let Some(bool_name) = attr_name.strip_prefix('?') {
                 // Boolean attribute: ?disabled={{isDisabled}}
                 if is_component {
-                    if let Some(val) = &attr_value {
-                        if let Some(signal_name) = Self::extract_single_handlebars(val) {
-                            let condition = ConditionExpr::identifier(&signal_name);
-                            let frag = Self::maybe_mark_attr_start(
-                                WebUIFragment::attribute_boolean(bool_name, condition),
-                                &mut first_dynamic_emitted,
-                            );
-                            self.add_fragment(frag, fragments);
-                            binding_count += 1;
-                        }
+                    if let Some(condition) = self.parse_boolean_condition(attr_value.as_deref()) {
+                        let frag = Self::maybe_mark_attr_start(
+                            WebUIFragment::attribute_boolean(bool_name, condition),
+                            &mut first_dynamic_emitted,
+                        );
+                        self.add_fragment(frag, fragments);
+                        binding_count += 1;
                     }
-                } else {
-                    self.process_boolean_attribute(bool_name, attr_value.as_deref(), fragments)?;
+                } else if self.process_boolean_attribute(
+                    bool_name,
+                    attr_value.as_deref(),
+                    fragments,
+                )? {
                     binding_count += 1;
                 }
             } else if attr_name.starts_with(':') {
@@ -839,25 +893,32 @@ impl HtmlParser {
 
     /// Process a boolean attribute (?prefix). Silently drops if value is not a
     /// pure handlebars expression.
+    fn parse_boolean_condition(&self, value: Option<&str>) -> Option<ConditionExpr> {
+        if let Some(val) = value {
+            if let Some(expr_str) = Self::extract_single_handlebars(val) {
+                return Some(
+                    self.condition_parser
+                        .parse(&expr_str)
+                        .unwrap_or_else(|_| ConditionExpr::identifier(&expr_str)),
+                );
+            }
+        }
+
+        None
+    }
+
     fn process_boolean_attribute(
         &mut self,
         name: &str,
         value: Option<&str>,
         fragments: &mut Vec<WebUIFragment>,
-    ) -> Result<()> {
-        if let Some(val) = value {
-            if let Some(expr_str) = Self::extract_single_handlebars(val) {
-                // Parse as a full condition expression (supports predicates like page == 'dashboard')
-                let condition = self
-                    .condition_parser
-                    .parse(&expr_str)
-                    .unwrap_or_else(|_| ConditionExpr::identifier(&expr_str));
-                self.add_fragment(WebUIFragment::attribute_boolean(name, condition), fragments);
-                return Ok(());
-            }
+    ) -> Result<bool> {
+        if let Some(condition) = self.parse_boolean_condition(value) {
+            self.add_fragment(WebUIFragment::attribute_boolean(name, condition), fragments);
+            return Ok(true);
         }
         // Invalid boolean attribute — silently drop (no output at all)
-        Ok(())
+        Ok(false)
     }
 
     /// Process a complex attribute (:prefix).
@@ -915,12 +976,7 @@ impl HtmlParser {
         fragments: &mut Vec<WebUIFragment>,
     ) -> Result<()> {
         self.add_raw_fragment("<head>");
-        for child in node.named_children(&mut node.walk()) {
-            let kind = child.kind();
-            if kind != "start_tag" && kind != "end_tag" {
-                self.process_child_node(child, source, fragments)?;
-            }
-        }
+        self.process_content_children(node, source, fragments)?;
         self.flush_raw_buffer(fragments);
         fragments.push(WebUIFragment::signal("head_end", true));
         self.add_raw_fragment("</head>");
@@ -937,19 +993,8 @@ impl HtmlParser {
         self.add_raw_fragment("<body>");
         self.flush_raw_buffer(fragments);
         fragments.push(WebUIFragment::signal("body_start", true));
-        for child in node.named_children(&mut node.walk()) {
-            let kind = child.kind();
-            if kind != "start_tag" && kind != "end_tag" {
-                self.process_child_node(child, source, fragments)?;
-            }
-        }
+        self.process_content_children(node, source, fragments)?;
         self.flush_raw_buffer(fragments);
-        // Let plugin inject content before body_end
-        if let Some(ref mut p) = self.plugin {
-            if let Some(body_end_content) = p.on_body_end() {
-                fragments.push(WebUIFragment::raw(body_end_content));
-            }
-        }
         fragments.push(WebUIFragment::signal("body_end", true));
         self.add_raw_fragment("</body>");
         Ok(())
@@ -1045,11 +1090,7 @@ impl HtmlParser {
         std::mem::swap(&mut self.raw_buffer, &mut temp_buffer);
 
         // Process the for loop body
-        for child in node.named_children(&mut node.walk()) {
-            if child.kind() != "start_tag" && child.kind() != "end_tag" {
-                self.process_child_node(child, source, &mut for_fragment)?;
-            }
-        }
+        self.process_content_children(node, source, &mut for_fragment)?;
 
         // Ensure any remaining content is flushed to the for loop's fragment
         self.flush_raw_buffer(&mut for_fragment);
@@ -1120,11 +1161,7 @@ impl HtmlParser {
         let parent_buffer = std::mem::take(&mut self.raw_buffer);
 
         // Process the if body - capture all content including closing tags
-        for child in node.named_children(&mut node.walk()) {
-            if child.kind() != "start_tag" && child.kind() != "end_tag" {
-                self.process_child_node(child, source, &mut if_fragment)?;
-            }
-        }
+        self.process_content_children(node, source, &mut if_fragment)?;
 
         // Make sure all content in the if buffer is flushed to the if fragment
         self.flush_raw_buffer(&mut if_fragment);
@@ -1257,46 +1294,27 @@ impl HtmlParser {
             return Ok(());
         }
 
-        if let Some(ref mut p) = self.plugin {
-            if let Some(comp) = self.component_registry.get(component) {
-                p.on_parse_component(component, comp)?;
-            }
-        }
-        let (html_content, css_content, css_tokens) = {
-            let comp = self.component_registry.get(component).ok_or_else(|| {
+        let component_data = self
+            .component_registry
+            .get(component)
+            .ok_or_else(|| {
                 crate::error::ParserError::Directive(format!("Component not found: {component}"))
-            })?;
-            (
-                comp.html_content.clone(),
-                comp.css_content.clone(),
-                comp.css_tokens.clone(),
-            )
-        };
-        self.token_store.extend(css_tokens);
-        let adopted_specifier = match self.css_strategy {
-            CssStrategy::Module if css_content.is_some() => Some(component.to_string()),
-            _ => None,
-        };
-        let css_injection = match self.css_strategy {
-            CssStrategy::Link => {
-                if css_content.is_some() {
-                    Some(format!(
-                        "<link rel=\"stylesheet\" href=\"/{component}.css\">"
-                    ))
-                } else {
-                    None
-                }
-            }
-            CssStrategy::Style => css_content
-                .as_ref()
-                .map(|css| format!("<style>{}</style>", css.trim())),
-            CssStrategy::Module => None,
-        };
-        let processed = self.process_component_template(
-            &html_content,
-            css_injection.as_deref(),
-            adopted_specifier.as_deref(),
+            })?
+            .clone();
+
+        self.token_store
+            .extend(component_data.css_tokens.iter().cloned());
+
+        let processed = self.build_component_template(
+            component,
+            &component_data.html_content,
+            component_data.css_content.as_deref(),
         );
+
+        if let Some(ref mut p) = self.plugin {
+            p.register_component_template(component, &component_data, &processed)?;
+        }
+
         let saved_buffer = std::mem::take(&mut self.raw_buffer);
         self.parse(component, &processed)?;
         self.raw_buffer = saved_buffer;
@@ -1335,7 +1353,7 @@ impl HtmlParser {
         if let Some(tag_node) = tag_node {
             let binding_count = self.process_tag_attributes(tag_node, source, fragments, true)?;
             if let Some(ref mut p) = self.plugin {
-                if let Some(data) = p.on_element_parsed(binding_count) {
+                if let Some(data) = p.finish_element(binding_count) {
                     self.add_fragment(WebUIFragment::plugin(data), fragments);
                 }
             }
@@ -1374,38 +1392,21 @@ impl HtmlParser {
 
         // Parse and register component template if not already done
         if !self.fragment_records.contains_key(tag_name) {
-            // Notify plugin about component (only on first encounter)
+            let component_data = self
+                .component_registry
+                .get(tag_name)
+                .ok_or_else(|| {
+                    ParserError::Directive(format!("Component not found: {}", tag_name))
+                })?
+                .clone();
+            let processed =
+                self.build_component_template(tag_name, &html_content, css_content.as_deref());
+
+            // Notify plugin about the final component template (only on first encounter)
             if let Some(ref mut p) = self.plugin {
-                if let Some(component) = self.component_registry.get(tag_name) {
-                    p.on_parse_component(tag_name, component)?;
-                }
+                p.register_component_template(tag_name, &component_data, &processed)?;
             }
 
-            let adopted_specifier = match self.css_strategy {
-                CssStrategy::Module if css_content.is_some() => Some(tag_name.to_string()),
-                _ => None,
-            };
-            let css_injection = match self.css_strategy {
-                CssStrategy::Link => {
-                    if css_content.is_some() {
-                        Some(format!(
-                            "<link rel=\"stylesheet\" href=\"/{}.css\">",
-                            tag_name
-                        ))
-                    } else {
-                        None
-                    }
-                }
-                CssStrategy::Style => css_content
-                    .as_ref()
-                    .map(|css| format!("<style>{}</style>", css.trim())),
-                CssStrategy::Module => None,
-            };
-            let processed = self.process_component_template(
-                &html_content,
-                css_injection.as_deref(),
-                adopted_specifier.as_deref(),
-            );
             self.parse(tag_name, &processed)?;
         }
 
@@ -1414,12 +1415,7 @@ impl HtmlParser {
 
         // Process slot content (skip start_tag/end_tag/self_closing_tag)
         if !is_self_closing {
-            for child in node.named_children(&mut node.walk()) {
-                let kind = child.kind();
-                if kind != "start_tag" && kind != "end_tag" && kind != "self_closing_tag" {
-                    self.process_child_node(child, source, fragments)?;
-                }
-            }
+            self.process_content_children(node, source, fragments)?;
         }
 
         // Emit closing tag
@@ -1428,6 +1424,41 @@ impl HtmlParser {
         }
 
         Ok(())
+    }
+
+    /// Process component template HTML: wrap in shadow DOM template if needed,
+    /// inject CSS snippet (link or inline style), and strip runtime-only attributes.
+    /// When `adopted_specifier` is `Some`, a `shadowrootadoptedstylesheets` attribute
+    /// is added to the `<template>` tag (used by [`CssStrategy::Module`]).
+    fn build_component_template(
+        &mut self,
+        tag_name: &str,
+        html: &str,
+        css_content: Option<&str>,
+    ) -> String {
+        let adopted_specifier = match self.css_strategy {
+            CssStrategy::Module if css_content.is_some() => Some(tag_name.to_string()),
+            _ => None,
+        };
+        let css_injection = match self.css_strategy {
+            CssStrategy::Link => {
+                if css_content.is_some() {
+                    Some(format!(
+                        "<link rel=\"stylesheet\" href=\"/{tag_name}.css\">"
+                    ))
+                } else {
+                    None
+                }
+            }
+            CssStrategy::Style => css_content.map(|css| format!("<style>{}</style>", css.trim())),
+            CssStrategy::Module => None,
+        };
+
+        self.process_component_template(
+            html,
+            css_injection.as_deref(),
+            adopted_specifier.as_deref(),
+        )
     }
 
     /// Process component template HTML: wrap in shadow DOM template if needed,
@@ -1591,6 +1622,28 @@ mod tests {
             fragment_records,
             "test.html",
             [raw("Hello, "), signal_raw("html_content"), raw("!"),]
+        );
+    }
+
+    #[test]
+    fn test_parse_preserves_inline_spaces_around_entity_between_bindings() {
+        let mut parser = HtmlParser::new();
+        let html = "<nav>{{sectionName}} &gt; {{topicName}}</nav>";
+        let result = parser.parse("test.html", html);
+
+        assert!(result.is_ok(), "Parse error: {:?}", result.err());
+        let fragment_records = parser.into_fragment_records();
+
+        assert_stream!(
+            fragment_records,
+            "test.html",
+            [
+                raw("<nav>"),
+                signal("sectionName"),
+                raw(" &gt; "),
+                signal("topicName"),
+                raw("</nav>"),
+            ]
         );
     }
 
@@ -1936,6 +1989,45 @@ mod tests {
                 raw("</custom-element>"),
             ]
         );
+    }
+
+    #[test]
+    fn test_component_boolean_predicate_preserves_condition_tree() {
+        let mut parser = HtmlParser::new();
+        parser
+            .component_registry
+            .register_component("custom-element", "<slot></slot>", None)
+            .expect("register");
+        let result = parser.parse(
+            "index.html",
+            r#"<custom-element ?disabled="{{page == 'dashboard'}}"></custom-element>"#,
+        );
+        assert!(result.is_ok());
+
+        let records = parser.into_fragment_records();
+        let fragments = &records["index.html"].fragments;
+        match fragments
+            .get(1)
+            .and_then(|fragment| fragment.fragment.as_ref())
+        {
+            Some(webui_protocol::web_ui_fragment::Fragment::Attribute(attr)) => {
+                assert_eq!(attr.name, "disabled");
+                assert!(attr.attr_start);
+                match attr
+                    .condition_tree
+                    .as_ref()
+                    .and_then(|condition| condition.expr.as_ref())
+                {
+                    Some(webui_protocol::condition_expr::Expr::Predicate(pred)) => {
+                        assert_eq!(pred.left, "page");
+                        assert_eq!(pred.operator, 3);
+                        assert_eq!(pred.right, "'dashboard'");
+                    }
+                    other => panic!("expected predicate condition tree, got {:?}", other),
+                }
+            }
+            other => panic!("expected attribute fragment, got {:?}", other),
+        }
     }
 
     #[test]
@@ -3082,33 +3174,30 @@ mod tests {
     }
 
     impl crate::plugin::ParserPlugin for BindingCountPlugin {
-        fn on_parse_component(&mut self, _tag_name: &str, _component: &Component) -> Result<()> {
+        fn register_component_template(
+            &mut self,
+            _tag_name: &str,
+            _component: &Component,
+            _processed_template: &str,
+        ) -> Result<()> {
             Ok(())
         }
 
-        fn should_skip_attribute(&self, attr_name: &str) -> bool {
-            attr_name.starts_with('@') || attr_name == "f-ref"
+        fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction {
+            if attr_name.starts_with('@') || attr_name == "f-ref" {
+                AttributeAction::SkipAndCountBinding
+            } else {
+                AttributeAction::Keep
+            }
         }
 
-        fn on_body_end(&mut self) -> Option<String> {
-            None
-        }
-
-        fn on_element_parsed(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>> {
+        fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>> {
             self.counts.push(binding_attribute_count);
             if binding_attribute_count > 0 {
                 Some(binding_attribute_count.to_le_bytes().to_vec())
             } else {
                 None
             }
-        }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
-        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-            self
         }
     }
 

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -3,13 +3,14 @@
 
 //! FAST parser plugin for the WebUI parser.
 //!
-//! Tracks component definitions during HTML parsing and generates `<f-template>`
-//! wrappers at body end. Converts WebUI Framework template syntax (`<if>`, `<for>`, `{{}}`)
+//! Tracks component definitions during HTML parsing and returns `<f-template>`
+//! artifacts after parsing. Converts WebUI Framework template syntax (`<if>`, `<for>`, `{{}}`)
 //! into FAST-compatible syntax (`<f-when>`, `<f-repeat>`, `{}`).
 
-use super::ParserPlugin;
+use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
 use crate::{CssStrategy, Result};
+use webui_protocol::FastElementData;
 
 /// Information about a tracked component for `<f-template>` generation.
 struct TrackedComponent {
@@ -23,7 +24,7 @@ struct TrackedComponent {
 /// Implements the `ParserPlugin` trait for the FAST framework:
 /// - Filters FAST-specific runtime binding attributes (`@click`, `f-ref`, etc.)
 /// - Tracks components encountered during parsing
-/// - Generates `<f-template>` wrappers with converted FAST syntax at body end
+/// - Returns `<f-template>` artifacts with converted FAST syntax after parsing
 /// - Emits binding attribute counts as `Plugin` protocol fragment data
 pub struct FastParserPlugin {
     /// Components tracked during parsing, in discovery order.
@@ -76,14 +77,12 @@ impl Default for FastParserPlugin {
 }
 
 impl ParserPlugin for FastParserPlugin {
-    fn should_skip_attribute(&self, attr_name: &str) -> bool {
-        attr_name.starts_with('@')
-            || attr_name == "f-ref"
-            || attr_name == "f-slotted"
-            || attr_name == "f-children"
-    }
-
-    fn on_parse_component(&mut self, tag_name: &str, component: &Component) -> Result<()> {
+    fn register_component_template(
+        &mut self,
+        tag_name: &str,
+        component: &Component,
+        _processed_template: &str,
+    ) -> Result<()> {
         // Only track each component once (avoids duplicate <f-template> blocks
         // when a component is used in multiple parent templates)
         if self.components.iter().any(|c| c.tag_name == tag_name) {
@@ -97,26 +96,34 @@ impl ParserPlugin for FastParserPlugin {
         Ok(())
     }
 
-    fn on_element_parsed(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>> {
+    fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction {
+        if attr_name.starts_with('@')
+            || attr_name == "f-ref"
+            || attr_name == "f-slotted"
+            || attr_name == "f-children"
+        {
+            AttributeAction::SkipAndCountBinding
+        } else {
+            AttributeAction::Keep
+        }
+    }
+
+    fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>> {
         if binding_attribute_count > 0 {
-            Some(binding_attribute_count.to_le_bytes().to_vec())
+            Some(
+                FastElementData {
+                    binding_count: binding_attribute_count,
+                }
+                .encode()
+                .to_vec(),
+            )
         } else {
             None
         }
     }
 
-    fn on_body_end(&mut self) -> Option<String> {
-        // f-templates are stored in protocol.components and emitted
-        // selectively by the handler based on which components were rendered.
-        None
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
+    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
+        ParserPluginArtifacts::ComponentTemplates(self.take_component_templates())
     }
 }
 
@@ -636,56 +643,77 @@ mod tests {
         }
     }
 
-    // --- should_skip_attribute ---
+    // --- classify_attribute ---
 
     #[test]
     fn skip_event_binding() {
-        let plugin = FastParserPlugin::new();
-        assert!(plugin.should_skip_attribute("@click"));
-        assert!(plugin.should_skip_attribute("@input"));
-        assert!(plugin.should_skip_attribute("@custom-event"));
+        let mut plugin = FastParserPlugin::new();
+        assert_eq!(
+            plugin.classify_attribute("@click"),
+            AttributeAction::SkipAndCountBinding
+        );
+        assert_eq!(
+            plugin.classify_attribute("@input"),
+            AttributeAction::SkipAndCountBinding
+        );
+        assert_eq!(
+            plugin.classify_attribute("@custom-event"),
+            AttributeAction::SkipAndCountBinding
+        );
     }
 
     #[test]
     fn skip_f_ref() {
-        let plugin = FastParserPlugin::new();
-        assert!(plugin.should_skip_attribute("f-ref"));
+        let mut plugin = FastParserPlugin::new();
+        assert_eq!(
+            plugin.classify_attribute("f-ref"),
+            AttributeAction::SkipAndCountBinding
+        );
     }
 
     #[test]
     fn skip_f_slotted() {
-        let plugin = FastParserPlugin::new();
-        assert!(plugin.should_skip_attribute("f-slotted"));
+        let mut plugin = FastParserPlugin::new();
+        assert_eq!(
+            plugin.classify_attribute("f-slotted"),
+            AttributeAction::SkipAndCountBinding
+        );
     }
 
     #[test]
     fn skip_f_children() {
-        let plugin = FastParserPlugin::new();
-        assert!(plugin.should_skip_attribute("f-children"));
+        let mut plugin = FastParserPlugin::new();
+        assert_eq!(
+            plugin.classify_attribute("f-children"),
+            AttributeAction::SkipAndCountBinding
+        );
     }
 
     #[test]
     fn do_not_skip_normal_attributes() {
-        let plugin = FastParserPlugin::new();
-        assert!(!plugin.should_skip_attribute("class"));
-        assert!(!plugin.should_skip_attribute("id"));
-        assert!(!plugin.should_skip_attribute("data-value"));
-        assert!(!plugin.should_skip_attribute(":title"));
-        assert!(!plugin.should_skip_attribute("f-other"));
+        let mut plugin = FastParserPlugin::new();
+        assert_eq!(plugin.classify_attribute("class"), AttributeAction::Keep);
+        assert_eq!(plugin.classify_attribute("id"), AttributeAction::Keep);
+        assert_eq!(
+            plugin.classify_attribute("data-value"),
+            AttributeAction::Keep
+        );
+        assert_eq!(plugin.classify_attribute(":title"), AttributeAction::Keep);
+        assert_eq!(plugin.classify_attribute("f-other"), AttributeAction::Keep);
     }
 
-    // --- on_element_parsed ---
+    // --- finish_element ---
 
     #[test]
     fn element_parsed_zero_count_returns_none() {
         let mut plugin = FastParserPlugin::new();
-        assert!(plugin.on_element_parsed(0).is_none());
+        assert!(plugin.finish_element(0).is_none());
     }
 
     #[test]
     fn element_parsed_nonzero_count_returns_le_bytes() {
         let mut plugin = FastParserPlugin::new();
-        let data = plugin.on_element_parsed(3);
+        let data = plugin.finish_element(3);
         assert!(data.is_some());
         let bytes = data.as_deref().unwrap_or_default();
         assert_eq!(bytes, &3u32.to_le_bytes());
@@ -694,25 +722,19 @@ mod tests {
     #[test]
     fn element_parsed_large_count() {
         let mut plugin = FastParserPlugin::new();
-        let data = plugin.on_element_parsed(256);
+        let data = plugin.finish_element(256);
         assert!(data.is_some());
         let bytes = data.as_deref().unwrap_or_default();
         assert_eq!(bytes, &256u32.to_le_bytes());
-    }
-
-    // --- on_body_end ---
-
-    #[test]
-    fn body_end_no_components_returns_none() {
-        let mut plugin = FastParserPlugin::new();
-        assert!(plugin.on_body_end().is_none());
     }
 
     #[test]
     fn component_template_simple_component() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component("my-comp", "<div>hello</div>", Some("div { color: red; }"));
-        plugin.on_parse_component("my-comp", &comp).unwrap();
+        plugin
+            .register_component_template("my-comp", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -730,7 +752,9 @@ mod tests {
     fn component_template_without_css() {
         let mut plugin = FastParserPlugin::new();
         let comp = make_component("no-css", "<span>text</span>", None);
-        plugin.on_parse_component("no-css", &comp).unwrap();
+        plugin
+            .register_component_template("no-css", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -746,7 +770,9 @@ mod tests {
         let mut plugin = FastParserPlugin::new();
         plugin.set_css_strategy(crate::CssStrategy::Style);
         let comp = make_component("my-comp", "<div>hello</div>", Some("div { color: red; }"));
-        plugin.on_parse_component("my-comp", &comp).unwrap();
+        plugin
+            .register_component_template("my-comp", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -766,7 +792,9 @@ mod tests {
         let mut plugin = FastParserPlugin::new();
         plugin.set_css_strategy(crate::CssStrategy::Module);
         let comp = make_component("my-comp", "<div>hello</div>", Some("div { color: red; }"));
-        plugin.on_parse_component("my-comp", &comp).unwrap();
+        plugin
+            .register_component_template("my-comp", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -799,7 +827,9 @@ mod tests {
         let mut plugin = FastParserPlugin::new();
         plugin.set_css_strategy(crate::CssStrategy::Module);
         let comp = make_component("my-comp", "<div>hello</div>", None);
-        plugin.on_parse_component("my-comp", &comp).unwrap();
+        plugin
+            .register_component_template("my-comp", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -819,8 +849,12 @@ mod tests {
         let mut plugin = FastParserPlugin::new();
         let comp1 = make_component("comp-a", "<div>A</div>", None);
         let comp2 = make_component("comp-b", "<div>B</div>", Some("b { }"));
-        plugin.on_parse_component("comp-a", &comp1).unwrap();
-        plugin.on_parse_component("comp-b", &comp2).unwrap();
+        plugin
+            .register_component_template("comp-a", &comp1, &comp1.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("comp-b", &comp2, &comp2.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 2);
@@ -845,9 +879,15 @@ mod tests {
 
         // Simulate the same component encountered multiple times
         // (e.g., <my-button> used in todo-app, todo-item, etc.)
-        plugin.on_parse_component("my-button", &comp).unwrap();
-        plugin.on_parse_component("my-button", &comp).unwrap();
-        plugin.on_parse_component("my-button", &comp).unwrap();
+        plugin
+            .register_component_template("my-button", &comp, &comp.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("my-button", &comp, &comp.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("my-button", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(
@@ -866,9 +906,15 @@ mod tests {
         let card = make_component("my-card", "<div><slot></slot></div>", Some(".card{}"));
 
         // my-button used in two different parent templates, my-card used once
-        plugin.on_parse_component("my-button", &btn).unwrap();
-        plugin.on_parse_component("my-card", &card).unwrap();
-        plugin.on_parse_component("my-button", &btn).unwrap();
+        plugin
+            .register_component_template("my-button", &btn, &btn.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("my-card", &card, &card.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("my-button", &btn, &btn.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 2);
@@ -946,7 +992,9 @@ mod tests {
         let mut plugin = FastParserPlugin::new();
         let html = r#"<div><if condition="visible"><span>hi</span></if></div>"#;
         let comp = make_component("my-widget", html, None);
-        plugin.on_parse_component("my-widget", &comp).unwrap();
+        plugin
+            .register_component_template("my-widget", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
@@ -979,7 +1027,9 @@ mod tests {
         let html =
             r#"<template shadowrootmode="open"><h1>Title</h1><main><outlet /></main></template>"#;
         let comp = make_component("my-shell", html, None);
-        plugin.on_parse_component("my-shell", &comp).unwrap();
+        plugin
+            .register_component_template("my-shell", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         let (_, result) = &templates[0];
@@ -1021,7 +1071,9 @@ mod tests {
             r#"<template shadowrootmode="open" @click="{onClick(e)}"><div>{{title}}</div></template>"#,
             Some("div { color: red; }"),
         );
-        plugin.on_parse_component("my-comp", &comp).unwrap();
+        plugin
+            .register_component_template("my-comp", &comp, &comp.html_content)
+            .unwrap();
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
         let (name, html) = &templates[0];
@@ -1069,7 +1121,9 @@ mod tests {
         // declarative shadow DOM (template with shadowrootmode).
         let html = r#"<div><child-comp><template shadowrootmode="open"><p>inner</p></template></child-comp></div>"#;
         let comp = make_component("parent-comp", html, None);
-        plugin.on_parse_component("parent-comp", &comp).unwrap();
+        plugin
+            .register_component_template("parent-comp", &comp, &comp.html_content)
+            .unwrap();
 
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);

--- a/crates/webui-parser/src/plugin/mod.rs
+++ b/crates/webui-parser/src/plugin/mod.rs
@@ -3,52 +3,70 @@
 
 //! Parser plugin trait and built-in plugin implementations.
 //!
-//! The plugin system is framework-agnostic — WebUI provides parsing hooks
-//! and plugins decide what to do. Different frameworks (FAST, LIT, etc.)
-//! implement `ParserPlugin` with their own component discovery and
-//! hydration data emission logic.
+//! The plugin system is framework-aware but phase-local — parser plugins
+//! classify framework-owned attributes, capture processed component templates,
+//! and emit per-element hydration metadata for the handler.
 
 pub mod fast;
 
-pub use fast::generate_f_template;
-pub use fast::FastParserPlugin;
-
 use crate::component_registry::Component;
 use crate::Result;
-use std::any::Any;
+
+/// Parser-owned decision about how an attribute should be handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttributeAction {
+    /// Let the parser process the attribute normally.
+    Keep,
+    /// Skip the attribute without incrementing the element binding count.
+    Skip,
+    /// Skip the attribute and count it as a dynamic binding.
+    SkipAndCountBinding,
+}
+
+/// Build artifacts extracted from a parser plugin after parsing completes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParserPluginArtifacts {
+    /// The plugin did not produce any post-parse artifacts.
+    None,
+    /// Client component templates keyed by tag name.
+    ComponentTemplates(Vec<(String, String)>),
+}
 
 /// A parser plugin that can customize template parsing behavior.
 ///
 /// Plugins receive callbacks at key points during HTML parsing:
-/// - **Component discovery**: `on_parse_component` when a custom element is found
-/// - **Attribute filtering**: `should_skip_attribute` to skip framework-specific attrs
-/// - **Body end injection**: `on_body_end` to inject framework content before `</body>`
-/// - **Element completion**: `on_element_parsed` after attributes are processed
+/// - **Fragment lifecycle**: `start_fragment` before a fragment parse begins
+/// - **Component registration**: `register_component_template` when a component template is finalized
+/// - **Attribute classification**: `classify_attribute` for framework-specific attrs
+/// - **Element completion**: `finish_element` after attributes are processed
 ///
 /// WebUI calls these hooks during parsing; plugins decide what (if anything) to do.
-pub trait ParserPlugin: Any {
-    /// Called when a component element is encountered during parsing.
-    /// Use to track components for later template generation.
-    fn on_parse_component(&mut self, tag_name: &str, component: &Component) -> Result<()>;
+pub trait ParserPlugin {
+    /// Called before parsing begins for a fragment.
+    ///
+    /// Plugins can use this to reset fragment-local counters while preserving
+    /// global build-level state such as tracked component templates.
+    fn start_fragment(&mut self, _fragment_id: &str) {}
 
-    /// Return `true` if this attribute should be skipped during parsing.
-    /// Framework-specific client-side bindings (e.g., `@click`, `f-ref`)
-    /// should be skipped since they are only meaningful at runtime.
-    fn should_skip_attribute(&self, attr_name: &str) -> bool;
+    /// Called when a component template has been fully processed for the active
+    /// CSS strategy and wrapped for shadow DOM rendering.
+    fn register_component_template(
+        &mut self,
+        tag_name: &str,
+        component: &Component,
+        processed_template: &str,
+    ) -> Result<()>;
 
-    /// Called when the `</body>` closing tag is encountered.
-    /// Returns optional raw HTML content to inject before `</body>`.
-    /// FAST uses this for `<f-template>` wrappers.
-    fn on_body_end(&mut self) -> Option<String>;
+    /// Decide how a framework-owned attribute should be handled.
+    fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction;
 
     /// Called after all attributes on an element have been processed.
     /// `binding_attribute_count` is the number of dynamic attribute bindings found.
     /// Returns optional opaque bytes to emit as a `Plugin` protocol fragment.
-    fn on_element_parsed(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
+    fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
 
-    /// Downcast to `Any` for plugin-specific access.
-    fn as_any(&self) -> &dyn Any;
-
-    /// Downcast to mutable `Any` for plugin-specific access.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// Consume the plugin and return any build artifacts it captured.
+    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
+        ParserPluginArtifacts::None
+    }
 }

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -8,9 +8,9 @@ package webui;
 // Root protocol containing all fragment records.
 // Per-component metadata keyed by tag name.
 message ComponentData {
-  // f-template HTML string for hydration.
-  // Populated by the FAST parser plugin at build time.
-  // Used by servers to send f-templates to the client during navigation.
+  // Client-side template string for hydration.
+  // Populated by the active parser plugin at build time.
+  // Used by servers to send templates to the client during navigation.
   string template = 1;
   // Component CSS content for the Module strategy.
   // Contains the full CSS content when CssStrategy::Module is active.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -14,12 +14,15 @@ use std::fmt;
 use std::io;
 use thiserror::Error;
 
+pub mod plugin;
+
 /// Generated protobuf types from `proto/webui.proto`.
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/webui.rs"));
 }
 
 // Re-export all generated types at the crate root.
+pub use plugin::FastElementData;
 pub use proto::*;
 
 // Type aliases preserving the `WebUI` naming convention.

--- a/crates/webui-protocol/src/plugin/fast.rs
+++ b/crates/webui-protocol/src/plugin/fast.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::{ProtocolError, Result};
+
+const FAST_ELEMENT_DATA_LEN: usize = 4;
+
+/// FAST hydration element metadata encoded in plugin fragments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FastElementData {
+    /// Number of dynamic attribute bindings on the element.
+    pub binding_count: u32,
+}
+
+impl FastElementData {
+    /// Encode this metadata using the FAST 4-byte little-endian wire format.
+    #[must_use]
+    pub fn encode(self) -> [u8; FAST_ELEMENT_DATA_LEN] {
+        self.binding_count.to_le_bytes()
+    }
+
+    /// Decode FAST hydration metadata from protocol bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::Validation`] when the payload length is not 4 bytes.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != FAST_ELEMENT_DATA_LEN {
+            return Err(ProtocolError::Validation(format!(
+                "FAST element data must be {FAST_ELEMENT_DATA_LEN} bytes, received {}",
+                bytes.len()
+            )));
+        }
+
+        Ok(Self {
+            binding_count: u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FastElementData;
+    use crate::ProtocolError;
+
+    #[test]
+    fn test_fast_element_data_roundtrip() {
+        let encoded = FastElementData { binding_count: 3 }.encode();
+        let decoded = FastElementData::decode(&encoded).expect("decode should succeed");
+        assert_eq!(decoded.binding_count, 3);
+    }
+
+    #[test]
+    fn test_fast_element_data_rejects_invalid_length() {
+        let result = FastElementData::decode(&[1, 2]);
+        assert!(
+            matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("4 bytes")),
+            "invalid payload length should be rejected: {result:?}"
+        );
+    }
+}

--- a/crates/webui-protocol/src/plugin/mod.rs
+++ b/crates/webui-protocol/src/plugin/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+mod fast;
+
+pub use fast::FastElementData;

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 readme = "README.md"
 keywords = ["webui", "testing", "test-utils", "ssr", "mocking"]
 categories = ["development-tools::testing", "web-programming"]
+publish = false
 
 [lib]
 name = "webui_test_utils"

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -14,7 +14,7 @@
 use serde_json::Value;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_parser::{CssStrategy, HtmlParser};
 use webui_protocol::WebUIProtocol;

--- a/crates/webui/README.md
+++ b/crates/webui/README.md
@@ -65,7 +65,7 @@ With the FAST-HTML hydration plugin:
 
 ```rust
 use webui::{WebUIHandler, HandlerPlugin};
-use webui::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 
 let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
 ```

--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -15,7 +15,7 @@ use std::hint::black_box;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use webui::{build, BuildOptions, CssStrategy, ResponseWriter, WebUIHandler};
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::RenderOptions;
 use webui_protocol::WebUIProtocol;
 

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -39,7 +39,8 @@ pub use webui_protocol::WebUIProtocol;
 use std::fs;
 use std::path::Path;
 use std::time::Instant;
-use webui_parser::plugin::FastParserPlugin;
+use webui_parser::plugin::fast::FastParserPlugin;
+use webui_parser::plugin::ParserPluginArtifacts;
 use webui_parser::HtmlParser;
 
 /// Options for building a WebUI application.
@@ -51,7 +52,7 @@ pub struct BuildOptions {
     pub entry: String,
     /// CSS delivery strategy for component stylesheets.
     pub css: CssStrategy,
-    /// Parser plugin to load (e.g., `"fast"` for FAST-HTML hydration support).
+    /// Framework plugin to load.
     pub plugin: Option<String>,
     /// Additional component sources (npm packages or local paths).
     pub components: Vec<String>,
@@ -261,16 +262,10 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
     let tokens = parser.take_tokens();
     let token_count = tokens.len();
 
-    // Extract individual component f-template strings from the FAST plugin
-    // before consuming the parser.
-    let component_templates = parser
-        .take_plugin()
-        .and_then(|p| {
-            p.as_any()
-                .downcast_ref::<FastParserPlugin>()
-                .map(|fast| fast.take_component_templates())
-        })
-        .unwrap_or_default();
+    let component_templates = match parser.take_plugin_artifacts() {
+        ParserPluginArtifacts::None => Vec::new(),
+        ParserPluginArtifacts::ComponentTemplates(templates) => templates,
+    };
 
     // Build protocol (consumes parser)
     let fragment_records = parser.into_fragment_records();
@@ -309,7 +304,7 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
                 .collect()
         };
 
-    // Store f-templates in the protocol so any host server can query them
+    // Store client templates in the protocol so any host server can query them
     for (tag, tmpl) in &component_templates {
         protocol.components.entry(tag.clone()).or_default().template = tmpl.clone();
     }

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -38,7 +38,7 @@ When `--plugin=fast` is specified:
 
 ::: code-group
 ```rust [Rust]
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui::WebUIHandler;
 
 let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use webui::{build, BuildOptions, CssStrategy, WebUIHandler, WebUIProtocol};
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::route_handler;
 use webui_handler::{RenderOptions, ResponseWriter};
 

--- a/examples/integration/rust/src/main.rs
+++ b/examples/integration/rust/src/main.rs
@@ -17,7 +17,7 @@
 use anyhow::{Context, Result};
 use std::env;
 use std::fs;
-use webui_handler::plugin::FastHydrationPlugin;
+use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_protocol::WebUIProtocol;
 

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -10,8 +10,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION
## Motivation

The plugin system was tightly coupled to the FAST framework with no clean
extension point for additional framework plugins (e.g. WebUI native).
Parser and handler plugin modules used inconsistent layouts
(`plugin.rs` vs `plugin/mod.rs`).

## Changes

### Plugin trait redesign
- **Parser**: replaced `on_parse_component`/`should_skip_attribute`/`on_element_parsed`/`on_body_end` with `start_fragment`/`
egister_component_template`/`classify_attribute`/`finish_element`/`into_artifacts`
- **Handler**: renamed `on_plugin_data` → `on_element_data`; moved template emission from plugin trait to shared `emit_rendered_component_templates` helper
- Removed `Any` downcasting from `ParserPlugin` — plugins return typed `ParserPluginArtifacts` instead

### Module structure alignment
- Converted handler from `plugin.rs` to `plugin/mod.rs` to match parser
- Both crates now export `pub mod fast` — callers use `plugin::fast::FastHydrationPlugin` (no re-exports)

### Protocol layer
- Added `plugin/` submodule in `webui-protocol` with `FastElementData` codec
- Moved element data encode/decode out of proto layer into plugin-owned type

### Fixes
- Fixed `webui-router` package.json export ordering (`types` before `default`)