### PR TITLE
fix(ci): replace flaky choco protoc install with direct GitHub download

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,10 +14,18 @@ inputs:
     description: Comma-separated list of extra Rust targets to install (e.g. aarch64-unknown-linux-gnu)
     required: false
     default: ''
+  rust-components:
+    description: Comma-separated list of extra Rust components to install (e.g. clippy, rustfmt)
+    required: false
+    default: ''
   dotnet:
     description: Install .NET SDK (set to version like '8.0.x' to enable)
     required: false
     default: ''
+  protoc-version:
+    description: Protobuf compiler version to install
+    required: false
+    default: '29.5'
   skip-build:
     description: Skip cargo build and build-examples steps
     required: false
@@ -46,13 +54,22 @@ runs:
     - name: Install protoc (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
-      run: choco install protoc -y
+      run: |
+        $version = "${{ inputs.protoc-version }}"
+        $url = "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-win64.zip"
+        $zip = "$env:RUNNER_TEMP\protoc.zip"
+        $dest = "$env:RUNNER_TEMP\protoc"
+        Invoke-WebRequest -Uri $url -OutFile $zip
+        Expand-Archive -Path $zip -DestinationPath $dest -Force
+        echo "$dest\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo "PROTOC=$dest\bin\protoc.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: 1.93
         targets: ${{ inputs.rust-targets }}
+        components: ${{ inputs.rust-components }}
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,18 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install protoc
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/build
         with:
-          toolchain: 1.93
-          components: clippy, rustfmt
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+          skip-build: 'true'
+          rust-components: clippy, rustfmt
 
       - name: License headers
         run: cargo xtask license-headers
@@ -51,17 +43,9 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install protoc
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/build
         with:
-          toolchain: 1.93
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+          skip-build: 'true'
 
       - name: Test
         run: cargo test --workspace


### PR DESCRIPTION
The Chocolatey community feed intermittently returns 504 Gateway Timeout errors when installing protoc, causing Windows CI builds to fail with:
```
  Failed to fetch results from V2 feed at
  'https://community.chocolatey.org/api/v2/...' : 504 (Gateway Timeout)
```
Replace \choco install protoc\ with a direct download from the official protobuf GitHub releases. This removes the Chocolatey CDN dependency entirely and makes Windows CI deterministic.

The protoc version is now a configurable input (\protoc-version\, default: 29.5) so it can be overridden per-workflow if needed.