### PR TITLE
Fix CD pipeline: split stages + git tag-based deployment tracking

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -41,12 +41,14 @@ extends:
       networkIsolationPolicy: Permissive
     stages:
 
-    # ── Download pre-built release artifacts and deploy ──
-    - stage: Package
+    # ── Stage 1: Lightweight version check (runs every hour, ~1-2 min) ──
+    # This stage is separate so that when no deployment is needed, the
+    # heavyweight Package stage (with all its 1ES SDL tasks) is skipped
+    # entirely — avoiding ~30 min of unnecessary agent provisioning and
+    # compliance scans on every hourly no-op run.
+    - stage: Check
       jobs:
-
-      # ── Job 1: Resolve the latest release tag and check registry status ──
-      - job: NeedsDeployment
+      - job: CheckVersion
         steps:
           - checkout: self
             persistCredentials: "true"
@@ -60,8 +62,7 @@ extends:
               downloadPath: '$(System.ArtifactsDirectory)'
 
           # Extract the version number from the downloaded .crate filename,
-          # e.g. microsoft-webui-0.0.3.crate → 0.0.3, and expose it as output
-          # variables for the Deploy job.
+          # e.g. microsoft-webui-0.0.3.crate → 0.0.3
           - script: |
               CRATE_FILE=$(ls "$(System.ArtifactsDirectory)"/microsoft-webui-*.crate 2>/dev/null | head -1)
               if [ -z "$CRATE_FILE" ]; then
@@ -106,12 +107,14 @@ extends:
             displayName: Check if already deployed
             name: deploymentCheck
 
-      # ── Job 2: Download artifacts and deploy (skipped if all already deployed) ──
+    # ── Stage 2: Download artifacts and deploy (entirely skipped if already deployed) ──
+    - stage: Package
+      dependsOn: Check
+      condition: eq(dependencies.Check.outputs['CheckVersion.deploymentCheck.needsDeployment'], 'true')
+      variables:
+        releaseTag: $[ stageDependencies.Check.CheckVersion.outputs['resolveTag.releaseTag'] ]
+      jobs:
       - job: Deploy
-        dependsOn: NeedsDeployment
-        condition: eq(dependencies.NeedsDeployment.outputs['deploymentCheck.needsDeployment'], 'true')
-        variables:
-          releaseTag: $[ dependencies.NeedsDeployment.outputs['resolveTag.releaseTag'] ]
         steps:
           - checkout: self
             persistCredentials: "true"

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -77,51 +77,23 @@ extends:
             displayName: Extract version from downloaded artifacts
             name: resolveTag
 
-          # Check whether this version is already deployed to all registries.
-          # Sets needsDeployment=true if any of npm or crates.io do not yet carry
-          # the version — so a partial deployment still reruns the template.
-          # Uses curl for both checks (no npm CLI dependency) with retries and
-          # timeouts. Fails on network errors to avoid false deployment triggers.
+          # Check whether this version has already been deployed by looking
+          # for a "deployed/vX.Y.Z" git tag. This avoids external network
+          # calls to npm/crates.io which are unreachable from 1ES agents.
+          # The Deploy job pushes this tag after a successful deployment.
           - script: |
               set -euo pipefail
               VERSION="$(releaseVersion)"
-              NEEDS_DEPLOYMENT=false
+              DEPLOY_TAG="deployed/v${VERSION}"
 
-              # Helper: curl with retry and timeout. Returns HTTP status code.
-              # Fails the script if the network is unreachable (HTTP 000).
-              check_registry() {
-                local name="$1" url="$2"
-                local status
-                status=$(curl -s -o /dev/null -w "%{http_code}" \
-                  --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 5 \
-                  -H "User-Agent: webui-cd-pipeline (microsoft/webui)" \
-                  "$url")
-                if [ "$status" = "000" ]; then
-                  echo "##vso[task.logissue type=error]Network error checking ${name} (HTTP 000 — could not connect). Check agent proxy/firewall settings."
-                  exit 1
-                fi
-                echo "$status"
-              }
-
-              # npm (uses the registry HTTP API directly — no npm CLI needed)
-              NPM_STATUS=$(check_registry "npm" "https://registry.npmjs.org/@microsoft%2Fwebui/${VERSION}")
-              if [ "$NPM_STATUS" = "200" ]; then
-                echo "npm @microsoft/webui@${VERSION} already deployed"
+              git fetch --tags --quiet
+              if git tag -l "${DEPLOY_TAG}" | grep -q .; then
+                echo "${DEPLOY_TAG} tag exists — version ${VERSION} already deployed"
+                echo "##vso[task.setvariable variable=needsDeployment;isOutput=true]false"
               else
-                echo "npm @microsoft/webui@${VERSION} not yet deployed (HTTP ${NPM_STATUS})"
-                NEEDS_DEPLOYMENT=true
+                echo "${DEPLOY_TAG} tag not found — version ${VERSION} needs deployment"
+                echo "##vso[task.setvariable variable=needsDeployment;isOutput=true]true"
               fi
-
-              # crates.io
-              CRATE_STATUS=$(check_registry "crates.io" "https://crates.io/api/v1/crates/microsoft-webui/${VERSION}")
-              if [ "$CRATE_STATUS" = "200" ]; then
-                echo "crates.io microsoft-webui ${VERSION} already deployed"
-              else
-                echo "crates.io microsoft-webui ${VERSION} not yet deployed (HTTP ${CRATE_STATUS})"
-                NEEDS_DEPLOYMENT=true
-              fi
-
-              echo "##vso[task.setvariable variable=needsDeployment;isOutput=true]${NEEDS_DEPLOYMENT}"
             displayName: Check if already deployed
             name: deploymentCheck
 
@@ -158,3 +130,14 @@ extends:
             displayName: Separate release artifacts
 
           - template: WebUI.Release.PipelineTemplate.yml@webuiPipelines  # Template reference
+
+          # Mark this version as deployed so future pipeline runs skip it.
+          # Uses the releaseTag stage variable (e.g. "v0.0.8") to create
+          # a "deployed/v0.0.8" tag and push it back to the repo.
+          - script: |
+              set -euo pipefail
+              DEPLOY_TAG="deployed/$(releaseTag)"
+              echo "Tagging successful deployment: ${DEPLOY_TAG}"
+              git tag "${DEPLOY_TAG}"
+              git push origin "${DEPLOY_TAG}"
+            displayName: Tag successful deployment

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -80,22 +80,40 @@ extends:
           # Check whether this version is already deployed to all registries.
           # Sets needsDeployment=true if any of npm or crates.io do not yet carry
           # the version — so a partial deployment still reruns the template.
+          # Uses curl for both checks (no npm CLI dependency) with retries and
+          # timeouts. Fails on network errors to avoid false deployment triggers.
           - script: |
+              set -euo pipefail
               VERSION="$(releaseVersion)"
               NEEDS_DEPLOYMENT=false
 
-              # npm
-              if npm view "@microsoft/webui@${VERSION}" version 2>/dev/null | grep -qxF "${VERSION}"; then
+              # Helper: curl with retry and timeout. Returns HTTP status code.
+              # Fails the script if the network is unreachable (HTTP 000).
+              check_registry() {
+                local name="$1" url="$2"
+                local status
+                status=$(curl -s -o /dev/null -w "%{http_code}" \
+                  --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 5 \
+                  -H "User-Agent: webui-cd-pipeline (microsoft/webui)" \
+                  "$url")
+                if [ "$status" = "000" ]; then
+                  echo "##vso[task.logissue type=error]Network error checking ${name} (HTTP 000 — could not connect). Check agent proxy/firewall settings."
+                  exit 1
+                fi
+                echo "$status"
+              }
+
+              # npm (uses the registry HTTP API directly — no npm CLI needed)
+              NPM_STATUS=$(check_registry "npm" "https://registry.npmjs.org/@microsoft%2Fwebui/${VERSION}")
+              if [ "$NPM_STATUS" = "200" ]; then
                 echo "npm @microsoft/webui@${VERSION} already deployed"
               else
-                echo "npm @microsoft/webui@${VERSION} not yet deployed"
+                echo "npm @microsoft/webui@${VERSION} not yet deployed (HTTP ${NPM_STATUS})"
                 NEEDS_DEPLOYMENT=true
               fi
 
               # crates.io
-              CRATE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-                -H "User-Agent: webui-cd-pipeline (microsoft/webui)" \
-                "https://crates.io/api/v1/crates/microsoft-webui/${VERSION}")
+              CRATE_STATUS=$(check_registry "crates.io" "https://crates.io/api/v1/crates/microsoft-webui/${VERSION}")
               if [ "$CRATE_STATUS" = "200" ]; then
                 echo "crates.io microsoft-webui ${VERSION} already deployed"
               else


### PR DESCRIPTION
## Problem

The hourly CD pipeline took **~30 minutes per run** even when no deployment was needed. Two issues:

1. **1ES SDL overhead on every run** — The pipeline had a single `Package` stage. Even when the `Deploy` job was skipped (version already published), the 1ES Official Pipeline Template still injected and ran all SDL/compliance tasks (CredScan, PoliCheck, BinSkim, Windows source analysis agent) at the stage level.

2. **Registry checks unreachable from 1ES agents** — The npm and crates.io HTTP checks returned `HTTP 000` (connection failure) due to firewall/proxy restrictions, falsely triggering deployments against already-published versions.

## Solution

### 1. Split into two stages

```yaml
# Before: one stage — SDL overhead always runs (~30 min)
- stage: Package
  jobs:
  - job: NeedsDeployment   # ~1 min check
  - job: Deploy             # conditional, often skipped
  # 1ES SDL tasks still execute for the stage

# After: two stages — heavyweight stage skipped entirely when not needed
- stage: Check              # Lightweight version check (~1-2 min)
  jobs:
  - job: CheckVersion

- stage: Package            # Entirely skipped when needsDeployment=false
  dependsOn: Check
  condition: eq(dependencies.Check.outputs[...], 'true')
  jobs:
  - job: Deploy
```

When `Package` is skipped at the stage level, Azure Pipelines does **not** provision agents or run any 1ES-injected SDL tasks.

### 2. Replace registry HTTP checks with git tag tracking

```bash
# Before: unreliable curl to external registries (HTTP 000 on 1ES agents)
curl ... "https://registry.npmjs.org/@microsoft%2Fwebui/${VERSION}"
curl ... "https://crates.io/api/v1/crates/microsoft-webui/${VERSION}"

# After: check for deployed/* git tag (zero external network needed)
git fetch --tags --quiet
if git tag -l "deployed/v${VERSION}" | grep -q .; then
  echo "Already deployed"    # needsDeployment=false
fi
```

After a successful deployment, the pipeline pushes a `deployed/vX.Y.Z` tag:

```bash
git tag "deployed/v${VERSION}"
git push origin "deployed/v${VERSION}"
```

## How it works

1. **Check stage** downloads the latest GitHub release, extracts version from `.crate` filename
2. Checks if `deployed/v0.0.8` tag exists in the repo
3. Tag exists → `needsDeployment=false` → Package stage **entirely skipped**
4. Tag missing → `needsDeployment=true` → Package stage runs deployment
5. After successful deploy → pushes `deployed/v0.0.8` tag

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Hourly no-op run time | ~30 min | ~1-2 min |
| External network dependency | npm + crates.io (broken) | None |
| False deployment triggers | Every run | None |
| Deploy history audit | Check pipeline logs | `git tag -l "deployed/*"` |

## Bootstrap

After merging, push the tag for the current version to prevent a re-deploy:

```bash
git tag deployed/v0.0.8
git push origin deployed/v0.0.8
```