### PR TITLE
chore: docker to deploy multiple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marketplace-api"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/examples/app/commerce/Dockerfile
+++ b/examples/app/commerce/Dockerfile
@@ -69,8 +69,12 @@ RUN chmod 0755 /usr/local/bin/commerce-entrypoint.sh && \
     chown app:app /usr/local/bin/commerce-entrypoint.sh
 
 USER app
-EXPOSE 3002 3003 3004
+EXPOSE 3000
 
+# Configure the CSS strategy and port at runtime:
+#   docker run -e CSS_STRATEGY=module -e PORT=3000 ...
+#   docker run ... -- --css module --port 3000
+#
 # Cart cookies are signed with HMAC-SHA256. Pass CART_COOKIE_SECRET at runtime:
 #   docker run -e CART_COOKIE_SECRET=<your-secret> ...
 # If unset, the server generates an ephemeral per-process key (carts do not

--- a/examples/app/commerce/README.md
+++ b/examples/app/commerce/README.md
@@ -88,7 +88,7 @@ commerce/
 
 ## Docker
 
-Build and run the commerce app as a container. Run all commands from the **repository root**.
+Build and run the commerce app as a container. Each container runs a **single CSS strategy** — run one container per strategy. All commands are from the **repository root**.
 
 ```bash
 # Build the image
@@ -96,27 +96,27 @@ docker build -t webui-commerce -f examples/app/commerce/Dockerfile .
 
 # Override cargo-chef version if needed
 docker build --build-arg CARGO_CHEF_VERSION=0.1.75 -t webui-commerce -f examples/app/commerce/Dockerfile .
-
-# List images
-docker images webui-commerce
-
-# Inspect image metadata
-docker inspect webui-commerce
-
-# Run the container:
-# - host 443  -> container 3004 (--css link)
-# - host 1443 -> container 3003 (--css module)
-# - host 2443  -> container 3002 (--css style)
-docker run -p 443:3004 -p 1443:3003 -p 2443:3002 webui-commerce
 ```
 
-The container runs both commerce variants:
+### Running containers
 
-- `http://localhost` serves the `--css link` app on container port `3004`
-- `http://localhost:1443` serves the `--css module` app on container port `3003`
+Configure the CSS strategy via the `CSS_STRATEGY` environment variable (`link`, `module`, or `style`). The default is `link`. The server listens on port `3000` inside the container by default (override with `PORT`).
+
+```bash
+# One container per CSS strategy
+docker run -d -p 3004:3000 -e CSS_STRATEGY=link   webui-commerce
+docker run -d -p 3003:3000 -e CSS_STRATEGY=module webui-commerce
+docker run -d -p 3002:3000 -e CSS_STRATEGY=style  webui-commerce
+```
+
+Or pass flags directly:
+
+```bash
+docker run -d -p 3004:3000 webui-commerce --css link --port 3000
+```
 
 These ports are plain HTTP because the container starts `marketplace-api` with `--no-tls`.
-Use a TLS-terminating proxy or ingress if you want external HTTPS on `443` and `1443`.
+Use a TLS-terminating proxy or ingress for external HTTPS.
 
 To tag with the project version:
 

--- a/examples/app/commerce/docker-entrypoint.sh
+++ b/examples/app/commerce/docker-entrypoint.sh
@@ -4,62 +4,25 @@
 
 set -eu
 
-cleanup() {
-    status=$?
-    trap - INT TERM EXIT
+# Usage: commerce-entrypoint.sh [--css <link|module|style>] [--port <port>]
+#
+# Each container runs a single marketplace-api instance with one CSS strategy.
+# Defaults: --css link --port 3000
 
-    if [ -n "${PID_LINK:-}" ]; then
-        kill "${PID_LINK}" 2>/dev/null || true
-    fi
-    if [ -n "${PID_MODULE:-}" ]; then
-        kill "${PID_MODULE}" 2>/dev/null || true
-    fi
-    if [ -n "${PID_STYLE:-}" ]; then
-        kill "${PID_STYLE}" 2>/dev/null || true
-    fi
+CSS_STRATEGY="${CSS_STRATEGY:-link}"
+PORT="${PORT:-3000}"
 
-    if [ -n "${PID_LINK:-}" ]; then
-        wait "${PID_LINK}" 2>/dev/null || true
-    fi
-    if [ -n "${PID_MODULE:-}" ]; then
-        wait "${PID_MODULE}" 2>/dev/null || true
-    fi
-    if [ -n "${PID_STYLE:-}" ]; then
-        wait "${PID_STYLE}" 2>/dev/null || true
-    fi
-
-    exit "${status}"
-}
-
-trap cleanup INT TERM EXIT
-
-# Run both commerce variants in the same container:
-# - 3004: link CSS strategy
-# - 3003: module CSS strategy
-marketplace-api --port 3004 --css link --no-tls &
-PID_LINK=$!
-
-marketplace-api --port 3003 --css module --no-tls &
-PID_MODULE=$!
-
-marketplace-api --port 3002 --css style --no-tls &
-PID_STYLE=$!
-
-status=0
-while kill -0 "${PID_LINK}" 2>/dev/null && kill -0 "${PID_MODULE}" 2>/dev/null && kill -0 "${PID_STYLE}" 2>/dev/null; do
-    sleep 1
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --css)  CSS_STRATEGY="$2"; shift 2 ;;
+        --port) PORT="$2";         shift 2 ;;
+        *)      echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
 done
 
-if ! kill -0 "${PID_LINK}" 2>/dev/null; then
-    wait "${PID_LINK}" || status=$?
-fi
+case "${CSS_STRATEGY}" in
+    link|module|style) ;;
+    *) echo "Invalid CSS strategy: ${CSS_STRATEGY} (expected link, module, or style)" >&2; exit 1 ;;
+esac
 
-if ! kill -0 "${PID_MODULE}" 2>/dev/null; then
-    wait "${PID_MODULE}" || status=$?
-fi
-
-if ! kill -0 "${PID_STYLE}" 2>/dev/null; then
-    wait "${PID_STYLE}" || status=$?
-fi
-
-exit "${status}"
+exec marketplace-api --port "${PORT}" --css "${CSS_STRATEGY}" --no-tls

--- a/examples/app/commerce/package.json
+++ b/examples/app/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/app/commerce/server/Cargo.toml
+++ b/examples/app/commerce/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marketplace-api"
-version = "1.2.1"
+version = "2.0.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Azure Container Apps only supports a single exposed port per container, so the entrypoint can no longer start three marketplace-api processes.

The entrypoint now accepts `--css <link|module|style>` and `--port <port>` (or CSS_STRATEGY / PORT env vars) and runs a single instance via exec. Deploy three containers — one per strategy — instead of one multi-process container.