### PR TITLE
fix(contact-book-manager): stabilize sidebar group labels after contact edit

### DIFF
--- a/examples/app/contact-book-manager/data/state.json
+++ b/examples/app/contact-book-manager/data/state.json
@@ -1,7 +1,7 @@
 {
   "searchQuery": "",
   "activeGroup": "all",
-  "groups": ["Family", "Work", "Friends", "Other"],
+  "groups": ["Work", "Family", "Friends", "Other"],
   "totalContacts": 15,
   "totalFavorites": 5,
   "totalGroups": 4,

--- a/examples/app/contact-book-manager/server/api.ts
+++ b/examples/app/contact-book-manager/server/api.ts
@@ -49,6 +49,7 @@ const AVATAR_COLORS = [
 
 const stateData = JSON.parse(readFileSync(DATA_PATH, 'utf-8'));
 let contacts: Contact[] = stateData.contacts;
+let groups: string[] = stateData.groups ?? [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -59,15 +60,14 @@ function findContact(id: string): Contact | undefined {
 }
 
 function uniqueGroups(): string[] {
-  const seen = new Set<string>();
-  const groups: string[] = [];
-  for (const c of contacts) {
-    if (c.group && !seen.has(c.group)) {
-      seen.add(c.group);
-      groups.push(c.group);
-    }
-  }
   return groups;
+}
+
+/** Ensures the group name exists in the stable groups list. */
+function ensureGroup(group: string): void {
+  if (group && !groups.includes(group)) {
+    groups.push(group);
+  }
 }
 
 function favoriteContacts(): Contact[] {
@@ -275,6 +275,7 @@ app.post('/api/contacts', (req: Request, res: Response) => {
     address: String(body.address || ''),
   };
   contacts.push(newContact);
+  ensureGroup(newContact.group);
   res.status(201).json(newContact);
 });
 
@@ -305,6 +306,7 @@ app.put('/api/contacts/:id', (req: Request, res: Response) => {
   };
 
   contacts[idx] = updated;
+  ensureGroup(updated.group);
   res.json(updated);
 });
 

--- a/examples/app/contact-book-manager/tests/contact-book.spec.ts
+++ b/examples/app/contact-book-manager/tests/contact-book.spec.ts
@@ -198,6 +198,54 @@ test.describe('client-side navigation', () => {
   });
 });
 
+// ── Regression: sidebar groups stable after contact edit (issue #177) ─
+
+test.describe('contact edit does not corrupt sidebar groups', () => {
+  test('editing a contact group from Work to Friends keeps sidebar labels stable', async ({ page, request }) => {
+    // Ensure contact #1 starts in group "Work" (reset from any prior test run)
+    await request.put('http://127.0.0.1:3013/api/contacts/1', { data: { group: 'Work' } });
+
+    // Navigate to contact #1 (Sarah Chen, group: Work)
+    await page.goto('/contacts/1');
+    await expect(page.locator('cb-contact-detail')).toBeVisible();
+    await expect(page.locator('cb-contact-detail .badge')).toHaveText('Work');
+
+    // Verify sidebar groups before edit
+    await expectSidebarGroupsStable(page);
+
+    // Click edit
+    await page.locator('cb-contact-detail .icon-edit').click();
+    await expect(page).toHaveURL('/contacts/1/edit');
+    await expect(page.locator('cb-contact-form .form-title')).toHaveText('Edit Contact');
+
+    // Change group from Work to Friends
+    const friendsLabel = page.locator('cb-contact-form .group-radio-label', { hasText: 'Friends' });
+    await friendsLabel.click();
+
+    // Save the contact
+    await page.locator('cb-contact-form .save-btn').click();
+    await expect(page).toHaveURL('/contacts/1');
+
+    // Sidebar groups must remain in the same stable order
+    await expectSidebarGroupsStable(page);
+
+    // The contact detail now shows Friends group
+    await expect(page.locator('cb-contact-detail .badge')).toHaveText('Friends');
+
+    // Navigate to Work group — should still exist and be clickable
+    await page.locator('cb-sidebar').getByRole('link', { name: 'Work' }).click();
+    await expect(page).toHaveURL('/groups/Work');
+    await expect(page.locator('cb-page-group .page-title')).toContainText('Work');
+
+    // Restore contact back to Work for test isolation
+    await page.goto('/contacts/1/edit');
+    await page.locator('cb-contact-form .group-radio-label', { hasText: 'Work' }).click();
+    await page.locator('cb-contact-form .save-btn').click();
+    await expect(page).toHaveURL('/contacts/1');
+    await expectSidebarGroupsStable(page);
+  });
+});
+
 // ── Visual regression tests ──────────────────────────────────────
 
 test.describe('visual regression', () => {


### PR DESCRIPTION
**What**
Editing a contact's group (e.g. Work → Friends) caused the sidebar navigation labels to reorder or swap, making the left nav point to the wrong group.

**Why**
The server derived sidebar groups dynamically via `uniqueGroups()`, which iterated contacts in insertion order and collected unique group names. When a contact's group changed, the iteration order shifted, causing sidebar labels to shuffle — the first position previously showing 'Work' would now show 'Friends'.

**How**
Use the stable groups array from state.json as the canonical group list instead of deriving it from contacts. A new ensureGroup() helper registers unknown group names on contact create/update so new groups still appear. Aligned the state.json groups order with the rendered order. Added an E2E regression test that edits a contact's group and asserts sidebar labels remain stable throughout.

Fixes #177