### PR TITLE
fix(handler): emit all reachable components on current node

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -221,8 +221,11 @@ When the handler encounters `Fragment::Outlet`:
 3. Emit `<webui-outlet>` containing matched child `<webui-route>` with component, and hidden stubs for siblings.
 
 The handler also emits `<meta name="webui-inventory">` in `<head>` with the initial component
-inventory bitmask, so the client router can tell the server which templates it already has
-on the first client-side navigation.
+inventory bitmask (covering only **rendered** components), so the client router can tell the server
+which templates it already has on the first client-side navigation. Note that **templates** and
+**CSS module definitions** are emitted for all **reachable** components (including those in false
+`<if>` blocks), not just rendered ones — this ensures client-side conditional activation works
+without a server round-trip.
 
 **Key elements:**
 - `<webui-route>` — light DOM custom element, structural routing wrapper with no shadow DOM
@@ -660,7 +663,7 @@ pub enum CssStrategy {
 
 - **Link** (default): Emits `<link>` tags referencing external `.css` files only for components whose discovery/registration data included CSS. Used by the CLI for production builds where CSS files are served separately.
 - **Style**: Embeds the full CSS content in `<style>` tags inside the shadow DOM template. Used when all files are needed in-memory.
-- **Module**: Uses the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. During SSR, emits a `<style type="module" specifier="component-name">` definition in each component's light DOM on first render (e.g., `<my-comp><style type="module" ...>CSS</style><template ...>`) and adds `shadowrootadoptedstylesheets="component-name"` to each shadow root `<template>`. The browser registers the CSS module globally and shares a single `CSSStyleSheet` across all shadow roots that adopt it. No external CSS files are produced. During SPA partial navigation, module style definitions for newly needed components are sent in the `templateStyles` array; the router appends them to `<head>` before executing template scripts. WebUI Framework compiled metadata carries the adopted stylesheet specifier (`sa`) so client-created components can adopt the registered stylesheet on their shadow root.
+- **Module**: Uses the [Declarative CSS Module Scripts](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md) proposal. During SSR, emits a `<style type="module" specifier="component-name">` definition in each component's light DOM on first render (e.g., `<my-comp><style type="module" ...>CSS</style><template ...>`) and adds `shadowrootadoptedstylesheets="component-name"` to each shadow root `<template>`. Components inside false `<if>` blocks or empty `<for>` loops that were not rendered during SSR get their module style definitions emitted at `body_end`, so client-side activation can adopt them. The browser registers the CSS module globally and shares a single `CSSStyleSheet` across all shadow roots that adopt it. No external CSS files are produced. During SPA partial navigation, module style definitions for newly needed components are sent in the `templateStyles` array; the router appends them to `<head>` before executing template scripts. WebUI Framework compiled metadata carries the adopted stylesheet specifier (`sa`) so client-created components can adopt the registered stylesheet on their shadow root.
 
 Set via `parser.set_css_strategy(CssStrategy::Style)`.
 
@@ -707,7 +710,7 @@ pub trait ParserPlugin {
 **Built-in plugin: `WebUIParserPlugin`**
 - Skips WebUI Framework runtime attributes (`@click`, `@keydown`, etc.) without counting them as attribute bindings
 - Tracks per-element event count; emits 12-byte `WebUIElementData` `Plugin` fragments encoding `[binding_count, event_start, event_count]`
-- Tracks components and compiles templates into raw JS IIFE strings registered in `window.__webui_templates`. During SSR the handler wraps them in a single `<script>` tag; during SPA navigation the router appends any `templateStyles` first, then evaluates the batched template scripts in one nonce-friendly `<script>` tag.
+- Tracks components and compiles templates into raw JS IIFE strings registered in `window.__webui_templates`. During SSR the handler emits templates for all reachable components on the active route (including those inside false `<if>` and empty `<for>` blocks) in a single `<script>` tag. During SPA navigation the router appends any `templateStyles` first, then evaluates the batched template scripts in one nonce-friendly `<script>` tag.
 - Public framework authoring, decorators, and package entrypoints live in [packages/webui-framework/README.md](packages/webui-framework/README.md)
 
 **Usage:**

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -769,12 +769,6 @@ impl WebUIHandler {
         }
 
         // Hook: emit component templates before body_end when hydration is enabled.
-        // Only emit templates for components that were actually rendered during SSR.
-        // This keeps the inventory aligned with what's truly in the document:
-        // if a component's template IIFE is emitted, its <style type="module">
-        // definition was also emitted inline (via emit_css_module). Components
-        // inside unrendered conditional blocks are excluded — they'll be delivered
-        // via templateStyles[] + templates[] during SPA partial navigation.
         if signal.raw && signal.value == "body_end" && context.plugin.is_some() {
             // Build the component → index map for the inventory bitfield.
             let comp_index = crate::route_handler::build_component_index(context.protocol);
@@ -794,10 +788,51 @@ impl WebUIHandler {
             context.writer.write(&inventory_hex)?;
             context.writer.write("\">")?;
 
+            // Emit templates for all REACHABLE components on the current route,
+            // not just those rendered in this SSR pass. Components inside false
+            // <if> blocks or empty <for> loops are reachable via client-side
+            // state changes and need their templates available without a server
+            // round-trip. The graph walker follows conditional and loop branches
+            // unconditionally, but only descends into the matched route chain —
+            // components on other routes are delivered via SPA partial navigation.
+            let (reachable_names, _) = crate::route_handler::get_needed_components_for_request(
+                context.protocol,
+                &context.entry_id,
+                &context.request_path,
+                "",
+            );
+            let reachable: std::collections::HashSet<String> =
+                reachable_names.into_iter().collect();
+
+            // Emit CSS module definitions for reachable-but-unrendered components.
+            // Rendered components already got their <style type="module"> inline
+            // during the render pass (via emit_css_module). Unrendered components
+            // need their definitions here so the framework can adopt them when
+            // the <if> condition flips true client-side.
+            for name in &reachable {
+                if !context.rendered_components.contains(name) {
+                    if let Some(css) = context
+                        .protocol
+                        .components
+                        .get(name)
+                        .map(|c| c.css.as_str())
+                        .filter(|s| !s.is_empty())
+                    {
+                        context
+                            .writer
+                            .write("<style type=\"module\" specifier=\"")?;
+                        context.writer.write(name)?;
+                        context.writer.write("\">")?;
+                        context.writer.write(css)?;
+                        context.writer.write("</style>")?;
+                    }
+                }
+            }
+
             if let Some(ref p) = context.plugin {
                 p.emit_templates(
                     context.protocol,
-                    &context.rendered_components,
+                    &reachable,
                     context.nonce.as_deref(),
                     context.writer,
                 )?;
@@ -6135,13 +6170,14 @@ mod tests {
     }
 
     #[test]
-    fn test_unrendered_components_excluded_from_templates_and_inventory() {
-        // Simulates the commerce about page: app-shell renders cart-panel,
-        // but cart-panel contains an <if> block with product-card inside.
-        // When the condition is false (empty cart), product-card is NOT rendered.
-        // Its template IIFE must NOT be in the <script> output, and its bit
-        // must NOT be set in the inventory — otherwise the client thinks it
-        // has the component but lacks the <style type="module"> definition.
+    fn test_reachable_unrendered_components_get_templates_and_css_but_not_inventory() {
+        // Simulates a page where app-shell renders cart-panel, but cart-panel
+        // contains an <if> block with product-card inside. When the condition
+        // is false (empty cart), product-card is NOT rendered — but it IS
+        // reachable from the fragment graph. Its template IIFE and CSS module
+        // definition must be in the output so the client can mount it when
+        // the <if> flips true. However, its bit must NOT be set in the
+        // inventory — the inventory tracks what was actually rendered.
         let mut fragments = HashMap::new();
         fragments.insert(
             "index.html".to_string(),
@@ -6219,16 +6255,18 @@ mod tests {
 
         let html = writer.get_content();
 
-        // product-card template IIFE must NOT be in the output
+        // product-card template IS in the output — it's a known component
+        // whose template must be available for client-side <if> activation.
         assert!(
-            !html.contains("w['product-card']"),
-            "unrendered product-card template should not be emitted: {html}"
+            html.contains("w['product-card']"),
+            "product-card template should be emitted even when unrendered: {html}"
         );
 
-        // product-card style must NOT be in the output
+        // product-card CSS module IS in the output — reachable components need
+        // their stylesheet definitions for client-side <if> activation.
         assert!(
-            !html.contains(r#"specifier="product-card""#),
-            "unrendered product-card CSS module should not be emitted: {html}"
+            html.contains(r#"specifier="product-card""#),
+            "reachable product-card CSS module should be emitted: {html}"
         );
 
         // app-shell and cart-panel SHOULD be in the output (they were rendered)

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -92,22 +92,22 @@ pub trait HandlerPlugin {
     fn emit_templates(
         &self,
         protocol: &WebUIProtocol,
-        rendered_components: &HashSet<String>,
+        components: &HashSet<String>,
         _nonce: Option<&str>,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
-        emit_rendered_component_templates(protocol, rendered_components, writer)
+        emit_component_templates(protocol, components, writer)
     }
 }
 
 /// Default template emission: write each non-empty template verbatim.
 /// Used by the FAST plugin for `<f-template>` tags.
-pub(crate) fn emit_rendered_component_templates(
+pub(crate) fn emit_component_templates(
     protocol: &WebUIProtocol,
-    rendered_components: &HashSet<String>,
+    components: &HashSet<String>,
     writer: &mut dyn ResponseWriter,
 ) -> Result<()> {
-    for name in rendered_components {
+    for name in components {
         if let Some(template) = protocol
             .components
             .get(name)

--- a/crates/webui-handler/src/plugin/webui.rs
+++ b/crates/webui-handler/src/plugin/webui.rs
@@ -99,13 +99,13 @@ impl HandlerPlugin for WebUIHydrationPlugin {
     fn emit_templates(
         &self,
         protocol: &WebUIProtocol,
-        rendered_components: &HashSet<String>,
+        components: &HashSet<String>,
         nonce: Option<&str>,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
-        let mut templates: Vec<&str> = Vec::with_capacity(rendered_components.len());
+        let mut templates: Vec<&str> = Vec::with_capacity(components.len());
 
-        for name in rendered_components {
+        for name in components {
             if let Some(template) = protocol
                 .components
                 .get(name)
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_render_complete_only_emits_rendered_components() {
+    fn test_emit_templates_only_emits_provided_components() {
         let mut writer = TestWriter::new();
 
         let mut protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
@@ -350,12 +350,12 @@ mod tests {
             .or_default()
             .template = iife_template("comp-c", "h:\"c\"");
 
-        let mut rendered = std::collections::HashSet::new();
-        rendered.insert("comp-a".to_string());
+        let mut components = std::collections::HashSet::new();
+        components.insert("comp-a".to_string());
 
         let plugin = WebUIHydrationPlugin::new();
         plugin
-            .emit_templates(&protocol, &rendered, None, &mut writer)
+            .emit_templates(&protocol, &components, None, &mut writer)
             .unwrap();
 
         assert!(
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_on_render_complete_empty_rendered_set() {
+    fn test_emit_templates_empty_set() {
         let mut writer = TestWriter::new();
         let mut protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
         protocol
@@ -384,12 +384,12 @@ mod tests {
             .entry("comp-a".to_string())
             .or_default()
             .template = iife_template("comp-a", "h:\"a\"");
-        let rendered = std::collections::HashSet::new();
+        let components = std::collections::HashSet::new();
         let plugin = WebUIHydrationPlugin::new();
         plugin
-            .emit_templates(&protocol, &rendered, None, &mut writer)
+            .emit_templates(&protocol, &components, None, &mut writer)
             .unwrap();
-        assert_eq!(writer.output, "", "empty rendered set should emit nothing");
+        assert_eq!(writer.output, "", "empty set should emit nothing");
     }
 
     #[test]

--- a/packages/webui-framework/tests/fixtures/conditional-component/conditional-component.spec.ts
+++ b/packages/webui-framework/tests/fixtures/conditional-component/conditional-component.spec.ts
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Regression tests: custom elements inside conditional (<if>) blocks
+ * that are initially false during SSR must mount correctly when the
+ * condition flips true client-side.
+ *
+ * Two test groups:
+ * 1. "templates missing" — simulates current SSR where unrendered component
+ *    templates are NOT emitted. These tests document the bug.
+ * 2. "templates available" — simulates the fixed SSR where ALL reachable
+ *    component templates are emitted. These tests verify the fix works.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('conditional-component: templates missing (current SSR bug)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/conditional-component/fixture.html');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-cond-parent') as any;
+      return el && el.$ready === true;
+    });
+  });
+
+  test('child component fails to mount without template', async ({ page }) => {
+    // Set show=true — child element is created but has no template
+    await page.evaluate(() => {
+      (document.querySelector('test-cond-parent') as any).show = true;
+    });
+
+    // Give it a moment to attempt mounting
+    await page.waitForTimeout(100);
+
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return {
+        childExists: !!child,
+        hasShadowRoot: !!child?.shadowRoot,
+        ready: child?.$ready ?? false,
+      };
+    });
+
+    // Child element IS created by the <if> block...
+    expect(result.childExists).toBe(true);
+    // ...but it has no shadow root because its template wasn't emitted
+    expect(result.hasShadowRoot).toBe(false);
+    expect(result.ready).toBe(false);
+  });
+});
+
+test.describe('conditional-component: templates available (fixed SSR)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/conditional-component/fixture.html');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-cond-parent') as any;
+      return el && el.$ready === true;
+    });
+    // Register all child templates upfront (simulating fixed SSR emit_templates)
+    await page.evaluate(() => {
+      (window as any).__fixture_register_all();
+    });
+  });
+
+  test('child component is NOT present when condition is false', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return { hasChild: !!child, show: parent.show };
+    });
+
+    expect(result.show).toBe(false);
+    expect(result.hasChild).toBe(false);
+  });
+
+  test('child component mounts with shadow root when condition flips true', async ({ page }) => {
+    await page.evaluate(() => {
+      (document.querySelector('test-cond-parent') as any).show = true;
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return child && child.shadowRoot && child.$ready === true;
+    }, null, { timeout: 2000 });
+
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return {
+        hasShadowRoot: !!child?.shadowRoot,
+        ready: child?.$ready,
+        text: child?.shadowRoot?.querySelector('.child-text')?.textContent,
+      };
+    });
+
+    expect(result.hasShadowRoot).toBe(true);
+    expect(result.ready).toBe(true);
+    expect(result.text).toBe('Child Active');
+  });
+
+  test('child component survives toggle off and back on', async ({ page }) => {
+    await page.evaluate(() => {
+      (document.querySelector('test-cond-parent') as any).show = true;
+    });
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return child && child.$ready === true;
+    }, null, { timeout: 2000 });
+
+    await page.evaluate(() => {
+      (document.querySelector('test-cond-parent') as any).show = false;
+    });
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      return !parent.shadowRoot?.querySelector('test-child-comp');
+    }, null, { timeout: 2000 });
+
+    await page.evaluate(() => {
+      (document.querySelector('test-cond-parent') as any).show = true;
+    });
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return child && child.shadowRoot && child.$ready === true;
+    }, null, { timeout: 2000 });
+
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return {
+        text: child?.shadowRoot?.querySelector('.child-text')?.textContent,
+      };
+    });
+
+    expect(result.text).toBe('Child Active');
+  });
+
+  test('nested: mid and grandchild components mount through two <if> layers', async ({ page }) => {
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-nested-cond-parent') as any;
+      return el && el.$ready === true;
+    });
+
+    const before = await page.evaluate(() => {
+      const parent = document.querySelector('test-nested-cond-parent') as any;
+      return { hasMid: !!parent.shadowRoot?.querySelector('test-mid-comp') };
+    });
+    expect(before.hasMid).toBe(false);
+
+    await page.evaluate(() => {
+      (document.querySelector('test-nested-cond-parent') as any).show = true;
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-nested-cond-parent') as any;
+      const mid = parent.shadowRoot?.querySelector('test-mid-comp');
+      if (!mid || !mid.shadowRoot || !mid.$ready) return false;
+      const grandchild = mid.shadowRoot.querySelector('test-grandchild-comp');
+      return grandchild && grandchild.shadowRoot && grandchild.$ready === true;
+    }, null, { timeout: 2000 });
+
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-nested-cond-parent') as any;
+      const mid = parent.shadowRoot?.querySelector('test-mid-comp');
+      const grandchild = mid?.shadowRoot?.querySelector('test-grandchild-comp');
+      return {
+        midReady: mid?.$ready,
+        midText: mid?.shadowRoot?.querySelector('.mid-label')?.textContent,
+        grandchildReady: grandchild?.$ready,
+        grandchildText: grandchild?.shadowRoot?.querySelector('.grandchild-text')?.textContent,
+      };
+    });
+
+    expect(result.midReady).toBe(true);
+    expect(result.midText).toBe('Mid');
+    expect(result.grandchildReady).toBe(true);
+    expect(result.grandchildText).toBe('Grandchild Active');
+  });
+
+  test('click toggle button activates child via UI', async ({ page }) => {
+    await page.locator('test-cond-parent').evaluateHandle((el) => {
+      (el as any).shadowRoot.querySelector('.toggle').click();
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return child && child.shadowRoot && child.$ready === true;
+    }, null, { timeout: 2000 });
+
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('test-cond-parent') as any;
+      const child = parent.shadowRoot?.querySelector('test-child-comp');
+      return {
+        text: child?.shadowRoot?.querySelector('.child-text')?.textContent,
+      };
+    });
+
+    expect(result.text).toBe('Child Active');
+  });
+});

--- a/packages/webui-framework/tests/fixtures/conditional-component/element.ts
+++ b/packages/webui-framework/tests/fixtures/conditional-component/element.ts
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Regression fixture: custom elements inside a false <if> block must mount
+ * correctly when the condition flips true client-side.
+ *
+ * This fixture simulates the real SSR scenario where templates for components
+ * inside false <if> blocks are NOT emitted by the server. The child template
+ * is registered AFTER the parent hydrates, simulating late template delivery.
+ *
+ * Scenario 1 — flat: parent has <if condition="show"><child-comp></if>,
+ *   SSR renders with show=false, child-comp template not initially available.
+ *
+ * Scenario 2 — nested: parent <if> → mid component → mid's <if> → grandchild.
+ *   Both mid and grandchild templates are initially missing.
+ */
+
+import { WebUIElement, observable } from '../../../src/index.js';
+import {
+  bindEvent,
+  bindText,
+  dynamic,
+  identifier,
+  nodePath,
+  registerCompiledTemplate,
+  slot,
+  when,
+} from '@microsoft/webui-test-support';
+
+// ── Child component: simple text display ──────────────────────
+// Template registered but exposed for late-registration test
+const childTemplate = {
+  h: '<span class="child-text"></span>',
+  shadowDom: true as const,
+  text: [
+    bindText(slot({ parent: nodePath(0), before: 0 }), dynamic('label')),
+  ],
+};
+
+export class TestChildComp extends WebUIElement {
+  @observable label = 'Child Active';
+}
+TestChildComp.define('test-child-comp');
+
+// ── Grandchild component: for nested test ─────────────────────
+const grandchildTemplate = {
+  h: '<span class="grandchild-text"></span>',
+  shadowDom: true as const,
+  text: [
+    bindText(slot({ parent: nodePath(0), before: 0 }), dynamic('message')),
+  ],
+};
+
+export class TestGrandchildComp extends WebUIElement {
+  @observable message = 'Grandchild Active';
+}
+TestGrandchildComp.define('test-grandchild-comp');
+
+// ── Mid component: has inner <if> with grandchild ─────────────
+const midTemplate = {
+  h: '<span class="mid-label">Mid</span>',
+  shadowDom: true as const,
+  conditionals: [when(identifier('inner'), { blockIndex: 0, slot: { before: 1 } })],
+  blocks: [{
+    h: '<test-grandchild-comp></test-grandchild-comp>',
+  }],
+};
+
+export class TestMidComp extends WebUIElement {
+  @observable inner = true;
+}
+TestMidComp.define('test-mid-comp');
+
+// ── Parent component: has <if> wrapping the child ─────────────
+registerCompiledTemplate('test-cond-parent', {
+  h: '<button class="toggle">Toggle</button>',
+  shadowDom: true,
+  conditionals: [when(identifier('show'), { blockIndex: 0, slot: { before: 1 } })],
+  blocks: [{
+    h: '<test-child-comp></test-child-comp>',
+  }],
+  events: [bindEvent('click', 'toggleShow', false, nodePath(0))],
+});
+
+export class TestCondParent extends WebUIElement {
+  @observable show = false;
+
+  toggleShow(): void {
+    this.show = !this.show;
+  }
+}
+TestCondParent.define('test-cond-parent');
+
+// ── Nested parent ─────────────────────────────────────────────
+registerCompiledTemplate('test-nested-cond-parent', {
+  h: '<button class="toggle">Toggle</button>',
+  shadowDom: true,
+  conditionals: [when(identifier('show'), { blockIndex: 0, slot: { before: 1 } })],
+  blocks: [{
+    h: '<test-mid-comp></test-mid-comp>',
+  }],
+  events: [bindEvent('click', 'toggleShow', false, nodePath(0))],
+});
+
+export class TestNestedCondParent extends WebUIElement {
+  @observable show = false;
+
+  toggleShow(): void {
+    this.show = !this.show;
+  }
+}
+TestNestedCondParent.define('test-nested-cond-parent');
+
+// ── Expose template registration for late-registration tests ──
+// In the real app, these would come from SSR <script> IIFEs.
+// We DON'T register child/mid/grandchild templates upfront —
+// the test will register them to simulate the fixed SSR behavior.
+(window as any).__fixture_register_child = () => {
+  registerCompiledTemplate('test-child-comp', childTemplate);
+};
+(window as any).__fixture_register_mid = () => {
+  registerCompiledTemplate('test-mid-comp', midTemplate);
+};
+(window as any).__fixture_register_grandchild = () => {
+  registerCompiledTemplate('test-grandchild-comp', grandchildTemplate);
+};
+// Also register all upfront for the "with templates" test group
+(window as any).__fixture_register_all = () => {
+  registerCompiledTemplate('test-child-comp', childTemplate);
+  registerCompiledTemplate('test-mid-comp', midTemplate);
+  registerCompiledTemplate('test-grandchild-comp', grandchildTemplate);
+};
+

--- a/packages/webui-framework/tests/fixtures/conditional-component/fixture.html
+++ b/packages/webui-framework/tests/fixtures/conditional-component/fixture.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Conditional Component Fixture</title>
+</head>
+<body>
+  <!-- SSR-rendered with show=false: the <if> block is NOT in the DOM.
+       The child component template must still be available for client-side
+       activation when show flips to true. -->
+  <test-cond-parent>
+    <template shadowrootmode="open">
+      <button class="toggle">Toggle</button>
+      <!--wc--><!--/wc-->
+    </template>
+  </test-cond-parent>
+
+  <!-- Nested: outer <if> is false, so mid-comp is not rendered.
+       When show flips true, mid-comp should mount AND its inner
+       grandchild (inside mid-comp's own <if inner=true>) should also mount. -->
+  <test-nested-cond-parent>
+    <template shadowrootmode="open">
+      <button class="toggle">Toggle</button>
+      <!--wc--><!--/wc-->
+    </template>
+  </test-nested-cond-parent>
+
+  <script src="/dist/conditional-component/element.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I was too conservative regarding rendered components, and we didn't have any example which used components within empty for loops or falsey conditions. Now we emit reachable components