### PR TITLE
fix(docs): add base path for GitHub Pages deployment

### DIFF
--- a/docs/.vitepress/components/Playground.vue
+++ b/docs/.vitepress/components/Playground.vue
@@ -304,7 +304,8 @@ async function render() {
 // --- Load WASM ---
 async function loadWasm() {
   try {
-    const wasmUrl = new URL('/wasm/webui_wasm.js', window.location.origin).href
+    const base = import.meta.env.BASE_URL || '/'
+    const wasmUrl = new URL(`${base}wasm/webui_wasm.js`, window.location.origin).href
     const mod = await import(/* @vite-ignore */ wasmUrl)
     await mod.default()
     wasmModule.value = mod

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -4,9 +4,10 @@
 export default {
   title: "WebUI Framework",
   description: "Language-Agnostic SSR with Web Components Islands Architecture",
+  base: '/webui/',
   appearance: true,
   head: [
-    ['link', { rel: 'icon', href: '/favicon.ico' }],
+    ['link', { rel: 'icon', href: '/webui/favicon.ico' }],
   ],
   themeConfig: {
     logo: '/logo.svg',


### PR DESCRIPTION
Add base: '/webui/' to VitePress config so CSS, JS, and image assets resolve correctly when hosted at microsoft.github.io/webui/. Update Playground WASM import to use import.meta.env.BASE_URL instead of a hardcoded root path.