### PR TITLE
chore: add React vs WebUI comparison docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Visit **[microsoft.github.io/webui](https://microsoft.github.io/webui)** for:
 - [Interactivity Guide](https://microsoft.github.io/webui/guide/concepts/interactivity) — Web Components with `@attr`, `@observable`, events
 - [CLI Reference](https://microsoft.github.io/webui/guide/cli/) — `webui build`, `webui serve`, `webui inspect`
 - [Language Integrations](https://microsoft.github.io/webui/guide/integrations) — Rust, Node, Go, C#, Python
-- [React vs WebUI](https://microsoft.github.io/webui/guide/concepts/react-comparison) — Side-by-side comparison with React
+- [React vs Web Components](https://microsoft.github.io/webui/guide/concepts/react-comparison) — Side-by-side comparison with React
 - [Playground](https://microsoft.github.io/webui/playground/) — Try WebUI in the browser
 - [Tutorials](https://microsoft.github.io/webui/tutorials/hello-world) — Hello World, Todo App
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Visit **[microsoft.github.io/webui](https://microsoft.github.io/webui)** for:
 - [Interactivity Guide](https://microsoft.github.io/webui/guide/concepts/interactivity) — Web Components with `@attr`, `@observable`, events
 - [CLI Reference](https://microsoft.github.io/webui/guide/cli/) — `webui build`, `webui serve`, `webui inspect`
 - [Language Integrations](https://microsoft.github.io/webui/guide/integrations) — Rust, Node, Go, C#, Python
+- [React vs WebUI](https://microsoft.github.io/webui/guide/concepts/react-comparison) — Side-by-side comparison with React
 - [Playground](https://microsoft.github.io/webui/playground/) — Try WebUI in the browser
 - [Tutorials](https://microsoft.github.io/webui/tutorials/hello-world) — Hello World, Todo App
 

--- a/docs/.vitepress/components/CodeComparison.vue
+++ b/docs/.vitepress/components/CodeComparison.vue
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+<template>
+  <div class="comparison-wrapper">
+    <div class="comparison-col">
+      <div class="comparison-label comparison-label--left">{{ leftLabel }}</div>
+      <slot name="left" />
+    </div>
+    <div class="comparison-col">
+      <div class="comparison-label comparison-label--right">{{ rightLabel }}</div>
+      <slot name="right" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  leftLabel: { type: String, default: 'React' },
+  rightLabel: { type: String, default: 'WebUI' },
+})
+</script>

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -90,6 +90,7 @@ export default {
               { text: 'webui inspect', link: '/guide/cli/#webui-inspect' },
             ]},
             { text: 'Language Integrations', link: '/guide/integrations' },
+            { text: 'React vs WebUI', link: '/guide/concepts/react-comparison' },
             { text: 'Best Practices', link: '/guide/concepts/best-practices' },
             { text: 'CSS Token Hoisting', link: '/guide/concepts/css-tokens' },
             { text: 'Plugins', link: '/guide/concepts/plugins/' },

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -90,7 +90,7 @@ export default {
               { text: 'webui inspect', link: '/guide/cli/#webui-inspect' },
             ]},
             { text: 'Language Integrations', link: '/guide/integrations' },
-            { text: 'React vs WebUI', link: '/guide/concepts/react-comparison' },
+            { text: 'React vs Web Components', link: '/guide/concepts/react-comparison' },
             { text: 'Best Practices', link: '/guide/concepts/best-practices' },
             { text: 'CSS Token Hoisting', link: '/guide/concepts/css-tokens' },
             { text: 'Plugins', link: '/guide/concepts/plugins/' },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -633,6 +633,16 @@ div[class*='language-']>button.copy {
   min-width: 0;
   display: flex;
   flex-direction: column;
+  border-radius: var(--radius-md);
+  padding: 0 0.5rem 0.5rem;
+}
+
+.comparison-col:first-child {
+  background: rgba(97, 218, 251, 0.05);
+}
+
+.comparison-col:last-child {
+  background: var(--accent-soft-bg);
 }
 
 .comparison-label {
@@ -642,7 +652,7 @@ div[class*='language-']>button.copy {
   text-transform: uppercase;
   padding: 0.4rem 1rem;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
-  margin-bottom: -2px;
+  margin: 0 -0.5rem -2px;
   position: relative;
   z-index: 1;
 }
@@ -669,6 +679,7 @@ div[class*='language-']>button.copy {
   margin: 0 !important;
   border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md) !important;
   flex: 1;
+  overflow-x: auto;
 }
 
 .comparison-col div[class*='language-']:not(:first-of-type) {
@@ -676,8 +687,20 @@ div[class*='language-']>button.copy {
   margin-top: 0.5rem !important;
 }
 
-@media (max-width: 768px) {
+.comparison-col div[class*='language-'] pre {
+  overflow-x: auto;
+}
+
+/* Collapse to single column on tablet and below */
+@media (max-width: 960px) {
   .comparison-wrapper {
     grid-template-columns: 1fr;
+  }
+}
+
+/* On larger screens where sidebar is visible, extra breathing room */
+@media (min-width: 961px) and (max-width: 1199px) {
+  .comparison-col div[class*='language-'] code {
+    font-size: 0.8rem;
   }
 }

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -617,3 +617,67 @@ div[class*='language-']>button.copy {
 .VPNavBarMenuGroup {
   transition: color 0.2s ease, background-color 0.2s ease;
 }
+/* ==========================================================
+  13. Side-by-side code comparison
+   ========================================================== */
+
+.comparison-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  align-items: start;
+}
+
+.comparison-col {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.comparison-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.4rem 1rem;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  margin-bottom: -2px;
+  position: relative;
+  z-index: 1;
+}
+
+.comparison-label--left {
+  background: rgba(97, 218, 251, 0.10);
+  color: #61aacb;
+  border: 1px solid rgba(97, 218, 251, 0.25);
+  border-bottom: none;
+}
+
+.comparison-label--right {
+  background: var(--accent-soft-bg);
+  color: var(--accent);
+  border: 1px solid var(--accent-soft-border);
+  border-bottom: none;
+}
+
+.dark .comparison-label--left {
+  color: #61dafb;
+}
+
+.comparison-col div[class*='language-'] {
+  margin: 0 !important;
+  border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md) !important;
+  flex: 1;
+}
+
+.comparison-col div[class*='language-']:not(:first-of-type) {
+  border-radius: var(--radius-md) !important;
+  margin-top: 0.5rem !important;
+}
+
+@media (max-width: 768px) {
+  .comparison-wrapper {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -5,9 +5,13 @@ import DefaultTheme from 'vitepress/theme'
 import { useRoute } from 'vitepress'
 import { watch, nextTick } from 'vue'
 import './custom.css'
+import CodeComparison from '../components/CodeComparison.vue'
 
 export default {
   extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('CodeComparison', CodeComparison)
+  },
   setup() {
     const route = useRoute()
     watch(() => route.path, () => {

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -155,6 +155,10 @@ function TodoList({ items }) {
 function SearchBox() {
   const [query, setQuery] = useState('');
 
+  const performSearch = (searchQuery) => {
+    // search logic
+  };
+
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') {
       performSearch(query);
@@ -183,7 +187,7 @@ function SearchBox() {
 ```html
 <div>
   <input
-    w-ref="inputEl"
+    @input="{onInput(e)}"
     @keydown="{onKeyDown(e)}"
     placeholder="Search..."
   />
@@ -197,8 +201,11 @@ function SearchBox() {
 import { WebUIElement, observable } from '@microsoft/webui-framework';
 
 export class SearchBox extends WebUIElement {
-  inputEl!: HTMLInputElement;
   @observable query = '';
+
+  onInput(e: InputEvent): void {
+    this.query = (e.currentTarget as HTMLInputElement).value;
+  }
 
   onKeyDown(e: KeyboardEvent): void {
     if (e.key === 'Enter') {
@@ -207,8 +214,7 @@ export class SearchBox extends WebUIElement {
   }
 
   performSearch(): void {
-    this.query = this.inputEl.value;
-    // search logic
+    // search logic using this.query
   }
 }
 
@@ -218,7 +224,7 @@ SearchBox.define('search-box');
 </template>
 </CodeComparison>
 
-**What changed:** Event handlers use `@event` syntax instead of `onEvent` props. DOM references use `w-ref` instead of `useRef`. No synthetic event system - the browser's native events are used directly.
+**What changed:** Event handlers use `@event` syntax instead of `onEvent` props. Input value is read from `e.currentTarget` in the `@input` handler — no DOM reference needed. No synthetic event system - the browser's native events are used directly.
 
 ## Parent-Child Communication
 

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -1,0 +1,477 @@
+# React vs WebUI
+
+This guide compares common UI patterns written in React (imperative, JavaScript-centric) with their WebUI equivalents (declarative, HTML-centric). Each section shows a React "Before" alongside the WebUI "After" so you can see how familiar patterns translate to WebUI's component model.
+
+## Key Differences at a Glance
+
+| | React | WebUI |
+|---|---|---|
+| **Component model** | JSX functions / classes with virtual DOM | Web Components with Shadow DOM |
+| **Rendering** | Client-side or Node.js SSR | Build-time compiled protocol, server-rendered HTML |
+| **Template language** | JSX (JavaScript + HTML mixed) | Separate HTML, CSS, and TypeScript files |
+| **State management** | `useState`, `useReducer`, context | `@observable` properties with targeted DOM updates |
+| **Styling** | CSS-in-JS, CSS Modules, or external | Scoped CSS via Shadow DOM |
+| **Runtime** | React runtime + ReactDOM in browser | No framework runtime for static content; thin hydration for interactive islands |
+| **Interactivity** | Every component ships JavaScript | Only interactive islands ship JavaScript |
+
+## Simple Counter
+
+### React
+
+```jsx
+import { useState } from 'react';
+
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount(count + 1)}>Increment</button>
+    </div>
+  );
+}
+```
+
+### WebUI
+
+**my-counter.html**
+
+```html
+<p>Count: {{count}}</p>
+<button @click="{increment()}">Increment</button>
+```
+
+**my-counter.ts**
+
+```typescript
+import { WebUIElement, observable } from '@microsoft/webui-framework';
+
+export class MyCounter extends WebUIElement {
+  @observable count = 0;
+
+  increment(): void {
+    this.count += 1;
+  }
+}
+
+MyCounter.define('my-counter');
+```
+
+**What changed:** Template and logic are separated into HTML and TypeScript files. No JSX, no `useState` hook, no `setState` call. The `@observable` decorator makes `count` reactive - when it changes, only the bound DOM nodes update.
+
+## Conditional Rendering
+
+### React
+
+```jsx
+function Greeting({ isLoggedIn, username }) {
+  return (
+    <div>
+      {isLoggedIn ? (
+        <p>Welcome back, {username}!</p>
+      ) : (
+        <p>Please sign in.</p>
+      )}
+    </div>
+  );
+}
+```
+
+### WebUI
+
+**user-greeting.html**
+
+```html
+<div>
+  <if condition="isLoggedIn">
+    <p>Welcome back, {{username}}!</p>
+  </if>
+  <if condition="!isLoggedIn">
+    <p>Please sign in.</p>
+  </if>
+</div>
+```
+
+**What changed:** Conditional logic moves from JavaScript ternary expressions into declarative `<if>` directives. These are evaluated on the server during rendering - no JavaScript is shipped to the browser for static conditionals.
+
+## List Rendering
+
+### React
+
+```jsx
+function TodoList({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={item.id}>
+          <span>{item.title}</span>
+          <span className={`status ${item.state}`}>{item.state}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### WebUI
+
+**todo-list.html**
+
+```html
+<ul>
+  <for each="item in items">
+    <li>
+      <span>{{item.title}}</span>
+      <span class="status {{item.state}}">{{item.state}}</span>
+    </li>
+  </for>
+</ul>
+```
+
+**What changed:** `Array.map()` with JSX becomes a declarative `<for>` directive. The `key` prop is replaced by the first attribute on the repeated element. This runs on the server and produces static HTML - no JavaScript array iteration in the browser.
+
+## Event Handling
+
+### React
+
+```jsx
+function SearchBox() {
+  const [query, setQuery] = useState('');
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      performSearch(query);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Search..."
+      />
+      <button onClick={() => performSearch(query)}>Search</button>
+    </div>
+  );
+}
+```
+
+### WebUI
+
+**search-box.html**
+
+```html
+<div>
+  <input
+    w-ref="inputEl"
+    @keydown="{onKeyDown(e)}"
+    placeholder="Search..."
+  />
+  <button @click="{performSearch()}">Search</button>
+</div>
+```
+
+**search-box.ts**
+
+```typescript
+import { WebUIElement, observable } from '@microsoft/webui-framework';
+
+export class SearchBox extends WebUIElement {
+  inputEl!: HTMLInputElement;
+  @observable query = '';
+
+  onKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      this.performSearch();
+    }
+  }
+
+  performSearch(): void {
+    this.query = this.inputEl.value;
+    // search logic
+  }
+}
+
+SearchBox.define('search-box');
+```
+
+**What changed:** Event handlers use `@event` syntax instead of `onEvent` props. DOM references use `w-ref` instead of `useRef`. No synthetic event system - the browser's native events are used directly.
+
+## Parent-Child Communication
+
+### React
+
+```jsx
+function ColorPicker({ onColorChange }) {
+  return (
+    <div className="colors">
+      <button onClick={() => onColorChange('red')}>Red</button>
+      <button onClick={() => onColorChange('blue')}>Blue</button>
+    </div>
+  );
+}
+
+function App() {
+  const [color, setColor] = useState('');
+
+  return (
+    <div>
+      <ColorPicker onColorChange={setColor} />
+      <p>Selected: {color}</p>
+    </div>
+  );
+}
+```
+
+### WebUI
+
+**color-picker.html**
+
+```html
+<div class="colors">
+  <button @click="{selectColor('red')}">Red</button>
+  <button @click="{selectColor('blue')}">Blue</button>
+</div>
+```
+
+**color-picker.ts**
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+
+export class ColorPicker extends WebUIElement {
+  selectColor(color: string): void {
+    this.$emit('color-change', { detail: { color } });
+  }
+}
+
+ColorPicker.define('color-picker');
+```
+
+**theme-app.html**
+
+```html
+<template shadowrootmode="open"
+  @color-change="{onColorChange(e)}"
+>
+  <color-picker></color-picker>
+  <p>Selected: {{currentColor}}</p>
+</template>
+```
+
+**theme-app.ts**
+
+```typescript
+import { WebUIElement, observable } from '@microsoft/webui-framework';
+
+export class ThemeApp extends WebUIElement {
+  @observable currentColor = '';
+
+  onColorChange(e: CustomEvent): void {
+    this.currentColor = e.detail.color;
+  }
+}
+
+ThemeApp.define('theme-app');
+```
+
+**What changed:** React passes callback props down; WebUI uses native Custom Events that bubble up through the DOM. The child emits an event with `this.$emit()`, and the parent catches it with `@event` syntax on the component tag. Components are fully decoupled - the child doesn't reference the parent.
+
+## Styling
+
+### React (CSS-in-JS)
+
+```jsx
+import styled from 'styled-components';
+
+const Card = styled.div`
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+`;
+
+const Title = styled.h3`
+  color: #333;
+  margin: 0 0 0.5rem 0;
+`;
+
+function ProductCard({ name, price }) {
+  return (
+    <Card>
+      <Title>{name}</Title>
+      <p>${price}</p>
+    </Card>
+  );
+}
+```
+
+### WebUI
+
+**product-card.html**
+
+```html
+<div class="card">
+  <h3>{{name}}</h3>
+  <p>${{price}}</p>
+</div>
+```
+
+**product-card.css**
+
+```css
+.card {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+h3 {
+  color: #333;
+  margin: 0 0 0.5rem 0;
+}
+```
+
+**What changed:** CSS-in-JS becomes a plain CSS file. Shadow DOM provides the style encapsulation that CSS-in-JS libraries simulate with generated class names. Styles cannot leak in or out of the component. No JavaScript runtime cost for styling.
+
+## Component Composition
+
+### React
+
+```jsx
+function UserProfile({ user }) {
+  return (
+    <div className="profile">
+      <img src={user.avatar} alt={user.name} />
+      <h2>{user.name}</h2>
+      <p>{user.bio}</p>
+      {user.isAdmin && <AdminBadge />}
+      <ul>
+        {user.skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+### WebUI
+
+**user-profile.html**
+
+```html
+<div class="profile">
+  <img src="{{user.avatar}}" alt="{{user.name}}" />
+  <h2>{{user.name}}</h2>
+  <p>{{user.bio}}</p>
+  <if condition="user.isAdmin">
+    <admin-badge></admin-badge>
+  </if>
+  <ul>
+    <for each="skill in user.skills">
+      <li>{{skill}}</li>
+    </for>
+  </ul>
+</div>
+```
+
+**What changed:** JSX expressions (`&&`, `.map()`, template literals) become HTML directives (`<if>`, `<for>`, <code v-pre>{{}}</code>). The template reads like HTML with declarative annotations, not JavaScript with embedded markup.
+
+## FAST-HTML Alternative
+
+WebUI supports two hydration plugins. The examples above use `@microsoft/webui-framework` (recommended). If your team uses the [FAST](https://fast.design/) ecosystem, the `--plugin=fast` option provides an alternative:
+
+```bash
+webui build ./src --out ./dist --plugin=fast
+```
+
+The **template syntax is identical** - `<if>`, `<for>`, <code v-pre>{{}}</code>, and `@click` work the same way in both plugins. The difference is in the TypeScript component class:
+
+### WebUI Framework (recommended)
+
+```typescript
+import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
+
+export class MyCounter extends WebUIElement {
+  @attr label = 'Count';
+  @observable count = 0;
+
+  increment(): void {
+    this.count += 1;
+  }
+}
+
+MyCounter.define('my-counter');
+```
+
+### FAST-HTML
+
+```typescript
+import { FASTElement, attr, observable } from '@microsoft/fast-element';
+import { RenderableFASTElement } from '@microsoft/fast-html';
+
+export class MyCounter extends RenderableFASTElement(FASTElement) {
+  @attr label = 'Count';
+  @observable count = 0;
+
+  increment(): void {
+    this.count += 1;
+  }
+
+  prepare(): void {
+    // Manually read state from pre-rendered DOM
+    this.count = Number(this.shadowRoot?.querySelector('span')?.textContent ?? 0);
+  }
+}
+
+MyCounter.define({ name: 'my-counter', template: /* ... */ });
+```
+
+| | WebUI Framework | FAST-HTML |
+|---|---|---|
+| **State seeding** | Automatic from SSR markers | Manual in `prepare()` |
+| **Update model** | Targeted path-indexed | Full observable chain |
+| **Package** | `@microsoft/webui-framework` | `@microsoft/fast-html` + `@microsoft/fast-element` |
+| **Best for** | SSR-first apps, minimal JS | Complex client interactivity, existing FAST projects |
+
+For new projects, **WebUI Framework** is recommended - it handles state seeding automatically and produces smaller client bundles. Choose FAST-HTML if you are already invested in the FAST ecosystem.
+
+## Architecture Comparison
+
+### React: client-side rendering pipeline
+
+```
+Build → JS Bundle → Browser downloads → Parse JS → Execute → Fetch data → Render
+```
+
+Every component ships JavaScript. The page is blank until the bundle loads, parses, and executes.
+
+### WebUI: server-rendered with interactive islands
+
+```
+Build → Protocol Binary → Server renders HTML → Browser displays immediately
+                                               → JS loads only for interactive islands
+```
+
+Static content is visible instantly. Only components that need interactivity ship JavaScript.
+
+| Metric | React SPA | WebUI Islands |
+|--------|-----------|---------------|
+| First paint | After JS bundle loads | Immediate (server HTML) |
+| JavaScript shipped | All components | Only interactive islands |
+| Server runtime | Node.js with V8 | Rust binary, no JS runtime |
+| Component encapsulation | Convention (CSS Modules, etc.) | Native (Shadow DOM) |
+
+## Summary
+
+Moving from React to WebUI means:
+
+1. **Separate files** instead of JSX - HTML, CSS, and TypeScript each have their own file
+2. **Declarative directives** instead of JavaScript expressions - `<if>`, `<for>`, <code v-pre>{{}}</code>
+3. **Native Web Components** instead of framework components - Shadow DOM, Custom Elements
+4. **Server-first rendering** instead of client-first - content is visible before any JavaScript loads
+5. **Targeted updates** instead of virtual DOM diffing - only the specific DOM nodes bound to a changed property update
+6. **Custom Events** instead of callback props - components communicate through the standard DOM event system

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -1,6 +1,6 @@
 # React vs Web Components
 
-This guide compares common UI patterns written in React (imperative, JavaScript-centric) with their WebUI and FAST equivalents (declarative, HTML-centric). Each section shows a React "Before" alongside the WebUI "After" so you can see how familiar patterns translate to a Web Components model.
+This guide compares common UI patterns written in React (imperative, JavaScript-centric) with their WebUI and FAST equivalents (declarative, HTML-centric). Each section shows React and WebUI side by side so you can see how familiar patterns translate to a Web Components model.
 
 ## Key Differences at a Glance
 
@@ -16,7 +16,8 @@ This guide compares common UI patterns written in React (imperative, JavaScript-
 
 ## Simple Counter
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 import { useState } from 'react';
@@ -33,7 +34,8 @@ function Counter() {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **my-counter.html**
 
@@ -58,11 +60,15 @@ export class MyCounter extends WebUIElement {
 MyCounter.define('my-counter');
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** Template and logic are separated into HTML and TypeScript files. No JSX, no `useState` hook, no `setState` call. The `@observable` decorator makes `count` reactive - when it changes, only the bound DOM nodes update.
 
 ## Conditional Rendering
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 function Greeting({ isLoggedIn, username }) {
@@ -78,7 +84,8 @@ function Greeting({ isLoggedIn, username }) {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **user-greeting.html**
 
@@ -93,11 +100,15 @@ function Greeting({ isLoggedIn, username }) {
 </div>
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** Conditional logic moves from JavaScript ternary expressions into declarative `<if>` directives. These are evaluated on the server during rendering - no JavaScript is shipped to the browser for static conditionals.
 
 ## List Rendering
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 function TodoList({ items }) {
@@ -114,7 +125,8 @@ function TodoList({ items }) {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **todo-list.html**
 
@@ -129,11 +141,15 @@ function TodoList({ items }) {
 </ul>
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** `Array.map()` with JSX becomes a declarative `<for>` directive. The `key` prop is replaced by the first attribute on the repeated element. This runs on the server and produces static HTML - no JavaScript array iteration in the browser.
 
 ## Event Handling
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 function SearchBox() {
@@ -159,7 +175,8 @@ function SearchBox() {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **search-box.html**
 
@@ -198,11 +215,15 @@ export class SearchBox extends WebUIElement {
 SearchBox.define('search-box');
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** Event handlers use `@event` syntax instead of `onEvent` props. DOM references use `w-ref` instead of `useRef`. No synthetic event system - the browser's native events are used directly.
 
 ## Parent-Child Communication
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 function ColorPicker({ onColorChange }) {
@@ -226,7 +247,8 @@ function App() {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **color-picker.html**
 
@@ -278,11 +300,15 @@ export class ThemeApp extends WebUIElement {
 ThemeApp.define('theme-app');
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** React passes callback props down; WebUI uses native Custom Events that bubble up through the DOM. The child emits an event with `this.$emit()`, and the parent catches it with `@event` syntax on the component tag. Components are fully decoupled - the child doesn't reference the parent.
 
 ## Styling
 
-### React (CSS-in-JS)
+<CodeComparison>
+<template #left>
 
 ```jsx
 import styled from 'styled-components';
@@ -308,7 +334,8 @@ function ProductCard({ name, price }) {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **product-card.html**
 
@@ -334,11 +361,15 @@ h3 {
 }
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** CSS-in-JS becomes a plain CSS file. Shadow DOM provides the style encapsulation that CSS-in-JS libraries simulate with generated class names. Styles cannot leak in or out of the component. No JavaScript runtime cost for styling.
 
 ## Component Composition
 
-### React
+<CodeComparison>
+<template #left>
 
 ```jsx
 function UserProfile({ user }) {
@@ -358,7 +389,8 @@ function UserProfile({ user }) {
 }
 ```
 
-### WebUI
+</template>
+<template #right>
 
 **user-profile.html**
 
@@ -378,6 +410,9 @@ function UserProfile({ user }) {
 </div>
 ```
 
+</template>
+</CodeComparison>
+
 **What changed:** JSX expressions (`&&`, `.map()`, template literals) become HTML directives (`<if>`, `<for>`, <code v-pre>{{}}</code>). The template reads like HTML with declarative annotations, not JavaScript with embedded markup.
 
 ## FAST Alternative
@@ -390,7 +425,8 @@ webui build ./src --out ./dist --plugin=fast
 
 The **template syntax is identical** - `<if>`, `<for>`, <code v-pre>{{}}</code>, and `@click` work the same way in both plugins. The difference is in the TypeScript component class:
 
-### WebUI Framework
+<CodeComparison left-label="WebUI Framework" right-label="FAST">
+<template #left>
 
 ```typescript
 import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
@@ -407,7 +443,8 @@ export class MyCounter extends WebUIElement {
 MyCounter.define('my-counter');
 ```
 
-### FAST
+</template>
+<template #right>
 
 ```typescript
 import { FASTElement, attr, observable } from '@microsoft/fast-element';
@@ -429,6 +466,9 @@ export class MyCounter extends RenderableFASTElement(FASTElement) {
 
 MyCounter.define({ name: 'my-counter', template: /* ... */ });
 ```
+
+</template>
+</CodeComparison>
 
 | | WebUI Framework | FAST |
 |---|---|---|

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -1,6 +1,6 @@
-# React vs WebUI
+# React vs Web Components
 
-This guide compares common UI patterns written in React (imperative, JavaScript-centric) with their WebUI equivalents (declarative, HTML-centric). Each section shows a React "Before" alongside the WebUI "After" so you can see how familiar patterns translate to WebUI's component model.
+This guide compares common UI patterns written in React (imperative, JavaScript-centric) with their WebUI and FAST equivalents (declarative, HTML-centric). Each section shows a React "Before" alongside the WebUI "After" so you can see how familiar patterns translate to a Web Components model.
 
 ## Key Differences at a Glance
 
@@ -380,9 +380,9 @@ function UserProfile({ user }) {
 
 **What changed:** JSX expressions (`&&`, `.map()`, template literals) become HTML directives (`<if>`, `<for>`, <code v-pre>{{}}</code>). The template reads like HTML with declarative annotations, not JavaScript with embedded markup.
 
-## FAST-HTML Alternative
+## FAST Alternative
 
-WebUI supports two hydration plugins. The examples above use `@microsoft/webui-framework` (recommended). If your team uses the [FAST](https://fast.design/) ecosystem, the `--plugin=fast` option provides an alternative:
+WebUI supports two hydration plugins. The examples above use `@microsoft/webui-framework`. If your team uses the [FAST](https://fast.design/) ecosystem, the `--plugin=fast` option provides an alternative:
 
 ```bash
 webui build ./src --out ./dist --plugin=fast
@@ -390,7 +390,7 @@ webui build ./src --out ./dist --plugin=fast
 
 The **template syntax is identical** - `<if>`, `<for>`, <code v-pre>{{}}</code>, and `@click` work the same way in both plugins. The difference is in the TypeScript component class:
 
-### WebUI Framework (recommended)
+### WebUI Framework
 
 ```typescript
 import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
@@ -407,7 +407,7 @@ export class MyCounter extends WebUIElement {
 MyCounter.define('my-counter');
 ```
 
-### FAST-HTML
+### FAST
 
 ```typescript
 import { FASTElement, attr, observable } from '@microsoft/fast-element';
@@ -430,14 +430,12 @@ export class MyCounter extends RenderableFASTElement(FASTElement) {
 MyCounter.define({ name: 'my-counter', template: /* ... */ });
 ```
 
-| | WebUI Framework | FAST-HTML |
+| | WebUI Framework | FAST |
 |---|---|---|
 | **State seeding** | Automatic from SSR markers | Manual in `prepare()` |
 | **Update model** | Targeted path-indexed | Full observable chain |
 | **Package** | `@microsoft/webui-framework` | `@microsoft/fast-html` + `@microsoft/fast-element` |
 | **Best for** | SSR-first apps, minimal JS | Complex client interactivity, existing FAST projects |
-
-For new projects, **WebUI Framework** is recommended - it handles state seeding automatically and produces smaller client bundles. Choose FAST-HTML if you are already invested in the FAST ecosystem.
 
 ## Architecture Comparison
 


### PR DESCRIPTION
Add a new documentation page comparing React (imperative) patterns with their WebUI (declarative) equivalents, covering:

- Simple counter component (useState vs @observable)
- Conditional rendering (ternary vs `<if>`)
- List rendering (.map() vs `<for>`)
- Event handling (@click, w-ref vs onClick, useRef)
- Parent-child communication (Custom Events vs callback props)
- Styling (CSS-in-JS vs scoped Shadow DOM CSS)
- Component composition
- FAST-HTML alternative syntax
- Architecture comparison (SPA vs Islands)

Also updates the sidebar config and README.

Closes #192