### PR TITLE
fix: use correct FAST syntax in f-template directive attributes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -704,7 +704,7 @@ pub trait ParserPlugin {
 - Marks FAST-specific runtime attributes (`@click`, `f-ref`, `f-slotted`, `f-children`) as skipped but still counted bindings
 - Emits `Plugin` fragments with u32 LE attribute binding counts
 - Tracks components and returns `<f-template>` artifacts after parsing
-- Converts syntax to FAST syntax: `<if>`→`<f-when>`, `<for>`→`<f-repeat>`, `{{expr}}`→`{expr}` in `:attr` values
+- Converts syntax to FAST syntax: `<if condition="X">`→`<f-when value="{{X}}">`, `<for each="X">`→`<f-repeat value="{{X}}">`, `{{expr}}`→`{expr}` in `:attr` values
 - FAST authoring details live in the canonical [FAST HTML README](https://github.com/microsoft/fast/blob/main/packages/fast-html/README.md)
 
 **Built-in plugin: `WebUIParserPlugin`**

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -1157,4 +1157,99 @@ mod tests {
         let output = convert_btr_to_fast(input);
         assert_eq!(output, input);
     }
+
+    // --- End-to-end f-template regression tests ---
+    // Verify that generated f-template blocks always use FAST syntax
+    // (<f-when>/<f-repeat>) instead of webui syntax (<if>/<for>).
+
+    #[test]
+    fn ftemplate_for_loop_converted_to_f_repeat() {
+        let mut plugin = FastParserPlugin::new();
+        let html = r#"<ul><for each="item in items"><li>{{item.name}}</li></for></ul>"#;
+        let comp = make_component("my-list", html, None);
+        plugin
+            .register_component_template("my-list", &comp, &comp.html_content)
+            .unwrap();
+
+        let templates = plugin.take_component_templates();
+        let (_, result) = &templates[0];
+
+        assert!(
+            result.contains("<f-repeat value=\"{item in items}\">"),
+            "f-template should use <f-repeat>, got: {result}"
+        );
+        assert!(
+            result.contains("</f-repeat>"),
+            "f-template should close with </f-repeat>, got: {result}"
+        );
+        assert!(
+            !result.contains("<for "),
+            "f-template should NOT contain <for>, got: {result}"
+        );
+    }
+
+    #[test]
+    fn ftemplate_shadow_dom_strips_shadowroot_and_converts_directives() {
+        let mut plugin = FastParserPlugin::new();
+        let html = r#"<template shadowrootmode="open"><div><if condition="visible">Shown</if><for each="x in list"><span>{{x}}</span></for></div></template>"#;
+        let comp = make_component("my-shadow", html, None);
+        plugin
+            .register_component_template("my-shadow", &comp, &comp.html_content)
+            .unwrap();
+
+        let templates = plugin.take_component_templates();
+        let (_, result) = &templates[0];
+
+        assert!(
+            result.contains("<f-when value=\"{visible}\">"),
+            "Shadow f-template should contain <f-when>, got: {result}"
+        );
+        assert!(
+            result.contains("<f-repeat value=\"{x in list}\">"),
+            "Shadow f-template should contain <f-repeat>, got: {result}"
+        );
+        assert!(
+            !result.contains("shadowrootmode"),
+            "Shadow f-template should strip shadowrootmode, got: {result}"
+        );
+        assert!(
+            !result.contains("<if "),
+            "Shadow f-template should NOT contain <if>, got: {result}"
+        );
+        assert!(
+            !result.contains("<for "),
+            "Shadow f-template should NOT contain <for>, got: {result}"
+        );
+    }
+
+    #[test]
+    fn ftemplate_nested_if_and_for_both_converted() {
+        let mut plugin = FastParserPlugin::new();
+        let html =
+            r#"<div><if condition="show"><for each="x in items"><p>{{x}}</p></for></if></div>"#;
+        let comp = make_component("my-nested", html, None);
+        plugin
+            .register_component_template("my-nested", &comp, &comp.html_content)
+            .unwrap();
+
+        let templates = plugin.take_component_templates();
+        let (_, result) = &templates[0];
+
+        assert!(
+            result.contains("<f-when value=\"{show}\">"),
+            "Nested f-template should contain <f-when>, got: {result}"
+        );
+        assert!(
+            result.contains("<f-repeat value=\"{x in items}\">"),
+            "Nested f-template should contain <f-repeat>, got: {result}"
+        );
+        assert!(
+            !result.contains("<if "),
+            "Nested f-template should NOT contain <if>, got: {result}"
+        );
+        assert!(
+            !result.contains("<for "),
+            "Nested f-template should NOT contain <for>, got: {result}"
+        );
+    }
 }

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -202,9 +202,9 @@ pub fn generate_f_template(
 /// Convert WebUI Framework template syntax to FAST syntax in HTML content.
 ///
 /// Performs the following transformations without regex:
-/// - `<if condition="EXPR">` → `<f-when value="{EXPR}">`
+/// - `<if condition="EXPR">` → `<f-when value="{{EXPR}}">`
 /// - `</if>` → `</f-when>`
-/// - `<for each="EXPR">` → `<f-repeat value="{EXPR}">`
+/// - `<for each="EXPR">` → `<f-repeat value="{{EXPR}}">`
 /// - `</for>` → `</f-repeat>`
 /// - `{{expr}}` inside `:attr` complex attribute values → `{expr}`
 /// - Strips `shadowrootmode` attributes from `<template>` tags
@@ -317,7 +317,7 @@ fn starts_with_tag_name(s: &str, name: &str) -> bool {
     next == b' ' || next == b'\t' || next == b'\n' || next == b'\r' || next == b'>'
 }
 
-/// Convert `<if condition="EXPR">` to `<f-when value="{EXPR}">`.
+/// Convert `<if condition="EXPR">` to `<f-when value="{{EXPR}}">`.
 /// Returns bytes consumed on success.
 fn convert_if_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find the closing '>'
@@ -327,14 +327,14 @@ fn convert_if_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find condition="..." attribute
     let attr_value = extract_attribute_value(tag_content, "condition")?;
 
-    result.push_str("<f-when value=\"{");
+    result.push_str("<f-when value=\"{{");
     result.push_str(attr_value);
-    result.push_str("}\">");
+    result.push_str("}}\">");
 
     Some(close + 1)
 }
 
-/// Convert `<for each="EXPR">` to `<f-repeat value="{EXPR}">`.
+/// Convert `<for each="EXPR">` to `<f-repeat value="{{EXPR}}">`.
 /// Returns bytes consumed on success.
 fn convert_for_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find the closing '>'
@@ -344,9 +344,9 @@ fn convert_for_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find each="..." attribute
     let attr_value = extract_attribute_value(tag_content, "each")?;
 
-    result.push_str("<f-repeat value=\"{");
+    result.push_str("<f-repeat value=\"{{");
     result.push_str(attr_value);
-    result.push_str("}\">");
+    result.push_str("}}\">");
 
     Some(close + 1)
 }
@@ -933,7 +933,7 @@ mod tests {
         let output = convert_btr_to_fast(input);
         assert_eq!(
             output,
-            r#"<f-when value="{isComplete}"><span>Done</span></f-when>"#
+            r#"<f-when value="{{isComplete}}"><span>Done</span></f-when>"#
         );
     }
 
@@ -943,7 +943,7 @@ mod tests {
         let output = convert_btr_to_fast(input);
         assert_eq!(
             output,
-            r#"<f-repeat value="{tag in tags}"><span>{{tag}}</span></f-repeat>"#
+            r#"<f-repeat value="{{tag in tags}}"><span>{{tag}}</span></f-repeat>"#
         );
     }
 
@@ -953,7 +953,7 @@ mod tests {
         let output = convert_btr_to_fast(input);
         assert_eq!(
             output,
-            r#"<f-when value="{show}"><f-repeat value="{x in items}"><p>{{x}}</p></f-repeat></f-when>"#
+            r#"<f-when value="{{show}}"><f-repeat value="{{x in items}}"><p>{{x}}</p></f-repeat></f-when>"#
         );
     }
 
@@ -1001,7 +1001,7 @@ mod tests {
         let (name, result) = &templates[0];
         assert_eq!(name, "my-widget");
 
-        assert!(result.contains("<f-when value=\"{visible}\">"));
+        assert!(result.contains("<f-when value=\"{{visible}}\">"));
         assert!(result.contains("</f-when>"));
         assert!(!result.contains("<if condition="));
         assert!(!result.contains("</if>"));
@@ -1175,7 +1175,7 @@ mod tests {
         let (_, result) = &templates[0];
 
         assert!(
-            result.contains("<f-repeat value=\"{item in items}\">"),
+            result.contains("<f-repeat value=\"{{item in items}}\">"),
             "f-template should use <f-repeat>, got: {result}"
         );
         assert!(
@@ -1201,11 +1201,11 @@ mod tests {
         let (_, result) = &templates[0];
 
         assert!(
-            result.contains("<f-when value=\"{visible}\">"),
+            result.contains("<f-when value=\"{{visible}}\">"),
             "Shadow f-template should contain <f-when>, got: {result}"
         );
         assert!(
-            result.contains("<f-repeat value=\"{x in list}\">"),
+            result.contains("<f-repeat value=\"{{x in list}}\">"),
             "Shadow f-template should contain <f-repeat>, got: {result}"
         );
         assert!(
@@ -1236,11 +1236,11 @@ mod tests {
         let (_, result) = &templates[0];
 
         assert!(
-            result.contains("<f-when value=\"{show}\">"),
+            result.contains("<f-when value=\"{{show}}\">"),
             "Nested f-template should contain <f-when>, got: {result}"
         );
         assert!(
-            result.contains("<f-repeat value=\"{x in items}\">"),
+            result.contains("<f-repeat value=\"{{x in items}}\">"),
             "Nested f-template should contain <f-repeat>, got: {result}"
         );
         assert!(


### PR DESCRIPTION
## Summary

Fix the FAST parser plugin to emit double curly braces in `<f-when>` and `<f-repeat>` value attributes, matching the FAST-HTML client-side parser expectations.

### Before
```html
<f-when value="{show}">
<f-repeat value="{item in items}">
```

### After
```html
<f-when value="{{show}}">
<f-repeat value="{{item in items}}">
```

## Changes

**`crates/webui-parser/src/plugin/fast.rs`**
- `convert_if_tag`: emit `{{EXPR}}` instead of `{EXPR}` in `<f-when value>`
- `convert_for_tag`: emit `{{EXPR}}` instead of `{EXPR}` in `<f-repeat value>`
- Add regression tests: for-loop conversion, shadow DOM with directive conversion, nested if+for conversion
- Update doc comments to reflect corrected syntax

**`DESIGN.md`**
- Update FastParserPlugin syntax documentation to show double-brace format