### PR TITLE
fix: add User-Agent header to crates.io deployment check

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -84,7 +84,7 @@ extends:
               NEEDS_DEPLOYMENT=false
 
               # npm
-              if npm view "@microsoft/webui@${VERSION}" version 2>/dev/null | grep -q "^${VERSION}$"; then
+              if npm view "@microsoft/webui@${VERSION}" version 2>/dev/null | grep -qxF "${VERSION}"; then
                 echo "npm @microsoft/webui@${VERSION} already deployed"
               else
                 echo "npm @microsoft/webui@${VERSION} not yet deployed"
@@ -93,6 +93,7 @@ extends:
 
               # crates.io
               CRATE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "User-Agent: webui-cd-pipeline (microsoft/webui)" \
                 "https://crates.io/api/v1/crates/microsoft-webui/${VERSION}")
               if [ "$CRATE_STATUS" = "200" ]; then
                 echo "crates.io microsoft-webui ${VERSION} already deployed"


### PR DESCRIPTION
The `deploymentCheck` step in the CD pipeline always set `NEEDS_DEPLOYMENT=true`, even when the version was already published to both npm and crates.io.

**Root cause:** The `curl` request to the crates.io API did not include a `User-Agent` header. crates.io requires one and returns `403 Forbidden` without it, so the HTTP status check always fell into the "not yet deployed" branch.

**Fixes:**
- Add `User-Agent: webui-cd-pipeline (microsoft/webui)` header to the crates.io `curl` call.
- Switch `grep -q "^${VERSION}$"` to `grep -qxF "${VERSION}"` for the npm check so version dots are matched literally instead of as regex wildcards.