### PR TITLE
feat(router): auto-register SSR-only components for SPA navigation

### DIFF
--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -17,8 +17,11 @@ Use this skill when building or modifying WebUI applications.
 6. **No `this.querySelector()` for reactive state.** Use `@observable` + template bindings.
 7. **Decorators: `@attr` (HTML attribute), `@observable` (reactive state).** Both work in SSR.
 8. **`@attr({ mode: 'boolean' })` for true/false.** Present = true, absent = false. Never use string `"false"`.
+9. **Only interactive components need a `.ts` file.** Components with no event handlers or reactive state are SSR-only — just `.html` (and optional `.css`). No class, no decorators, no `.define()`.
 
 ## Quick reference
+
+**Interactive component (needs .ts):**
 
 ```typescript
 import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
@@ -35,6 +38,17 @@ export class MyComponent extends WebUIElement {
 }
 MyComponent.define('my-component');
 ```
+
+**SSR-only component (no .ts needed):**
+
+```
+stat-card/
+├── stat-card.html   ← Template only
+└── stat-card.css    ← Optional styles
+```
+
+The server renders it. On SPA navigation, the router auto-registers it
+if `elementBase: WebUIElement` is set in `Router.start()`.
 
 ```bash
 webui build ./src --out ./dist --plugin=webui

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -46,7 +46,12 @@ webui build         + JSON state          hydrate as islands
    takes over after hydration for user interactions.
 
 4. **Static content never ships JavaScript.** Only components with event
-   handlers, reactive state, or user input need client-side code.
+   handlers, reactive state, or user input need a `.ts` file. Components
+   without interactivity are **SSR-only** — they have an `.html` template
+   (and optional `.css`) but no TypeScript class, no `@attr`/`@observable`,
+   and no `.define()` call. The server renders them from the template at
+   build time. On SPA navigations, the router auto-registers them if
+   `elementBase` is configured.
 
 ## Project Structure
 
@@ -55,14 +60,15 @@ my-app/
 ├── src/
 │   ├── index.html              ← Entry template
 │   ├── index.ts                ← Hydration entry point
-│   ├── my-component/
-│   │   ├── my-component.html   ← Component template
-│   │   ├── my-component.css    ← Component styles (scoped)
-│   │   └── my-component.ts     ← Component behavior
-│   └── other-widget/
-│       ├── other-widget.html
-│       ├── other-widget.css
-│       └── other-widget.ts
+│   ├── my-counter/
+│   │   ├── my-counter.html     ← Template (interactive island)
+│   │   ├── my-counter.css      ← Styles (scoped)
+│   │   └── my-counter.ts       ← Behavior (WebUIElement class)
+│   ├── stat-card/
+│   │   ├── stat-card.html      ← Template (SSR-only, no .ts needed)
+│   │   └── stat-card.css       ← Styles
+│   └── hero-banner/
+│       └── hero-banner.html    ← Template only (SSR-only)
 ├── data/
 │   └── state.json              ← Server state for dev
 └── package.json
@@ -71,7 +77,8 @@ my-app/
 **Component discovery rules:**
 - HTML files with a hyphen in the name are components (`my-card.html` → `<my-card>`)
 - CSS files with the same name are auto-paired (`my-card.css`)
-- TypeScript files provide client-side behavior (`my-card.ts`)
+- TypeScript files provide client-side behavior (`my-card.ts`) — **optional**
+- Components without a `.ts` file are SSR-only (no JavaScript shipped)
 - Discovery is recursive through subdirectories
 
 ## The `<template>` Tag
@@ -214,6 +221,9 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 ```
 
 ## Component Class
+
+**Only interactive components need a class.** If a component has no event
+handlers, no reactive state, and no user input, skip the `.ts` file entirely.
 
 Every interactive component extends `WebUIElement`:
 
@@ -379,11 +389,13 @@ import { WebUIElement } from '@microsoft/webui-framework';
 import { Router } from '@microsoft/webui-router';
 import './app-shell/app-shell.js';
 
-// Start router after components are registered
+// Start router after components are registered.
+// elementBase enables auto-registration of SSR-only components
+// during SPA navigations — no .ts file needed for static pages.
 Router.start({
+  elementBase: WebUIElement,
   loaders: {
-    'home-page': () => import('./pages/home-page.js'),
-    'user-list': () => import('./pages/user-list.js'),
+    // Only interactive components need lazy loaders
     'user-detail': () => import('./pages/user-detail.js'),
   },
 });

--- a/docs/guide/concepts/interactivity.md
+++ b/docs/guide/concepts/interactivity.md
@@ -385,3 +385,36 @@ Not every component needs JavaScript. Hydrating a component that has no interact
 - Client-side data manipulation (sorting, filtering, pagination)
 
 The goal is minimal JavaScript: hydrate only what the user will interact with, and let the server handle everything else.
+
+## SSR-Only Components (No TypeScript)
+
+Components that have no interactivity don't need a `.ts` file at all. Just create the `.html` template (and optional `.css`):
+
+```
+cb-stat-card/
+├── cb-stat-card.html   ← Template only
+└── cb-stat-card.css    ← Optional styles
+```
+
+No class, no `@attr`, no `define()`. The server renders these from their HTML template at build time. On the client, they render as static HTML — zero JavaScript.
+
+### SPA Navigation for SSR-Only Components
+
+When using the router for client-side navigation, SSR-only components need to render on route changes too. Pass `elementBase` to `Router.start()` and the router auto-registers bare `WebUIElement` subclasses on demand:
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+import { Router } from '@microsoft/webui-router';
+
+Router.start({
+  elementBase: WebUIElement,
+  loaders: {
+    // Only interactive components need lazy loaders
+    'contact-form': () => import('./pages/contact-form.js'),
+  },
+});
+```
+
+When the router navigates to a route whose component has no registered custom element, it checks `window.__webui_templates` for template metadata. If found, it auto-registers `class extends WebUIElement {}` — the base class's `connectedCallback` handles rendering the template.
+
+This means only components with event handlers or reactive state need a `.ts` file. Everything else is pure SSR.

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -117,8 +117,9 @@ Starts the router. Call after hydration completes.
 
 ```typescript
 Router.start({
-  basePath: '/app',   // optional: prefix for all route URLs
-  loaders: { ... },   // optional: lazy-loading map
+  basePath: '/app',         // optional: prefix for all route URLs
+  elementBase: WebUIElement, // optional: auto-register SSR-only components
+  loaders: { ... },         // optional: lazy-loading map
 });
 ```
 
@@ -182,6 +183,26 @@ Router.start({
 - Components **not in `loaders`** are eagerly loaded
 - Each loader runs **at most once** - cached after first call
 - On SSR'd initial load, the lazy loader is skipped (content already rendered)
+
+## SSR-Only Route Components
+
+Route components that have no interactivity (no event handlers, no reactive state) don't need a `.ts` file. Pass `elementBase` to auto-register them on demand:
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+
+Router.start({
+  elementBase: WebUIElement,
+  loaders: {
+    // Only interactive components need loaders
+    'contact-form': () => import('./pages/contact-form.js'),
+  },
+});
+```
+
+When navigating to a route whose component isn't registered, the router checks `window.__webui_templates` for template metadata. If found, it defines a bare `WebUIElement` subclass automatically. The component renders its template, resolves bindings against the server state, and displays content — all without a custom `.ts` file.
+
+Components that are auto-registered have their state set as plain properties (not `@observable`). They render correctly on mount and update when navigating between routes with the same component tag (e.g., switching between groups).
 
 ## Navigation Events
 

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -77,6 +77,27 @@ TemplateElement.options({
 
 Components in `loaders` are lazy-loaded on first navigation. Components not listed are assumed eagerly loaded.
 
+## SSR-Only Components
+
+Components with no interactivity don't need a `.ts` file — just the `.html` template (and optional `.css`). Pass `elementBase` so the router can auto-register them during SPA navigations:
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+import { Router } from '@microsoft/webui-router';
+
+Router.start({
+  elementBase: WebUIElement,
+  loaders: {
+    // Only interactive components need loaders
+    'contact-form': () => import('./pages/contact-form.js'),
+  },
+});
+```
+
+When navigating to a route whose component has no registered custom element but has template metadata in `window.__webui_templates`, the router auto-registers a bare `WebUIElement` subclass. The base class renders the template and resolves bindings against the server-provided state.
+
+This enables a pure islands architecture: only components with event handlers or reactive state ship JavaScript. Everything else is server-rendered HTML.
+
 ## Nested Routes
 
 Routes nest to any depth. Each parent uses `<outlet />` for child content:
@@ -109,6 +130,7 @@ Start the router. Call after hydration completes.
 | Option | Type | Description |
 |--------|------|-------------|
 | `basePath` | `string` | Prefix for all route URLs (e.g., `"/app"`) |
+| `elementBase` | `CustomElementConstructor` | Base class for auto-registering SSR-only components (pass `WebUIElement`) |
 | `loaders` | `Record<string, () => Promise<unknown>>` | Lazy-loading map: component tag → dynamic import |
 
 ### `Router.navigate(path)`

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -125,6 +125,8 @@ export class WebUIRouter {
   private loaders: Record<string, () => Promise<unknown>> = {};
   /** Deduplication cache for in-flight / completed loader promises. */
   private loaderPromises = new Map<string, Promise<void>>();
+  /** Tags auto-registered as bare WebUIElement subclasses (SSR-only). */
+  private autoRegistered = new Set<string>();
   /** Current active route chain for reconciliation on next navigation. */
   private activeChain: RouteChainEntry[] = [];
 
@@ -220,6 +222,7 @@ export class WebUIRouter {
   /** Tear down. */
   destroy(): void {
     this.loaderPromises.clear();
+    this.autoRegistered.clear();
     this.loaders = {};
     this.activeChain = [];
     for (const fn of this.cleanupFns) fn();
@@ -315,10 +318,14 @@ export class WebUIRouter {
           const oldEntry = i < this.activeChain.length ? this.activeChain[i] : null;
           const parent = i > 0 ? newChain[i - 1] : null;
 
-          // Same component tag at this level → reuse instance, update state
+          // Same component tag at this level — reuse instance if the route
+          // path pattern also matches. Different path patterns (e.g.
+          // "contacts/:id/edit" vs "contacts/add") get a fresh mount so
+          // components like forms start with clean state.
           if (
             oldEntry &&
             oldEntry.component === entry.component &&
+            oldEntry.path === entry.path &&
             oldEntry.el
           ) {
             entry.el = oldEntry.el;
@@ -594,14 +601,25 @@ export class WebUIRouter {
     params: Record<string, string>,
   ): void {
     const component = document.createElement(componentTag);
+
+    // For auto-registered SSR-only components, set state as plain properties
+    // BEFORE appendChild so connectedCallback → $wire populates the binding
+    // tree. $update is called explicitly after mount.
+    if (this.autoRegistered.has(componentTag)) {
+      this.applyPlainState(component as any, data.state, params);
+    }
+
     routeEl.textContent = '';
     routeEl.appendChild(component);
 
-    // Component module is pre-loaded and defined before commitNavigation.
-    // connectedCallback fires synchronously on appendChild, populating
-    // the component's light DOM immediately.
-
-    if (typeof (component as any).setInitialState === 'function') {
+    if (this.autoRegistered.has(componentTag)) {
+      // Auto-registered components have no @observable setters to trigger
+      // updates. Flush bindings now so text/attrs resolve against the
+      // properties set above.
+      if (typeof (component as any).$update === 'function') {
+        (component as any).$update();
+      }
+    } else if (typeof (component as any).setInitialState === 'function') {
       (component as any).setInitialState(data.state, params);
     } else {
       this.applyStateAsAttributes(component, data.state, params);
@@ -616,11 +634,25 @@ export class WebUIRouter {
     if (!entry.component || !entry.el) return;
     const compEl = entry.el.querySelector(entry.component) as any;
     if (!compEl) return;
-    if (typeof compEl.setInitialState === 'function') {
+
+    if (this.autoRegistered.has(entry.component)) {
+      this.applyPlainState(compEl, data.state, entry.params);
+      if (typeof compEl.$update === 'function') compEl.$update();
+    } else if (typeof compEl.setInitialState === 'function') {
       compEl.setInitialState(data.state, entry.params);
     } else {
       this.applyStateAsAttributes(compEl, data.state, entry.params);
     }
+  }
+
+  /** Set state as plain JS properties — used for auto-registered SSR-only components. */
+  private applyPlainState(
+    el: Record<string, unknown>,
+    state: Record<string, unknown>,
+    params: Record<string, string>,
+  ): void {
+    for (const [key, value] of Object.entries(state)) el[key] = value;
+    for (const [key, value] of Object.entries(params)) el[key] = value;
   }
 
   /**
@@ -680,19 +712,33 @@ export class WebUIRouter {
    * configured for this tag and the element isn't already registered,
    * invoke the loader. The promise is cached so each loader runs at
    * most once.
+   *
+   * If no loader is configured and the tag is still unregistered,
+   * auto-register a lightweight WebUIElement subclass when template
+   * metadata exists. This enables pure-SSR components (no client JS
+   * class) to render their templates on client-side navigations.
    */
   private async ensureComponentLoaded(tag: string): Promise<void> {
     if (customElements.get(tag)) return;
 
     const loader = this.loaders[tag];
-    if (!loader) return;
-
-    let promise = this.loaderPromises.get(tag);
-    if (!promise) {
-      promise = loader().then(() => {});
-      this.loaderPromises.set(tag, promise);
+    if (loader) {
+      let promise = this.loaderPromises.get(tag);
+      if (!promise) {
+        promise = loader().then(() => {});
+        this.loaderPromises.set(tag, promise);
+      }
+      await promise;
     }
-    await promise;
+
+    // Auto-register SSR-only components that have template metadata
+    // but no client-side class. A bare subclass of the provided
+    // elementBase renders templates on SPA navigations.
+    if (!customElements.get(tag) && this.config.elementBase && window.__webui_templates?.[tag]) {
+      const Base = this.config.elementBase;
+      customElements.define(tag, class extends Base {});
+      this.autoRegistered.add(tag);
+    }
   }
 
   // ── Dev-mode Validation ─────────────────────────────────────────

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -42,6 +42,24 @@ export interface RouterConfig {
    */
   loaders?: Record<string, () => Promise<unknown>>;
 
+  /**
+   * Base custom element class for auto-registering SSR-only components.
+   *
+   * When a route's component tag is not a registered custom element but
+   * has template metadata in `window.__webui_templates`, the router
+   * auto-registers a bare subclass of this base. This enables pure-SSR
+   * components (no client JS class) to render on SPA navigations.
+   *
+   * Pass `WebUIElement` from `@microsoft/webui-framework`.
+   *
+   * @example
+   * ```ts
+   * import { WebUIElement } from '@microsoft/webui-framework';
+   * Router.start({ elementBase: WebUIElement });
+   * ```
+   */
+  elementBase?: CustomElementConstructor;
+
   /** Enable development mode warnings for common routing mistakes. */
   dev?: boolean;
 }

--- a/packages/webui-router/test/router.test.ts
+++ b/packages/webui-router/test/router.test.ts
@@ -527,4 +527,115 @@ describe('WebUIRouter', () => {
       }
     });
   });
+
+  describe('auto-registration of SSR-only components', () => {
+    test('auto-registers a bare subclass when elementBase is set and template exists', async () => {
+      class FakeBase extends (globalThis as any).HTMLElement {}
+      const router = new WebUIRouter();
+      (router as any).config = { elementBase: FakeBase };
+      (router as any).loaders = {};
+      (router as any).loaderPromises = new Map();
+
+      globals().__webui_templates = { 'ssr-widget': { h: '<div>hello</div>' } };
+
+      assert.equal(customElements.get('ssr-widget'), undefined);
+
+      await (router as any).ensureComponentLoaded('ssr-widget');
+
+      const ctor = customElements.get('ssr-widget');
+      assert.ok(ctor, 'ssr-widget should be auto-registered');
+      assert.ok(
+        (router as any).autoRegistered.has('ssr-widget'),
+        'tag should be in autoRegistered set',
+      );
+    });
+
+    test('does not auto-register when elementBase is not set', async () => {
+      const router = new WebUIRouter();
+      (router as any).config = {};
+      (router as any).loaders = {};
+      (router as any).loaderPromises = new Map();
+
+      globals().__webui_templates = { 'no-base-widget': { h: '<p>test</p>' } };
+
+      await (router as any).ensureComponentLoaded('no-base-widget');
+
+      assert.equal(
+        customElements.get('no-base-widget'),
+        undefined,
+        'should not auto-register without elementBase',
+      );
+    });
+
+    test('does not auto-register when no template metadata exists', async () => {
+      class FakeBase extends (globalThis as any).HTMLElement {}
+      const router = new WebUIRouter();
+      (router as any).config = { elementBase: FakeBase };
+      (router as any).loaders = {};
+      (router as any).loaderPromises = new Map();
+
+      globals().__webui_templates = {};
+
+      await (router as any).ensureComponentLoaded('missing-widget');
+
+      assert.equal(
+        customElements.get('missing-widget'),
+        undefined,
+        'should not auto-register without template metadata',
+      );
+    });
+
+    test('does not auto-register when tag is already defined', async () => {
+      class FakeBase extends (globalThis as any).HTMLElement {}
+      class ExistingEl extends (globalThis as any).HTMLElement {}
+      customElements.define('existing-widget', ExistingEl);
+
+      const router = new WebUIRouter();
+      (router as any).config = { elementBase: FakeBase };
+      (router as any).loaders = {};
+      (router as any).loaderPromises = new Map();
+
+      globals().__webui_templates = { 'existing-widget': { h: '<span>hi</span>' } };
+
+      await (router as any).ensureComponentLoaded('existing-widget');
+
+      assert.equal(
+        customElements.get('existing-widget'),
+        ExistingEl,
+        'should keep the existing registration',
+      );
+      assert.ok(
+        !(router as any).autoRegistered.has('existing-widget'),
+        'should not be tracked as auto-registered',
+      );
+    });
+
+    test('prefers lazy loader over auto-registration', async () => {
+      class FakeBase extends (globalThis as any).HTMLElement {}
+      class LazyLoaded extends (globalThis as any).HTMLElement {}
+
+      const router = new WebUIRouter();
+      (router as any).config = { elementBase: FakeBase };
+      (router as any).loaders = {
+        'lazy-widget': () => Promise.resolve().then(() => {
+          customElements.define('lazy-widget', LazyLoaded);
+        }),
+      };
+      (router as any).loaderPromises = new Map();
+
+      globals().__webui_templates = { 'lazy-widget': { h: '<div>lazy</div>' } };
+
+      await (router as any).ensureComponentLoaded('lazy-widget');
+
+      assert.equal(
+        customElements.get('lazy-widget'),
+        LazyLoaded,
+        'lazy loader registration should take precedence',
+      );
+      assert.ok(
+        !(router as any).autoRegistered.has('lazy-widget'),
+        'should not be tracked as auto-registered',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## What
The router can now auto-register bare WebUIElement subclasses for components that have template metadata but no client-side JS class. This enables a pure islands architecture where only interactive components need explicit `define()` calls — static/presentational components are rendered by the server and auto-registered on demand during client-side navigation.

## Why
In an islands architecture, most components are purely server-rendered: they have an HTML template and maybe CSS, but no event handlers or reactive state. Previously, every component needed a TS class with `@attr`/`@observable` decorators and a `.define()` call, even if it had zero interactivity. This bloated the client bundle with unused custom element registrations and hydration work.

The gap: on initial SSR page load, static components render fine (the server outputs their HTML). But on SPA navigation, the router creates new elements via `document.createElement(tag)` — without a registered custom element, the browser treats them as inert generic elements with no template rendering.

## How

### New `elementBase` config option
Apps pass `WebUIElement` to `Router.start({ elementBase: WebUIElement })`. The router uses this as the base class for auto-registration, avoiding a hard dependency on the framework package.

### Auto-registration in `ensureComponentLoaded`
After lazy loaders run (or if none exist), if a tag is still unregistered but has template metadata in `window.__webui_templates`, the router defines `class extends elementBase {}` for it. The base class's `connectedCallback` handles template rendering automatically.

### State application for auto-registered components Auto-registered components have no `@observable` declarations, so `setInitialState()` would skip all keys. Instead:
- On mount: state is set as plain properties BEFORE `appendChild`, then `$update()` is called after to flush bindings.
- On reuse (same-route navigation): `applyPlainState()` sets properties and calls `$update()` directly.

### Route path comparison for same-component remount When two different route patterns use the same component tag (e.g. `contacts/:id/edit` and `contacts/add` both use `cb-contact-form`), the router now compares path patterns — not just component tags — to decide reuse vs remount. Different patterns get a fresh mount so components like forms start with clean state.