### PR TITLE
fix: build framework and router packages before commerce in Docker

### DIFF
--- a/examples/app/commerce/Dockerfile
+++ b/examples/app/commerce/Dockerfile
@@ -39,6 +39,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .
 RUN pnpm install --frozen-lockfile --filter=commerce... && \
+    pnpm --filter=@microsoft/webui-framework --filter=@microsoft/webui-router run build && \
     cd examples/app/commerce && pnpm build
 
 RUN cargo build --release -p marketplace-api


### PR DESCRIPTION
The commerce app imports from @microsoft/webui-framework and @microsoft/webui-router, but the Dockerfile never built those workspace packages before running the commerce build. This caused esbuild to fail because dist/index.js did not exist.

Add a pnpm build step for both packages between install and the commerce build.