### PR TITLE
chore: Replace stringly-typed plugin field with Plugin enum

### DIFF
--- a/crates/webui-cli/src/commands/build.rs
+++ b/crates/webui-cli/src/commands/build.rs
@@ -50,7 +50,7 @@ fn run(args: &BuildArgs) -> Result<()> {
     output::field("App", &app.display());
     output::field("Entry", &args.app_args.entry);
     output::field("Output", &out.display());
-    output::field("CSS", &format!("{:?}", args.app_args.css));
+    output::field("CSS", &args.app_args.css);
     if let Some(ref plugin_name) = args.app_args.plugin {
         output::field("Plugin", plugin_name);
     }

--- a/crates/webui-cli/src/commands/common.rs
+++ b/crates/webui-cli/src/commands/common.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use std::path::PathBuf;
 pub use webui::CssStrategy;
 pub use webui::DomStrategy;
+pub use webui::Plugin;
 
 /// Shared CLI arguments used by both `build` and `serve` commands.
 #[derive(Args, Clone)]
@@ -26,8 +27,8 @@ pub struct AppArgs {
     pub dom: DomStrategy,
 
     /// Framework plugin to load
-    #[arg(long)]
-    pub plugin: Option<String>,
+    #[arg(long, value_enum)]
+    pub plugin: Option<Plugin>,
 
     /// Additional component sources (npm packages or local paths, repeatable)
     #[arg(long, value_name = "SOURCE")]
@@ -42,7 +43,7 @@ impl AppArgs {
             entry: self.entry.clone(),
             css: self.css,
             dom: self.dom,
-            plugin: self.plugin.clone(),
+            plugin: self.plugin,
             components: self.components.clone(),
         }
     }

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -331,7 +331,7 @@ fn run(args: &ServeArgs) -> Result<()> {
     }
     output::field("Entry", &args.app_args.entry);
     output::field("Port", &args.port);
-    output::field("CSS", &format!("{:?}", args.app_args.css));
+    output::field("CSS", &args.app_args.css);
     if let Some(api_port) = args.api_port {
         output::field("API Port", &api_port);
     }
@@ -388,7 +388,7 @@ fn run(args: &ServeArgs) -> Result<()> {
         hmr_backend,
         assets_dir: paths.serve_dir,
         api_port: args.api_port,
-        plugin: args.app_args.plugin.clone(),
+        plugin: args.app_args.plugin,
         token_css: render_config.token_css.clone(),
     });
 
@@ -503,10 +503,10 @@ fn build_and_render(
 
     // Render to memory
     let mut writer = MemoryWriter::with_capacity(4096);
-    let handler = match config.app_args.plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
-        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
-        _ => WebUIHandler::new(),
+    let handler = match config.app_args.plugin {
+        Some(Plugin::Fast) => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some(Plugin::WebUI) => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
+        None => WebUIHandler::new(),
     };
     handler.handle(
         &build_result.protocol,
@@ -555,7 +555,7 @@ struct ServerContext {
     hmr_backend: Option<Arc<dyn HmrBackend>>,
     assets_dir: Option<PathBuf>,
     api_port: Option<u16>,
-    plugin: Option<String>,
+    plugin: Option<Plugin>,
     /// Pre-resolved token CSS keyed by theme name, injected into state at render time.
     token_css: Option<HashMap<String, String>>,
 }
@@ -657,7 +657,7 @@ async fn render_page_response(
     let mut state = resolve_state(context, request_path).await;
 
     let (protocol, entry, plugin) = match context.state.lock() {
-        Ok(s) => (s.protocol.clone(), s.entry.clone(), context.plugin.clone()),
+        Ok(s) => (s.protocol.clone(), s.entry.clone(), context.plugin),
         Err(_) => return HttpResponse::InternalServerError().body("Internal Server Error"),
     };
 
@@ -675,10 +675,10 @@ async fn render_page_response(
     }
 
     let mut writer = MemoryWriter::with_capacity(4096);
-    let handler = match plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
-        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
-        _ => WebUIHandler::new(),
+    let handler = match plugin {
+        Some(Plugin::Fast) => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
+        Some(Plugin::WebUI) => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
+        None => WebUIHandler::new(),
     };
 
     if let Err(e) = handler.handle(

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -85,23 +85,25 @@ pub struct JsBuildOptions {
 /// Returns the compiled protocol bytes, CSS files, and build statistics.
 #[napi]
 pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
-    let css = match options.css.as_deref() {
-        Some("style") => webui::CssStrategy::Style,
-        Some("module") => webui::CssStrategy::Module,
-        Some("link") | None => webui::CssStrategy::Link,
-        Some(unknown) => {
-            return Err(NapiError::from_reason(format!(
-                "Unknown CSS mode: {unknown}. Use \"link\", \"style\", or \"module\"."
-            )));
-        }
-    };
+    let css = options
+        .css
+        .map(|s| s.parse::<webui::CssStrategy>())
+        .transpose()
+        .map_err(NapiError::from_reason)?
+        .unwrap_or_default();
+
+    let plugin = options
+        .plugin
+        .map(|s| s.parse::<webui::Plugin>())
+        .transpose()
+        .map_err(NapiError::from_reason)?;
 
     let build_options = webui::BuildOptions {
         app_dir: std::path::PathBuf::from(&options.app_dir),
         entry: options.entry.unwrap_or_else(|| "index.html".to_string()),
         css,
         dom: webui::DomStrategy::Shadow,
-        plugin: options.plugin,
+        plugin,
         components: options.components.unwrap_or_default(),
     };
 
@@ -231,11 +233,16 @@ pub fn render(
         .map_err(|e| NapiError::from_reason(format!("State JSON error: {e}")))?;
 
     let mut writer = CallbackWriter::new(&on_chunk);
-    let handler = match plugin.as_deref() {
-        Some("fast") => WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new())),
-        Some("webui") => WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new())),
-        Some(unknown) => {
-            return Err(NapiError::from_reason(format!("Unknown plugin: {unknown}")));
+    let plugin = plugin
+        .map(|s| s.parse::<webui::Plugin>())
+        .transpose()
+        .map_err(NapiError::from_reason)?;
+    let handler = match plugin {
+        Some(webui::Plugin::Fast) => {
+            WebUIHandler::with_plugin(|| Box::new(FastHydrationPlugin::new()))
+        }
+        Some(webui::Plugin::WebUI) => {
+            WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()))
         }
         None => WebUIHandler::new(),
     };

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -41,6 +41,31 @@ pub enum CssStrategy {
     Module,
 }
 
+impl std::fmt::Display for CssStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CssStrategy::Link => write!(f, "link"),
+            CssStrategy::Style => write!(f, "style"),
+            CssStrategy::Module => write!(f, "module"),
+        }
+    }
+}
+
+impl std::str::FromStr for CssStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "link" => Ok(CssStrategy::Link),
+            "style" => Ok(CssStrategy::Style),
+            "module" => Ok(CssStrategy::Module),
+            other => Err(format!(
+                "Unknown CSS strategy: {other}. Use \"link\", \"style\", or \"module\"."
+            )),
+        }
+    }
+}
+
 /// Strategy for how component DOM is structured.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
@@ -50,6 +75,61 @@ pub enum DomStrategy {
     Shadow,
     /// Use light DOM — component content is rendered as direct children.
     Light,
+}
+
+impl std::fmt::Display for DomStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DomStrategy::Shadow => write!(f, "shadow"),
+            DomStrategy::Light => write!(f, "light"),
+        }
+    }
+}
+
+impl std::str::FromStr for DomStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "shadow" => Ok(DomStrategy::Shadow),
+            "light" => Ok(DomStrategy::Light),
+            other => Err(format!(
+                "Unknown DOM strategy: {other}. Use \"shadow\" or \"light\"."
+            )),
+        }
+    }
+}
+
+/// Framework plugin to load for build-time and render-time processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+pub enum Plugin {
+    /// Fast hydration plugin — lightweight client-side interactivity.
+    Fast,
+    /// WebUI plugin — full component model with shadow DOM support.
+    #[cfg_attr(feature = "cli", value(name = "webui"))]
+    WebUI,
+}
+
+impl std::fmt::Display for Plugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Plugin::Fast => write!(f, "fast"),
+            Plugin::WebUI => write!(f, "webui"),
+        }
+    }
+}
+
+impl std::str::FromStr for Plugin {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "fast" => Ok(Plugin::Fast),
+            "webui" => Ok(Plugin::WebUI),
+            other => Err(format!("Unknown plugin: {other}")),
+        }
+    }
 }
 
 /// Counter for generating unique fragment IDs.

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::prelude::*;
 use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
-use webui_parser::{CssStrategy, HtmlParser};
+use webui_parser::{CssStrategy, HtmlParser, Plugin};
 use webui_protocol::WebUIProtocol;
 
 /// A simple string buffer for collecting rendered output.
@@ -63,14 +63,12 @@ pub fn render(
     request_path: &str,
     plugin: Option<String>,
 ) -> Result<String, JsValue> {
-    render_inner(
-        protocol_json,
-        state_json,
-        entry,
-        request_path,
-        plugin.as_deref(),
-    )
-    .map_err(|e| JsValue::from_str(&e.to_string()))
+    let plugin = plugin
+        .map(|s| s.parse::<Plugin>())
+        .transpose()
+        .map_err(|e| JsValue::from_str(&e))?;
+    render_inner(protocol_json, state_json, entry, request_path, plugin)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 /// Build and render a WebUI application from virtual files.
@@ -155,15 +153,14 @@ fn build_protocol_inner(
 }
 
 /// Create a handler with an optional plugin.
-fn create_handler(plugin: Option<&str>) -> Result<WebUIHandler, BuildError> {
+fn create_handler(plugin: Option<Plugin>) -> Result<WebUIHandler, BuildError> {
     match plugin {
-        Some("fast") => Ok(WebUIHandler::with_plugin(|| {
+        Some(Plugin::Fast) => Ok(WebUIHandler::with_plugin(|| {
             Box::new(FastHydrationPlugin::new())
         })),
-        Some("webui") => Ok(WebUIHandler::with_plugin(|| {
+        Some(Plugin::WebUI) => Ok(WebUIHandler::with_plugin(|| {
             Box::new(WebUIHydrationPlugin::new())
         })),
-        Some(unknown) => Err(BuildError::Render(format!("Unknown plugin: {unknown}"))),
         None => Ok(WebUIHandler::new()),
     }
 }
@@ -173,7 +170,7 @@ fn render_inner(
     state_json: &str,
     entry: &str,
     request_path: &str,
-    plugin: Option<&str>,
+    plugin: Option<Plugin>,
 ) -> Result<String, BuildError> {
     let protocol: WebUIProtocol =
         serde_json::from_str(protocol_json).map_err(|e| BuildError::Protocol(e.to_string()))?;

--- a/crates/webui/src/error.rs
+++ b/crates/webui/src/error.rs
@@ -12,10 +12,6 @@ pub enum WebUIError {
     #[error("I/O error: {0}")]
     Io(String),
 
-    /// Invalid or unknown parser plugin.
-    #[error("Unknown plugin: {0}")]
-    InvalidPlugin(String),
-
     /// Component registration failure.
     #[error("Component registration error: {0}")]
     ComponentRegistration(String),

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -37,6 +37,7 @@ pub use webui_handler::route_handler::{
 pub use webui_handler::{plugin::HandlerPlugin, HandlerError, ResponseWriter, WebUIHandler};
 pub use webui_parser::CssStrategy;
 pub use webui_parser::DomStrategy;
+pub use webui_parser::Plugin;
 pub use webui_protocol::WebUIProtocol;
 
 use std::fs;
@@ -59,7 +60,7 @@ pub struct BuildOptions {
     /// DOM strategy for component rendering (shadow or light).
     pub dom: DomStrategy,
     /// Framework plugin to load.
-    pub plugin: Option<String>,
+    pub plugin: Option<Plugin>,
     /// Additional component sources (npm packages or local paths).
     pub components: Vec<String>,
 }
@@ -197,19 +198,18 @@ struct RawBuildOutput {
 
 /// Internal build logic shared by `build()` and `build_to_disk()`.
 fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIError> {
-    let mut parser = match options.plugin.as_deref() {
-        Some("fast") => {
+    let mut parser = match options.plugin {
+        Some(Plugin::Fast) => {
             let mut plugin = FastParserPlugin::new();
             plugin.set_css_strategy(options.css);
             HtmlParser::with_plugin(Box::new(plugin))
         }
-        Some("webui") => {
+        Some(Plugin::WebUI) => {
             let mut plugin = WebUIParserPlugin::new();
             plugin.set_css_strategy(options.css);
             plugin.set_dom_strategy(options.dom);
             HtmlParser::with_plugin(Box::new(plugin))
         }
-        Some(unknown) => return Err(WebUIError::InvalidPlugin(unknown.to_string())),
         None => HtmlParser::new(),
     };
     parser.set_css_strategy(options.css);
@@ -449,17 +449,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_invalid_plugin() {
-        let app = create_app_dir(&[("index.html", "<h1>Hello</h1>")]);
-        let mut options = default_options(app.path());
-        options.plugin = Some("nonexistent".to_string());
-
-        let result = build(options);
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), WebUIError::InvalidPlugin(_)));
-    }
-
-    #[test]
     fn test_build_stats_populated() {
         let app = create_app_dir(&[("index.html", "<h1>{{title}}</h1>")]);
         let result = build(default_options(app.path())).unwrap();
@@ -676,7 +665,7 @@ mod tests {
     fn test_build_with_fast_plugin() {
         let app = create_app_dir(&[("index.html", "<h1>Hello</h1>")]);
         let mut options = default_options(app.path());
-        options.plugin = Some("fast".to_string());
+        options.plugin = Some(Plugin::Fast);
 
         let result = build(options).unwrap();
         assert!(result.protocol.fragments.contains_key("index.html"));

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use webui::{build, BuildOptions, CssStrategy, DomStrategy, WebUIHandler, WebUIProtocol};
+use webui::{build, BuildOptions, CssStrategy, DomStrategy, Plugin, WebUIHandler, WebUIProtocol};
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::route_handler;
 use webui_handler::{RenderOptions, ResponseWriter};
@@ -39,7 +39,7 @@ impl FrontendRuntime {
             entry: "index.html".to_string(),
             css,
             dom: DomStrategy::Shadow,
-            plugin: Some("webui".to_string()),
+            plugin: Some(Plugin::WebUI),
             components: Vec::new(),
         })
         .with_context(|| "Failed to build the commerce WebUI protocol")?;


### PR DESCRIPTION
## What
The `plugin` field on `BuildOptions`, `AppArgs`, and `ServerContext` was `Option<String>`, matched at runtime against "fast" and "webui" literals scattered across webui, webui-cli, webui-node, and webui-wasm crates.

## Why
Stringly-typed values bypass compile-time validation, allow silent typos, and require an `InvalidPlugin` error variant that only fires at runtime. The neighboring `CssStrategy` and `DomStrategy` fields are already proper enums with `clap::ValueEnum` support, so `plugin` was the odd one out.

## How
- Add `Plugin` enum (Fast, WebUI) in webui-parser with Display, FromStr, and conditional clap::ValueEnum, mirroring CssStrategy/DomStrategy.
- Add Display and FromStr to CssStrategy and DomStrategy for consistency.
- Change `BuildOptions.plugin` from `Option<String>` to `Option<Plugin>`.
- Update CLI (common, build, serve) to use `value_enum` on the arg.
- Convert string→Plugin at the JS/WASM FFI boundaries (webui-node, webui-wasm) using FromStr, replacing manual match arms.
- Simplify node crate CSS parsing to use CssStrategy::FromStr.
- Remove dead `WebUIError::InvalidPlugin` variant and its test (now enforced at compile time).
- Update commerce example to use `Plugin::WebUI`.