### PR TITLE
chore: fix package build warnings and enable tree-shaking for libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm -r --parallel run build",
+    "build": "pnpm -r run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -16,7 +16,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --platform=browser && tsc --emitDeclarationOnly",
+    "build": "find src -name '*.ts' ! -name '*.test.ts' | xargs esbuild --outdir=dist --outbase=src --format=esm --platform=browser && tsc --emitDeclarationOnly",
     "typecheck": "tsc --noEmit",
     "typecheck:e2e": "tsc -p tsconfig.test.json --noEmit",
     "build:e2e:scripts": "esbuild ./tests/server.ts --bundle --external:esbuild --outdir=tests/dist --format=esm --platform=node --target=es2022",

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "name": "@microsoft/webui-router",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --platform=browser && tsc --emitDeclarationOnly",
+    "build": "esbuild src/*.ts --outdir=dist --format=esm --platform=browser && tsc --emitDeclarationOnly",
     "test": "esbuild test/navigation-path.test.ts test/inventory.test.ts --bundle --outdir=test/dist --format=esm --platform=node && esbuild test/browser-shim.ts test/router.test.ts --bundle --outdir=test/dist --format=esm --platform=node && node --test test/dist/navigation-path.test.js test/dist/inventory.test.js test/dist/router.test.js",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -14,8 +14,8 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION
- Reorder exports conditions in webui package.json so types precedes default
- Remove --parallel from root build to respect workspace dependency order
- Switch webui-router and webui-framework from bundled to per-file transpilation