### PR TITLE
feat: ﻿Adds the new WebUI framework plugin end-to-end across everything

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,8 +34,20 @@ pub struct WebUIProtocol {
     /// Sorted, deduplicated CSS custom property names used across all
     /// components and entry page styles (without `--` prefix).
     pub tokens: Vec<String>,
-    /// Per-component data keyed by tag name (f-template + CSS).
+    /// Per-component data keyed by tag name (client template + CSS).
     pub components: HashMap<String, ComponentData>,
+}
+
+/// Per-component metadata populated by the active parser plugin at build time.
+/// Framework-neutral: each plugin populates the fields it needs.
+/// Generated from protobuf `message ComponentData`.
+pub struct ComponentData {
+    /// Client-side template string for hydration.
+    /// Populated by the active parser plugin (e.g., f-template HTML for FAST,
+    /// compiled template JS for WebUI Framework).
+    pub template: String,
+    /// Component CSS content for the Module strategy.
+    pub css: String,
 }
 
 /// A list of fragments (needed because protobuf maps cannot have repeated values directly).
@@ -194,6 +206,11 @@ optional parameters. Exact matches (most literal segments) take precedence over 
 2. Matched route: emit `<webui-route path="..." component="..." active>`, render component, recurse into children.
 3. Non-matched routes: emit `<webui-route ... style="display:none">`.
 
+For the WebUI framework path, matched route components do **not** receive route
+state as scalar attributes or `data-state`. Initial SSR state comes from the
+rendered DOM plus hydration markers, and client-side navigations apply fresh
+state through the partial-response `setInitialState(...)` path.
+
 When the handler encounters `Fragment::Outlet`:
 1. Take children from the currently active route.
 2. Match children against the request path (relative to route base).
@@ -217,7 +234,7 @@ on the first client-side navigation.
 
 **Partial response:** The server returns `{ state, templates, inventory, path, chain }`:
 - `state`: route params from all nesting levels injected into API state
-- `templates`: `f-template` HTML strings the client doesn't already have (filtered by inventory bitmask)
+- `templates`: client template strings the client doesn't already have (filtered by inventory bitmask)
 - `inventory`: updated hex bitmask of loaded templates
 - `chain`: matched route chain array — each entry has `component`, `path`, optional `params` and `exact`
 
@@ -245,7 +262,7 @@ route chain rather than trying to mirror a transient server-side state snapshot.
 **Attribute types:**
 - **Simple dynamic:** `href="{{url}}"` → `{ name: "href", value: "url" }`
 - **Boolean (`?` prefix):** `?disabled={{isDisabled}}` → `{ name: "disabled", condition_tree: identifier("isDisabled") }` — rendered only if condition is truthy; silently dropped if value is not a pure handlebars expression.
-- **Complex (`:` prefix):** `:config="{{settings}}"` → `{ name: ":config", value: "settings", complex: true }`
+- **Pass-through / property (`:` prefix):** `:config="{{settings}}"` or `:value="{{searchQuery}}"` → `{ name: ":config", value: "settings", complex: true }` — reserved for direct pass-through/property bindings, including live form-control values.
 - **Mixed/template:** `value="hello {{world}}"` → `{ name: "value", template: "attr-1" }` with sub-stream `attr-1: [raw("hello "), signal("world")]`
 #### Condition Expressions
 Condition expressions are protobuf messages with a `oneof expr` field:
@@ -413,9 +430,9 @@ pub trait ResponseWriter {
 ```
 
 ### Handler Plugin System
-The handler supports a framework-agnostic plugin system. Plugins receive lifecycle
-callbacks during rendering and can inject arbitrary content. WebUI does not interpret
-what plugins write — each framework defines its own marker format.
+The handler supports framework-specific hydration plugins. Plugins receive lifecycle
+callbacks during rendering and write marker formats for their framework, while shared
+completion work such as rendered-component template emission stays in handler core.
 
 ```rust
 pub trait HandlerPlugin {
@@ -425,7 +442,12 @@ pub trait HandlerPlugin {
     fn on_binding_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_start(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
-    fn on_plugin_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn write_route_component_state(
+        &self,
+        state: &serde_json::Value,
+        writer: &mut dyn ResponseWriter,
+    ) -> Result<()>;
 }
 ```
 
@@ -434,7 +456,8 @@ pub trait HandlerPlugin {
 - **For loop**: `on_binding_start/end` around entire loop; `on_repeat_item_start/end` + `push_scope/pop_scope` per item
 - **If condition**: `on_binding_start/end` around condition; `push_scope/pop_scope` if condition is true
 - **Component**: `push_scope/pop_scope` around component body
-- **Plugin fragment**: `on_plugin_data` with opaque bytes from protocol
+- **Plugin fragment**: `on_element_data` with parser-produced hydration bytes from protocol
+- **Matched route component**: `write_route_component_state` before the opening tag closes
 
 **Built-in plugin: `FastHydrationPlugin`**
 Injects FAST-HTML hydration comment markers for client-side re-hydration:
@@ -443,9 +466,32 @@ Injects FAST-HTML hydration comment markers for client-side re-hydration:
 - Attribute (single): ` data-fe-b-INDEX`
 - Attribute (multi): ` data-fe-c-INDEX-COUNT`
 
+FAST template authoring and runtime usage are documented in the canonical
+[FAST HTML README](https://github.com/microsoft/fast/blob/main/packages/fast-html/README.md).
+`DESIGN.md` only specifies the parser/handler integration contracts.
+
+**Built-in plugin: `WebUIHydrationPlugin`**
+Injects WebUI Framework SSR hydration markers and attributes:
+- Binding: `<!--w-b:start:INDEX:NAME-->` / `<!--w-b:end:INDEX:NAME-->`
+- Repeat: `<!--w-r:start:INDEX-->` / `<!--w-r:end:INDEX-->`
+- Attribute (single): ` data-w-b-INDEX`
+- Attribute (multi): ` data-w-c-INDEX-COUNT`
+- Event: ` data-ev="COUNT"` once per element with event handlers
+
+Markers are emitted only in active child scopes; the root page scope stays
+marker-free. During hydration the runtime walks `data-ev` elements in DOM order,
+consumes `COUNT` consecutive entries from metadata `e[]`, then installs delegated
+shadow-root listeners using runtime `data-eh-*` attributes on the target elements.
+See [WebUI Framework Plugin](#webui-framework-plugin) for the protocol details, and
+[packages/webui-framework/README.md](packages/webui-framework/README.md) for the
+public framework API and authoring model.
+
 **Usage:**
 ```rust
+// FAST plugin
 let handler = WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()));
+// WebUI Framework plugin
+let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
 handler.handle(&protocol, &state, &options, &mut writer)?;
 ```
 ### Fragment Processing
@@ -457,7 +503,7 @@ handler.handle(&protocol, &state, &options, &mut writer)?;
   - **Boolean (with `condition_tree`):** Evaluate condition; if truthy, render attribute name only. If false, omit entirely.
   - **Simple dynamic (with `value`):** Resolve signal from state, render as `name="resolved_value"`.
   - **Template (with `template`):** Render `name="`, process referenced sub-stream, render closing `"`.
-  - **Complex (with `complex: true`):** Same as simple dynamic but for `:` prefixed pass-through attributes.
+  - **Pass-through / property (with `complex: true`):** Same as simple dynamic on the SSR output, but reserved for `:` prefixed direct pass-through/property bindings.
 - **If fragments:**
   - Evaluate condition using `evaluate`
   - If true, process referenced fragment
@@ -474,7 +520,7 @@ handler.handle(&protocol, &state, &options, &mut writer)?;
     the fields of the current item being looped over and the global state. The `Component` fragment doesn't need to use
     the `For` fragment item moniker and can access the fields without the qualification. If the `Component` fragment is
     nested in multiple `For` fragments only the closest enclosing `For` fragment item's state is accessible to it.
-- **Plugin fragments:** Pass opaque `data` bytes to the handler plugin's `on_plugin_data` hook. Skipped silently when no plugin is configured.
+- **Plugin fragments:** Pass opaque `data` bytes to the handler plugin's `on_element_data` hook. Skipped silently when no plugin is configured.
 
 ### State Management
 - Global state refers to the global application state that is available to all fragments at all times.
@@ -595,7 +641,8 @@ pub struct HtmlParser {
 ```rust
 /// Strategy for how component CSS is delivered in rendered output.
 pub enum CssStrategy {
-    /// Emit `<link rel="stylesheet" href="./component.css">` tags (default).
+    /// Emit `<link rel="stylesheet" href="./component.css">` tags for
+    /// components that actually have discovered CSS (default).
     Link,
     /// Embed CSS content inline in `<style>` tags within the shadow DOM template.
     Style,
@@ -606,9 +653,9 @@ pub enum CssStrategy {
 }
 ```
 
-- **Link** (default): Emits `<link>` tags referencing external `.css` files. Used by the CLI for production builds where CSS files are served separately.
+- **Link** (default): Emits `<link>` tags referencing external `.css` files only for components whose discovery/registration data included CSS. Used by the CLI for production builds where CSS files are served separately.
 - **Style**: Embeds the full CSS content in `<style>` tags inside the shadow DOM template. Used when all files are needed in-memory.
-- **Module**: Uses the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. Emits a `<style type="module" specifier="component-name">` definition in each component's light DOM (once per component) and adds `shadowrootadoptedstylesheets="component-name"` to the `<template>` tag. The browser registers the CSS module globally and shares a single `CSSStyleSheet` across all shadow roots that adopt it. No external CSS files are produced. For partial rendering, CSS module definitions are prepended to f-template strings so the client inserts both as a single DocumentFragment.
+- **Module**: Uses the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. Emits a `<style type="module" specifier="component-name">` definition in each component's light DOM (once per component) and adds `shadowrootadoptedstylesheets="component-name"` to the `<template>` tag. The browser registers the CSS module globally and shares a single `CSSStyleSheet` across all shadow roots that adopt it. No external CSS files are produced. For partial rendering, CSS module definitions are prepended to client template payloads so the client inserts the definition before the companion template/script runs; WebUI Framework compiled metadata also carries the adopted stylesheet specifier so client-created components can reuse the registered stylesheet.
 
 Set via `parser.set_css_strategy(CssStrategy::Style)`.
 
@@ -619,42 +666,69 @@ pub fn into_fragment_records(self) -> WebUIFragmentRecords
 ```
 
 ### Parser Plugin System
-The parser supports a framework-agnostic plugin system. Plugins customize parsing
-behavior for framework-specific needs (component discovery, attribute filtering,
-hydration data emission) without WebUI knowing framework internals.
+The parser supports a framework-aware plugin system. Plugins classify framework-owned
+attributes, capture finalized component templates, and emit per-element hydration
+metadata without requiring the build layer to downcast concrete plugin types.
 
 ```rust
 pub trait ParserPlugin {
-    fn on_parse_component(&mut self, tag_name: &str, component: &Component) -> Result<()>;
-    fn should_skip_attribute(&self, attr_name: &str) -> bool;
-    fn on_body_end(&mut self) -> Option<String>;
-    fn on_element_parsed(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
+    fn start_fragment(&mut self, fragment_id: &str) {}
+    fn register_component_template(
+        &mut self,
+        tag_name: &str,
+        component: &Component,
+        processed_template: &str,
+    ) -> Result<()>;
+    fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction;
+    fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
+    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts;
 }
 ```
 
 **Hook invocation points:**
-- **Attribute loop**: `should_skip_attribute` called per attribute; skipped attrs are not parsed
-- **Element completion**: `on_element_parsed` called with binding count after all attrs processed; returned bytes emitted as `Plugin` fragment
-- **Component encounter**: `on_parse_component` called when a custom element is found
-- **Body end**: `on_body_end` called before `body_end` signal; returned HTML injected as raw fragment
+- **Fragment start**: `start_fragment` runs before each `HtmlParser::parse(...)` call so plugins can reset fragment-local counters
+- **Attribute loop**: `classify_attribute` decides whether framework-owned attrs are kept, skipped, or skipped-and-counted as bindings
+- **Element completion**: `finish_element` runs with the final binding count after all attrs are processed; returned bytes are emitted as a `Plugin` fragment
+- **Component registration**: `register_component_template` receives the final processed component template HTML
+- **Artifact extraction**: `into_artifacts` returns post-parse outputs such as client component templates without `Any` downcasts
 
 **Built-in plugin: `FastParserPlugin`**
-- Skips FAST-specific runtime attributes (`@click`, `f-ref`, `f-slotted`, `f-children`)
+- Marks FAST-specific runtime attributes (`@click`, `f-ref`, `f-slotted`, `f-children`) as skipped but still counted bindings
 - Emits `Plugin` fragments with u32 LE attribute binding counts
-- Tracks components and injects `<f-template>` wrappers at body end
+- Tracks components and returns `<f-template>` artifacts after parsing
 - Converts syntax to FAST syntax: `<if>`→`<f-when>`, `<for>`→`<f-repeat>`, `{{expr}}`→`{expr}` in `:attr` values
+- FAST authoring details live in the canonical [FAST HTML README](https://github.com/microsoft/fast/blob/main/packages/fast-html/README.md)
+
+**Built-in plugin: `WebUIParserPlugin`**
+- Skips WebUI Framework runtime attributes (`@click`, `@keydown`, etc.) without counting them as attribute bindings
+- Tracks per-element event count; emits 12-byte `WebUIElementData` `Plugin` fragments encoding `[binding_count, event_start, event_count]`
+- Tracks components and compiles templates into metadata `<script>` blocks registered in `window.__webui_templates`
+- Public framework authoring, decorators, and package entrypoints live in [packages/webui-framework/README.md](packages/webui-framework/README.md)
 
 **Usage:**
 ```rust
+// FAST plugin
 let mut parser = HtmlParser::with_plugin(Box::new(FastParserPlugin::new()));
+// WebUI Framework plugin
+let mut parser = HtmlParser::with_plugin(Box::new(WebUIParserPlugin::new()));
 parser.parse("index.html", &html)?;
 ```
 
 **CLI integration:**
 ```bash
+# FAST plugin
 webui build ./templates --out ./dist --plugin=fast
 webui serve ./templates --state ./data/state.json --plugin=fast
+
+# WebUI Framework plugin
+webui build ./templates --out ./dist --plugin=webui
+webui serve ./templates --state ./data/state.json --plugin=webui
 ```
+
+`webui serve` performs a preflight bind check on its configured HTTP port and
+fails before the initial build if that port is already in use, returning an
+actionable message so stale dev processes can be stopped explicitly.
+
 #### Content Processing
 
 ##### Raw Content
@@ -802,6 +876,133 @@ pub enum ParserError {
     Io(#[from] std::io::Error),
 }
 ```
+## WebUI Framework Plugin
+
+This section specifies only the cross-crate wire contract for `--plugin=webui`: the metadata emitted by `webui-parser`, the SSR markers emitted by `webui-handler`, and the hydration/runtime expectations consumed by `@microsoft/webui-framework`.
+
+It intentionally does **not** duplicate package tutorials or framework API docs. Use the canonical sources instead:
+
+- WebUI Framework public API, decorators, and component authoring: [packages/webui-framework/README.md](packages/webui-framework/README.md)
+- FAST template authoring and runtime reference: [FAST HTML README](https://github.com/microsoft/fast/blob/main/packages/fast-html/README.md)
+
+### Metadata object format
+
+Each component's compiled template is registered in `window.__webui_templates[tagName]` as a marker-free metadata object consumed by the browser runtime:
+
+| Field | Type                              | Description                                        |
+|-------|-----------------------------------|----------------------------------------------------|
+| `h`   | `string`                          | Marker-free static HTML for client-created DOM, including baked-in `<link>` / `<style>` nodes for link/style CSS strategies |
+| `tx`  | `[slot, parts][]`                 | Client text runs inserted at precompiled slots     |
+| `a`   | `CompiledAttrMeta[]`              | Attribute binding metadata                         |
+| `ag`  | `[elementPath, start, count][]`   | Attribute-target groups for `a[]`                  |
+| `c`   | `[ConditionExpr, blockIndex][]`   | Conditional blocks                                 |
+| `cl`  | `SlotPath[]`                      | Conditional anchor slots aligned to `c[]`          |
+| `r`   | `[collection, itemVar, blockIndex][]` | Repeat blocks                                  |
+| `rl`  | `SlotPath[]`                      | Repeat anchor slots aligned to `r[]`               |
+| `e`   | `[event, handler, needsEvent][]`  | Body events                                        |
+| `el`  | `NodePath[]`                      | Event target element paths aligned to `e[]`        |
+| `b`   | `TemplateBlockMeta[]`             | Nested compiled block table referenced by `c` / `r` |
+| `sa`  | `string`                          | Optional module-mode adopted stylesheet specifier copied from `shadowrootadoptedstylesheets` |
+| `re`  | `[event, handler, needsEvent][]`  | Root events, attached to the host element          |
+
+All arrays are optional — omitted from the output when empty to minimize payload.
+
+`ConditionExpr` in compiled framework metadata reuses the protocol condition AST in a compact tuple form:
+
+- `[0, path]` — identifier / truthy path lookup
+- `[1, left, operator, right]` — predicate comparison
+- `[2, condition]` — logical NOT
+- `[3, left, operator, right]` — logical compound (`AND` / `OR`)
+
+Comparison operators match the protocol enum values:
+
+- `1` = `GREATER_THAN`
+- `2` = `LESS_THAN`
+- `3` = `EQUAL`
+- `4` = `NOT_EQUAL`
+- `5` = `GREATER_THAN_OR_EQUAL`
+- `6` = `LESS_THAN_OR_EQUAL`
+
+Logical operators also match the protocol enum values:
+
+- `1` = `AND`
+- `2` = `OR`
+
+`a[]` uses compact tuple forms to avoid runtime parsing:
+
+- `[name, 0, path]` — simple attribute binding, e.g. `href="{{url}}"`
+- `[name, 1, path]` — pass-through/property binding, e.g. `:config="{{settings}}"` or `:value="{{searchQuery}}"`
+- `[name, 2, ConditionExpr]` — boolean attribute binding, e.g. `?disabled="{{expr}}"`
+- `[name, 3, parts]` — mixed/template attribute binding, e.g. `class="item {{state}}"`
+
+### Compilation rules
+
+The Rust compiler (`generate_compiled_template` in `webui-parser/src/plugin/webui.rs`) transforms the HTML template in a single forward pass, then finalizes it into marker-free client HTML plus locator metadata:
+
+| Source syntax                        | Metadata field(s)      | Client `h` result                 |
+|--------------------------------------|------------------------|-----------------------------------|
+| `{{expr}}`, `{{{expr}}}`, mixed text | `tx[]`                 | dynamic text run removed          |
+| `href="{{url}}"`                     | `a[]` + `ag[]`         | element kept marker-free          |
+| `class="item {{state}}"`             | `a[]` + `ag[]`         | element kept marker-free          |
+| `?disabled="{{expr}}"`               | `a[]` + `ag[]`         | element kept marker-free          |
+| `:config="{{settings}}"`, `:value="{{searchQuery}}"` | `a[]` + `ag[]` | element kept marker-free |
+| `<if condition="expr">body</if>`     | `c[]` + `cl[]` + `b[]` | block removed; anchor slot stored |
+| `<for each="v in coll">body</for>`   | `r[]` + `rl[]` + `b[]` | block removed; anchor slot stored |
+| `@event="{handler(e)}"`              | `e[]` + `el[]`         | element kept marker-free          |
+| `@event` on `<template>` wrapper     | `re[N]`                | *(stripped)*                      |
+| `w-ref="name"`                       | *(stays)*              | *(unchanged)*                     |
+| `<outlet />`                         | *(stays)*              | `<outlet></outlet>`               |
+
+`tx[]` stores text runs as `[slot, parts]`, where `parts` reuse the compact attribute-part encoding (`string` for static text, `[path]` for dynamic text). Client-created DOM inserts one runtime `Text` node per run instead of scanning compiled marker comments.
+
+Attribute bindings are recorded in `a[]`, while `ag[]` points at the owning element and the contiguous `[start, count)` range inside `a[]`. The compiled client HTML never embeds `data-w-*` markers; those remain SSR-only handler markers.
+
+Nested `<if>` / `<for>` blocks are recursively compiled into the shared `b[]` block table. The client runtime instantiates compiled child blocks directly and evaluates precompiled condition AST tuples — it does not parse raw template syntax or condition strings from repeat or conditional body content.
+
+The private workspace package `packages/webui-test-support` (`@microsoft/webui-test-support`) exists to build this metadata shape in JS-side tests without duplicating tuple encodings or fixture infrastructure across `webui-framework` and `webui-router`. It centralizes fixture builders such as `buildTemplate`, `registerCompiledTemplate`, and the condition AST helpers, and it also provides shared Node-side fixture bundling/server helpers so browser fixture apps and Playwright servers stay aligned with the runtime/compiler contract as that contract evolves.
+
+### Plugin data and SSR hydration markers
+
+The current WebUI parser emits a 12-byte `Plugin` fragment (`WebUIElementData`) for each element that has attribute bindings or `@event` handlers:
+
+```
+Bytes 0–3:  binding_count   (u32 LE)  — number of dynamic attribute bindings
+Bytes 4–7:  event_start_idx (u32 LE)  — global index into metadata `e[]`
+Bytes 8–11: event_count     (u32 LE)  — number of @event attrs on this element
+```
+
+The handler decodes this in `on_element_data` and emits SSR-only markers:
+
+- `data-w-b-N` for one bound attribute, or `data-w-c-START-COUNT` for multiple `a[]` entries on the same element
+- `data-ev="COUNT"` once per element, where `COUNT` is the number of consecutive entries in the metadata `e[]` array that belong to that element
+
+For compatibility during mixed parser/handler rollouts, the handler also accepts the legacy 4-byte binding-only payload and upgrades it to `event_count = 0`.
+
+WebUI SSR marker formats are:
+
+| Marker | Format | Notes |
+|--------|--------|-------|
+| Binding start | `<!--w-b:start:INDEX:NAME-->` | Used for text bindings and block boundaries |
+| Binding end | `<!--w-b:end:INDEX:NAME-->` | Matches the corresponding start marker |
+| Repeat item start | `<!--w-r:start:INDEX-->` | Wraps one concrete `<for>` iteration |
+| Repeat item end | `<!--w-r:end:INDEX-->` | Closes that iteration |
+| Attribute single | `data-w-b-INDEX` | One dynamic attribute bound to `a[INDEX]` |
+| Attribute multi | `data-w-c-START-COUNT` | `COUNT` consecutive `a[]` entries on the same element |
+| Event count | `data-ev="COUNT"` | `COUNT` consecutive `e[]` entries belong to this element |
+
+For `<if>` and `<for>` blocks, `NAME` in the `w-b:*` marker pair uses block labels such as `if-2` or `for-3`. The handler only emits these markers in active child scopes; the root page scope remains marker-free.
+
+### Runtime contract
+
+`@microsoft/webui-framework` consumes the metadata object above plus the SSR markers emitted by `WebUIHydrationPlugin`.
+
+- SSR hydration uses one DOM walk to discover `w-b:*`, `w-r:*`, `data-w-*`, and `data-ev` markers, wire the relevant bindings, then remove SSR-only markers.
+- Client-created DOM never reparses template syntax; it clones marker-free `h` and resolves `tx`, `ag`, `cl`, `rl`, and `el` locators directly.
+- Events are mapped from `data-ev="COUNT"` to consecutive `e[]` entries in DOM order. After target discovery, the runtime stores `data-eh-*` attributes on the target elements and installs one delegated listener per event type on the shadow root. Root events from `re[]` attach directly to the host element.
+- The full package entrypoint supports repeat metadata (`r[]` / `rl[]`). The additive `@microsoft/webui-framework/element-no-repeat` entrypoint preserves the same public `WebUIElement` API but must reject compiled templates that contain repeat metadata.
+
+Detailed component examples, decorators, and package entrypoint guidance live in [packages/webui-framework/README.md](packages/webui-framework/README.md) rather than being duplicated in this design spec.
+
 ## Integration and Testing
 ### Test Suite Requirements
 - Unit tests for each module
@@ -826,16 +1027,19 @@ webui/
 │   ├── webui-test-utils/     # Testing utilities
 │   └── webui-wasm/           # WebAssembly bindings
 ├── packages/
-│   └── @microsoft/
-│       ├── webui/            # npm package (CLI + programmatic JS API)
-│       ├── webui-darwin-arm64/   # Platform binary (macOS ARM64)
-│       ├── webui-darwin-x64/     # Platform binary (macOS x64)
-│       ├── webui-linux-x64/      # Platform binary (Linux x64)
-│       ├── webui-linux-arm64/    # Platform binary (Linux ARM64)
-│       ├── webui-win32-x64/      # Platform binary (Windows x64)
-│       └── webui-win32-arm64/    # Platform binary (Windows ARM64)
-├── examples/                 # Example applications
-├── docs/                     # Documentation
+│   ├── @microsoft/
+│   │   ├── webui/            # npm package (CLI + programmatic JS API)
+│   │   ├── webui-darwin-arm64/   # Platform binary (macOS ARM64)
+│   │   ├── webui-darwin-x64/     # Platform binary (macOS x64)
+│   │   ├── webui-linux-x64/      # Platform binary (Linux x64)
+│   │   ├── webui-linux-arm64/    # Platform binary (Linux ARM64)
+│   │   ├── webui-win32-x64/      # Platform binary (Windows x64)
+│   │   └── webui-win32-arm64/    # Platform binary (Windows ARM64)
+│   ├── webui-framework/      # WebUI Framework client runtime (@microsoft/webui-framework)
+│   ├── webui-router/         # SPA router for WebUI Framework (@microsoft/webui-router)
+│   └── webui-test-support/   # Private shared JS test metadata helpers (@microsoft/webui-test-support)
+├── examples/                 # Example applications (todo-fast, todo-webui, routes, …)
+├── docs/                     # Documentation (VitePress)
 ├── tests/                    # Integration tests
 └── benchmarks/               # Performance benchmarks
 ```
@@ -903,3 +1107,4 @@ The CLI specification and usage details are maintained in [crates/webui-cli/READ
 ## Example Workflow
 
 Examples and end-to-end walkthroughs are maintained in [examples/README.md](examples/README.md)
+

--- a/crates/webui-cli/README.md
+++ b/crates/webui-cli/README.md
@@ -26,11 +26,11 @@ webui build [APP] --out <DIR> [--entry <FILE>] [--css <MODE>] [--plugin <NAME>]
 | `--out` | *(required)* | Output directory for protocol.bin + CSS |
 | `--entry` | `index.html` | Entry HTML file |
 | `--css` | `link` | CSS mode: `link` (external files) or `style` (inline) |
-| `--plugin` | *(none)* | Parser plugin (e.g., `fast` for FAST-HTML) |
+| `--plugin` | *(none)* | Framework plugin: `webui` for WebUI Framework compiled templates and hydration markers or `fast` for FAST-HTML hydration |
 
 ```bash
 webui build ./src --out ./dist
-webui build ./src --out ./dist --plugin fast --css style
+webui build ./src --out ./dist --plugin webui --css style
 ```
 
 ### `webui serve`
@@ -48,12 +48,12 @@ webui serve [APP] [--state <FILE>] [--servedir <DIR>] [--port <PORT>] [--api-por
 | `--servedir` | *(none)* | Static assets directory served at `/*` |
 | `--port` | `3000` | Server port |
 | `--api-port` | *(none)* | Proxy API requests to this port |
-| `--plugin` | *(none)* | Parser plugin (e.g., `fast`) |
+| `--plugin` | *(none)* | Framework plugin: `webui` for WebUI Framework compiled templates and hydration markers or `fast` for FAST-HTML hydration |
 | `--watch` | off | Enable file watching + HMR |
 
 ```bash
 webui serve ./src --state ./data/state.json --port 3000 --watch
-webui serve ./src --plugin fast --servedir ./dist --port 3003 --api-port 3013 --watch
+webui serve ./src --plugin webui --servedir ./dist --port 3004 --api-port 3014 --watch
 ```
 
 Features:

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -9,12 +9,15 @@ use mime_guess::from_path;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
+use std::io::ErrorKind;
+use std::net::{Ipv4Addr, SocketAddrV4, TcpListener};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime};
 use webui::WebUIHandler;
 use webui_handler::plugin::fast::FastHydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter};
 use webui_protocol::WebUIProtocol;
 
@@ -258,6 +261,10 @@ pub fn execute(args: &ServeArgs) -> Result<()> {
             output::hint("Pass a valid --state path to a JSON file");
         } else if err_msg.contains("Serve directory not found") {
             output::hint("Pass a valid --servedir path for static assets");
+        } else if err_msg.contains("already in use") {
+            output::hint(
+                "Stop the process using that port, or rerun with --port <free-port>. Previous dev sessions may have left a server running.",
+            );
         }
         eprintln!();
         err
@@ -301,6 +308,8 @@ fn run(args: &ServeArgs) -> Result<()> {
     }
     eprintln!();
 
+    ensure_local_port_available(args.port)?;
+
     // Initial build + render
     let initial_result = build_and_render(&render_config, hmr_backend.as_deref())?;
     output::success("Initial build and render complete");
@@ -335,6 +344,7 @@ fn run(args: &ServeArgs) -> Result<()> {
 
     let addr = format!("127.0.0.1:{}", args.port);
     let bind_addr = addr.clone();
+    let server_port = args.port;
 
     output::field("URL", &format!("http://{addr}/"));
     output::finish("Server is running \u{2014} press Ctrl+C to stop");
@@ -380,7 +390,7 @@ fn run(args: &ServeArgs) -> Result<()> {
                 app
             })
             .bind(&bind_addr)
-            .with_context(|| format!("Failed to bind to {bind_addr}"))?
+            .map_err(|error| map_bind_error(server_port, &bind_addr, error))?
             .run()
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))
@@ -388,6 +398,22 @@ fn run(args: &ServeArgs) -> Result<()> {
         .with_context(|| format!("Failed to start actix-web server on {addr}"))?;
 
     Ok(())
+}
+
+fn ensure_local_port_available(port: u16) -> Result<()> {
+    let bind_addr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+    let listener = TcpListener::bind(bind_addr)
+        .map_err(|error| map_bind_error(port, &bind_addr.to_string(), error))?;
+    drop(listener);
+    Ok(())
+}
+
+fn map_bind_error(port: u16, bind_addr: &str, error: std::io::Error) -> anyhow::Error {
+    if error.kind() == ErrorKind::AddrInUse {
+        return anyhow::anyhow!("Port {port} on 127.0.0.1 is already in use");
+    }
+
+    anyhow::anyhow!("Failed to bind to {bind_addr}: {error}")
 }
 
 #[derive(Clone)]
@@ -427,6 +453,7 @@ fn build_and_render(
     let mut writer = MemoryWriter::with_capacity(4096);
     let handler = match config.app_args.plugin.as_deref() {
         Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
         _ => WebUIHandler::new(),
     };
     handler.handle(
@@ -581,6 +608,7 @@ async fn render_page_response(
     let mut writer = MemoryWriter::with_capacity(4096);
     let handler = match plugin.as_deref() {
         Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
         _ => WebUIHandler::new(),
     };
 
@@ -1097,6 +1125,19 @@ mod tests {
         };
         let BuildRenderResult { html, .. } = build_and_render(&config, None).unwrap();
         assert!(!html.contains("/hmr"));
+    }
+
+    #[test]
+    fn test_ensure_local_port_available_reports_port_in_use() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let error = ensure_local_port_available(port).unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains(&format!("Port {port} on 127.0.0.1 is already in use"))
+        );
+        drop(listener);
     }
 
     #[test]

--- a/crates/webui-ffi/include/webui_ffi.h
+++ b/crates/webui-ffi/include/webui_ffi.h
@@ -27,7 +27,6 @@ void *webui_handler_create();
 /// # Arguments
 ///
 /// * `plugin_id` - Null-terminated UTF-8 string identifying the plugin.
-///   Currently supported: `"fast"`. Pass `NULL` for no plugin.
 ///
 /// # Returns
 ///

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -32,6 +32,7 @@ use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use webui_handler::plugin::fast::FastHydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_parser::HtmlParser;
 use webui_protocol::WebUIProtocol;
@@ -142,7 +143,7 @@ pub extern "C" fn webui_handler_create() -> *mut c_void {
 /// # Arguments
 ///
 /// * `plugin_id` - Null-terminated UTF-8 string identifying the plugin.
-///   Currently supported: `"fast"`. Pass `NULL` for no plugin.
+///   Currently supported: `"fast"`, `"webui"`. Pass `NULL` for no plugin.
 ///
 /// # Returns
 ///
@@ -161,6 +162,7 @@ pub unsafe extern "C" fn webui_handler_create_with_plugin(plugin_id: *const c_ch
     } else {
         match CStr::from_ptr(plugin_id).to_str() {
             Ok("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+            Ok("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
             Ok(unknown) => {
                 set_last_error(format!("unknown plugin: {unknown}"));
                 return std::ptr::null_mut();

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -7,6 +7,7 @@
 //! completion work, such as component template emission, stays in handler core.
 
 pub mod fast;
+pub mod webui;
 
 use crate::{ResponseWriter, Result};
 use std::collections::HashSet;

--- a/crates/webui-handler/src/plugin/webui.rs
+++ b/crates/webui-handler/src/plugin/webui.rs
@@ -1,0 +1,746 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! WebUI Framework handler plugin.
+//!
+//! # Overview
+//!
+//! Injects HTML comment markers and data attributes into server-rendered
+//! output that enable the client-side WebUI Framework to locate and
+//! re-hydrate dynamic content. The plugin operates within the handler's
+//! scope-based lifecycle — each component and for-loop item gets its own
+//! scope with an independent binding counter starting from 0.
+//!
+//! # Comment format
+//!
+//! | Marker type       | Format                                    | Purpose                          |
+//! |-------------------|-------------------------------------------|----------------------------------|
+//! | Binding start     | `<!--w-b:start:INDEX:NAME-->`             | Wraps a text binding             |
+//! | Binding end       | `<!--w-b:end:INDEX:NAME-->`               | Closes the binding pair          |
+//! | Repeat item start | `<!--w-r:start:INDEX-->`                  | Wraps one iteration of a loop    |
+//! | Repeat item end   | `<!--w-r:end:INDEX-->`                    | Closes the iteration             |
+//! | Attribute single  | ` data-w-b-INDEX`                         | One dynamic attribute binding    |
+//! | Attribute multi   | ` data-w-c-INDEX-COUNT`                   | Multiple attribute bindings      |
+//! | Event             | ` data-ev="COUNT"`                        | Wires COUNT events on one element |
+//!
+//! # Scoping
+//!
+//! - The **root scope** (depth 0) is disabled — no markers are emitted.
+//!   This prevents markers from appearing in the page-level HTML outside
+//!   any component.
+//! - Each `push_scope` opens a new child scope with counter reset to 0.
+//! - Each `pop_scope` returns to the parent scope's counter position.
+//!
+//! # Plugin data decoding
+//!
+//! The parser plugin emits 12-byte payloads per element:
+//!
+//! ```text
+//! [binding_count: u32 LE | event_start_idx: u32 LE | event_count: u32 LE]
+//! ```
+//!
+//! The handler decodes this in
+//! [`on_element_data`](WebUIHydrationPlugin::on_element_data)
+//! and emits `data-w-*` markers for bindings plus a single `data-ev="COUNT"`
+//! marker per element. A 4-byte payload (bindings only) is also supported for
+//! backward compatibility.
+
+use super::HandlerPlugin;
+use crate::{HandlerError, ResponseWriter, Result};
+use std::fmt::Write;
+use webui_protocol::{FastElementData, WebUIElementData};
+
+// Comment format constants
+const BINDING_START_PREFIX: &str = "<!--w-b:start:";
+const BINDING_END_PREFIX: &str = "<!--w-b:end:";
+const BINDING_SUFFIX: &str = "-->";
+const SEPARATOR: &str = ":";
+const REPEAT_START_PREFIX: &str = "<!--w-r:start:";
+const REPEAT_END_PREFIX: &str = "<!--w-r:end:";
+const REPEAT_SUFFIX: &str = "-->";
+const ATTR_SINGLE_PREFIX: &str = " data-w-b-";
+const ATTR_MULTI_PREFIX: &str = " data-w-c-";
+const EVENT_PREFIX: &str = " data-ev=\"";
+const EVENT_SUFFIX: &str = "\"";
+
+/// WebUI Framework handler plugin.
+///
+/// Emits HTML comment markers around dynamic bindings so that the WebUI
+/// Framework client runtime can re-hydrate server-rendered content.
+///
+/// The root scope is disabled (no markers) — hydration only activates in
+/// child scopes (components, for-loop items, if-condition bodies).
+pub struct WebUIHydrationPlugin {
+    /// Stack of local binding counters (one per scope).
+    /// The bottom of the stack is the root scope (disabled).
+    scopes: Vec<usize>,
+    /// Stack of binding indices for matching start/end pairs.
+    binding_stack: Vec<usize>,
+    /// Reusable buffer for formatting markers without allocation.
+    buffer: String,
+}
+
+impl WebUIHydrationPlugin {
+    /// Create a new WebUI Framework hydration plugin.
+    /// The initial root scope is disabled — markers only emitted in child scopes.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            scopes: vec![0],
+            binding_stack: Vec::with_capacity(8),
+            buffer: String::with_capacity(64),
+        }
+    }
+
+    /// Whether the current scope is active (not the root scope).
+    fn is_active(&self) -> bool {
+        self.scopes.len() > 1
+    }
+
+    /// Get the next binding index in the current scope, advancing the counter.
+    fn next_index(&mut self) -> usize {
+        if let Some(counter) = self.scopes.last_mut() {
+            let index = *counter;
+            *counter += 1;
+            index
+        } else {
+            0
+        }
+    }
+
+    /// Get the next binding index, advancing the counter by `count`.
+    fn next_index_n(&mut self, count: u32) -> usize {
+        if let Some(counter) = self.scopes.last_mut() {
+            let index = *counter;
+            *counter += count as usize;
+            index
+        } else {
+            0
+        }
+    }
+
+    /// Build a binding comment into the reusable buffer.
+    fn build_binding_comment(&mut self, prefix: &str, index: usize, name: &str) {
+        self.buffer.clear();
+        self.buffer.push_str(prefix);
+        let _ = write!(self.buffer, "{}", index);
+        self.buffer.push_str(SEPARATOR);
+        self.buffer.push_str(name);
+        self.buffer.push_str(BINDING_SUFFIX);
+    }
+
+    /// Build a repeat comment into the reusable buffer.
+    fn build_repeat_comment(&mut self, prefix: &str, index: usize) {
+        self.buffer.clear();
+        self.buffer.push_str(prefix);
+        let _ = write!(self.buffer, "{}", index);
+        self.buffer.push_str(REPEAT_SUFFIX);
+    }
+
+    /// Build an attribute binding marker into the reusable buffer.
+    fn build_attribute_marker(&mut self, binding_index: usize, count: u32) {
+        self.buffer.clear();
+        if count == 1 {
+            self.buffer.push_str(ATTR_SINGLE_PREFIX);
+            let _ = write!(self.buffer, "{}", binding_index);
+        } else {
+            self.buffer.push_str(ATTR_MULTI_PREFIX);
+            let _ = write!(self.buffer, "{}-{}", binding_index, count);
+        }
+    }
+
+    /// Build an event marker into the reusable buffer.
+    fn build_event_marker(&mut self, count: u32) {
+        self.buffer.clear();
+        self.buffer.push_str(EVENT_PREFIX);
+        let _ = write!(self.buffer, "{}", count);
+        self.buffer.push_str(EVENT_SUFFIX);
+    }
+}
+
+impl Default for WebUIHydrationPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HandlerPlugin for WebUIHydrationPlugin {
+    fn push_scope(&mut self) {
+        self.scopes.push(0);
+    }
+
+    fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn on_binding_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()> {
+        if !self.is_active() {
+            return Ok(());
+        }
+        let index = self.next_index();
+        self.binding_stack.push(index);
+        self.build_binding_comment(BINDING_START_PREFIX, index, name);
+        writer.write(&self.buffer)
+    }
+
+    fn on_binding_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()> {
+        if !self.is_active() {
+            return Ok(());
+        }
+        let index = self.binding_stack.pop().ok_or_else(|| {
+            crate::HandlerError::Invariant(format!(
+                "binding end for '{name}' had no matching start marker; regenerate the protocol and ensure the parser and handler use the same WebUI plugin version"
+            ))
+        })?;
+        self.build_binding_comment(BINDING_END_PREFIX, index, name);
+        writer.write(&self.buffer)
+    }
+
+    fn on_repeat_item_start(
+        &mut self,
+        index: usize,
+        writer: &mut dyn ResponseWriter,
+    ) -> Result<()> {
+        if !self.is_active() {
+            return Ok(());
+        }
+        self.build_repeat_comment(REPEAT_START_PREFIX, index);
+        writer.write(&self.buffer)
+    }
+
+    fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()> {
+        if !self.is_active() {
+            return Ok(());
+        }
+        self.build_repeat_comment(REPEAT_END_PREFIX, index);
+        writer.write(&self.buffer)
+    }
+
+    fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()> {
+        if !self.is_active() {
+            return Ok(());
+        }
+        let decoded = match data.len() {
+            4 => {
+                let fast = FastElementData::decode(data).map_err(|error| {
+                    HandlerError::PluginData(format!(
+                        "WebUI hydration plugin expected 4 or 12 bytes of element data: {error}"
+                    ))
+                })?;
+                WebUIElementData {
+                    binding_count: fast.binding_count,
+                    event_start: 0,
+                    event_count: 0,
+                }
+            }
+            12 => WebUIElementData::decode(data).map_err(|error| {
+                HandlerError::PluginData(format!(
+                    "WebUI hydration plugin expected 4 or 12 bytes of element data: {error}"
+                ))
+            })?,
+            _ => {
+                return Err(HandlerError::PluginData(format!(
+                    "WebUI hydration plugin expected 4 or 12 bytes, received {}. Regenerate the protocol with a matching parser/handler pair.",
+                    data.len()
+                )));
+            }
+        };
+
+        if decoded.binding_count > 0 {
+            let binding_index = self.next_index_n(decoded.binding_count);
+            self.build_attribute_marker(binding_index, decoded.binding_count);
+            writer.write(&self.buffer)?;
+        }
+        // Emit one data-ev marker per element so browser parsing stays stable.
+        if decoded.event_count > 0 {
+            self.build_event_marker(decoded.event_count);
+            writer.write(&self.buffer)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::WebUIHandler;
+    use std::collections::HashMap;
+    use webui_protocol::{FragmentList, WebUIFragment, WebUIProtocol};
+    use webui_test_utils::test_json;
+
+    struct TestWriter {
+        output: String,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                output: String::new(),
+            }
+        }
+    }
+
+    impl ResponseWriter for TestWriter {
+        fn write(&mut self, content: &str) -> Result<()> {
+            self.output.push_str(content);
+            Ok(())
+        }
+        fn end(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn render_component_with_webui_plugin(
+        protocol: &WebUIProtocol,
+        state: &serde_json::Value,
+        entry_id: &str,
+    ) -> String {
+        let mut writer = TestWriter::new();
+        let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
+        handler
+            .handle_as_component(protocol, state, entry_id, &mut writer)
+            .unwrap();
+        writer.output
+    }
+
+    #[test]
+    fn test_root_scope_disabled() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.on_binding_start("x", &mut writer).unwrap();
+        plugin.on_binding_end("x", &mut writer).unwrap();
+        plugin.on_repeat_item_start(0, &mut writer).unwrap();
+        plugin.on_repeat_item_end(0, &mut writer).unwrap();
+        let data = 3u32.to_le_bytes();
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, "");
+    }
+
+    #[test]
+    fn test_binding_markers_in_child_scope() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        plugin.on_binding_start("userName", &mut writer).unwrap();
+        plugin.on_binding_end("userName", &mut writer).unwrap();
+        assert_eq!(
+            writer.output,
+            "<!--w-b:start:0:userName--><!--w-b:end:0:userName-->"
+        );
+    }
+
+    #[test]
+    fn test_repeat_markers() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        plugin.on_repeat_item_start(0, &mut writer).unwrap();
+        plugin.on_repeat_item_end(0, &mut writer).unwrap();
+        assert_eq!(writer.output, "<!--w-r:start:0--><!--w-r:end:0-->");
+    }
+
+    #[test]
+    fn test_attribute_single_binding() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let data = 1u32.to_le_bytes();
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, " data-w-b-0");
+    }
+
+    #[test]
+    fn test_attribute_multi_binding() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let data = 3u32.to_le_bytes();
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, " data-w-c-0-3");
+    }
+
+    #[test]
+    fn test_scope_reset_on_push_pop() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        plugin.on_binding_start("a", &mut writer).unwrap();
+        plugin.on_binding_end("a", &mut writer).unwrap();
+        plugin.push_scope();
+        plugin.on_binding_start("b", &mut writer).unwrap();
+        plugin.on_binding_end("b", &mut writer).unwrap();
+        plugin.pop_scope();
+        plugin.on_binding_start("c", &mut writer).unwrap();
+        plugin.on_binding_end("c", &mut writer).unwrap();
+        // After pop, counter continues from where the outer scope was
+        assert!(writer.output.contains("<!--w-b:start:0:a-->"));
+        assert!(writer.output.contains("<!--w-b:start:0:b-->"));
+        assert!(writer.output.contains("<!--w-b:start:1:c-->"));
+    }
+
+    #[test]
+    fn test_on_render_complete_only_emits_rendered_components() {
+        let mut writer = TestWriter::new();
+
+        // Build a protocol with 3 components — only 1 was rendered
+        let mut protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
+        protocol
+            .components
+            .entry("comp-a".to_string())
+            .or_default()
+            .template = "<script>/*comp-a*/</script>".to_string();
+        protocol
+            .components
+            .entry("comp-b".to_string())
+            .or_default()
+            .template = "<script>/*comp-b*/</script>".to_string();
+        protocol
+            .components
+            .entry("comp-c".to_string())
+            .or_default()
+            .template = "<script>/*comp-c*/</script>".to_string();
+
+        // Only comp-a was rendered
+        let mut rendered = std::collections::HashSet::new();
+        rendered.insert("comp-a".to_string());
+
+        crate::plugin::emit_rendered_component_templates(&protocol, &rendered, &mut writer)
+            .unwrap();
+
+        // Should contain only comp-a's template
+        assert!(
+            writer.output.contains("comp-a"),
+            "rendered component should be emitted: {}",
+            writer.output
+        );
+        assert!(
+            !writer.output.contains("comp-b"),
+            "non-rendered component should NOT be emitted: {}",
+            writer.output
+        );
+        assert!(
+            !writer.output.contains("comp-c"),
+            "non-rendered component should NOT be emitted: {}",
+            writer.output
+        );
+    }
+
+    #[test]
+    fn test_route_component_is_noop() {
+        let plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        let state = serde_json::json!({
+            "title": "Hello",
+            "cartOpen": true,
+            "items": [{"name": "A&B"}],
+        });
+
+        plugin
+            .write_route_component_state(&state, &mut writer)
+            .unwrap();
+
+        assert_eq!(writer.output, "");
+    }
+
+    #[test]
+    fn test_hydration_preserves_inline_spaces_around_entity_between_bindings() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<nav>"),
+                    WebUIFragment::signal("sectionName", false),
+                    WebUIFragment::raw(" &gt; "),
+                    WebUIFragment::signal("topicName", false),
+                    WebUIFragment::raw("</nav>"),
+                ],
+            },
+        );
+
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({
+            "sectionName": "Backend",
+            "topicName": "Rust"
+        });
+
+        let html = render_component_with_webui_plugin(&protocol, &state, "index.html");
+
+        assert_eq!(
+            html,
+            "<nav><!--w-b:start:0:sectionName-->Backend<!--w-b:end:0:sectionName--> &gt; <!--w-b:start:1:topicName-->Rust<!--w-b:end:1:topicName--></nav>"
+        );
+    }
+
+    #[test]
+    fn test_hydration_for_loop_marker_format() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<ul>"),
+                    WebUIFragment::for_loop("item", "items", "item-tpl"),
+                    WebUIFragment::raw("</ul>"),
+                ],
+            },
+        );
+        fragments.insert(
+            "item-tpl".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<li>"),
+                    WebUIFragment::signal("item.name", false),
+                    WebUIFragment::raw("</li>"),
+                ],
+            },
+        );
+
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({
+            "items": [
+                {"name": "Alpha"},
+                {"name": "Beta"}
+            ]
+        });
+
+        let html = render_component_with_webui_plugin(&protocol, &state, "index.html");
+
+        assert!(
+            html.contains("<!--w-b:start:0:item-tpl-->"),
+            "should have outer binding start for for-loop: {html}"
+        );
+        assert!(
+            html.contains("<!--w-b:end:0:item-tpl-->"),
+            "should have outer binding end for for-loop: {html}"
+        );
+        assert!(
+            html.contains("<!--w-r:start:0-->"),
+            "should have first repeat marker: {html}"
+        );
+        assert!(
+            html.contains("<!--w-r:end:1-->"),
+            "should have second repeat end marker: {html}"
+        );
+        assert!(
+            html.contains("<!--w-b:start:0:item.name-->Alpha<!--w-b:end:0:item.name-->"),
+            "should have item binding markers: {html}"
+        );
+    }
+
+    #[test]
+    fn test_data_ev_single_event() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        // Encode: [binding_count=0, event_start=0, event_count=1]
+        let mut data = Vec::new();
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&1u32.to_le_bytes());
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, " data-ev=\"1\"");
+    }
+
+    #[test]
+    fn test_data_ev_multiple_events() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let mut data = Vec::new();
+        data.extend_from_slice(&0u32.to_le_bytes()); // binding_count
+        data.extend_from_slice(&5u32.to_le_bytes()); // event_start
+        data.extend_from_slice(&3u32.to_le_bytes()); // event_count
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, " data-ev=\"3\"");
+    }
+
+    #[test]
+    fn test_data_ev_with_bindings() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let mut data = Vec::new();
+        data.extend_from_slice(&2u32.to_le_bytes()); // binding_count=2
+        data.extend_from_slice(&0u32.to_le_bytes()); // event_start=0
+        data.extend_from_slice(&1u32.to_le_bytes()); // event_count=1
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert!(
+            writer.output.contains("data-w-c-0-2"),
+            "binding marker: {}",
+            writer.output
+        );
+        assert!(
+            writer.output.contains("data-ev=\"1\""),
+            "event marker: {}",
+            writer.output
+        );
+    }
+
+    #[test]
+    fn test_data_ev_zero_events_no_marker() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let mut data = Vec::new();
+        data.extend_from_slice(&0u32.to_le_bytes()); // binding_count=0
+        data.extend_from_slice(&0u32.to_le_bytes()); // event_start=0
+        data.extend_from_slice(&0u32.to_le_bytes()); // event_count=0
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(
+            writer.output, "",
+            "no markers for zero bindings and zero events"
+        );
+    }
+
+    #[test]
+    fn test_data_ev_root_scope_suppressed() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        // Don't push a child scope — stay at root
+        let mut data = Vec::new();
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&2u32.to_le_bytes());
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(
+            writer.output, "",
+            "root scope should suppress all markers including data-ev"
+        );
+    }
+
+    #[test]
+    fn test_binding_index_advances_with_plugin_data() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        // First element: 2 bindings
+        let data1 = 2u32.to_le_bytes();
+        plugin.on_element_data(&data1, &mut writer).unwrap();
+        // Second element: 1 binding
+        let data2 = 1u32.to_le_bytes();
+        plugin.on_element_data(&data2, &mut writer).unwrap();
+        assert!(
+            writer.output.contains("data-w-c-0-2"),
+            "first element bindings at 0: {}",
+            writer.output
+        );
+        assert!(
+            writer.output.contains("data-w-b-2"),
+            "second element binding at 2: {}",
+            writer.output
+        );
+    }
+
+    #[test]
+    fn test_on_render_complete_empty_rendered_set() {
+        let mut writer = TestWriter::new();
+        let mut protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
+        protocol
+            .components
+            .entry("comp-a".to_string())
+            .or_default()
+            .template = "<script>/*a*/</script>".to_string();
+        let rendered = std::collections::HashSet::new();
+        crate::plugin::emit_rendered_component_templates(&protocol, &rendered, &mut writer)
+            .unwrap();
+        assert_eq!(writer.output, "", "empty rendered set should emit nothing");
+    }
+
+    #[test]
+    fn test_on_render_complete_skips_empty_template() {
+        let mut writer = TestWriter::new();
+        let mut protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
+        protocol
+            .components
+            .entry("comp-a".to_string())
+            .or_default()
+            .template = String::new();
+        let mut rendered = std::collections::HashSet::new();
+        rendered.insert("comp-a".to_string());
+        crate::plugin::emit_rendered_component_templates(&protocol, &rendered, &mut writer)
+            .unwrap();
+        assert_eq!(writer.output, "", "empty template should not be emitted");
+    }
+
+    #[test]
+    fn test_on_render_complete_unknown_component() {
+        let mut writer = TestWriter::new();
+        let protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
+        let mut rendered = std::collections::HashSet::new();
+        rendered.insert("nonexistent-comp".to_string());
+        crate::plugin::emit_rendered_component_templates(&protocol, &rendered, &mut writer)
+            .unwrap();
+        assert_eq!(
+            writer.output, "",
+            "unknown component should not cause error"
+        );
+    }
+
+    #[test]
+    fn test_invalid_plugin_data_length_returns_error() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let data = [0u8, 0u8]; // only 2 bytes
+        let result = plugin.on_element_data(&data, &mut writer);
+        assert!(
+            matches!(result, Err(crate::HandlerError::PluginData(ref msg)) if msg.contains("expected 4 or 12 bytes")),
+            "invalid payload length should produce a plugin-data error: {result:?}"
+        );
+        assert_eq!(
+            writer.output, "",
+            "invalid payload must not write partial output"
+        );
+    }
+
+    #[test]
+    fn test_plugin_data_4_bytes_no_events() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+        let data = 1u32.to_le_bytes(); // only 4 bytes — binding_count=1, no event data
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(
+            writer.output, " data-w-b-0",
+            "4-byte payload should emit binding marker only"
+        );
+    }
+
+    #[test]
+    fn test_binding_end_without_start_returns_error() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+
+        let result = plugin.on_binding_end("missing", &mut writer);
+
+        assert!(
+            matches!(result, Err(crate::HandlerError::Invariant(ref msg)) if msg.contains("missing")),
+            "binding underflow should produce an invariant error: {result:?}"
+        );
+        assert_eq!(writer.output, "", "failed binding end must not emit output");
+    }
+
+    #[test]
+    fn test_invalid_plugin_data_length_rejects_partial_payloads() {
+        let mut plugin = WebUIHydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.push_scope();
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes()); // 8 bytes total is still invalid
+
+        let result = plugin.on_element_data(&data, &mut writer);
+
+        assert!(
+            matches!(result, Err(crate::HandlerError::PluginData(ref msg)) if msg.contains("expected 4 or 12 bytes")),
+            "partial 12-byte payload should be rejected: {result:?}"
+        );
+        assert_eq!(
+            writer.output, "",
+            "invalid payload must not write partial output"
+        );
+    }
+}

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -33,6 +33,7 @@ use napi::Error as NapiError;
 use napi_derive::napi;
 use serde_json::Value;
 use webui_handler::plugin::fast::FastHydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_protocol::WebUIProtocol;
 
@@ -73,7 +74,7 @@ pub struct JsBuildOptions {
     pub entry: Option<String>,
     /// CSS mode: "link" (default) or "style".
     pub css: Option<String>,
-    /// Parser plugin (e.g., "fast").
+    /// Framework plugin.
     pub plugin: Option<String>,
     /// Additional component sources (npm packages or local paths).
     pub components: Option<Vec<String>>,
@@ -231,6 +232,7 @@ pub fn render(
     let mut writer = CallbackWriter::new(&on_chunk);
     let handler = match plugin.as_deref() {
         Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
         Some(unknown) => {
             return Err(NapiError::from_reason(format!("Unknown plugin: {unknown}")));
         }

--- a/crates/webui-parser/src/plugin/mod.rs
+++ b/crates/webui-parser/src/plugin/mod.rs
@@ -8,6 +8,7 @@
 //! and emit per-element hydration metadata for the handler.
 
 pub mod fast;
+pub mod webui;
 
 use crate::component_registry::Component;
 use crate::Result;

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -1,0 +1,2751 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! WebUI Framework parser plugin.
+//!
+//! # Overview
+//!
+//! Compiles HTML templates into structured metadata objects emitted as
+//! `<script>` blocks in the rendered page. Each metadata object contains
+//! **marker-free static HTML** plus locator arrays for client-created DOM
+//! (`tx`, `ag`, `cl`, `rl`, `el`) and semantic arrays (`a`, `c`, `r`, `e`,
+//! `re`, `b`). The client runtime resolves those locators once and then
+//! patches direct node references — **no template string parsing, no regex,
+//! no DOM scanning** on the client-created path.
+//!
+//! # Metadata object format
+//!
+//! ```js
+//! window.__webui_templates['my-component'] = {
+//!   h: "<button class=\"item\"><span></span></button>",
+//!   tx: [[[[0, 0], 0], [["title"]]]],
+//!   a: [["title", 0, "title"]],
+//!   ag: [[[0], 0, 1]],
+//!   c: [[[1, "state", 3, "'done'"], 0]],
+//!   cl: [[[0], 1]],
+//!   e: [["click", "onClick", 0]],
+//!   el: [[0]],
+//!   b: [{ h: "<span class=\"check\">✓</span>" }],
+//!   sa: "my-component",
+//!   re: [["submit", "onSubmit", 1]],
+//! };
+//! ```
+//!
+//! # Plugin data protocol
+//!
+//! Each element with attribute bindings or events produces a 12-byte
+//! `Plugin` fragment via [`finish_element`](ParserPlugin::finish_element):
+//!
+//! | Bytes  | Field              | Description                               |
+//! |--------|--------------------|-------------------------------------------|
+//! | 0–3    | `binding_count`    | Number of dynamic attribute bindings      |
+//! | 4–7    | `event_start_idx`  | Starting index in the global event list   |
+//! | 8–11   | `event_count`      | Number of `@event` attrs on this element  |
+//!
+//! The handler plugin decodes this to emit `data-w-*` binding markers
+//! and single `data-ev="COUNT"` event markers on **SSR HTML only**. Compiled templates
+//! keep the same binding/event indices but encode client targets via locator
+//! arrays instead of embedding client-only marker attrs/comments in `h`.
+//!
+//! # Lifecycle
+//!
+//! 1. **`classify_attribute`** — intercepts `@event` attributes,
+//!    counts them per-element, and keeps them out of the parsed protocol.
+//! 2. **`finish_element`** — encodes the accumulated event count
+//!    plus attribute binding count into 12 bytes.
+//! 3. **`register_component_template`** — caches the component's final template
+//!    HTML for later compilation (deduplicates by tag name).
+//! 4. **`take_component_templates`** — called after parsing is complete;
+//!    compiles each tracked component into a `<script>` block.
+
+use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
+use crate::component_registry::Component;
+use crate::{ConditionParser, CssStrategy, Result};
+use std::cell::Cell;
+use std::fmt::Write;
+use webui_protocol::{condition_expr, ConditionExpr, WebUIElementData};
+
+/// A component whose final template HTML has been captured for compilation.
+/// Repeated tracking for the same tag updates the stored template so the plugin
+/// can prefer processed HTML over raw component source.
+struct TrackedComponent {
+    tag_name: String,
+    template_html: String,
+    root_event_source: String,
+}
+
+/// WebUI Framework parser plugin.
+///
+/// Intercepts `@event` attributes and component registrations during parsing,
+/// then compiles each component's HTML template into a metadata `<script>` block.
+///
+/// # Event tracking
+///
+/// Event indices are assigned **globally** across all elements in a component.
+/// `element_events` counts events on the current element (reset per element),
+/// while `next_event_idx` is a monotonically increasing global counter.
+/// This preserves event order in the emitted metadata while letting SSR HTML
+/// mark one element with a single `data-ev="COUNT"` attribute.
+pub struct WebUIParserPlugin {
+    components: Vec<TrackedComponent>,
+    /// Per-element event count, reset on each `finish_element` call.
+    element_events: Cell<u32>,
+    /// Global event index, incremented across all elements in a component.
+    next_event_idx: Cell<u32>,
+}
+
+impl WebUIParserPlugin {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            components: Vec::new(),
+            element_events: Cell::new(0),
+            next_event_idx: Cell::new(0),
+        }
+    }
+
+    pub fn set_css_strategy(&mut self, strategy: CssStrategy) {
+        let _ = strategy;
+    }
+
+    /// Compile all tracked components and return `(tag_name, script_block)` pairs.
+    ///
+    /// Each script block is a self-executing IIFE that registers a metadata
+    /// object into `window.__webui_templates[tagName]`. Call this after all
+    /// HTML parsing is complete.
+    #[must_use]
+    pub fn take_component_templates(&self) -> Vec<(String, String)> {
+        self.components
+            .iter()
+            .map(|c| {
+                let script = generate_compiled_template_with_root_source(
+                    &c.tag_name,
+                    &c.template_html,
+                    &c.root_event_source,
+                );
+                (c.tag_name.clone(), script)
+            })
+            .collect()
+    }
+
+    fn store_component_template(
+        &mut self,
+        tag_name: &str,
+        template_html: &str,
+        root_event_source: &str,
+    ) {
+        if let Some(component) = self.components.iter_mut().find(|c| c.tag_name == tag_name) {
+            component.template_html.clear();
+            component.template_html.push_str(template_html);
+            component.root_event_source.clear();
+            component.root_event_source.push_str(root_event_source);
+            return;
+        }
+
+        self.components.push(TrackedComponent {
+            tag_name: tag_name.to_string(),
+            template_html: template_html.to_string(),
+            root_event_source: root_event_source.to_string(),
+        });
+    }
+}
+
+impl Default for WebUIParserPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParserPlugin for WebUIParserPlugin {
+    fn start_fragment(&mut self, _fragment_id: &str) {
+        self.element_events.set(0);
+        self.next_event_idx.set(0);
+    }
+
+    fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction {
+        if attr_name.starts_with('@') {
+            self.element_events.set(self.element_events.get() + 1);
+            return AttributeAction::Skip;
+        }
+        AttributeAction::Keep
+    }
+
+    fn register_component_template(
+        &mut self,
+        tag_name: &str,
+        component: &Component,
+        processed_template: &str,
+    ) -> Result<()> {
+        self.store_component_template(tag_name, processed_template, &component.html_content);
+        Ok(())
+    }
+
+    fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>> {
+        let ev_count = self.element_events.get();
+        let ev_start = self.next_event_idx.get();
+
+        // Advance the global event index
+        self.next_event_idx.set(ev_start + ev_count);
+        // Reset per-element event counter
+        self.element_events.set(0);
+
+        if binding_attribute_count == 0 && ev_count == 0 {
+            return None;
+        }
+
+        Some(
+            WebUIElementData {
+                binding_count: binding_attribute_count,
+                event_start: ev_start,
+                event_count: ev_count,
+            }
+            .encode()
+            .to_vec(),
+        )
+    }
+
+    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
+        ParserPluginArtifacts::ComponentTemplates(self.take_component_templates())
+    }
+}
+
+// ── Compiled template generation ───────────────────────────────────
+
+/// A compiled template section.
+///
+/// Used for the root template and for nested block-table entries.
+/// `conditionals` and `repeats` point at block-table indices instead of
+/// inlining raw body HTML so the client never reparses nested template syntax.
+/// The final `html` payload is marker-free; client-created DOM uses the
+/// locator tables to connect bindings without scanning comments or attrs.
+#[derive(Default)]
+struct TemplateSectionMeta {
+    /// Marker-free static HTML for client-created DOM.
+    html: String,
+    /// Intermediate text binding paths collected during compilation.
+    /// These are resolved into `text_runs` during finalization.
+    text_bindings: Vec<String>,
+    /// Client text-run metadata: `(slot, parts)`.
+    text_runs: Vec<(SlotLocator, Vec<CompiledAttrPart>)>,
+    /// Attribute bindings in source order, shared by SSR markers and client `ag[]` locators.
+    attr_bindings: Vec<CompiledAttrBinding>,
+    /// Client attribute groups: `(element_path, start, count)`.
+    attr_groups: Vec<(Vec<usize>, usize, usize)>,
+    /// Conditional blocks: `(condition_expression_ast, block_index)`.
+    conditionals: Vec<(ConditionExpr, usize)>,
+    /// Client conditional anchor slots aligned to `conditionals`.
+    condition_slots: Vec<SlotLocator>,
+    /// For-loop blocks: `(collection_path, item_variable, block_index)`.
+    repeats: Vec<(String, String, usize)>,
+    /// Client repeat anchor slots aligned to `repeats`.
+    repeat_slots: Vec<SlotLocator>,
+    /// Body-level events: `(event_name, handler_method, needs_event_arg)`.
+    events: Vec<(String, String, bool)>,
+    /// Client event target element paths aligned to `events`.
+    event_targets: Vec<Vec<usize>>,
+}
+
+#[derive(Clone)]
+struct SlotLocator {
+    parent_path: Vec<usize>,
+    before_index: usize,
+    order: usize,
+}
+
+/// Collected metadata produced by [`compile_to_metadata`].
+///
+/// The root template emits directly into the top-level metadata object.
+/// Nested blocks live in `blocks` and are referenced by index from `c` / `r`.
+struct TemplateMeta {
+    root: TemplateSectionMeta,
+    blocks: Vec<TemplateSectionMeta>,
+    /// Root-level events from the `<template>` wrapper tag.
+    /// Attached to the host element (shadow root host) by the client.
+    root_events: Vec<(String, String, bool)>,
+}
+
+enum CompiledAttrBinding {
+    Simple {
+        name: String,
+        value: String,
+    },
+    Complex {
+        name: String,
+        value: String,
+    },
+    Boolean {
+        name: String,
+        condition: ConditionExpr,
+    },
+    Template {
+        name: String,
+        parts: Vec<CompiledAttrPart>,
+    },
+}
+
+enum CompiledAttrPart {
+    Static(String),
+    Dynamic(String),
+}
+
+/// Generate a compiled template `<script>` block with a metadata object.
+///
+/// # Flow
+///
+/// 1. Extract `@event` bindings from the `<template>` wrapper (→ `root_events`).
+/// 2. Strip the `<template shadowrootmode="…">` wrapper if present.
+/// 3. Compile the inner body via [`compile_to_metadata`].
+/// 4. Serialize into a self-executing `<script>` IIFE that registers
+///    the metadata on `window.__webui_templates[tagName]`.
+///
+/// # Compilation rules
+///
+/// | Source syntax                          | Metadata field(s)          | Client `h` result                 |
+/// |---------------------------------------|----------------------------|-----------------------------------|
+/// | `{{expr}}`, `{{{expr}}}`, mixed text  | `tx[]`                     | dynamic text run removed          |
+/// | `href="{{url}}"`, `class="x {{y}}"`   | `a[]` + `ag[]`             | element kept marker-free          |
+/// | `?disabled="{{expr}}"`                | `a[]` + `ag[]`             | element kept marker-free          |
+/// | `:config="{{settings}}"`              | `a[]` + `ag[]`             | element kept marker-free          |
+/// | `<if condition="…">body</if>`         | `c[]` + `cl[]` + `b[]`     | block removed; anchor slot stored |
+/// | `<for each="v in coll">body</for>`    | `r[]` + `rl[]` + `b[]`     | block removed; anchor slot stored |
+/// | `<link>` / `<style>` child nodes      | `h`                        | preserved in static HTML          |
+/// | module adopted stylesheet specifier   | `sa`                       | stored from `<template>` wrapper  |
+/// | `@event="{handler(e)}"`               | `e[]` + `el[]`             | element kept marker-free          |
+/// | `w-ref="name"` / `w-ref={name}`       | *(stays in HTML)*          | *(unchanged)*                     |
+/// | `<outlet />` / `<outlet>`             | *(stays in HTML)*          | `<outlet></outlet>`               |
+pub fn generate_compiled_template(tag_name: &str, html_content: &str) -> String {
+    generate_compiled_template_with_root_source(tag_name, html_content, html_content)
+}
+
+fn generate_compiled_template_with_root_source(
+    tag_name: &str,
+    html_content: &str,
+    root_event_source: &str,
+) -> String {
+    let trimmed = html_content.trim();
+    let root_events = extract_root_events(root_event_source.trim());
+    let adopted_stylesheet = extract_adopted_stylesheet_specifier(trimmed);
+    let body = strip_template_wrapper(trimmed);
+    let meta = compile_to_metadata(body, root_events);
+
+    let mut out = String::with_capacity(512 + html_content.len());
+    out.push_str("<script>\n");
+    out.push_str("(function(){var w=window.__webui_templates||(window.__webui_templates={});w['");
+    out.push_str(tag_name);
+    out.push_str("']={");
+
+    emit_js_template_section(&meta.root, &mut out);
+
+    if let Some(adopted_stylesheet) = adopted_stylesheet.as_deref() {
+        out.push_str(",sa:");
+        emit_js_string(adopted_stylesheet, &mut out);
+    }
+
+    // re: root events
+    if !meta.root_events.is_empty() {
+        out.push_str(",re:[");
+        for (i, (event, handler, needs_event)) in meta.root_events.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_string(event, &mut out);
+            out.push(',');
+            emit_js_string(handler, &mut out);
+            out.push(',');
+            out.push(if *needs_event { '1' } else { '0' });
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    // b: nested block table
+    if !meta.blocks.is_empty() {
+        out.push_str(",b:[");
+        for (i, block) in meta.blocks.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('{');
+            emit_js_template_section(block, &mut out);
+            out.push('}');
+        }
+        out.push(']');
+    }
+
+    out.push_str("};})();\n");
+    out.push_str("</script>\n");
+    out
+}
+
+/// Emit a JS string literal with script-safe escaping.
+fn emit_js_string(s: &str, out: &mut String) {
+    out.push('"');
+    let mut index = 0usize;
+    while index < s.len() {
+        let remaining = &s[index..];
+        if remaining.as_bytes().starts_with(b"</")
+            && remaining
+                .as_bytes()
+                .get(2..8)
+                .map(|bytes| bytes.eq_ignore_ascii_case(b"script"))
+                .unwrap_or(false)
+        {
+            out.push_str("\\u003C");
+            index += 1;
+            continue;
+        }
+        let Some(ch) = remaining.chars().next() else {
+            break;
+        };
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            _ => out.push(ch),
+        }
+        index += ch.len_utf8();
+    }
+    out.push('"');
+}
+
+fn emit_js_attr_binding(binding: &CompiledAttrBinding, out: &mut String) {
+    out.push('[');
+    match binding {
+        CompiledAttrBinding::Simple { name, value } => {
+            emit_js_string(name, out);
+            out.push_str(",0,");
+            emit_js_string(value, out);
+        }
+        CompiledAttrBinding::Complex { name, value } => {
+            emit_js_string(name, out);
+            out.push_str(",1,");
+            emit_js_string(value, out);
+        }
+        CompiledAttrBinding::Boolean { name, condition } => {
+            emit_js_string(name, out);
+            out.push_str(",2,");
+            emit_js_condition(condition, out);
+        }
+        CompiledAttrBinding::Template { name, parts } => {
+            emit_js_string(name, out);
+            out.push_str(",3,[");
+            for (i, part) in parts.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                match part {
+                    CompiledAttrPart::Static(value) => emit_js_string(value, out),
+                    CompiledAttrPart::Dynamic(path) => {
+                        out.push('[');
+                        emit_js_string(path, out);
+                        out.push(']');
+                    }
+                }
+            }
+            out.push(']');
+        }
+    }
+    out.push(']');
+}
+
+fn emit_js_condition(condition: &ConditionExpr, out: &mut String) {
+    match &condition.expr {
+        Some(condition_expr::Expr::Identifier(identifier)) => {
+            out.push_str("[0,");
+            emit_js_string(&identifier.value, out);
+            out.push(']');
+        }
+        Some(condition_expr::Expr::Predicate(predicate)) => {
+            out.push_str("[1,");
+            emit_js_string(&predicate.left, out);
+            out.push(',');
+            let _ = write!(out, "{}", predicate.operator);
+            out.push(',');
+            emit_js_string(&predicate.right, out);
+            out.push(']');
+        }
+        Some(condition_expr::Expr::Not(not_condition)) => {
+            out.push_str("[2,");
+            if let Some(inner) = not_condition.condition.as_ref() {
+                emit_js_condition(inner, out);
+            } else {
+                out.push_str("[0,\"\"]");
+            }
+            out.push(']');
+        }
+        Some(condition_expr::Expr::Compound(compound)) => {
+            out.push_str("[3,");
+            if let Some(left) = compound.left.as_ref() {
+                emit_js_condition(left, out);
+            } else {
+                out.push_str("[0,\"\"]");
+            }
+            out.push(',');
+            let _ = write!(out, "{}", compound.op);
+            out.push(',');
+            if let Some(right) = compound.right.as_ref() {
+                emit_js_condition(right, out);
+            } else {
+                out.push_str("[0,\"\"]");
+            }
+            out.push(']');
+        }
+        None => out.push_str("[0,\"\"]"),
+    }
+}
+
+fn emit_js_node_path(path: &[usize], out: &mut String) {
+    out.push('[');
+    for (i, index) in path.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        let _ = write!(out, "{}", index);
+    }
+    out.push(']');
+}
+
+fn emit_js_slot(slot: &SlotLocator, out: &mut String) {
+    out.push('[');
+    emit_js_node_path(&slot.parent_path, out);
+    out.push(',');
+    let _ = write!(out, "{}", slot.before_index);
+    if slot.order > 0 {
+        out.push(',');
+        let _ = write!(out, "{}", slot.order);
+    }
+    out.push(']');
+}
+
+fn emit_js_text_parts(parts: &[CompiledAttrPart], out: &mut String) {
+    out.push('[');
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        match part {
+            CompiledAttrPart::Static(value) => emit_js_string(value, out),
+            CompiledAttrPart::Dynamic(path) => {
+                out.push('[');
+                emit_js_string(path, out);
+                out.push(']');
+            }
+        }
+    }
+    out.push(']');
+}
+
+fn emit_js_template_section(meta: &TemplateSectionMeta, out: &mut String) {
+    out.push_str("h:");
+    emit_js_string(&meta.html, out);
+
+    if !meta.text_runs.is_empty() {
+        out.push_str(",tx:[");
+        for (i, (slot, parts)) in meta.text_runs.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_slot(slot, out);
+            out.push(',');
+            emit_js_text_parts(parts, out);
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    if !meta.attr_bindings.is_empty() {
+        out.push_str(",a:[");
+        for (i, binding) in meta.attr_bindings.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            emit_js_attr_binding(binding, out);
+        }
+        out.push(']');
+    }
+
+    if !meta.attr_groups.is_empty() {
+        out.push_str(",ag:[");
+        for (i, (path, start, count)) in meta.attr_groups.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_node_path(path, out);
+            out.push(',');
+            let _ = write!(out, "{}", start);
+            out.push(',');
+            let _ = write!(out, "{}", count);
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    if !meta.conditionals.is_empty() {
+        out.push_str(",c:[");
+        for (i, (cond, block_index)) in meta.conditionals.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_condition(cond, out);
+            out.push(',');
+            let _ = write!(out, "{}", block_index);
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    if !meta.condition_slots.is_empty() {
+        out.push_str(",cl:[");
+        for (i, slot) in meta.condition_slots.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            emit_js_slot(slot, out);
+        }
+        out.push(']');
+    }
+
+    if !meta.repeats.is_empty() {
+        out.push_str(",r:[");
+        for (i, (collection, item_var, block_index)) in meta.repeats.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_string(collection, out);
+            out.push(',');
+            emit_js_string(item_var, out);
+            out.push(',');
+            let _ = write!(out, "{}", block_index);
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    if !meta.repeat_slots.is_empty() {
+        out.push_str(",rl:[");
+        for (i, slot) in meta.repeat_slots.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            emit_js_slot(slot, out);
+        }
+        out.push(']');
+    }
+
+    if !meta.events.is_empty() {
+        out.push_str(",e:[");
+        for (i, (event, handler, needs_event)) in meta.events.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push('[');
+            emit_js_string(event, out);
+            out.push(',');
+            emit_js_string(handler, out);
+            out.push(',');
+            out.push(if *needs_event { '1' } else { '0' });
+            out.push(']');
+        }
+        out.push(']');
+    }
+
+    if !meta.event_targets.is_empty() {
+        out.push_str(",el:[");
+        for (i, path) in meta.event_targets.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            emit_js_node_path(path, out);
+        }
+        out.push(']');
+    }
+}
+
+/// Compile a template body into a [`TemplateMeta`] struct.
+///
+/// Performs a single forward pass over the input bytes to build an intermediate
+/// section, then finalizes that section into marker-free client HTML plus
+/// locator metadata. During the forward pass:
+///
+/// - **Multi-byte char boundary check** — ensures we don't split UTF-8 (e.g. emoji).
+/// - **`{{{expr}}}`** — triple-brace raw binding → text run metadata.
+/// - **`{{expr}}`** — double-brace escaped binding → text run metadata.
+/// - **regular start tags** — attrs are compiled into explicit `a[]` metadata plus
+///   SSR binding markers that are later stripped from client `h`.
+/// - **`<if condition="…">`** — parsed via [`parse_if_block`] → conditional slot.
+/// - **`<for each="v in coll">`** — parsed via [`parse_for_block`] → repeat slot.
+/// - **`<outlet …>`** — normalized to `<outlet></outlet>`.
+/// - **`@event="…"`** (inside a tag) — parsed into `e[]` entries plus
+///   SSR `data-ev="COUNT"` markers that are later replaced by client locators.
+/// - **Everything else** — copied verbatim to the intermediate static HTML.
+///
+fn compile_to_metadata(input: &str, root_events: Vec<(String, String, bool)>) -> TemplateMeta {
+    let mut blocks = Vec::new();
+    let mut root = compile_section(input, &mut blocks);
+    finalize_template_section(&mut root);
+    for block in &mut blocks {
+        finalize_template_section(block);
+    }
+    TemplateMeta {
+        root,
+        blocks,
+        root_events,
+    }
+}
+
+fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> TemplateSectionMeta {
+    let mut meta = TemplateSectionMeta {
+        html: String::with_capacity(input.len()),
+        text_bindings: Vec::new(),
+        text_runs: Vec::new(),
+        attr_bindings: Vec::new(),
+        attr_groups: Vec::new(),
+        conditionals: Vec::new(),
+        condition_slots: Vec::new(),
+        repeats: Vec::new(),
+        repeat_slots: Vec::new(),
+        events: Vec::new(),
+        event_targets: Vec::new(),
+    };
+
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if !input.is_char_boundary(i) {
+            meta.html.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+
+        // Triple-brace {{{expr}}} → marker + text binding
+        if i + 4 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' && bytes[i + 2] == b'{' {
+            if let Some(end) = find_brace_end(input, i + 3, 3) {
+                let expr = input[i + 3..end].trim();
+                let idx = meta.text_bindings.len();
+                meta.text_bindings.push(expr.to_string());
+                meta.html.push_str(&format!("<!--t:{idx}-->"));
+                i = end + 3;
+                continue;
+            }
+        }
+
+        // Double-brace {{expr}} → marker + text binding
+        if i + 3 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            if let Some(end) = find_brace_end(input, i + 2, 2) {
+                let expr = input[i + 2..end].trim();
+                let idx = meta.text_bindings.len();
+                meta.text_bindings.push(expr.to_string());
+                meta.html.push_str(&format!("<!--t:{idx}-->"));
+                i = end + 2;
+                continue;
+            }
+        }
+
+        // <if condition="...">...</if> → marker + conditional
+        if bytes[i] == b'<' {
+            let remaining = &input[i..];
+            if remaining.starts_with("<if ") || remaining.starts_with("<if\n") {
+                if let Some((cond, body, consumed)) = parse_if_block(remaining) {
+                    let block_index = blocks.len();
+                    blocks.push(TemplateSectionMeta::default());
+                    let block = compile_section(&body, blocks);
+                    blocks[block_index] = block;
+                    let idx = meta.conditionals.len();
+                    meta.conditionals.push((cond, block_index));
+                    meta.html.push_str(&format!("<!--c:{idx}-->"));
+                    i += consumed;
+                    continue;
+                }
+            }
+
+            // <for each="item in collection">...</for> → marker + repeat
+            if remaining.starts_with("<for ") || remaining.starts_with("<for\n") {
+                if let Some((collection, item_var, body, consumed)) = parse_for_block(remaining) {
+                    let block_index = blocks.len();
+                    blocks.push(TemplateSectionMeta::default());
+                    let block = compile_section(&body, blocks);
+                    blocks[block_index] = block;
+                    let idx = meta.repeats.len();
+                    meta.repeats.push((collection, item_var, block_index));
+                    meta.html.push_str(&format!("<!--r:{idx}-->"));
+                    i += consumed;
+                    continue;
+                }
+            }
+
+            // <outlet ... /> → keep as <outlet></outlet>
+            if remaining.starts_with("<outlet") {
+                if let Some(close) = find_tag_end(remaining) {
+                    meta.html.push_str("<outlet></outlet>");
+                    i += close + 1;
+                    continue;
+                }
+            }
+
+            if let Some((tag_html, consumed)) = parse_regular_tag(remaining, &mut meta) {
+                meta.html.push_str(&tag_html);
+                i += consumed;
+                continue;
+            }
+        }
+
+        // @event attributes → replace with a per-element event-count marker
+        if bytes[i] == b'@' && is_inside_tag(input, i) {
+            if let Some((event_name, handler, needs_event, consumed)) = parse_event_attr(input, i) {
+                meta.events.push((event_name, handler, needs_event));
+                meta.html.push_str("data-ev=\"1\"");
+                i += consumed;
+                continue;
+            }
+        }
+
+        // w-ref stays in static HTML as-is — the runtime binds from the DOM directly.
+        // No metadata entry needed; the attribute value IS the property name.
+
+        // Copy character
+        let ch = &input[i..];
+        if let Some(c) = ch.chars().next() {
+            meta.html.push(c);
+            i += c.len_utf8();
+        } else {
+            i += 1;
+        }
+    }
+
+    meta
+}
+
+#[derive(Clone)]
+enum FragmentNode {
+    Element(FragmentElement),
+    Text(String),
+    Comment(String),
+}
+
+#[derive(Clone)]
+struct FragmentElement {
+    tag_name: String,
+    attrs: Vec<FragmentAttr>,
+    children: Vec<FragmentNode>,
+    self_closing: bool,
+}
+
+#[derive(Clone)]
+struct FragmentAttr {
+    name: String,
+    value: Option<String>,
+}
+
+fn finalize_template_section(meta: &mut TemplateSectionMeta) {
+    let raw_html = std::mem::take(&mut meta.html);
+    let nodes = parse_fragment_nodes(&raw_html);
+    let text_bindings = meta.text_bindings.clone();
+    let mut finalized_html = String::with_capacity(raw_html.len());
+    let mut text_runs = Vec::new();
+    let mut attr_groups = Vec::new();
+    let mut condition_slots = vec![None; meta.conditionals.len()];
+    let mut repeat_slots = vec![None; meta.repeats.len()];
+    let mut event_targets = vec![None; meta.events.len()];
+    let mut event_cursor = 0usize;
+
+    process_fragment_children(
+        &nodes,
+        &[],
+        &text_bindings,
+        &mut finalized_html,
+        &mut text_runs,
+        &mut attr_groups,
+        &mut condition_slots,
+        &mut repeat_slots,
+        &mut event_targets,
+        &mut event_cursor,
+    );
+    debug_assert_eq!(event_cursor, meta.events.len());
+
+    meta.html = finalized_html;
+    meta.text_runs = text_runs;
+    meta.attr_groups = attr_groups;
+    meta.condition_slots = condition_slots.into_iter().flatten().collect();
+    meta.repeat_slots = repeat_slots.into_iter().flatten().collect();
+    meta.event_targets = event_targets.into_iter().flatten().collect();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_fragment_children(
+    nodes: &[FragmentNode],
+    parent_path: &[usize],
+    text_bindings: &[String],
+    out: &mut String,
+    text_runs: &mut Vec<(SlotLocator, Vec<CompiledAttrPart>)>,
+    attr_groups: &mut Vec<(Vec<usize>, usize, usize)>,
+    condition_slots: &mut [Option<SlotLocator>],
+    repeat_slots: &mut [Option<SlotLocator>],
+    event_targets: &mut [Option<Vec<usize>>],
+    event_cursor: &mut usize,
+) {
+    let mut child_index = 0usize;
+    let mut index = 0usize;
+    // Browser HTML parsing merges adjacent emitted text into a single Text node.
+    // Track that here so marker-free locator paths match the real client DOM.
+    let mut previous_emitted_text = false;
+    let mut slot_orders = std::collections::BTreeMap::<usize, usize>::new();
+
+    while index < nodes.len() {
+        if let Some((parts, consumed, has_dynamic)) =
+            collect_text_run(&nodes[index..], text_bindings)
+        {
+            if has_dynamic {
+                // Decode HTML entities in static parts so that runtime
+                // textContent assignment renders decoded characters
+                // (e.g. `&gt;` → `>`).  Static-only text runs are
+                // baked into `meta.h` and parsed via innerHTML which
+                // handles entity decoding natively.
+                let decoded_parts = parts
+                    .into_iter()
+                    .map(|part| match part {
+                        CompiledAttrPart::Static(s) => {
+                            let decoded = html_escape::decode_html_entities(&s);
+                            CompiledAttrPart::Static(decoded.into_owned())
+                        }
+                        other => other,
+                    })
+                    .collect();
+                let order = slot_orders.get(&child_index).copied().unwrap_or(0);
+                slot_orders.insert(child_index, order + 1);
+                text_runs.push((
+                    SlotLocator {
+                        parent_path: parent_path.to_vec(),
+                        before_index: child_index,
+                        order,
+                    },
+                    decoded_parts,
+                ));
+            } else {
+                let static_text = collect_static_text(&parts);
+                if !static_text.is_empty() {
+                    out.push_str(&static_text);
+                    if !previous_emitted_text {
+                        child_index += 1;
+                    }
+                    previous_emitted_text = true;
+                }
+            }
+            index += consumed;
+            continue;
+        }
+
+        match &nodes[index] {
+            FragmentNode::Comment(data) => {
+                if let Some(idx) = parse_marker_index(data, "c:") {
+                    if let Some(slot) = condition_slots.get_mut(idx) {
+                        let order = slot_orders.get(&child_index).copied().unwrap_or(0);
+                        slot_orders.insert(child_index, order + 1);
+                        *slot = Some(SlotLocator {
+                            parent_path: parent_path.to_vec(),
+                            before_index: child_index,
+                            order,
+                        });
+                    }
+                } else if let Some(idx) = parse_marker_index(data, "r:") {
+                    if let Some(slot) = repeat_slots.get_mut(idx) {
+                        let order = slot_orders.get(&child_index).copied().unwrap_or(0);
+                        slot_orders.insert(child_index, order + 1);
+                        *slot = Some(SlotLocator {
+                            parent_path: parent_path.to_vec(),
+                            before_index: child_index,
+                            order,
+                        });
+                    }
+                } else {
+                    out.push_str("<!--");
+                    out.push_str(data);
+                    out.push_str("-->");
+                    child_index += 1;
+                    previous_emitted_text = false;
+                }
+            }
+            FragmentNode::Text(text) => {
+                out.push_str(text);
+                if !text.is_empty() {
+                    if !previous_emitted_text {
+                        child_index += 1;
+                    }
+                    previous_emitted_text = true;
+                }
+            }
+            FragmentNode::Element(element) => {
+                let mut element_path = parent_path.to_vec();
+                element_path.push(child_index);
+                serialize_fragment_element(
+                    element,
+                    &element_path,
+                    text_bindings,
+                    out,
+                    text_runs,
+                    attr_groups,
+                    condition_slots,
+                    repeat_slots,
+                    event_targets,
+                    event_cursor,
+                );
+                child_index += 1;
+                previous_emitted_text = false;
+            }
+        }
+
+        index += 1;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn serialize_fragment_element(
+    element: &FragmentElement,
+    element_path: &[usize],
+    text_bindings: &[String],
+    out: &mut String,
+    text_runs: &mut Vec<(SlotLocator, Vec<CompiledAttrPart>)>,
+    attr_groups: &mut Vec<(Vec<usize>, usize, usize)>,
+    condition_slots: &mut [Option<SlotLocator>],
+    repeat_slots: &mut [Option<SlotLocator>],
+    event_targets: &mut [Option<Vec<usize>>],
+    event_cursor: &mut usize,
+) {
+    out.push('<');
+    out.push_str(&element.tag_name);
+
+    for attr in &element.attrs {
+        if let Some((start, count)) = parse_attr_group_marker(&attr.name) {
+            attr_groups.push((element_path.to_vec(), start, count));
+            continue;
+        }
+
+        if attr.name == "data-ev" {
+            if let Some(count) = attr.value.as_deref().and_then(parse_event_marker_count) {
+                let target_path = element_path.to_vec();
+                for slot in event_targets.iter_mut().skip(*event_cursor).take(count) {
+                    *slot = Some(target_path.clone());
+                }
+                *event_cursor += count;
+            }
+            continue;
+        }
+
+        out.push(' ');
+        out.push_str(&attr.name);
+        if let Some(value) = &attr.value {
+            out.push_str("=\"");
+            emit_html_attr_value(value, out);
+            out.push('"');
+        }
+    }
+
+    if element.self_closing {
+        out.push_str(" />");
+        return;
+    }
+
+    out.push('>');
+    process_fragment_children(
+        &element.children,
+        element_path,
+        text_bindings,
+        out,
+        text_runs,
+        attr_groups,
+        condition_slots,
+        repeat_slots,
+        event_targets,
+        event_cursor,
+    );
+    out.push_str("</");
+    out.push_str(&element.tag_name);
+    out.push('>');
+}
+
+fn collect_text_run(
+    nodes: &[FragmentNode],
+    text_bindings: &[String],
+) -> Option<(Vec<CompiledAttrPart>, usize, bool)> {
+    let mut parts = Vec::new();
+    let mut consumed = 0usize;
+    let mut has_dynamic = false;
+
+    for node in nodes {
+        match node {
+            FragmentNode::Text(text) => {
+                if !text.is_empty() {
+                    parts.push(CompiledAttrPart::Static(text.clone()));
+                }
+                consumed += 1;
+            }
+            FragmentNode::Comment(data) => {
+                if let Some(index) = parse_marker_index(data, "t:") {
+                    if let Some(path) = text_bindings.get(index) {
+                        parts.push(CompiledAttrPart::Dynamic(path.clone()));
+                        has_dynamic = true;
+                    }
+                    consumed += 1;
+                } else {
+                    break;
+                }
+            }
+            FragmentNode::Element(_) => break,
+        }
+    }
+
+    if consumed == 0 {
+        return None;
+    }
+
+    Some((parts, consumed, has_dynamic))
+}
+
+fn collect_static_text(parts: &[CompiledAttrPart]) -> String {
+    let mut text = String::new();
+    for part in parts {
+        if let CompiledAttrPart::Static(value) = part {
+            text.push_str(value);
+        }
+    }
+    text
+}
+
+fn parse_marker_index(data: &str, prefix: &str) -> Option<usize> {
+    data.strip_prefix(prefix)?.parse().ok()
+}
+
+fn parse_attr_group_marker(name: &str) -> Option<(usize, usize)> {
+    if let Some(start) = name.strip_prefix("data-w-b-") {
+        return start.parse::<usize>().ok().map(|index| (index, 1));
+    }
+
+    let rest = name.strip_prefix("data-w-c-")?;
+    let mut parts = rest.split('-');
+    let start = parts.next()?.parse::<usize>().ok()?;
+    let count = parts.next()?.parse::<usize>().ok()?;
+    Some((start, count))
+}
+
+fn parse_event_marker_count(value: &str) -> Option<usize> {
+    let count = value.parse::<usize>().ok()?;
+    (count > 0).then_some(count)
+}
+
+fn emit_html_attr_value(value: &str, out: &mut String) {
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+fn parse_fragment_nodes(input: &str) -> Vec<FragmentNode> {
+    let mut roots = Vec::new();
+    let mut stack: Vec<FragmentElement> = Vec::new();
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut index = 0usize;
+
+    while index < len {
+        let remaining = &input[index..];
+        if remaining.starts_with("<!--") {
+            if let Some(close) = remaining.find("-->") {
+                push_fragment_node(
+                    &mut roots,
+                    &mut stack,
+                    FragmentNode::Comment(remaining[4..close].to_string()),
+                );
+                index += close + 3;
+                continue;
+            }
+        }
+
+        if remaining.starts_with("</") {
+            if let Some(close) = remaining.find('>') {
+                if let Some(element) = stack.pop() {
+                    push_fragment_node(&mut roots, &mut stack, FragmentNode::Element(element));
+                }
+                index += close + 1;
+                continue;
+            }
+        }
+
+        if remaining.starts_with('<') {
+            if let Some((element, consumed)) = parse_fragment_start_tag(remaining) {
+                if element.self_closing {
+                    push_fragment_node(&mut roots, &mut stack, FragmentNode::Element(element));
+                } else {
+                    stack.push(element);
+                }
+                index += consumed;
+                continue;
+            }
+        }
+
+        let next = remaining.find('<').unwrap_or(remaining.len());
+        let text = &remaining[..next];
+        if !text.is_empty() {
+            push_fragment_node(&mut roots, &mut stack, FragmentNode::Text(text.to_string()));
+        }
+        index += next.max(1);
+    }
+
+    while let Some(element) = stack.pop() {
+        push_fragment_node(&mut roots, &mut stack, FragmentNode::Element(element));
+    }
+
+    roots
+}
+
+fn push_fragment_node(
+    roots: &mut Vec<FragmentNode>,
+    stack: &mut [FragmentElement],
+    node: FragmentNode,
+) {
+    if let Some(parent) = stack.last_mut() {
+        parent.children.push(node);
+    } else {
+        roots.push(node);
+    }
+}
+
+fn parse_fragment_start_tag(input: &str) -> Option<(FragmentElement, usize)> {
+    if !input.starts_with('<') || input.starts_with("</") || input.starts_with("<!--") {
+        return None;
+    }
+
+    let end = find_tag_end(input)?;
+    let tag_content = &input[1..end];
+    let tag_body = tag_content.trim_end();
+    let self_closing = tag_body.ends_with('/');
+    let tag_body = if self_closing {
+        tag_body[..tag_body.len().saturating_sub(1)].trim_end()
+    } else {
+        tag_body
+    };
+
+    let body_bytes = tag_body.as_bytes();
+    let mut cursor = 0usize;
+    while cursor < body_bytes.len() && !body_bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+
+    let tag_name = &tag_body[..cursor];
+    if tag_name.is_empty() {
+        return None;
+    }
+
+    let mut attrs = Vec::new();
+    while cursor < body_bytes.len() {
+        while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= body_bytes.len() {
+            break;
+        }
+
+        let attr_start = cursor;
+        while cursor < body_bytes.len()
+            && !body_bytes[cursor].is_ascii_whitespace()
+            && body_bytes[cursor] != b'='
+        {
+            cursor += 1;
+        }
+        if attr_start == cursor {
+            cursor += 1;
+            continue;
+        }
+
+        let name = tag_body[attr_start..cursor].to_string();
+        while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+
+        let mut value: Option<String> = None;
+        if cursor < body_bytes.len() && body_bytes[cursor] == b'=' {
+            cursor += 1;
+            while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+
+            if cursor < body_bytes.len()
+                && (body_bytes[cursor] == b'"' || body_bytes[cursor] == b'\'')
+            {
+                let quote = body_bytes[cursor];
+                cursor += 1;
+                let value_start = cursor;
+                while cursor < body_bytes.len() && body_bytes[cursor] != quote {
+                    cursor += 1;
+                }
+                value = Some(tag_body[value_start..cursor].to_string());
+                if cursor < body_bytes.len() {
+                    cursor += 1;
+                }
+            } else {
+                let value_start = cursor;
+                while cursor < body_bytes.len() && !body_bytes[cursor].is_ascii_whitespace() {
+                    cursor += 1;
+                }
+                value = Some(tag_body[value_start..cursor].to_string());
+            }
+        }
+
+        attrs.push(FragmentAttr { name, value });
+    }
+
+    Some((
+        FragmentElement {
+            tag_name: tag_name.to_string(),
+            attrs,
+            children: Vec::new(),
+            self_closing: self_closing || is_void_element(tag_name),
+        },
+        end + 1,
+    ))
+}
+
+fn is_void_element(tag_name: &str) -> bool {
+    matches!(
+        tag_name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+// ── Parsing helpers ────────────────────────────────────────────────
+
+/// Find the position of `count` consecutive closing braces (`}`).
+/// Returns `Some(start_of_closing_braces)` or `None` if not found.
+fn find_brace_end(input: &str, start: usize, count: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut i = start;
+    while i + count - 1 < bytes.len() {
+        let all_close = (0..count).all(|j| bytes[i + j] == b'}');
+        if all_close {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Check whether byte position `pos` is inside an HTML tag (between `<` and `>`).
+/// Scans backward from `pos` — returns `true` if we hit `<` before `>`.
+fn is_inside_tag(input: &str, pos: usize) -> bool {
+    let bytes = input.as_bytes();
+    let mut i = pos;
+    while i > 0 {
+        i -= 1;
+        if bytes[i] == b'>' {
+            return false;
+        }
+        if bytes[i] == b'<' {
+            return true;
+        }
+    }
+    false
+}
+
+/// Strip `<template shadowrootmode="…">…</template>` wrapper, returning inner content.
+/// Returns the input unchanged if no wrapper is present.
+fn strip_template_wrapper(html: &str) -> &str {
+    if !html.starts_with("<template") {
+        return html;
+    }
+    let Some(open_end) = find_tag_end(html) else {
+        return html;
+    };
+    let inner_start = open_end + 1;
+    let inner_end = html.rfind("</template>").unwrap_or(html.len());
+    if inner_start >= inner_end {
+        return "";
+    }
+    &html[inner_start..inner_end]
+}
+
+fn find_next_block_token(input: &str, cursor: usize, token: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let token_bytes = token.as_bytes();
+    let mut index = cursor;
+    let mut in_tag = false;
+    let mut in_comment = false;
+    let mut quote: Option<u8> = None;
+
+    while index + token_bytes.len() <= bytes.len() {
+        if in_comment {
+            if bytes[index..].starts_with(b"-->") {
+                in_comment = false;
+                index += 3;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+
+        if let Some(active) = quote {
+            if bytes[index] == active {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+
+        if in_tag {
+            match bytes[index] {
+                b'"' | b'\'' => quote = Some(bytes[index]),
+                b'>' => in_tag = false,
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+
+        if &bytes[index..index + token_bytes.len()] == token_bytes {
+            return Some(index);
+        }
+
+        if bytes[index] == b'<' {
+            if bytes[index..].starts_with(b"<!--") {
+                in_comment = true;
+                index += 4;
+                continue;
+            }
+            in_tag = true;
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn find_next_block_open(input: &str, cursor: usize, name: &str) -> Option<usize> {
+    let token = format!("<{name}");
+    let bytes = input.as_bytes();
+    let token_bytes = token.as_bytes();
+    let mut search = cursor;
+
+    while let Some(index) = find_next_block_token(input, search, &token) {
+        let next = bytes.get(index + token_bytes.len()).copied();
+        if match next {
+            None => true,
+            Some(byte) => byte == b'>' || byte.is_ascii_whitespace(),
+        } {
+            return Some(index);
+        }
+        search = index + 1;
+    }
+
+    None
+}
+
+fn find_next_block_close(input: &str, cursor: usize, name: &str) -> Option<usize> {
+    let token = format!("</{name}>");
+    find_next_block_token(input, cursor, &token)
+}
+
+fn find_matching_block_end(input: &str, name: &str) -> Option<usize> {
+    let open_token = format!("<{name}");
+    let close_token = format!("</{name}>");
+    if !input.starts_with(&open_token) {
+        return None;
+    }
+
+    let mut depth = 1usize;
+    let mut cursor = open_token.len();
+
+    while cursor < input.len() {
+        let next_open = find_next_block_open(input, cursor, name);
+        let next_close = find_next_block_close(input, cursor, name);
+
+        match (next_open, next_close) {
+            (_, None) => return None,
+            (Some(open_pos), Some(close_pos)) if open_pos < close_pos => {
+                depth += 1;
+                cursor = open_pos + open_token.len();
+            }
+            (_, Some(close_pos)) => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(close_pos);
+                }
+                cursor = close_pos + close_token.len();
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse `<if condition="EXPR">BODY</if>` → `(condition, body, bytes_consumed)`.
+///
+/// Only handles the outermost `<if>` — nested `<if>` blocks inside the body
+/// are left as raw HTML for the client runtime to process.
+fn parse_if_block(input: &str) -> Option<(ConditionExpr, String, usize)> {
+    let close_tag = "</if>";
+    let end_pos = find_matching_block_end(input, "if")?;
+    let tag_content = &input[..end_pos];
+
+    // Extract condition
+    let cond_start = tag_content.find("condition=\"")? + "condition=\"".len();
+    let cond_end = tag_content[cond_start..].find('"')? + cond_start;
+    let condition = compile_condition_expr(&tag_content[cond_start..cond_end]);
+
+    // Extract body (after the closing >)
+    let body_start = find_tag_end(tag_content)? + 1;
+    let body = tag_content[body_start..].trim().to_string();
+
+    Some((condition, body, end_pos + close_tag.len()))
+}
+
+fn compile_condition_expr(input: &str) -> ConditionExpr {
+    let parser = ConditionParser::new();
+    match parser.parse(input) {
+        Ok(condition) => condition,
+        // Component HTML is compiled after the main parser has already validated
+        // condition syntax. Keep the emitted metadata structurally valid if that
+        // earlier guarantee regresses.
+        Err(_) => ConditionExpr::identifier(input),
+    }
+}
+
+/// Parse `<for each="item in collection">BODY</for>` → `(collection, item_var, body, consumed)`.
+///
+/// The `each` attribute must follow the `"item in collection"` pattern.
+/// The body template retains `{{expr}}` mustaches — they are resolved by the
+/// client runtime during reconciliation.
+fn parse_for_block(input: &str) -> Option<(String, String, String, usize)> {
+    let close_tag = "</for>";
+    let end_pos = find_matching_block_end(input, "for")?;
+    let tag_content = &input[..end_pos];
+
+    // Extract each="item in collection"
+    let each_start = tag_content.find("each=\"")? + "each=\"".len();
+    let each_end = tag_content[each_start..].find('"')? + each_start;
+    let each_val = &tag_content[each_start..each_end];
+
+    let parts: Vec<&str> = each_val.splitn(3, ' ').collect();
+    if parts.len() != 3 || parts[1] != "in" {
+        return None;
+    }
+    let item_var = parts[0].to_string();
+    let collection = parts[2].to_string();
+
+    // Extract body
+    let body_start = find_tag_end(tag_content)? + 1;
+    let body = tag_content[body_start..].trim().to_string();
+
+    Some((collection, item_var, body, end_pos + close_tag.len()))
+}
+
+/// Parse `@event="{handler()}"` or `@event={handler()}` → `(event_name, handler_name, needs_event, consumed)`.
+///
+/// Supports three value quoting styles:
+/// - `@click="{onClick()}"` — quoted with braces inside
+/// - `@click={onClick()}` — unquoted braces
+/// - `@click='onClick()'` — single-quoted
+///
+/// The handler name is extracted from the function call syntax. `needs_event`
+/// is `true` when the argument list contains `(e)`.
+fn parse_event_attr(input: &str, pos: usize) -> Option<(String, String, bool, usize)> {
+    let remaining = &input[pos..];
+    let eq_pos = remaining.find('=')?;
+    let event_name = remaining[1..eq_pos].to_string(); // skip @
+
+    let after_eq = &remaining[eq_pos + 1..];
+    if after_eq.is_empty() {
+        return None;
+    }
+
+    let first = after_eq.as_bytes()[0];
+    let (raw_value, total_consumed) = if first == b'"' || first == b'\'' {
+        let value_start = eq_pos + 2;
+        let close = remaining[value_start..].find(first as char)?;
+        (
+            &remaining[value_start..value_start + close],
+            value_start + close + 1,
+        )
+    } else if first == b'{' {
+        let value_start = eq_pos + 2;
+        let close = remaining[value_start..].find('}')?;
+        (
+            &remaining[value_start..value_start + close],
+            value_start + close + 1,
+        )
+    } else {
+        return None;
+    };
+
+    let inner = raw_value
+        .trim()
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or(raw_value)
+        .trim();
+
+    // Extract method name from "handler()" or "handler(e)"
+    let paren = inner.find('(')?;
+    let handler_name = inner[..paren].to_string();
+    let needs_event = inner.contains("(e)");
+
+    Some((event_name, handler_name, needs_event, total_consumed))
+}
+
+fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(String, usize)> {
+    if !input.starts_with('<') || input.starts_with("</") || input.starts_with("<!") {
+        return None;
+    }
+
+    let bytes = input.as_bytes();
+    if bytes.len() < 2 || !bytes[1].is_ascii_alphabetic() {
+        return None;
+    }
+
+    let end = find_tag_end(input)?;
+    let tag_content = &input[1..end];
+    let tag_body = tag_content.trim_end();
+    let self_closing = tag_body.ends_with('/');
+    let tag_body = if self_closing {
+        tag_body[..tag_body.len().saturating_sub(1)].trim_end()
+    } else {
+        tag_body
+    };
+
+    let body_bytes = tag_body.as_bytes();
+    let mut cursor = 0;
+    while cursor < body_bytes.len() && !body_bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+
+    let tag_name = &tag_body[..cursor];
+    if tag_name.is_empty() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(tag_body.len() + 24);
+    out.push('<');
+    out.push_str(tag_name);
+
+    let binding_start = meta.attr_bindings.len();
+    let event_start = meta.events.len();
+    let mut binding_count = 0usize;
+
+    while cursor < body_bytes.len() {
+        while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= body_bytes.len() {
+            break;
+        }
+
+        let attr_start = cursor;
+        while cursor < body_bytes.len()
+            && !body_bytes[cursor].is_ascii_whitespace()
+            && body_bytes[cursor] != b'='
+        {
+            cursor += 1;
+        }
+        if attr_start == cursor {
+            cursor += 1;
+            continue;
+        }
+
+        let name = &tag_body[attr_start..cursor];
+
+        while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+
+        let mut value: Option<&str> = None;
+        if cursor < body_bytes.len() && body_bytes[cursor] == b'=' {
+            cursor += 1;
+            while cursor < body_bytes.len() && body_bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+
+            if cursor < body_bytes.len()
+                && (body_bytes[cursor] == b'"' || body_bytes[cursor] == b'\'')
+            {
+                let quote = body_bytes[cursor];
+                cursor += 1;
+                let value_start = cursor;
+                while cursor < body_bytes.len() && body_bytes[cursor] != quote {
+                    cursor += 1;
+                }
+                value = Some(&tag_body[value_start..cursor]);
+                if cursor < body_bytes.len() {
+                    cursor += 1;
+                }
+            } else {
+                let value_start = cursor;
+                while cursor < body_bytes.len() && !body_bytes[cursor].is_ascii_whitespace() {
+                    cursor += 1;
+                }
+                value = Some(&tag_body[value_start..cursor]);
+            }
+        }
+
+        let raw_attr = tag_body[attr_start..cursor].trim();
+        if raw_attr.is_empty() {
+            continue;
+        }
+
+        if let Some(event_name) = name.strip_prefix('@') {
+            let Some(raw_value) = value else {
+                continue;
+            };
+            if let Some((handler_name, needs_event)) = parse_event_handler(raw_value) {
+                meta.events
+                    .push((event_name.to_string(), handler_name, needs_event));
+            }
+            continue;
+        }
+
+        if name == "w-ref" {
+            out.push(' ');
+            out.push_str(raw_attr);
+            continue;
+        }
+
+        if let Some(bool_name) = name.strip_prefix('?') {
+            if let Some(raw_value) = value.and_then(extract_single_handlebars) {
+                meta.attr_bindings.push(CompiledAttrBinding::Boolean {
+                    name: bool_name.to_string(),
+                    condition: compile_condition_expr(&raw_value),
+                });
+                binding_count += 1;
+            }
+            continue;
+        }
+
+        if name.starts_with(':') {
+            if let Some(raw_value) = value.and_then(extract_single_handlebars) {
+                meta.attr_bindings.push(CompiledAttrBinding::Complex {
+                    name: name.to_string(),
+                    value: raw_value,
+                });
+                binding_count += 1;
+            }
+            continue;
+        }
+
+        if let Some(raw_value) = value {
+            if let Some(parts) = parse_attr_parts(raw_value) {
+                let is_simple =
+                    parts.len() == 1 && matches!(parts.first(), Some(CompiledAttrPart::Dynamic(_)));
+                if is_simple {
+                    if let Some(CompiledAttrPart::Dynamic(path)) = parts.into_iter().next() {
+                        meta.attr_bindings.push(CompiledAttrBinding::Simple {
+                            name: name.to_string(),
+                            value: path,
+                        });
+                    }
+                } else {
+                    meta.attr_bindings.push(CompiledAttrBinding::Template {
+                        name: name.to_string(),
+                        parts,
+                    });
+                }
+                binding_count += 1;
+                continue;
+            }
+        }
+
+        out.push(' ');
+        out.push_str(raw_attr);
+    }
+
+    if binding_count == 1 {
+        out.push_str(" data-w-b-");
+        out.push_str(&binding_start.to_string());
+    } else if binding_count > 1 {
+        out.push_str(" data-w-c-");
+        out.push_str(&binding_start.to_string());
+        out.push('-');
+        out.push_str(&binding_count.to_string());
+    }
+
+    let event_count = meta.events.len().saturating_sub(event_start);
+    if event_count > 0 {
+        out.push_str(" data-ev=\"");
+        let _ = write!(out, "{}", event_count);
+        out.push('"');
+    }
+
+    if self_closing {
+        out.push_str(" />");
+    } else {
+        out.push('>');
+    }
+
+    Some((out, end + 1))
+}
+
+fn find_tag_end(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut i = 1;
+
+    while i < bytes.len() {
+        let ch = bytes[i];
+        if let Some(active) = quote {
+            if ch == active {
+                quote = None;
+            }
+        } else if ch == b'"' || ch == b'\'' {
+            quote = Some(ch);
+        } else if ch == b'>' {
+            return Some(i);
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn parse_event_handler(raw_value: &str) -> Option<(String, bool)> {
+    let inner = raw_value
+        .trim()
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .unwrap_or(raw_value)
+        .trim();
+    let paren = inner.find('(')?;
+    Some((inner[..paren].trim().to_string(), inner.contains("(e)")))
+}
+
+fn extract_single_handlebars(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if let Some(inner) = trimmed
+        .strip_prefix("{{{")
+        .and_then(|s| s.strip_suffix("}}}"))
+    {
+        return Some(inner.trim().to_string());
+    }
+
+    if let Some(inner) = trimmed
+        .strip_prefix("{{")
+        .and_then(|s| s.strip_suffix("}}"))
+    {
+        return Some(inner.trim().to_string());
+    }
+
+    None
+}
+
+fn parse_attr_parts(value: &str) -> Option<Vec<CompiledAttrPart>> {
+    let bytes = value.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    let mut last = 0;
+    let mut dynamic_found = false;
+    let mut parts = Vec::new();
+
+    while i < len {
+        if i + 2 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            let brace_count = if i + 2 < len && bytes[i + 2] == b'{' {
+                3
+            } else {
+                2
+            };
+
+            if let Some(end) = find_brace_end(value, i + brace_count, brace_count) {
+                if last < i {
+                    parts.push(CompiledAttrPart::Static(value[last..i].to_string()));
+                }
+                parts.push(CompiledAttrPart::Dynamic(
+                    value[i + brace_count..end].trim().to_string(),
+                ));
+                dynamic_found = true;
+                i = end + brace_count;
+                last = i;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    if !dynamic_found {
+        return None;
+    }
+
+    if last < len {
+        parts.push(CompiledAttrPart::Static(value[last..].to_string()));
+    }
+
+    Some(parts)
+}
+
+/// Extract `@event` bindings from the opening `<template>` tag.
+///
+/// These become "root events" (`re` array) attached to the host element
+/// rather than to an element inside the shadow DOM.
+fn extract_root_events(html: &str) -> Vec<(String, String, bool)> {
+    if !html.starts_with("<template") {
+        return Vec::new();
+    }
+    let Some(close) = find_tag_end(html) else {
+        return Vec::new();
+    };
+    let tag = &html[..close];
+    let mut events = Vec::new();
+    let bytes = tag.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] == b'@' {
+            if let Some((name, handler, needs_event, consumed)) = parse_event_attr(tag, i) {
+                events.push((name, handler, needs_event));
+                i += consumed;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    events
+}
+
+fn extract_adopted_stylesheet_specifier(html: &str) -> Option<String> {
+    if !html.starts_with("<template") {
+        return None;
+    }
+    let close = find_tag_end(html)?;
+    let tag = &html[..close];
+    let attr = "shadowrootadoptedstylesheets=\"";
+    let start = tag.find(attr)? + attr.len();
+    let end = tag[start..].find('"')? + start;
+    Some(tag[start..end].to_string())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_no_client_markers(result: &str) {
+        assert!(!result.contains("<!--t:"), "text markers should be removed");
+        assert!(
+            !result.contains("<!--c:"),
+            "conditional markers should be removed"
+        );
+        assert!(
+            !result.contains("<!--r:"),
+            "repeat markers should be removed"
+        );
+        assert!(
+            !result.contains("data-w-b-"),
+            "attribute binding markers should be removed"
+        );
+        assert!(
+            !result.contains("data-w-c-"),
+            "attribute binding range markers should be removed"
+        );
+        assert!(
+            !result.contains("data-ev="),
+            "event markers should be removed"
+        );
+    }
+
+    #[test]
+    fn test_skip_event_attributes() {
+        let mut plugin = WebUIParserPlugin::new();
+        assert_eq!(plugin.classify_attribute("@click"), AttributeAction::Skip);
+        assert_eq!(plugin.classify_attribute("@keydown"), AttributeAction::Skip);
+        assert_eq!(plugin.classify_attribute("w-ref"), AttributeAction::Keep);
+        assert_eq!(plugin.classify_attribute("class"), AttributeAction::Keep);
+    }
+
+    #[test]
+    fn test_metadata_has_text_bindings() {
+        let result = generate_compiled_template("my-comp", "<h1>{{title}}</h1>");
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#"h:"<h1></h1>""#));
+        assert!(result.contains("\"title\""));
+        assert!(result.contains(r#",tx:[[[[0],0],[["title"]]]]"#));
+        assert!(!result.contains("{{"));
+    }
+
+    #[test]
+    fn test_metadata_has_conditionals() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<if condition="state == 'done'"><span>yes</span></if>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#"c:[[[1,"state",3,"'done'"],0]]"#));
+        assert!(result.contains("<span>yes</span>"));
+        assert!(result.contains(",cl:[[[],0]]"));
+        assert!(!result.contains("<if"));
+    }
+
+    #[test]
+    fn test_metadata_has_conditionals_with_gt_in_condition_attr() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<if condition="count > 0"><span>yes</span></if>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",c:["), "conditional metadata expected");
+        assert!(result.contains("<span>yes</span>"));
+        assert!(result.contains(",cl:[[[],0]]"));
+        assert!(!result.contains("<if"));
+    }
+
+    #[test]
+    fn test_parse_if_block_ignores_close_marker_inside_attr_value() {
+        let input = r#"<if condition="count > 0"><div data-note="</if>">yes</div></if>"#;
+        let (_, body, consumed) = parse_if_block(input).expect("if block should parse");
+
+        assert_eq!(body, r#"<div data-note="</if>">yes</div>"#);
+        assert_eq!(consumed, input.len());
+    }
+
+    #[test]
+    fn test_metadata_has_for_loops() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p>{{item.name}}</p></for>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"items\""));
+        assert!(result.contains("\"item\""));
+        assert!(result.contains(",rl:[[[],0]]"));
+        assert!(!result.contains("<for"));
+    }
+
+    #[test]
+    fn test_parse_for_block_ignores_open_marker_inside_attr_value() {
+        let input =
+            r#"<for each="item in items"><div data-note="<for fake>">{{item.name}}</div></for>"#;
+        let (collection, item_var, body, consumed) =
+            parse_for_block(input).expect("for block should parse");
+
+        assert_eq!(collection, "items");
+        assert_eq!(item_var, "item");
+        assert_eq!(body, r#"<div data-note="<for fake>">{{item.name}}</div>"#);
+        assert_eq!(consumed, input.len());
+    }
+
+    #[test]
+    fn test_metadata_has_for_loops_with_gt_in_other_attr() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items" data-note="a > b"><p>{{item.name}}</p></for>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"items\""));
+        assert!(result.contains("\"item\""));
+        assert!(result.contains(",rl:[[[],0]]"));
+        assert!(!result.contains("<for"));
+        assert!(!result.contains("{{item.name}}"));
+    }
+
+    #[test]
+    fn test_metadata_has_events() {
+        let result =
+            generate_compiled_template("my-comp", r#"<button @click="{onClick()}">Go</button>"#);
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"click\""));
+        assert!(result.contains("\"onClick\""));
+        assert!(result.contains(",el:[[0]]"));
+        assert!(!result.contains("@click"));
+    }
+
+    #[test]
+    fn test_metadata_has_events_unquoted() {
+        let result =
+            generate_compiled_template("my-comp", r#"<button @click={onClick()}>Go</button>"#);
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"click\""));
+        assert!(result.contains("\"onClick\""));
+        assert!(result.contains(",el:[[0]]"));
+    }
+
+    #[test]
+    fn test_metadata_has_events_with_arg() {
+        let result = generate_compiled_template("my-comp", r#"<input @keydown="{onKey(e)}" />"#);
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"keydown\""));
+        assert!(result.contains("\"onKey\""));
+        assert!(result.contains(",el:[[0]]"));
+        assert!(result.contains(",1")); // needs_event = true
+    }
+
+    #[test]
+    fn test_metadata_has_simple_attr_bindings() {
+        let result = generate_compiled_template("my-comp", r#"<input title="{{title}}" />"#);
+        assert_no_client_markers(&result);
+        assert!(result.contains(",a:["));
+        assert!(result.contains(",ag:[[[0],0,1]]"));
+        assert!(result.contains(r#"["title",0,"title"]"#));
+        assert!(!result.contains(r#"title=\"<!--t:"#));
+    }
+
+    #[test]
+    fn test_metadata_has_template_attr_bindings() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<a href="/product/{{handle}}" class="card {{variant}}">Go</a>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",a:["));
+        assert!(result.contains(",ag:[[[0],0,2]]"));
+        assert!(result.contains(r#"["href",3,["/product/",["handle"]]]"#));
+        assert!(result.contains(r#"["class",3,["card ",["variant"]]]"#));
+        assert!(!result.contains(r#"/product/<!--t:"#));
+    }
+
+    #[test]
+    fn test_metadata_has_boolean_attr_bindings() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<a ?data-active="{{page == 'dashboard'}}">Go</a>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",a:["));
+        assert!(result.contains(",ag:[[[0],0,1]]"));
+        assert!(result.contains(r#"["data-active",2,[1,"page",3,"'dashboard'"]]"#));
+    }
+
+    #[test]
+    fn test_metadata_has_complex_attr_bindings() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<child-view :config="{{settings}}"></child-view>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",a:["));
+        assert!(result.contains(",ag:[[[0],0,1]]"));
+        assert!(result.contains(r#"":config",1,"settings""#));
+    }
+
+    #[test]
+    fn test_w_ref_stays_in_html() {
+        let result = generate_compiled_template("my-comp", r#"<input w-ref="myInput" />"#);
+        // w-ref stays in the static HTML — runtime binds from the DOM directly
+        assert!(result.contains("w-ref"));
+        assert!(result.contains("myInput"));
+    }
+
+    #[test]
+    fn test_w_ref_unquoted_stays_in_html() {
+        let result = generate_compiled_template("my-comp", r#"<span w-ref={myLabel}>0</span>"#);
+        assert!(result.contains("w-ref"));
+        assert!(result.contains("myLabel"));
+    }
+
+    #[test]
+    fn test_metadata_has_root_events() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open" @click="{onClick(e)}"><div>hi</div></template>"#,
+        );
+        assert!(result.contains(",re:["));
+        assert!(result.contains("\"click\""));
+        assert!(result.contains("\"onClick\""));
+    }
+
+    #[test]
+    fn test_strips_shadowrootmode() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open"><p>{{title}}</p></template>"#,
+        );
+        assert!(!result.contains("shadowrootmode"));
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#",tx:[[[[0],0],[["title"]]]]"#));
+    }
+
+    #[test]
+    fn test_root_template_allows_gt_in_quoted_attr_values() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open" data-note="a > b" @click="{onClick()}"><p>hi</p></template>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#"h:"<p>hi</p>""#));
+        assert!(result.contains(r#",re:[["click","onClick",0]]"#));
+    }
+
+    #[test]
+    fn test_outlet_converted() {
+        let result = generate_compiled_template("my-comp", r#"<main><outlet /></main>"#);
+        assert!(result.contains("<outlet></outlet>"));
+    }
+
+    #[test]
+    fn test_emoji_safe() {
+        let result = generate_compiled_template("my-comp", r#"<span>📚 {{title}}</span>"#);
+        assert!(result.contains("📚"));
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#",tx:[[[[0],0],["📚 ",["title"]]]]"#));
+    }
+
+    #[test]
+    fn test_boolean_attr_in_for() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="s in sections"><a ?active="{{s.id == sectionId}}">{{s.name}}</a></for>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",rl:[[[],0]]"));
+        assert!(result.contains(r#"["active",2,[1,"s.id",3,"sectionId"]]"#));
+        assert!(!result.contains("?active"));
+    }
+
+    #[test]
+    fn test_deduplicates_components() {
+        let mut plugin = WebUIParserPlugin::new();
+        let comp = Component {
+            tag_name: "test-el".to_string(),
+            html_content: "<p>hi</p>".to_string(),
+            css_content: None,
+            css_tokens: Vec::new(),
+            source_path: std::path::PathBuf::new(),
+            class_name: None,
+        };
+        plugin
+            .register_component_template("test-el", &comp, &comp.html_content)
+            .unwrap();
+        plugin
+            .register_component_template("test-el", &comp, &comp.html_content)
+            .unwrap();
+        assert_eq!(plugin.take_component_templates().len(), 1);
+    }
+
+    #[test]
+    fn test_compiled_template_preserves_link_node_in_static_html() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open"><link rel="stylesheet" href="/my-comp.css"><p>hi</p></template>"#,
+        );
+        assert!(result.contains(r#"rel=\"stylesheet\""#));
+        assert!(result.contains(r#"href=\"/my-comp.css\""#));
+        assert!(result.contains(r#"<p>hi</p>"#));
+        assert!(!result.contains(",css:"));
+    }
+
+    #[test]
+    fn test_compiled_template_preserves_inline_style_in_static_html() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open"><style>.root{color:red}</style><p>hi</p></template>"#,
+        );
+        assert!(result.contains(r#"h:"<style>.root{color:red}</style><p>hi</p>""#));
+    }
+
+    #[test]
+    fn test_compiled_template_emits_adopted_stylesheet_specifier() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="my-comp"><p>hi</p></template>"#,
+        );
+        assert!(result.contains(r#",sa:"my-comp""#));
+    }
+
+    #[test]
+    fn test_plugin_uses_processed_link_template_html() {
+        let mut plugin = WebUIParserPlugin::new();
+
+        let comp = Component {
+            tag_name: "test-el".to_string(),
+            html_content: "<p>hi</p>".to_string(),
+            css_content: Some(".root { color: red; }".to_string()),
+            css_tokens: Vec::new(),
+            source_path: std::path::PathBuf::new(),
+            class_name: None,
+        };
+
+        plugin
+            .register_component_template(
+                "test-el",
+                &comp,
+                r#"<template shadowrootmode="open"><link rel="stylesheet" href="/test-el.css"><p>hi</p></template>"#,
+            )
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        assert!(templates[0].1.contains(r#"rel=\"stylesheet\""#));
+        assert!(templates[0].1.contains(r#"href=\"/test-el.css\""#));
+        assert!(templates[0].1.contains(r#"<p>hi</p>"#));
+    }
+
+    #[test]
+    fn test_plugin_preserves_root_events_from_raw_template_source() {
+        let mut plugin = WebUIParserPlugin::new();
+
+        let comp = Component {
+            tag_name: "test-el".to_string(),
+            html_content:
+                r#"<template shadowrootmode="open" @click="{onClick(e)}"><p>hi</p></template>"#
+                    .to_string(),
+            css_content: Some(".root { color: red; }".to_string()),
+            css_tokens: Vec::new(),
+            source_path: std::path::PathBuf::new(),
+            class_name: None,
+        };
+
+        plugin
+            .register_component_template(
+                "test-el",
+                &comp,
+                r#"<template shadowrootmode="open"><link rel="stylesheet" href="/test-el.css"><p>hi</p></template>"#,
+            )
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        assert!(templates[0].1.contains(r#",re:[["click","onClick",1]]"#));
+    }
+
+    #[test]
+    fn test_plugin_uses_processed_module_template_html() {
+        let mut plugin = WebUIParserPlugin::new();
+
+        let comp = Component {
+            tag_name: "test-el".to_string(),
+            html_content: "<p>hi</p>".to_string(),
+            css_content: Some(".root { color: red; }".to_string()),
+            css_tokens: Vec::new(),
+            source_path: std::path::PathBuf::new(),
+            class_name: None,
+        };
+
+        plugin
+            .register_component_template(
+                "test-el",
+                &comp,
+                r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="test-el"><p>hi</p></template>"#,
+            )
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        assert_eq!(templates.len(), 1);
+        assert!(templates[0].1.contains(r#",sa:"test-el""#));
+    }
+
+    #[test]
+    fn test_nested_if_inside_for_compiles_nested_blocks() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><if condition="item.active"><span>{{item.name}}</span></if></for>"#,
+        );
+
+        assert_no_client_markers(&result);
+        assert!(result.contains(",rl:[[[],0]]"), "repeat locator expected");
+        assert!(result.contains(",b:["), "compiled block table expected");
+        assert!(
+            result.contains(r#"["items","item",0]"#),
+            "repeat block index expected"
+        );
+        assert!(
+            result.contains(r#"[[0,"item.active"],1]"#),
+            "nested conditional block index expected"
+        );
+        assert!(!result.contains("<if"), "nested if should be compiled");
+        assert!(!result.contains("{{"), "nested bindings should be compiled");
+    }
+
+    #[test]
+    fn test_for_inside_if_compiles_nested_blocks() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<if condition="showList"><for each="item in items"><p>{{item.name}}</p></for></if>"#,
+        );
+
+        assert_no_client_markers(&result);
+        assert!(
+            result.contains(",cl:[[[],0]]"),
+            "conditional locator expected"
+        );
+        assert!(result.contains(",b:["), "compiled block table expected");
+        assert!(
+            result.contains(r#"[[0,"showList"],0]"#),
+            "conditional block index expected"
+        );
+        assert!(
+            result.contains(r#"["items","item",1]"#),
+            "nested repeat block index expected"
+        );
+        assert!(!result.contains("<for"), "nested for should be compiled");
+        assert!(!result.contains("{{"), "nested bindings should be compiled");
+    }
+
+    #[test]
+    fn test_nested_for_inside_for_compiles_nested_blocks() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="group in groups"><div><for each="item in group.items"><button data-group="{{group.name}}" ?disabled="{{item.disabled}}">{{item.label}}</button></for></div></for>"#,
+        );
+
+        assert_no_client_markers(&result);
+        assert!(
+            result.contains(",rl:[[[],0]]"),
+            "outer repeat locator expected"
+        );
+        assert!(result.contains(",b:["), "compiled block table expected");
+        assert!(
+            result.contains(r#"["groups","group",0]"#),
+            "outer repeat block index expected"
+        );
+        assert!(
+            result.contains(r#"["group.items","item",1]"#),
+            "inner repeat block index expected"
+        );
+        assert!(!result.contains("<for"), "nested for should be compiled");
+        assert!(!result.contains("{{"), "nested bindings should be compiled");
+        assert!(
+            !result.contains("?disabled"),
+            "nested boolean attrs should be compiled"
+        );
+    }
+
+    #[test]
+    fn test_multiple_events_on_same_element() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<input @keydown="{onKey(e)}" @focus="{onFocus()}" />"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"keydown\""), "keydown event expected");
+        assert!(result.contains("\"onKey\""), "onKey handler expected");
+        assert!(result.contains("\"focus\""), "focus event expected");
+        assert!(result.contains("\"onFocus\""), "onFocus handler expected");
+        assert!(
+            result.contains(",el:[[0],[0]]"),
+            "shared event target expected"
+        );
+    }
+
+    #[test]
+    fn test_regular_tag_uses_single_event_marker_per_element() {
+        let mut meta = TemplateSectionMeta::default();
+        let (tag_html, _) = parse_regular_tag(
+            r#"<input @keydown="{onKey(e)}" @focus="{onFocus()}" />"#,
+            &mut meta,
+        )
+        .expect("regular tag should parse");
+
+        assert_eq!(tag_html, r#"<input data-ev="2" />"#);
+    }
+
+    #[test]
+    fn test_empty_template() {
+        let result = generate_compiled_template("my-comp", "");
+        assert!(result.contains("__webui_templates"));
+        assert!(result.contains("h:\"\""), "empty html expected");
+        // No optional arrays should be present
+        assert!(!result.contains(",t:"), "no text bindings");
+        assert!(!result.contains(",c:"), "no conditionals");
+        assert!(!result.contains(",r:"), "no repeats");
+        assert!(!result.contains(",e:"), "no events");
+        assert!(!result.contains(",re:"), "no root events");
+    }
+
+    #[test]
+    fn test_whitespace_only_template() {
+        let result = generate_compiled_template("my-comp", "   \n  ");
+        assert!(result.contains("__webui_templates"));
+        assert!(
+            result.contains("h:\"\""),
+            "whitespace-only should produce empty html"
+        );
+    }
+
+    #[test]
+    fn test_multiple_text_bindings() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<p>{{first}}</p><p>{{second}}</p><p>{{third}}</p>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(
+            r#",tx:[[[[0],0],[["first"]]],[[[1],0],[["second"]]],[[[2],0],[["third"]]]]"#
+        ));
+        assert!(result.contains("\"first\""));
+        assert!(result.contains("\"second\""));
+        assert!(result.contains("\"third\""));
+    }
+
+    #[test]
+    fn test_multiple_conditionals() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<if condition="a"><span>A</span></if><if condition="b"><span>B</span></if>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains(",cl:[[[],0],[[],0,1]]"));
+    }
+
+    #[test]
+    fn test_locator_paths_merge_adjacent_static_text_nodes() {
+        let result = generate_compiled_template(
+            "mp-product-grid",
+            r#"
+<template shadowrootmode="open">
+  <if condition="products.length == 0 && query">
+    <p class="empty-results">There are no products that match "<strong>{{query}}</strong>"</p>
+  </if>
+  <div class="grid">
+    <for each="product in products">
+      <mp-product-card
+        handle="{{product.handle}}"
+        title="{{product.title}}"
+        price="{{product.price}}"
+        gradient="{{product.gradient}}"
+        image-url="{{product.imageUrl}}"
+        image-loading="lazy"
+        variant="grid"
+      ></mp-product-card>
+    </for>
+  </div>
+</template>
+"#,
+        );
+
+        assert_no_client_markers(&result);
+        assert!(result.contains(",cl:[[[],1]]"));
+        assert!(result.contains(",rl:[[[1],1]]"));
+    }
+
+    #[test]
+    fn test_mixed_bindings_events_refs() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<button w-ref="myBtn" @click="{onClick()}">{{label}}</button>"#,
+        );
+        // w-ref stays in HTML (quotes escaped inside JS string)
+        assert_no_client_markers(&result);
+        assert!(result.contains("w-ref"));
+        assert!(result.contains("myBtn"));
+        // event compiled
+        assert!(result.contains("\"click\""));
+        assert!(result.contains("\"onClick\""));
+        assert!(result.contains(",el:[[0]]"));
+        // text binding compiled
+        assert!(result.contains(r#",tx:[[[[0],0],[["label"]]]]"#));
+        assert!(result.contains("\"label\""));
+    }
+
+    #[test]
+    fn test_event_without_e_arg() {
+        let result =
+            generate_compiled_template("my-comp", r#"<button @click="{onClick()}">Go</button>"#);
+        assert!(result.contains(",0]"), "needs_event should be 0");
+    }
+
+    #[test]
+    fn test_root_event_without_e_arg() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<template shadowrootmode="open" @submit="{onSubmit()}"><form>hi</form></template>"#,
+        );
+        assert!(result.contains(",re:["));
+        assert!(result.contains("\"submit\""));
+        assert!(result.contains("\"onSubmit\""));
+        assert!(result.contains(",0]"), "needs_event should be 0 for no (e)");
+    }
+
+    #[test]
+    fn test_triple_brace_raw_binding() {
+        let result = generate_compiled_template("my-comp", r#"<div>{{{rawHtml}}}</div>"#);
+        assert_no_client_markers(&result);
+        assert!(
+            result.contains(r#",tx:[[[[0],0],[["rawHtml"]]]]"#),
+            "triple brace produces text locator"
+        );
+        assert!(
+            result.contains("\"rawHtml\""),
+            "rawHtml path in text bindings"
+        );
+    }
+
+    #[test]
+    fn test_for_with_complex_body() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="user in users"><div class="card"><h2>{{user.name}}</h2><p>{{user.bio}}</p></div></for>"#,
+        );
+        assert_no_client_markers(&result);
+        assert!(result.contains("\"users\""), "collection path");
+        assert!(result.contains("\"user\""), "item variable");
+        assert!(result.contains(",b:["), "compiled block table expected");
+        assert!(
+            !result.contains("{{user.name}}"),
+            "bindings should be compiled"
+        );
+        assert!(
+            !result.contains("{{user.bio}}"),
+            "bindings should be compiled"
+        );
+    }
+
+    #[test]
+    fn test_mixed_text_uses_text_runs() {
+        let result = generate_compiled_template("my-comp", r#"<p>Hello {{name}}!</p>"#);
+
+        assert_no_client_markers(&result);
+        assert!(result.contains(r#"h:"<p></p>""#));
+        assert!(result.contains(r#",tx:[[[[0],0],["Hello ",["name"],"!"]]]"#));
+    }
+
+    #[test]
+    fn test_js_string_escaping() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<if condition="name == &quot;test&quot;"><span>ok</span></if>"#,
+        );
+        assert!(result.contains(",c:["), "conditional array present");
+        // The right-side literal should remain properly escaped in the AST payload.
+        assert!(
+            result.contains(r#"[1,"name",3,"&quot;test&quot;"]"#),
+            "condition AST with escaped quotes should be present: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_js_string_escapes_script_breakout_sequences() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<div title="</script><script>alert(1)</script>"></div>"#,
+        );
+
+        assert!(
+            result.contains(r#"\u003C/script><script>alert(1)\u003C/script>"#),
+            "script-closing sequences should be neutralized inside metadata strings: {result}"
+        );
+        assert!(
+            !result.contains(r#"title=\"</script><script>alert(1)</script>\""#),
+            "raw </script> must not appear inside serialized metadata strings: {result}"
+        );
+    }
+
+    #[test]
+    fn test_js_string_escapes_line_separator_codepoints() {
+        let html = format!("<p>before{}middle{}after</p>", '\u{2028}', '\u{2029}');
+        let result = generate_compiled_template("my-comp", &html);
+
+        assert!(
+            result.contains(r#"\u2028"#),
+            "U+2028 should be escaped in metadata strings: {result}"
+        );
+        assert!(
+            result.contains(r#"\u2029"#),
+            "U+2029 should be escaped in metadata strings: {result}"
+        );
+    }
+
+    #[test]
+    fn test_on_element_parsed_encodes_12_bytes() {
+        let mut plugin = WebUIParserPlugin::new();
+        // Simulate 2 event attributes skipped
+        let _ = plugin.classify_attribute("@click");
+        let _ = plugin.classify_attribute("@keydown");
+        // Call on_element_parsed with 3 binding attributes
+        let data = plugin.finish_element(3);
+        assert!(data.is_some());
+        let bytes = data.unwrap();
+        assert_eq!(bytes.len(), 12, "plugin data should be 12 bytes");
+        let binding_count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let event_start = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let event_count = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        assert_eq!(binding_count, 3);
+        assert_eq!(event_start, 0);
+        assert_eq!(event_count, 2);
+    }
+
+    #[test]
+    fn test_on_element_parsed_no_data_when_empty() {
+        let mut plugin = WebUIParserPlugin::new();
+        let data = plugin.finish_element(0);
+        assert!(
+            data.is_none(),
+            "no plugin data when no bindings and no events"
+        );
+    }
+
+    #[test]
+    fn test_on_element_parsed_events_only() {
+        let mut plugin = WebUIParserPlugin::new();
+        let _ = plugin.classify_attribute("@click");
+        let data = plugin.finish_element(0);
+        assert!(
+            data.is_some(),
+            "should emit data for events even with 0 bindings"
+        );
+        let bytes = data.unwrap();
+        let binding_count = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let event_count = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+        assert_eq!(binding_count, 0);
+        assert_eq!(event_count, 1);
+    }
+
+    #[test]
+    fn test_event_index_increments_across_elements() {
+        let mut plugin = WebUIParserPlugin::new();
+        // First element: 2 events
+        let _ = plugin.classify_attribute("@click");
+        let _ = plugin.classify_attribute("@focus");
+        let data1 = plugin.finish_element(0).unwrap();
+        let ev_start_1 = u32::from_le_bytes([data1[4], data1[5], data1[6], data1[7]]);
+        assert_eq!(ev_start_1, 0, "first element starts at event 0");
+
+        // Second element: 1 event
+        let _ = plugin.classify_attribute("@blur");
+        let data2 = plugin.finish_element(0).unwrap();
+        let ev_start_2 = u32::from_le_bytes([data2[4], data2[5], data2[6], data2[7]]);
+        assert_eq!(
+            ev_start_2, 2,
+            "second element starts at event 2 (after first element's 2 events)"
+        );
+    }
+
+    #[test]
+    fn test_text_run_decodes_html_entities_in_static_parts() {
+        // Template: `<nav>{{sectionName}} &gt; {{topicName}}</nav>`
+        // The `&gt;` is a static part between two dynamic bindings.
+        // On the client, $resolveAttrParts concatenates parts and sets
+        // textContent, which does NOT decode entities — so the compiler
+        // must decode them in the metadata.
+        let result =
+            generate_compiled_template("my-comp", "<nav>{{sectionName}} &gt; {{topicName}}</nav>");
+        assert_no_client_markers(&result);
+        // The static part " > " should be decoded, not " &gt; "
+        assert!(
+            result.contains(r#"" > ""#),
+            "static text run part should contain decoded '>' not '&gt;': {}",
+            result
+        );
+        assert!(
+            !result.contains(r#"" &gt; ""#),
+            "static text run part should not contain raw '&gt;': {}",
+            result
+        );
+    }
+}

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::io;
 use thiserror::Error;
 
+/// Plugin-specific protocol helpers for framework hydration metadata.
 pub mod plugin;
 
 /// Generated protobuf types from `proto/webui.proto`.
@@ -23,6 +24,7 @@ pub mod proto {
 
 // Re-export all generated types at the crate root.
 pub use plugin::FastElementData;
+pub use plugin::WebUIElementData;
 pub use proto::*;
 
 // Type aliases preserving the `WebUI` naming convention.

--- a/crates/webui-protocol/src/plugin/mod.rs
+++ b/crates/webui-protocol/src/plugin/mod.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+//! Plugin-specific protocol helpers for framework hydration metadata.
+
 mod fast;
+mod webui;
 
 pub use fast::FastElementData;
+pub use webui::WebUIElementData;

--- a/crates/webui-protocol/src/plugin/webui.rs
+++ b/crates/webui-protocol/src/plugin/webui.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use crate::{ProtocolError, Result};
+
+const WEBUI_ELEMENT_DATA_LEN: usize = 12;
+
+/// WebUI hydration element metadata encoded in plugin fragments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebUIElementData {
+    /// Number of dynamic attribute bindings on the element.
+    pub binding_count: u32,
+    /// Starting event index for this element within the fragment-local event list.
+    pub event_start: u32,
+    /// Number of framework event handlers on the element.
+    pub event_count: u32,
+}
+
+impl WebUIElementData {
+    /// Encode this metadata using the WebUI 12-byte little-endian wire format.
+    #[must_use]
+    pub fn encode(self) -> [u8; WEBUI_ELEMENT_DATA_LEN] {
+        let mut data = [0u8; WEBUI_ELEMENT_DATA_LEN];
+        data[..4].copy_from_slice(&self.binding_count.to_le_bytes());
+        data[4..8].copy_from_slice(&self.event_start.to_le_bytes());
+        data[8..12].copy_from_slice(&self.event_count.to_le_bytes());
+        data
+    }
+
+    /// Decode WebUI hydration metadata from protocol bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::Validation`] when the payload length is not 12 bytes.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != WEBUI_ELEMENT_DATA_LEN {
+            return Err(ProtocolError::Validation(format!(
+                "WebUI element data must be {WEBUI_ELEMENT_DATA_LEN} bytes, received {}",
+                bytes.len()
+            )));
+        }
+
+        Ok(Self {
+            binding_count: u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+            event_start: u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            event_count: u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WebUIElementData;
+    use crate::ProtocolError;
+
+    #[test]
+    fn test_webui_element_data_roundtrip() {
+        let encoded = WebUIElementData {
+            binding_count: 2,
+            event_start: 5,
+            event_count: 1,
+        }
+        .encode();
+        let decoded = WebUIElementData::decode(&encoded).expect("decode should succeed");
+        assert_eq!(decoded.binding_count, 2);
+        assert_eq!(decoded.event_start, 5);
+        assert_eq!(decoded.event_count, 1);
+    }
+
+    #[test]
+    fn test_webui_element_data_rejects_invalid_length() {
+        let result = WebUIElementData::decode(&[1, 2, 3, 4]);
+        assert!(
+            matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("12 bytes")),
+            "invalid payload length should be rejected: {result:?}"
+        );
+    }
+}

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use webui_handler::plugin::fast::FastHydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_parser::{CssStrategy, HtmlParser};
 use webui_protocol::WebUIProtocol;
@@ -49,7 +50,7 @@ impl ResponseWriter for StringWriter {
 ///
 /// * `protocol_json` — JSON string of the serialized `WebUIProtocol`.
 /// * `state_json` — JSON string of the state data.
-/// * `plugin` — Optional plugin identifier (e.g., `"fast"`).
+/// * `plugin` — Optional plugin identifier.
 ///
 /// # Returns
 ///
@@ -158,6 +159,9 @@ fn create_handler(plugin: Option<&str>) -> Result<WebUIHandler, BuildError> {
     match plugin {
         Some("fast") => Ok(WebUIHandler::with_plugin(|| {
             Box::new(FastHydrationPlugin::new())
+        })),
+        Some("webui") => Ok(WebUIHandler::with_plugin(|| {
+            Box::new(WebUIHydrationPlugin::new())
         })),
         Some(unknown) => Err(BuildError::Render(format!("Unknown plugin: {unknown}"))),
         None => Ok(WebUIHandler::new()),

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -40,6 +40,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 use webui_parser::plugin::fast::FastParserPlugin;
+use webui_parser::plugin::webui::WebUIParserPlugin;
 use webui_parser::plugin::ParserPluginArtifacts;
 use webui_parser::HtmlParser;
 
@@ -194,6 +195,11 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
     let mut parser = match options.plugin.as_deref() {
         Some("fast") => {
             let mut plugin = FastParserPlugin::new();
+            plugin.set_css_strategy(options.css);
+            HtmlParser::with_plugin(Box::new(plugin))
+        }
+        Some("webui") => {
+            let mut plugin = WebUIParserPlugin::new();
             plugin.set_css_strategy(options.css);
             HtmlParser::with_plugin(Box::new(plugin))
         }

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,12 @@ Current entries:
 | Example | Description |
 |---------|-------------|
 | `app/hello-world` | Basic WebUI app with signals, for-loops, if-conditions |
+| `app/calculator` | Basic WebUI app with calculator that has custom views and events |
 | `app/todo-fast` | FAST-HTML hydration app with components, `@event` bindings, `f-ref`, and `<f-template>` injection |
-| `integration/node` | Node.js integration via native addon (supports `--plugin=fast`) |
-| `integration/rust` | Rust integration via `webui-handler` (supports `--plugin=fast`) |
+| `app/commerce` | FAST-HTML hydration app with a rust backend for commerce demo app, dozens of controls. | 
+| `app/routes` | Nested declaritive routing demo showing 4 level deep routes full server side and client handoff. |
+| `integration/node` | Node.js integration via native addon (supports `--plugin=webui` and `--plugin=fast`) |
+| `integration/rust` | Rust integration via `webui-handler` (supports `--plugin=webui` and `--plugin=fast`) |
 
 ## Quick Start
 

--- a/examples/integration/rust/src/main.rs
+++ b/examples/integration/rust/src/main.rs
@@ -18,6 +18,7 @@ use anyhow::{Context, Result};
 use std::env;
 use std::fs;
 use webui_handler::plugin::fast::FastHydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_protocol::WebUIProtocol;
 
@@ -61,6 +62,7 @@ fn main() -> Result<()> {
 
     let handler = match plugin_name {
         Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
         Some(unknown) => anyhow::bail!("Unknown plugin: {unknown}"),
         None => WebUIHandler::new(),
     };

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -110,6 +110,11 @@ Base class for framework components.
 
 In most components you do not call `$update()` directly. Property changes through `@observable` and `@attr` trigger updates for you.
 
+### Alternative entrypoints
+
+- `@microsoft/webui-framework` exports the full `WebUIElement` runtime, including repeat (`<for>`) reconciliation.
+- `@microsoft/webui-framework/element-no-repeat` exports the same `WebUIElement` class API without the repeat subsystem. Use it only for components whose compiled templates never include `<for>`.
+
 ### `@observable`
 
 Marks a property as reactive.  When the value changes, the framework


### PR DESCRIPTION
﻿ ## Summary
 
 Adds the new WebUI framework plugin end-to-end across protocol, parser, handler, FFI, Node, WASM, and Rust entrypoints.
 
 This also updates the WebUI design/docs surface so the plugin contract and hydration markers stay current while framework-specific usage 
details point to the canonical package README instead of being duplicated.
 
 ## What changed
 
 - Added the WebUI protocol payload and root re-exports for framework plugin metadata.
 - Added parser support for compiling WebUI templates into metadata, including bindings, events, conditionals, repeats, and block locators.
 - Added handler support for emitting the WebUI SSR markers and element metadata expected by the runtime.
 - Wired the plugin through `webui`, `webui-wasm`, `webui-node`, and `webui-ffi`.
 - Updated `DESIGN.md`, `examples/README.md`, `crates/webui-cli/README.md`, and `packages/webui-framework/README.md` to document the current 
contract and link to canonical framework docs.
 - Fixed parser edge cases where quoted attribute values could confuse block parsing:
   - `>` inside quoted attributes in `<if>` / `<for>` opening tags
   - `<if`, `</if>`, `<for`, or `</for>` text inside quoted attribute values in block bodies
 
 ## Validation
 
 - Ran targeted parser tests, including new regression coverage for quoted-marker edge cases.
 - Ran staged-only `cargo xtask check` in an isolated worktree.
 - Completed final staged diff review with no blocking issues found.
 
 ## Notes
 
 - This PR only covers the plugin/docs/framework commit set already present on `feat/webui-plugin`.