### PR TITLE
fix(cli): Add bin/webui stub and postinstall binary copy

### DIFF
--- a/packages/webui/.gitignore
+++ b/packages/webui/.gitignore
@@ -1,1 +1,2 @@
 test/integration.test.js
+!bin/

--- a/packages/webui/bin/webui
+++ b/packages/webui/bin/webui
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "webui: binary not installed. Run 'pnpm build' or reinstall." >&2; exit 1

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,12 +1,26 @@
 {
+  "name": "@microsoft/webui",
+  "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
+  "license": "MIT",
+  "version": "0.0.7",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/webui.git"
+  },
   "bin": {
     "webui": "bin/webui"
   },
-  "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
-  "devDependencies": {
-    "@types/node": "catalog:",
-    "esbuild": "catalog:",
-    "typescript": "catalog:"
+  "files": [
+    "bin/",
+    "dist/",
+    "wasm/"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "postbuild": "node dist/install.js",
+    "postinstall": "node --input-type=module -e \"try{await import('./dist/install.js')}catch{}\"",
+    "test": "tsc --project tsconfig.test.json && node --test dist/test/integration.test.js"
   },
   "engines": {
     "node": ">=18"
@@ -19,13 +33,6 @@
       }
     }
   },
-  "files": [
-    "bin/",
-    "dist/",
-    "wasm/"
-  ],
-  "license": "MIT",
-  "name": "@microsoft/webui",
   "optionalDependencies": {
     "@microsoft/webui-darwin-arm64": "workspace:*",
     "@microsoft/webui-darwin-x64": "workspace:*",
@@ -34,15 +41,8 @@
     "@microsoft/webui-win32-arm64": "workspace:*",
     "@microsoft/webui-win32-x64": "workspace:*"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/webui.git"
-  },
-  "scripts": {
-    "build": "esbuild src/index.ts src/platform.ts src/install.ts --outdir=dist --format=esm --platform=node && tsc --emitDeclarationOnly",
-    "postinstall": "node --input-type=module -e \"try{await import('./dist/install.js')}catch{}\"",
-    "test": "esbuild test/integration.test.ts --outfile=test/integration.test.js --format=esm --platform=node && node --test test/integration.test.js"
-  },
-  "type": "module",
-  "version": "0.0.7"
+   "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
 }

--- a/packages/webui/src/install.ts
+++ b/packages/webui/src/install.ts
@@ -2,13 +2,23 @@
 // Licensed under the MIT license.
 
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { resolve, platformKey, packageName } from "./platform.js";
 
-// Validate that the platform binary exists after install.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const binDir = path.resolve(__dirname, "..", "bin");
+const binName = process.platform === "win32" ? "webui.exe" : "webui";
+const binDest = path.join(binDir, binName);
+
+// Locate the platform binary and copy it into bin/ so the package.json
+// "bin" entry points at a real native executable.
 try {
-  const binPath = resolve("bin");
-  if (binPath && fs.existsSync(binPath)) {
-    // Success — binary is available.
+  const srcBin = resolve("bin");
+  if (srcBin && fs.existsSync(srcBin)) {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.copyFileSync(srcBin, binDest);
+    fs.chmodSync(binDest, 0o755);
     process.exit(0);
   }
 } catch {

--- a/packages/webui/test/integration.test.ts
+++ b/packages/webui/test/integration.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, test, before, after } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { build, render, renderStream, inspect } from '../dist/index.js';
+import { build, render, renderStream, inspect } from '@microsoft/webui';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/webui/tsconfig.test.json
+++ b/packages/webui/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "test",
+    "outDir": "dist/test",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,9 +308,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.3.5
-      esbuild:
-        specifier: 'catalog:'
-        version: 0.27.3
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
The package.json declared "bin": { "webui": "bin/webui" } but no bin/ directory or launcher existed, so pnpm could never create the .bin/webui symlink for consumers.

Changes:
- Add bin/webui as a committed shell stub that prints a helpful error if the native binary hasn't been installed yet. This ensures pnpm can always create bin symlinks without ENOENT warnings.
- Update install.ts (postinstall) to copy the resolved native binary from the platform-specific package (or cargo build fallback) into bin/webui, replacing the stub with the real executable.
- Split build script: "build" runs tsc only, "postbuild" runs install.js to copy the native binary for local development.
- Switch build and test from esbuild to tsc for consistency with webui-framework. Remove esbuild from devDependencies.
- Add tsconfig.test.json for test compilation (outputs to dist/test/).
- Update test import to use self-referencing package name instead of relative path to dist/. exclusion.

Fixes #225 