### PR TITLE
feat: add attribute name mapping for ARIA and HTML global attributes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,6 +148,29 @@ pub struct WebUIFragmentAttribute {
 }
 ```
 
+##### ARIA Attribute Name Mapping
+
+Multi-word ARIA attributes use concatenated lowercase after `aria-` (e.g.,
+`aria-describedby`, `aria-activedescendant`), which does not follow standard
+camelCase-to-kebab-case conversion rules. The parser, handler, and framework
+maintain a lookup table mapping between these irregular attribute names and
+their corresponding JavaScript property names (e.g., `ariaDescribedBy`,
+`ariaActiveDescendant`).
+
+This mapping is used in three places:
+
+1. **Handler** (`camel_to_kebab`) - when converting camelCase state keys to
+   HTML attribute names (e.g., `ariaDescribedBy` to `aria-describedby`).
+2. **Handler** (`convert_hyphen_to_camel_case`) - when converting HTML attribute
+   names to camelCase property names for component state lookup.
+3. **Parser** (`kebab_to_camel`) - when converting kebab-case attribute names
+   to camelCase property names for compiled metadata.
+4. **Framework** (`toKebabCase`) - when converting camelCase `@attr` property
+   names to HTML attribute names for reflection.
+
+Single-word ARIA attributes (e.g., `aria-label` to `ariaLabel`) work correctly
+with standard conversion and do not require the lookup table.
+
 #### Plugin Fragment
 Plugin fragments carry opaque data from parser plugins to handler plugins. WebUI does
 not interpret this data — each parser/handler plugin pair defines its own binary contract.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,8 +151,9 @@ pub struct WebUIFragmentAttribute {
 ##### Attribute Name Mapping
 
 Some HTML attributes use concatenated lowercase names that do not follow
-standard camelCase-to-kebab-case conversion rules. The parser, handler,
-and framework maintain a lookup table covering two categories:
+standard camelCase-to-kebab-case conversion rules. The canonical lookup
+table lives in `webui-protocol` (`webui_protocol::attrs`) and covers two
+categories:
 
 1. **Multi-word ARIA attributes** — e.g., `aria-describedby` ↔
    `ariaDescribedBy`, `aria-activedescendant` ↔ `ariaActiveDescendant`,
@@ -160,17 +161,9 @@ and framework maintain a lookup table covering two categories:
 2. **HTML global/element attributes** — e.g., `readonly` ↔ `readOnly`,
    `tabindex` ↔ `tabIndex`, `contenteditable` ↔ `contentEditable`.
 
-This mapping is used in four places:
-
-1. **Handler** (`camel_to_kebab`) — converting camelCase state keys to
-   HTML attribute names (e.g., `readOnly` → `readonly`).
-2. **Handler** (`convert_hyphen_to_camel_case`, `component_attr_name`) —
-   converting HTML attribute names to camelCase property names for
-   component state lookup (e.g., `tabindex` → `tabIndex`).
-3. **Parser** (`kebab_to_camel`) — converting attribute names to camelCase
-   property names for compiled metadata.
-4. **Framework** (`toKebabCase`) — converting camelCase `@attr` property
-   names to HTML attribute names for reflection.
+The handler and parser both call into `webui_protocol::attrs` — there is
+no duplicated table. The framework (`toKebabCase` in `decorators.ts`)
+maintains a TypeScript copy of the same table for client-side use.
 
 Attributes that follow standard conversion (e.g., `aria-label` ↔ `ariaLabel`,
 `data-title` ↔ `dataTitle`) use the generic algorithm and do not require

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,28 +148,33 @@ pub struct WebUIFragmentAttribute {
 }
 ```
 
-##### ARIA Attribute Name Mapping
+##### Attribute Name Mapping
 
-Multi-word ARIA attributes use concatenated lowercase after `aria-` (e.g.,
-`aria-describedby`, `aria-activedescendant`), which does not follow standard
-camelCase-to-kebab-case conversion rules. The parser, handler, and framework
-maintain a lookup table mapping between these irregular attribute names and
-their corresponding JavaScript property names (e.g., `ariaDescribedBy`,
-`ariaActiveDescendant`).
+Some HTML attributes use concatenated lowercase names that do not follow
+standard camelCase-to-kebab-case conversion rules. The parser, handler,
+and framework maintain a lookup table covering two categories:
 
-This mapping is used in three places:
+1. **Multi-word ARIA attributes** — e.g., `aria-describedby` ↔
+   `ariaDescribedBy`, `aria-activedescendant` ↔ `ariaActiveDescendant`,
+   per the [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
+2. **HTML global/element attributes** — e.g., `readonly` ↔ `readOnly`,
+   `tabindex` ↔ `tabIndex`, `contenteditable` ↔ `contentEditable`.
 
-1. **Handler** (`camel_to_kebab`) - when converting camelCase state keys to
-   HTML attribute names (e.g., `ariaDescribedBy` to `aria-describedby`).
-2. **Handler** (`convert_hyphen_to_camel_case`) - when converting HTML attribute
-   names to camelCase property names for component state lookup.
-3. **Parser** (`kebab_to_camel`) - when converting kebab-case attribute names
-   to camelCase property names for compiled metadata.
-4. **Framework** (`toKebabCase`) - when converting camelCase `@attr` property
+This mapping is used in four places:
+
+1. **Handler** (`camel_to_kebab`) — converting camelCase state keys to
+   HTML attribute names (e.g., `readOnly` → `readonly`).
+2. **Handler** (`convert_hyphen_to_camel_case`, `component_attr_name`) —
+   converting HTML attribute names to camelCase property names for
+   component state lookup (e.g., `tabindex` → `tabIndex`).
+3. **Parser** (`kebab_to_camel`) — converting attribute names to camelCase
+   property names for compiled metadata.
+4. **Framework** (`toKebabCase`) — converting camelCase `@attr` property
    names to HTML attribute names for reflection.
 
-Single-word ARIA attributes (e.g., `aria-label` to `ariaLabel`) work correctly
-with standard conversion and do not require the lookup table.
+Attributes that follow standard conversion (e.g., `aria-label` ↔ `ariaLabel`,
+`data-title` ↔ `dataTitle`) use the generic algorithm and do not require
+the lookup table.
 
 #### Plugin Fragment
 Plugin fragments carry opaque data from parser plugins to handler plugins. WebUI does

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -136,14 +136,19 @@ struct WebUIProcessContext<'a> {
     nonce: Option<String>,
 }
 
-/// Map an ARIA camelCase property name to its HTML attribute.
+/// Map a camelCase property name to its HTML attribute.
 ///
-/// Multi-word ARIA attributes use concatenated lowercase after `aria-`
-/// (e.g., `aria-describedby`), which doesn't match standard camelCase-to-kebab
-/// conversion. This table covers every multi-word ARIA attribute in the
-/// [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
-fn aria_property_to_attribute(name: &str) -> Option<&'static str> {
+/// Covers two categories of irregular mappings:
+///
+/// 1. **Multi-word ARIA attributes** — use concatenated lowercase after `aria-`
+///    (e.g., `ariaDescribedBy` → `aria-describedby`), per the
+///    [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
+/// 2. **HTML global/element attributes** — concatenated lowercase attribute names
+///    with camelCase property counterparts (e.g., `readOnly` → `readonly`,
+///    `tabIndex` → `tabindex`).
+fn property_to_attribute(name: &str) -> Option<&'static str> {
     match name {
+        // --- ARIA (ARIAMixin) ---
         "ariaActiveDescendant" => Some("aria-activedescendant"),
         "ariaAutoComplete" => Some("aria-autocomplete"),
         "ariaBrailleLabel" => Some("aria-braillelabel"),
@@ -173,15 +178,40 @@ fn aria_property_to_attribute(name: &str) -> Option<&'static str> {
         "ariaValueMin" => Some("aria-valuemin"),
         "ariaValueNow" => Some("aria-valuenow"),
         "ariaValueText" => Some("aria-valuetext"),
+        // --- HTML global/element attributes ---
+        "accessKey" => Some("accesskey"),
+        "autoCapitalize" => Some("autocapitalize"),
+        "contentEditable" => Some("contenteditable"),
+        "crossOrigin" => Some("crossorigin"),
+        "dirName" => Some("dirname"),
+        "fetchPriority" => Some("fetchpriority"),
+        "formAction" => Some("formaction"),
+        "formEnctype" => Some("formenctype"),
+        "formMethod" => Some("formmethod"),
+        "formNoValidate" => Some("formnovalidate"),
+        "formTarget" => Some("formtarget"),
+        "inputMode" => Some("inputmode"),
+        "isMap" => Some("ismap"),
+        "maxLength" => Some("maxlength"),
+        "minLength" => Some("minlength"),
+        "noModule" => Some("nomodule"),
+        "noValidate" => Some("novalidate"),
+        "readOnly" => Some("readonly"),
+        "referrerPolicy" => Some("referrerpolicy"),
+        "tabIndex" => Some("tabindex"),
+        "useMap" => Some("usemap"),
         _ => None,
     }
 }
 
-/// Map an ARIA HTML attribute to its camelCase property name.
+/// Map an HTML attribute to its camelCase property name.
 ///
-/// Inverse of [`aria_property_to_attribute`].
-fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
+/// Inverse of [`property_to_attribute`]. Covers multi-word ARIA attributes
+/// and HTML global/element attributes whose attribute names are concatenated
+/// lowercase (e.g., `readonly` → `readOnly`, `tabindex` → `tabIndex`).
+fn attribute_to_property(name: &str) -> Option<&'static str> {
     match name {
+        // --- ARIA (ARIAMixin) ---
         "aria-activedescendant" => Some("ariaActiveDescendant"),
         "aria-autocomplete" => Some("ariaAutoComplete"),
         "aria-braillelabel" => Some("ariaBrailleLabel"),
@@ -211,17 +241,38 @@ fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
         "aria-valuemin" => Some("ariaValueMin"),
         "aria-valuenow" => Some("ariaValueNow"),
         "aria-valuetext" => Some("ariaValueText"),
+        // --- HTML global/element attributes ---
+        "accesskey" => Some("accessKey"),
+        "autocapitalize" => Some("autoCapitalize"),
+        "contenteditable" => Some("contentEditable"),
+        "crossorigin" => Some("crossOrigin"),
+        "dirname" => Some("dirName"),
+        "fetchpriority" => Some("fetchPriority"),
+        "formaction" => Some("formAction"),
+        "formenctype" => Some("formEnctype"),
+        "formmethod" => Some("formMethod"),
+        "formnovalidate" => Some("formNoValidate"),
+        "formtarget" => Some("formTarget"),
+        "inputmode" => Some("inputMode"),
+        "ismap" => Some("isMap"),
+        "maxlength" => Some("maxLength"),
+        "minlength" => Some("minLength"),
+        "nomodule" => Some("noModule"),
+        "novalidate" => Some("noValidate"),
+        "readonly" => Some("readOnly"),
+        "referrerpolicy" => Some("referrerPolicy"),
+        "tabindex" => Some("tabIndex"),
+        "usemap" => Some("useMap"),
         _ => None,
     }
 }
 
 /// Convert hyphenated name to camelCase (e.g., "data-title" → "dataTitle").
 ///
-/// Multi-word ARIA attributes are handled via a lookup table so that
-/// `aria-describedby` correctly maps to `ariaDescribedBy` rather than
-/// the naive `ariaDescribedby`.
+/// Irregular attributes (multi-word ARIA and global HTML attributes like
+/// `readonly`, `tabindex`) are handled via a lookup table.
 fn convert_hyphen_to_camel_case(name: &str) -> String {
-    if let Some(prop) = aria_attribute_to_property(name) {
+    if let Some(prop) = attribute_to_property(name) {
         return prop.to_string();
     }
     let mut result = String::with_capacity(name.len());
@@ -241,11 +292,10 @@ fn convert_hyphen_to_camel_case(name: &str) -> String {
 
 /// Convert camelCase to kebab-case (e.g., "totalContacts" → "total-contacts").
 ///
-/// Multi-word ARIA properties are handled via a lookup table so that
-/// `ariaDescribedBy` correctly maps to `aria-describedby` rather than
-/// the naive `aria-described-by`.
+/// Irregular attributes (multi-word ARIA and global HTML attributes like
+/// `readOnly`, `tabIndex`) are handled via a lookup table.
 pub(crate) fn camel_to_kebab(name: &str) -> String {
-    if let Some(attr) = aria_property_to_attribute(name) {
+    if let Some(attr) = property_to_attribute(name) {
         return attr.to_string();
     }
     let mut result = String::with_capacity(name.len() + 4);
@@ -263,8 +313,15 @@ pub(crate) fn camel_to_kebab(name: &str) -> String {
 }
 
 /// Get the component attribute name, stripping `:` prefix and converting to camelCase.
+///
+/// Non-hyphenated attributes (e.g., `readonly`, `tabindex`) are checked against
+/// the lookup table so they map to the correct property name (e.g., `readOnly`,
+/// `tabIndex`).
 fn component_attr_name(name: &str) -> String {
     let stripped = name.strip_prefix(':').unwrap_or(name);
+    if let Some(prop) = attribute_to_property(stripped) {
+        return prop.to_string();
+    }
     if stripped.contains('-') {
         convert_hyphen_to_camel_case(stripped)
     } else {
@@ -6463,6 +6520,47 @@ mod tests {
     }
 
     #[test]
+    fn test_html_global_property_to_attribute() {
+        assert_eq!(camel_to_kebab("readOnly"), "readonly");
+        assert_eq!(camel_to_kebab("tabIndex"), "tabindex");
+        assert_eq!(camel_to_kebab("accessKey"), "accesskey");
+        assert_eq!(camel_to_kebab("contentEditable"), "contenteditable");
+        assert_eq!(camel_to_kebab("crossOrigin"), "crossorigin");
+        assert_eq!(camel_to_kebab("inputMode"), "inputmode");
+        assert_eq!(camel_to_kebab("maxLength"), "maxlength");
+        assert_eq!(camel_to_kebab("minLength"), "minlength");
+        assert_eq!(camel_to_kebab("noValidate"), "novalidate");
+        assert_eq!(camel_to_kebab("formAction"), "formaction");
+        assert_eq!(camel_to_kebab("formEnctype"), "formenctype");
+        assert_eq!(camel_to_kebab("formMethod"), "formmethod");
+        assert_eq!(camel_to_kebab("formNoValidate"), "formnovalidate");
+        assert_eq!(camel_to_kebab("formTarget"), "formtarget");
+        assert_eq!(camel_to_kebab("isMap"), "ismap");
+        assert_eq!(camel_to_kebab("useMap"), "usemap");
+        assert_eq!(camel_to_kebab("noModule"), "nomodule");
+        assert_eq!(camel_to_kebab("autoCapitalize"), "autocapitalize");
+        assert_eq!(camel_to_kebab("dirName"), "dirname");
+        assert_eq!(camel_to_kebab("fetchPriority"), "fetchpriority");
+        assert_eq!(camel_to_kebab("referrerPolicy"), "referrerpolicy");
+    }
+
+    #[test]
+    fn test_html_global_attribute_to_property() {
+        assert_eq!(component_attr_name("readonly"), "readOnly");
+        assert_eq!(component_attr_name("tabindex"), "tabIndex");
+        assert_eq!(component_attr_name("accesskey"), "accessKey");
+        assert_eq!(component_attr_name("contenteditable"), "contentEditable");
+        assert_eq!(component_attr_name("crossorigin"), "crossOrigin");
+        assert_eq!(component_attr_name("inputmode"), "inputMode");
+        assert_eq!(component_attr_name("maxlength"), "maxLength");
+        assert_eq!(component_attr_name("minlength"), "minLength");
+        assert_eq!(component_attr_name("novalidate"), "noValidate");
+        assert_eq!(component_attr_name("formaction"), "formAction");
+        assert_eq!(component_attr_name("ismap"), "isMap");
+        assert_eq!(component_attr_name("usemap"), "useMap");
+    }
+
+    #[test]
     fn test_aria_roundtrip() {
         // Property → attribute → property must be a no-op
         let props = [
@@ -6477,6 +6575,25 @@ mod tests {
         for prop in props {
             let attr = camel_to_kebab(prop);
             let back = convert_hyphen_to_camel_case(&attr);
+            assert_eq!(back, prop, "roundtrip failed for {prop}");
+        }
+    }
+
+    #[test]
+    fn test_html_global_roundtrip() {
+        let props = [
+            "readOnly",
+            "tabIndex",
+            "accessKey",
+            "contentEditable",
+            "maxLength",
+            "inputMode",
+            "formAction",
+            "crossOrigin",
+        ];
+        for prop in props {
+            let attr = camel_to_kebab(prop);
+            let back = component_attr_name(&attr);
             assert_eq!(back, prop, "roundtrip failed for {prop}");
         }
     }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -136,8 +136,94 @@ struct WebUIProcessContext<'a> {
     nonce: Option<String>,
 }
 
+/// Map an ARIA camelCase property name to its HTML attribute.
+///
+/// Multi-word ARIA attributes use concatenated lowercase after `aria-`
+/// (e.g., `aria-describedby`), which doesn't match standard camelCase-to-kebab
+/// conversion. This table covers every multi-word ARIA attribute in the
+/// [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
+fn aria_property_to_attribute(name: &str) -> Option<&'static str> {
+    match name {
+        "ariaActiveDescendant" => Some("aria-activedescendant"),
+        "ariaAutoComplete" => Some("aria-autocomplete"),
+        "ariaBrailleLabel" => Some("aria-braillelabel"),
+        "ariaBrailleRoleDescription" => Some("aria-brailleroledescription"),
+        "ariaColCount" => Some("aria-colcount"),
+        "ariaColIndex" => Some("aria-colindex"),
+        "ariaColIndexText" => Some("aria-colindextext"),
+        "ariaColSpan" => Some("aria-colspan"),
+        "ariaDescribedBy" => Some("aria-describedby"),
+        "ariaDropEffect" => Some("aria-dropeffect"),
+        "ariaErrorMessage" => Some("aria-errormessage"),
+        "ariaFlowTo" => Some("aria-flowto"),
+        "ariaHasPopup" => Some("aria-haspopup"),
+        "ariaKeyShortcuts" => Some("aria-keyshortcuts"),
+        "ariaLabelledBy" => Some("aria-labelledby"),
+        "ariaMultiLine" => Some("aria-multiline"),
+        "ariaMultiSelectable" => Some("aria-multiselectable"),
+        "ariaPosInSet" => Some("aria-posinset"),
+        "ariaReadOnly" => Some("aria-readonly"),
+        "ariaRoleDescription" => Some("aria-roledescription"),
+        "ariaRowCount" => Some("aria-rowcount"),
+        "ariaRowIndex" => Some("aria-rowindex"),
+        "ariaRowIndexText" => Some("aria-rowindextext"),
+        "ariaRowSpan" => Some("aria-rowspan"),
+        "ariaSetSize" => Some("aria-setsize"),
+        "ariaValueMax" => Some("aria-valuemax"),
+        "ariaValueMin" => Some("aria-valuemin"),
+        "ariaValueNow" => Some("aria-valuenow"),
+        "ariaValueText" => Some("aria-valuetext"),
+        _ => None,
+    }
+}
+
+/// Map an ARIA HTML attribute to its camelCase property name.
+///
+/// Inverse of [`aria_property_to_attribute`].
+fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
+    match name {
+        "aria-activedescendant" => Some("ariaActiveDescendant"),
+        "aria-autocomplete" => Some("ariaAutoComplete"),
+        "aria-braillelabel" => Some("ariaBrailleLabel"),
+        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
+        "aria-colcount" => Some("ariaColCount"),
+        "aria-colindex" => Some("ariaColIndex"),
+        "aria-colindextext" => Some("ariaColIndexText"),
+        "aria-colspan" => Some("ariaColSpan"),
+        "aria-describedby" => Some("ariaDescribedBy"),
+        "aria-dropeffect" => Some("ariaDropEffect"),
+        "aria-errormessage" => Some("ariaErrorMessage"),
+        "aria-flowto" => Some("ariaFlowTo"),
+        "aria-haspopup" => Some("ariaHasPopup"),
+        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
+        "aria-labelledby" => Some("ariaLabelledBy"),
+        "aria-multiline" => Some("ariaMultiLine"),
+        "aria-multiselectable" => Some("ariaMultiSelectable"),
+        "aria-posinset" => Some("ariaPosInSet"),
+        "aria-readonly" => Some("ariaReadOnly"),
+        "aria-roledescription" => Some("ariaRoleDescription"),
+        "aria-rowcount" => Some("ariaRowCount"),
+        "aria-rowindex" => Some("ariaRowIndex"),
+        "aria-rowindextext" => Some("ariaRowIndexText"),
+        "aria-rowspan" => Some("ariaRowSpan"),
+        "aria-setsize" => Some("ariaSetSize"),
+        "aria-valuemax" => Some("ariaValueMax"),
+        "aria-valuemin" => Some("ariaValueMin"),
+        "aria-valuenow" => Some("ariaValueNow"),
+        "aria-valuetext" => Some("ariaValueText"),
+        _ => None,
+    }
+}
+
 /// Convert hyphenated name to camelCase (e.g., "data-title" → "dataTitle").
+///
+/// Multi-word ARIA attributes are handled via a lookup table so that
+/// `aria-describedby` correctly maps to `ariaDescribedBy` rather than
+/// the naive `ariaDescribedby`.
 fn convert_hyphen_to_camel_case(name: &str) -> String {
+    if let Some(prop) = aria_attribute_to_property(name) {
+        return prop.to_string();
+    }
     let mut result = String::with_capacity(name.len());
     let mut capitalize_next = false;
     for ch in name.chars() {
@@ -154,7 +240,14 @@ fn convert_hyphen_to_camel_case(name: &str) -> String {
 }
 
 /// Convert camelCase to kebab-case (e.g., "totalContacts" → "total-contacts").
-fn camel_to_kebab(name: &str) -> String {
+///
+/// Multi-word ARIA properties are handled via a lookup table so that
+/// `ariaDescribedBy` correctly maps to `aria-describedby` rather than
+/// the naive `aria-described-by`.
+pub(crate) fn camel_to_kebab(name: &str) -> String {
+    if let Some(attr) = aria_property_to_attribute(name) {
+        return attr.to_string();
+    }
     let mut result = String::with_capacity(name.len() + 4);
     for ch in name.chars() {
         if ch.is_uppercase() && !result.is_empty() {
@@ -6278,5 +6371,113 @@ mod tests {
             html.contains("w['cart-panel']"),
             "rendered cart-panel template should be emitted: {html}"
         );
+    }
+
+    #[test]
+    fn test_aria_property_to_attribute() {
+        // Multi-word ARIA attributes must use the lookup table
+        assert_eq!(camel_to_kebab("ariaDescribedBy"), "aria-describedby");
+        assert_eq!(camel_to_kebab("ariaLabelledBy"), "aria-labelledby");
+        assert_eq!(
+            camel_to_kebab("ariaActiveDescendant"),
+            "aria-activedescendant"
+        );
+        assert_eq!(camel_to_kebab("ariaAutoComplete"), "aria-autocomplete");
+        assert_eq!(camel_to_kebab("ariaColCount"), "aria-colcount");
+        assert_eq!(camel_to_kebab("ariaColIndex"), "aria-colindex");
+        assert_eq!(camel_to_kebab("ariaColIndexText"), "aria-colindextext");
+        assert_eq!(camel_to_kebab("ariaColSpan"), "aria-colspan");
+        assert_eq!(camel_to_kebab("ariaDropEffect"), "aria-dropeffect");
+        assert_eq!(camel_to_kebab("ariaErrorMessage"), "aria-errormessage");
+        assert_eq!(camel_to_kebab("ariaFlowTo"), "aria-flowto");
+        assert_eq!(camel_to_kebab("ariaHasPopup"), "aria-haspopup");
+        assert_eq!(camel_to_kebab("ariaKeyShortcuts"), "aria-keyshortcuts");
+        assert_eq!(camel_to_kebab("ariaMultiLine"), "aria-multiline");
+        assert_eq!(
+            camel_to_kebab("ariaMultiSelectable"),
+            "aria-multiselectable"
+        );
+        assert_eq!(camel_to_kebab("ariaPosInSet"), "aria-posinset");
+        assert_eq!(camel_to_kebab("ariaReadOnly"), "aria-readonly");
+        assert_eq!(
+            camel_to_kebab("ariaRoleDescription"),
+            "aria-roledescription"
+        );
+        assert_eq!(camel_to_kebab("ariaRowCount"), "aria-rowcount");
+        assert_eq!(camel_to_kebab("ariaRowIndex"), "aria-rowindex");
+        assert_eq!(camel_to_kebab("ariaRowIndexText"), "aria-rowindextext");
+        assert_eq!(camel_to_kebab("ariaRowSpan"), "aria-rowspan");
+        assert_eq!(camel_to_kebab("ariaSetSize"), "aria-setsize");
+        assert_eq!(camel_to_kebab("ariaValueMax"), "aria-valuemax");
+        assert_eq!(camel_to_kebab("ariaValueMin"), "aria-valuemin");
+        assert_eq!(camel_to_kebab("ariaValueNow"), "aria-valuenow");
+        assert_eq!(camel_to_kebab("ariaValueText"), "aria-valuetext");
+        assert_eq!(camel_to_kebab("ariaBrailleLabel"), "aria-braillelabel");
+        assert_eq!(
+            camel_to_kebab("ariaBrailleRoleDescription"),
+            "aria-brailleroledescription"
+        );
+    }
+
+    #[test]
+    fn test_aria_attribute_to_property() {
+        // Multi-word ARIA attributes must use the lookup table
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-describedby"),
+            "ariaDescribedBy"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-labelledby"),
+            "ariaLabelledBy"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-activedescendant"),
+            "ariaActiveDescendant"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-autocomplete"),
+            "ariaAutoComplete"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-errormessage"),
+            "ariaErrorMessage"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-roledescription"),
+            "ariaRoleDescription"
+        );
+        assert_eq!(
+            convert_hyphen_to_camel_case("aria-valuetext"),
+            "ariaValueText"
+        );
+    }
+
+    #[test]
+    fn test_aria_single_word_attrs_use_fallback() {
+        // Single-word ARIA attributes work correctly via naive conversion
+        assert_eq!(camel_to_kebab("ariaLabel"), "aria-label");
+        assert_eq!(camel_to_kebab("ariaHidden"), "aria-hidden");
+        assert_eq!(camel_to_kebab("ariaDisabled"), "aria-disabled");
+        assert_eq!(convert_hyphen_to_camel_case("aria-label"), "ariaLabel");
+        assert_eq!(convert_hyphen_to_camel_case("aria-hidden"), "ariaHidden");
+    }
+
+    #[test]
+    fn test_aria_roundtrip() {
+        // Property → attribute → property must be a no-op
+        let props = [
+            "ariaDescribedBy",
+            "ariaLabelledBy",
+            "ariaActiveDescendant",
+            "ariaAutoComplete",
+            "ariaColCount",
+            "ariaPosInSet",
+            "ariaValueText",
+        ];
+        for prop in props {
+            let attr = camel_to_kebab(prop);
+            let back = convert_hyphen_to_camel_case(&attr);
+            assert_eq!(back, prop, "roundtrip failed for {prop}");
+        }
     }
 }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -136,68 +136,14 @@ struct WebUIProcessContext<'a> {
     nonce: Option<String>,
 }
 
-/// Convert hyphenated name to camelCase (e.g., "data-title" → "dataTitle").
-///
-/// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readonly`, `tabindex`) are handled via the shared lookup table in
-/// `webui_protocol::attrs`.
-fn convert_hyphen_to_camel_case(name: &str) -> String {
-    if let Some(prop) = webui_protocol::attrs::attribute_to_property(name) {
-        return prop.to_string();
-    }
-    let mut result = String::with_capacity(name.len());
-    let mut capitalize_next = false;
-    for ch in name.chars() {
-        if ch == '-' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.extend(ch.to_uppercase());
-            capitalize_next = false;
-        } else {
-            result.push(ch);
-        }
-    }
-    result
-}
-
-/// Convert camelCase to kebab-case (e.g., "totalContacts" → "total-contacts").
-///
-/// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readOnly`, `tabIndex`) are handled via the shared lookup table in
-/// `webui_protocol::attrs`.
-pub(crate) fn camel_to_kebab(name: &str) -> String {
-    if let Some(attr) = webui_protocol::attrs::property_to_attribute(name) {
-        return attr.to_string();
-    }
-    let mut result = String::with_capacity(name.len() + 4);
-    for ch in name.chars() {
-        if ch.is_uppercase() && !result.is_empty() {
-            result.push('-');
-            for lc in ch.to_lowercase() {
-                result.push(lc);
-            }
-        } else {
-            result.push(ch);
-        }
-    }
-    result
-}
-
 /// Get the component attribute name, stripping `:` prefix and converting to camelCase.
 ///
-/// Non-hyphenated attributes (e.g., `readonly`, `tabindex`) are checked against
-/// the shared lookup table so they map to the correct property name (e.g.,
-/// `readOnly`, `tabIndex`).
+/// Uses `webui_protocol::attrs::attribute_to_camel` which handles irregular
+/// attributes (multi-word ARIA and global HTML attributes like `readonly`,
+/// `tabindex`) via the shared lookup table.
 fn component_attr_name(name: &str) -> String {
     let stripped = name.strip_prefix(':').unwrap_or(name);
-    if let Some(prop) = webui_protocol::attrs::attribute_to_property(stripped) {
-        return prop.to_string();
-    }
-    if stripped.contains('-') {
-        convert_hyphen_to_camel_case(stripped)
-    } else {
-        stripped.to_string()
-    }
+    webui_protocol::attrs::attribute_to_camel(stripped)
 }
 
 impl WebUIHandler {
@@ -6302,121 +6248,20 @@ mod tests {
     }
 
     #[test]
-    fn test_aria_property_to_attribute() {
-        // Multi-word ARIA attributes must use the lookup table
-        assert_eq!(camel_to_kebab("ariaDescribedBy"), "aria-describedby");
-        assert_eq!(camel_to_kebab("ariaLabelledBy"), "aria-labelledby");
+    fn test_component_attr_name_aria() {
+        // component_attr_name correctly maps ARIA attributes via the shared table
+        assert_eq!(component_attr_name("aria-describedby"), "ariaDescribedBy");
+        assert_eq!(component_attr_name("aria-labelledby"), "ariaLabelledBy");
         assert_eq!(
-            camel_to_kebab("ariaActiveDescendant"),
-            "aria-activedescendant"
-        );
-        assert_eq!(camel_to_kebab("ariaAutoComplete"), "aria-autocomplete");
-        assert_eq!(camel_to_kebab("ariaColCount"), "aria-colcount");
-        assert_eq!(camel_to_kebab("ariaColIndex"), "aria-colindex");
-        assert_eq!(camel_to_kebab("ariaColIndexText"), "aria-colindextext");
-        assert_eq!(camel_to_kebab("ariaColSpan"), "aria-colspan");
-        assert_eq!(camel_to_kebab("ariaDropEffect"), "aria-dropeffect");
-        assert_eq!(camel_to_kebab("ariaErrorMessage"), "aria-errormessage");
-        assert_eq!(camel_to_kebab("ariaFlowTo"), "aria-flowto");
-        assert_eq!(camel_to_kebab("ariaHasPopup"), "aria-haspopup");
-        assert_eq!(camel_to_kebab("ariaKeyShortcuts"), "aria-keyshortcuts");
-        assert_eq!(camel_to_kebab("ariaMultiLine"), "aria-multiline");
-        assert_eq!(
-            camel_to_kebab("ariaMultiSelectable"),
-            "aria-multiselectable"
-        );
-        assert_eq!(camel_to_kebab("ariaPosInSet"), "aria-posinset");
-        assert_eq!(camel_to_kebab("ariaReadOnly"), "aria-readonly");
-        assert_eq!(
-            camel_to_kebab("ariaRoleDescription"),
-            "aria-roledescription"
-        );
-        assert_eq!(camel_to_kebab("ariaRowCount"), "aria-rowcount");
-        assert_eq!(camel_to_kebab("ariaRowIndex"), "aria-rowindex");
-        assert_eq!(camel_to_kebab("ariaRowIndexText"), "aria-rowindextext");
-        assert_eq!(camel_to_kebab("ariaRowSpan"), "aria-rowspan");
-        assert_eq!(camel_to_kebab("ariaSetSize"), "aria-setsize");
-        assert_eq!(camel_to_kebab("ariaValueMax"), "aria-valuemax");
-        assert_eq!(camel_to_kebab("ariaValueMin"), "aria-valuemin");
-        assert_eq!(camel_to_kebab("ariaValueNow"), "aria-valuenow");
-        assert_eq!(camel_to_kebab("ariaValueText"), "aria-valuetext");
-        assert_eq!(camel_to_kebab("ariaBrailleLabel"), "aria-braillelabel");
-        assert_eq!(
-            camel_to_kebab("ariaBrailleRoleDescription"),
-            "aria-brailleroledescription"
-        );
-    }
-
-    #[test]
-    fn test_aria_attribute_to_property() {
-        // Multi-word ARIA attributes must use the lookup table
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-describedby"),
-            "ariaDescribedBy"
-        );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-labelledby"),
-            "ariaLabelledBy"
-        );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-activedescendant"),
+            component_attr_name("aria-activedescendant"),
             "ariaActiveDescendant"
         );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-autocomplete"),
-            "ariaAutoComplete"
-        );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-errormessage"),
-            "ariaErrorMessage"
-        );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-roledescription"),
-            "ariaRoleDescription"
-        );
-        assert_eq!(
-            convert_hyphen_to_camel_case("aria-valuetext"),
-            "ariaValueText"
-        );
+        assert_eq!(component_attr_name("aria-label"), "ariaLabel");
+        assert_eq!(component_attr_name("aria-hidden"), "ariaHidden");
     }
 
     #[test]
-    fn test_aria_single_word_attrs_use_fallback() {
-        // Single-word ARIA attributes work correctly via naive conversion
-        assert_eq!(camel_to_kebab("ariaLabel"), "aria-label");
-        assert_eq!(camel_to_kebab("ariaHidden"), "aria-hidden");
-        assert_eq!(camel_to_kebab("ariaDisabled"), "aria-disabled");
-        assert_eq!(convert_hyphen_to_camel_case("aria-label"), "ariaLabel");
-        assert_eq!(convert_hyphen_to_camel_case("aria-hidden"), "ariaHidden");
-    }
-
-    #[test]
-    fn test_html_global_property_to_attribute() {
-        assert_eq!(camel_to_kebab("readOnly"), "readonly");
-        assert_eq!(camel_to_kebab("tabIndex"), "tabindex");
-        assert_eq!(camel_to_kebab("accessKey"), "accesskey");
-        assert_eq!(camel_to_kebab("contentEditable"), "contenteditable");
-        assert_eq!(camel_to_kebab("crossOrigin"), "crossorigin");
-        assert_eq!(camel_to_kebab("inputMode"), "inputmode");
-        assert_eq!(camel_to_kebab("maxLength"), "maxlength");
-        assert_eq!(camel_to_kebab("minLength"), "minlength");
-        assert_eq!(camel_to_kebab("noValidate"), "novalidate");
-        assert_eq!(camel_to_kebab("formAction"), "formaction");
-        assert_eq!(camel_to_kebab("formEnctype"), "formenctype");
-        assert_eq!(camel_to_kebab("formMethod"), "formmethod");
-        assert_eq!(camel_to_kebab("formNoValidate"), "formnovalidate");
-        assert_eq!(camel_to_kebab("formTarget"), "formtarget");
-        assert_eq!(camel_to_kebab("isMap"), "ismap");
-        assert_eq!(camel_to_kebab("useMap"), "usemap");
-        assert_eq!(camel_to_kebab("noModule"), "nomodule");
-        assert_eq!(camel_to_kebab("autoCapitalize"), "autocapitalize");
-        assert_eq!(camel_to_kebab("dirName"), "dirname");
-        assert_eq!(camel_to_kebab("fetchPriority"), "fetchpriority");
-        assert_eq!(camel_to_kebab("referrerPolicy"), "referrerpolicy");
-    }
-
-    #[test]
-    fn test_html_global_attribute_to_property() {
+    fn test_component_attr_name_html_global() {
         assert_eq!(component_attr_name("readonly"), "readOnly");
         assert_eq!(component_attr_name("tabindex"), "tabIndex");
         assert_eq!(component_attr_name("accesskey"), "accessKey");
@@ -6432,40 +6277,16 @@ mod tests {
     }
 
     #[test]
-    fn test_aria_roundtrip() {
-        // Property → attribute → property must be a no-op
-        let props = [
-            "ariaDescribedBy",
-            "ariaLabelledBy",
-            "ariaActiveDescendant",
-            "ariaAutoComplete",
-            "ariaColCount",
-            "ariaPosInSet",
-            "ariaValueText",
-        ];
-        for prop in props {
-            let attr = camel_to_kebab(prop);
-            let back = convert_hyphen_to_camel_case(&attr);
-            assert_eq!(back, prop, "roundtrip failed for {prop}");
-        }
+    fn test_component_attr_name_strips_colon() {
+        assert_eq!(component_attr_name(":readonly"), "readOnly");
+        assert_eq!(component_attr_name(":aria-describedby"), "ariaDescribedBy");
+        assert_eq!(component_attr_name(":data-title"), "dataTitle");
     }
 
     #[test]
-    fn test_html_global_roundtrip() {
-        let props = [
-            "readOnly",
-            "tabIndex",
-            "accessKey",
-            "contentEditable",
-            "maxLength",
-            "inputMode",
-            "formAction",
-            "crossOrigin",
-        ];
-        for prop in props {
-            let attr = camel_to_kebab(prop);
-            let back = component_attr_name(&attr);
-            assert_eq!(back, prop, "roundtrip failed for {prop}");
-        }
+    fn test_component_attr_name_regular() {
+        assert_eq!(component_attr_name("data-title"), "dataTitle");
+        assert_eq!(component_attr_name("key-hyphen"), "keyHyphen");
+        assert_eq!(component_attr_name("simple"), "simple");
     }
 }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -136,143 +136,13 @@ struct WebUIProcessContext<'a> {
     nonce: Option<String>,
 }
 
-/// Map a camelCase property name to its HTML attribute.
-///
-/// Covers two categories of irregular mappings:
-///
-/// 1. **Multi-word ARIA attributes** — use concatenated lowercase after `aria-`
-///    (e.g., `ariaDescribedBy` → `aria-describedby`), per the
-///    [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
-/// 2. **HTML global/element attributes** — concatenated lowercase attribute names
-///    with camelCase property counterparts (e.g., `readOnly` → `readonly`,
-///    `tabIndex` → `tabindex`).
-fn property_to_attribute(name: &str) -> Option<&'static str> {
-    match name {
-        // --- ARIA (ARIAMixin) ---
-        "ariaActiveDescendant" => Some("aria-activedescendant"),
-        "ariaAutoComplete" => Some("aria-autocomplete"),
-        "ariaBrailleLabel" => Some("aria-braillelabel"),
-        "ariaBrailleRoleDescription" => Some("aria-brailleroledescription"),
-        "ariaColCount" => Some("aria-colcount"),
-        "ariaColIndex" => Some("aria-colindex"),
-        "ariaColIndexText" => Some("aria-colindextext"),
-        "ariaColSpan" => Some("aria-colspan"),
-        "ariaDescribedBy" => Some("aria-describedby"),
-        "ariaDropEffect" => Some("aria-dropeffect"),
-        "ariaErrorMessage" => Some("aria-errormessage"),
-        "ariaFlowTo" => Some("aria-flowto"),
-        "ariaHasPopup" => Some("aria-haspopup"),
-        "ariaKeyShortcuts" => Some("aria-keyshortcuts"),
-        "ariaLabelledBy" => Some("aria-labelledby"),
-        "ariaMultiLine" => Some("aria-multiline"),
-        "ariaMultiSelectable" => Some("aria-multiselectable"),
-        "ariaPosInSet" => Some("aria-posinset"),
-        "ariaReadOnly" => Some("aria-readonly"),
-        "ariaRoleDescription" => Some("aria-roledescription"),
-        "ariaRowCount" => Some("aria-rowcount"),
-        "ariaRowIndex" => Some("aria-rowindex"),
-        "ariaRowIndexText" => Some("aria-rowindextext"),
-        "ariaRowSpan" => Some("aria-rowspan"),
-        "ariaSetSize" => Some("aria-setsize"),
-        "ariaValueMax" => Some("aria-valuemax"),
-        "ariaValueMin" => Some("aria-valuemin"),
-        "ariaValueNow" => Some("aria-valuenow"),
-        "ariaValueText" => Some("aria-valuetext"),
-        // --- HTML global/element attributes ---
-        "accessKey" => Some("accesskey"),
-        "autoCapitalize" => Some("autocapitalize"),
-        "contentEditable" => Some("contenteditable"),
-        "crossOrigin" => Some("crossorigin"),
-        "dirName" => Some("dirname"),
-        "fetchPriority" => Some("fetchpriority"),
-        "formAction" => Some("formaction"),
-        "formEnctype" => Some("formenctype"),
-        "formMethod" => Some("formmethod"),
-        "formNoValidate" => Some("formnovalidate"),
-        "formTarget" => Some("formtarget"),
-        "inputMode" => Some("inputmode"),
-        "isMap" => Some("ismap"),
-        "maxLength" => Some("maxlength"),
-        "minLength" => Some("minlength"),
-        "noModule" => Some("nomodule"),
-        "noValidate" => Some("novalidate"),
-        "readOnly" => Some("readonly"),
-        "referrerPolicy" => Some("referrerpolicy"),
-        "tabIndex" => Some("tabindex"),
-        "useMap" => Some("usemap"),
-        _ => None,
-    }
-}
-
-/// Map an HTML attribute to its camelCase property name.
-///
-/// Inverse of [`property_to_attribute`]. Covers multi-word ARIA attributes
-/// and HTML global/element attributes whose attribute names are concatenated
-/// lowercase (e.g., `readonly` → `readOnly`, `tabindex` → `tabIndex`).
-fn attribute_to_property(name: &str) -> Option<&'static str> {
-    match name {
-        // --- ARIA (ARIAMixin) ---
-        "aria-activedescendant" => Some("ariaActiveDescendant"),
-        "aria-autocomplete" => Some("ariaAutoComplete"),
-        "aria-braillelabel" => Some("ariaBrailleLabel"),
-        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
-        "aria-colcount" => Some("ariaColCount"),
-        "aria-colindex" => Some("ariaColIndex"),
-        "aria-colindextext" => Some("ariaColIndexText"),
-        "aria-colspan" => Some("ariaColSpan"),
-        "aria-describedby" => Some("ariaDescribedBy"),
-        "aria-dropeffect" => Some("ariaDropEffect"),
-        "aria-errormessage" => Some("ariaErrorMessage"),
-        "aria-flowto" => Some("ariaFlowTo"),
-        "aria-haspopup" => Some("ariaHasPopup"),
-        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
-        "aria-labelledby" => Some("ariaLabelledBy"),
-        "aria-multiline" => Some("ariaMultiLine"),
-        "aria-multiselectable" => Some("ariaMultiSelectable"),
-        "aria-posinset" => Some("ariaPosInSet"),
-        "aria-readonly" => Some("ariaReadOnly"),
-        "aria-roledescription" => Some("ariaRoleDescription"),
-        "aria-rowcount" => Some("ariaRowCount"),
-        "aria-rowindex" => Some("ariaRowIndex"),
-        "aria-rowindextext" => Some("ariaRowIndexText"),
-        "aria-rowspan" => Some("ariaRowSpan"),
-        "aria-setsize" => Some("ariaSetSize"),
-        "aria-valuemax" => Some("ariaValueMax"),
-        "aria-valuemin" => Some("ariaValueMin"),
-        "aria-valuenow" => Some("ariaValueNow"),
-        "aria-valuetext" => Some("ariaValueText"),
-        // --- HTML global/element attributes ---
-        "accesskey" => Some("accessKey"),
-        "autocapitalize" => Some("autoCapitalize"),
-        "contenteditable" => Some("contentEditable"),
-        "crossorigin" => Some("crossOrigin"),
-        "dirname" => Some("dirName"),
-        "fetchpriority" => Some("fetchPriority"),
-        "formaction" => Some("formAction"),
-        "formenctype" => Some("formEnctype"),
-        "formmethod" => Some("formMethod"),
-        "formnovalidate" => Some("formNoValidate"),
-        "formtarget" => Some("formTarget"),
-        "inputmode" => Some("inputMode"),
-        "ismap" => Some("isMap"),
-        "maxlength" => Some("maxLength"),
-        "minlength" => Some("minLength"),
-        "nomodule" => Some("noModule"),
-        "novalidate" => Some("noValidate"),
-        "readonly" => Some("readOnly"),
-        "referrerpolicy" => Some("referrerPolicy"),
-        "tabindex" => Some("tabIndex"),
-        "usemap" => Some("useMap"),
-        _ => None,
-    }
-}
-
 /// Convert hyphenated name to camelCase (e.g., "data-title" → "dataTitle").
 ///
 /// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readonly`, `tabindex`) are handled via a lookup table.
+/// `readonly`, `tabindex`) are handled via the shared lookup table in
+/// `webui_protocol::attrs`.
 fn convert_hyphen_to_camel_case(name: &str) -> String {
-    if let Some(prop) = attribute_to_property(name) {
+    if let Some(prop) = webui_protocol::attrs::attribute_to_property(name) {
         return prop.to_string();
     }
     let mut result = String::with_capacity(name.len());
@@ -293,9 +163,10 @@ fn convert_hyphen_to_camel_case(name: &str) -> String {
 /// Convert camelCase to kebab-case (e.g., "totalContacts" → "total-contacts").
 ///
 /// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readOnly`, `tabIndex`) are handled via a lookup table.
+/// `readOnly`, `tabIndex`) are handled via the shared lookup table in
+/// `webui_protocol::attrs`.
 pub(crate) fn camel_to_kebab(name: &str) -> String {
-    if let Some(attr) = property_to_attribute(name) {
+    if let Some(attr) = webui_protocol::attrs::property_to_attribute(name) {
         return attr.to_string();
     }
     let mut result = String::with_capacity(name.len() + 4);
@@ -315,11 +186,11 @@ pub(crate) fn camel_to_kebab(name: &str) -> String {
 /// Get the component attribute name, stripping `:` prefix and converting to camelCase.
 ///
 /// Non-hyphenated attributes (e.g., `readonly`, `tabindex`) are checked against
-/// the lookup table so they map to the correct property name (e.g., `readOnly`,
-/// `tabIndex`).
+/// the shared lookup table so they map to the correct property name (e.g.,
+/// `readOnly`, `tabIndex`).
 fn component_attr_name(name: &str) -> String {
     let stripped = name.strip_prefix(':').unwrap_or(name);
-    if let Some(prop) = attribute_to_property(stripped) {
+    if let Some(prop) = webui_protocol::attrs::attribute_to_property(stripped) {
         return prop.to_string();
     }
     if stripped.contains('-') {

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -218,7 +218,7 @@ impl HandlerPlugin for FastHydrationPlugin {
                 Value::Bool(false) => std::borrow::Cow::Borrowed("false"),
                 _ => continue,
             };
-            let attr_name = crate::camel_to_kebab(key);
+            let attr_name = webui_protocol::attrs::camel_to_kebab(key);
             writer.write(" ")?;
             writer.write(&attr_name)?;
             writer.write("=\"")?;

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -402,7 +402,14 @@ fn generate_compiled_template_with_root_source(
 
 /// Emit a JS string literal with script-safe escaping.
 /// Convert a kebab-case string to camelCase. `"my-prop"` → `"myProp"`.
+///
+/// Multi-word ARIA attributes are handled via a lookup table so that
+/// `aria-describedby` correctly maps to `ariaDescribedBy` rather than
+/// the naive `ariaDescribedby`.
 fn kebab_to_camel(s: &str) -> String {
+    if let Some(prop) = aria_attribute_to_property(s) {
+        return prop.to_string();
+    }
     let mut result = String::with_capacity(s.len());
     let mut capitalize = false;
     for ch in s.chars() {
@@ -416,6 +423,46 @@ fn kebab_to_camel(s: &str) -> String {
         }
     }
     result
+}
+
+/// Map an ARIA HTML attribute to its camelCase property name.
+///
+/// Multi-word ARIA attributes use concatenated lowercase after `aria-`
+/// (e.g., `aria-describedby` → `ariaDescribedBy`), which doesn't match
+/// standard kebab-to-camel conversion.
+fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
+    match name {
+        "aria-activedescendant" => Some("ariaActiveDescendant"),
+        "aria-autocomplete" => Some("ariaAutoComplete"),
+        "aria-braillelabel" => Some("ariaBrailleLabel"),
+        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
+        "aria-colcount" => Some("ariaColCount"),
+        "aria-colindex" => Some("ariaColIndex"),
+        "aria-colindextext" => Some("ariaColIndexText"),
+        "aria-colspan" => Some("ariaColSpan"),
+        "aria-describedby" => Some("ariaDescribedBy"),
+        "aria-dropeffect" => Some("ariaDropEffect"),
+        "aria-errormessage" => Some("ariaErrorMessage"),
+        "aria-flowto" => Some("ariaFlowTo"),
+        "aria-haspopup" => Some("ariaHasPopup"),
+        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
+        "aria-labelledby" => Some("ariaLabelledBy"),
+        "aria-multiline" => Some("ariaMultiLine"),
+        "aria-multiselectable" => Some("ariaMultiSelectable"),
+        "aria-posinset" => Some("ariaPosInSet"),
+        "aria-readonly" => Some("ariaReadOnly"),
+        "aria-roledescription" => Some("ariaRoleDescription"),
+        "aria-rowcount" => Some("ariaRowCount"),
+        "aria-rowindex" => Some("ariaRowIndex"),
+        "aria-rowindextext" => Some("ariaRowIndexText"),
+        "aria-rowspan" => Some("ariaRowSpan"),
+        "aria-setsize" => Some("ariaSetSize"),
+        "aria-valuemax" => Some("ariaValueMax"),
+        "aria-valuemin" => Some("ariaValueMin"),
+        "aria-valuenow" => Some("ariaValueNow"),
+        "aria-valuetext" => Some("ariaValueText"),
+        _ => None,
+    }
 }
 
 fn emit_js_string(s: &str, out: &mut String) {
@@ -2949,5 +2996,35 @@ mod tests {
     #[test]
     fn test_parse_event_handler_empty_value() {
         assert!(matches!(parse_event_handler("{}"), EventHandler::Empty));
+    }
+
+    #[test]
+    fn test_aria_kebab_to_camel() {
+        // Multi-word ARIA attributes must use the lookup table
+        assert_eq!(kebab_to_camel("aria-describedby"), "ariaDescribedBy");
+        assert_eq!(kebab_to_camel("aria-labelledby"), "ariaLabelledBy");
+        assert_eq!(
+            kebab_to_camel("aria-activedescendant"),
+            "ariaActiveDescendant"
+        );
+        assert_eq!(kebab_to_camel("aria-autocomplete"), "ariaAutoComplete");
+        assert_eq!(kebab_to_camel("aria-errormessage"), "ariaErrorMessage");
+        assert_eq!(
+            kebab_to_camel("aria-roledescription"),
+            "ariaRoleDescription"
+        );
+        assert_eq!(kebab_to_camel("aria-valuetext"), "ariaValueText");
+        assert_eq!(kebab_to_camel("aria-posinset"), "ariaPosInSet");
+        assert_eq!(kebab_to_camel("aria-colspan"), "ariaColSpan");
+        assert_eq!(kebab_to_camel("aria-haspopup"), "ariaHasPopup");
+        assert_eq!(kebab_to_camel("aria-keyshortcuts"), "ariaKeyShortcuts");
+    }
+
+    #[test]
+    fn test_aria_single_word_fallback() {
+        // Single-word ARIA attributes work correctly via naive conversion
+        assert_eq!(kebab_to_camel("aria-label"), "ariaLabel");
+        assert_eq!(kebab_to_camel("aria-hidden"), "ariaHidden");
+        assert_eq!(kebab_to_camel("aria-disabled"), "ariaDisabled");
     }
 }

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -404,9 +404,10 @@ fn generate_compiled_template_with_root_source(
 /// Convert a kebab-case string to camelCase. `"my-prop"` → `"myProp"`.
 ///
 /// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readonly`, `tabindex`) are handled via a lookup table.
+/// `readonly`, `tabindex`) are handled via the shared lookup table in
+/// `webui_protocol::attrs`.
 fn kebab_to_camel(s: &str) -> String {
-    if let Some(prop) = attribute_to_property(s) {
+    if let Some(prop) = webui_protocol::attrs::attribute_to_property(s) {
         return prop.to_string();
     }
     let mut result = String::with_capacity(s.len());
@@ -422,72 +423,6 @@ fn kebab_to_camel(s: &str) -> String {
         }
     }
     result
-}
-
-/// Map an HTML attribute to its camelCase property name.
-///
-/// Covers two categories of irregular mappings:
-///
-/// 1. **Multi-word ARIA attributes** — concatenated lowercase after `aria-`
-///    (e.g., `aria-describedby` → `ariaDescribedBy`).
-/// 2. **HTML global/element attributes** — concatenated lowercase attribute names
-///    with camelCase property counterparts (e.g., `readonly` → `readOnly`).
-fn attribute_to_property(name: &str) -> Option<&'static str> {
-    match name {
-        // --- ARIA (ARIAMixin) ---
-        "aria-activedescendant" => Some("ariaActiveDescendant"),
-        "aria-autocomplete" => Some("ariaAutoComplete"),
-        "aria-braillelabel" => Some("ariaBrailleLabel"),
-        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
-        "aria-colcount" => Some("ariaColCount"),
-        "aria-colindex" => Some("ariaColIndex"),
-        "aria-colindextext" => Some("ariaColIndexText"),
-        "aria-colspan" => Some("ariaColSpan"),
-        "aria-describedby" => Some("ariaDescribedBy"),
-        "aria-dropeffect" => Some("ariaDropEffect"),
-        "aria-errormessage" => Some("ariaErrorMessage"),
-        "aria-flowto" => Some("ariaFlowTo"),
-        "aria-haspopup" => Some("ariaHasPopup"),
-        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
-        "aria-labelledby" => Some("ariaLabelledBy"),
-        "aria-multiline" => Some("ariaMultiLine"),
-        "aria-multiselectable" => Some("ariaMultiSelectable"),
-        "aria-posinset" => Some("ariaPosInSet"),
-        "aria-readonly" => Some("ariaReadOnly"),
-        "aria-roledescription" => Some("ariaRoleDescription"),
-        "aria-rowcount" => Some("ariaRowCount"),
-        "aria-rowindex" => Some("ariaRowIndex"),
-        "aria-rowindextext" => Some("ariaRowIndexText"),
-        "aria-rowspan" => Some("ariaRowSpan"),
-        "aria-setsize" => Some("ariaSetSize"),
-        "aria-valuemax" => Some("ariaValueMax"),
-        "aria-valuemin" => Some("ariaValueMin"),
-        "aria-valuenow" => Some("ariaValueNow"),
-        "aria-valuetext" => Some("ariaValueText"),
-        // --- HTML global/element attributes ---
-        "accesskey" => Some("accessKey"),
-        "autocapitalize" => Some("autoCapitalize"),
-        "contenteditable" => Some("contentEditable"),
-        "crossorigin" => Some("crossOrigin"),
-        "dirname" => Some("dirName"),
-        "fetchpriority" => Some("fetchPriority"),
-        "formaction" => Some("formAction"),
-        "formenctype" => Some("formEnctype"),
-        "formmethod" => Some("formMethod"),
-        "formnovalidate" => Some("formNoValidate"),
-        "formtarget" => Some("formTarget"),
-        "inputmode" => Some("inputMode"),
-        "ismap" => Some("isMap"),
-        "maxlength" => Some("maxLength"),
-        "minlength" => Some("minLength"),
-        "nomodule" => Some("noModule"),
-        "novalidate" => Some("noValidate"),
-        "readonly" => Some("readOnly"),
-        "referrerpolicy" => Some("referrerPolicy"),
-        "tabindex" => Some("tabIndex"),
-        "usemap" => Some("useMap"),
-        _ => None,
-    }
 }
 
 fn emit_js_string(s: &str, out: &mut String) {

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -403,11 +403,10 @@ fn generate_compiled_template_with_root_source(
 /// Emit a JS string literal with script-safe escaping.
 /// Convert a kebab-case string to camelCase. `"my-prop"` → `"myProp"`.
 ///
-/// Multi-word ARIA attributes are handled via a lookup table so that
-/// `aria-describedby` correctly maps to `ariaDescribedBy` rather than
-/// the naive `ariaDescribedby`.
+/// Irregular attributes (multi-word ARIA and global HTML attributes like
+/// `readonly`, `tabindex`) are handled via a lookup table.
 fn kebab_to_camel(s: &str) -> String {
-    if let Some(prop) = aria_attribute_to_property(s) {
+    if let Some(prop) = attribute_to_property(s) {
         return prop.to_string();
     }
     let mut result = String::with_capacity(s.len());
@@ -425,13 +424,17 @@ fn kebab_to_camel(s: &str) -> String {
     result
 }
 
-/// Map an ARIA HTML attribute to its camelCase property name.
+/// Map an HTML attribute to its camelCase property name.
 ///
-/// Multi-word ARIA attributes use concatenated lowercase after `aria-`
-/// (e.g., `aria-describedby` → `ariaDescribedBy`), which doesn't match
-/// standard kebab-to-camel conversion.
-fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
+/// Covers two categories of irregular mappings:
+///
+/// 1. **Multi-word ARIA attributes** — concatenated lowercase after `aria-`
+///    (e.g., `aria-describedby` → `ariaDescribedBy`).
+/// 2. **HTML global/element attributes** — concatenated lowercase attribute names
+///    with camelCase property counterparts (e.g., `readonly` → `readOnly`).
+fn attribute_to_property(name: &str) -> Option<&'static str> {
     match name {
+        // --- ARIA (ARIAMixin) ---
         "aria-activedescendant" => Some("ariaActiveDescendant"),
         "aria-autocomplete" => Some("ariaAutoComplete"),
         "aria-braillelabel" => Some("ariaBrailleLabel"),
@@ -461,6 +464,28 @@ fn aria_attribute_to_property(name: &str) -> Option<&'static str> {
         "aria-valuemin" => Some("ariaValueMin"),
         "aria-valuenow" => Some("ariaValueNow"),
         "aria-valuetext" => Some("ariaValueText"),
+        // --- HTML global/element attributes ---
+        "accesskey" => Some("accessKey"),
+        "autocapitalize" => Some("autoCapitalize"),
+        "contenteditable" => Some("contentEditable"),
+        "crossorigin" => Some("crossOrigin"),
+        "dirname" => Some("dirName"),
+        "fetchpriority" => Some("fetchPriority"),
+        "formaction" => Some("formAction"),
+        "formenctype" => Some("formEnctype"),
+        "formmethod" => Some("formMethod"),
+        "formnovalidate" => Some("formNoValidate"),
+        "formtarget" => Some("formTarget"),
+        "inputmode" => Some("inputMode"),
+        "ismap" => Some("isMap"),
+        "maxlength" => Some("maxLength"),
+        "minlength" => Some("minLength"),
+        "nomodule" => Some("noModule"),
+        "novalidate" => Some("noValidate"),
+        "readonly" => Some("readOnly"),
+        "referrerpolicy" => Some("referrerPolicy"),
+        "tabindex" => Some("tabIndex"),
+        "usemap" => Some("useMap"),
         _ => None,
     }
 }
@@ -3026,5 +3051,19 @@ mod tests {
         assert_eq!(kebab_to_camel("aria-label"), "ariaLabel");
         assert_eq!(kebab_to_camel("aria-hidden"), "ariaHidden");
         assert_eq!(kebab_to_camel("aria-disabled"), "ariaDisabled");
+    }
+
+    #[test]
+    fn test_html_global_attribute_to_property() {
+        assert_eq!(kebab_to_camel("readonly"), "readOnly");
+        assert_eq!(kebab_to_camel("tabindex"), "tabIndex");
+        assert_eq!(kebab_to_camel("accesskey"), "accessKey");
+        assert_eq!(kebab_to_camel("contenteditable"), "contentEditable");
+        assert_eq!(kebab_to_camel("crossorigin"), "crossOrigin");
+        assert_eq!(kebab_to_camel("inputmode"), "inputMode");
+        assert_eq!(kebab_to_camel("maxlength"), "maxLength");
+        assert_eq!(kebab_to_camel("minlength"), "minLength");
+        assert_eq!(kebab_to_camel("novalidate"), "noValidate");
+        assert_eq!(kebab_to_camel("formaction"), "formAction");
     }
 }

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -400,31 +400,6 @@ fn generate_compiled_template_with_root_source(
     out
 }
 
-/// Emit a JS string literal with script-safe escaping.
-/// Convert a kebab-case string to camelCase. `"my-prop"` → `"myProp"`.
-///
-/// Irregular attributes (multi-word ARIA and global HTML attributes like
-/// `readonly`, `tabindex`) are handled via the shared lookup table in
-/// `webui_protocol::attrs`.
-fn kebab_to_camel(s: &str) -> String {
-    if let Some(prop) = webui_protocol::attrs::attribute_to_property(s) {
-        return prop.to_string();
-    }
-    let mut result = String::with_capacity(s.len());
-    let mut capitalize = false;
-    for ch in s.chars() {
-        if ch == '-' {
-            capitalize = true;
-        } else if capitalize {
-            result.push(ch.to_ascii_uppercase());
-            capitalize = false;
-        } else {
-            result.push(ch);
-        }
-    }
-    result
-}
-
 fn emit_js_string(s: &str, out: &mut String) {
     out.push('"');
     let mut index = 0usize;
@@ -1918,7 +1893,9 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
             if let Some(raw_value) = value.and_then(extract_single_handlebars) {
                 // Strip the ':' prefix and convert to camelCase for the JS property name.
                 // The runtime uses el[name] = value directly — no conversion needed.
-                let prop_name = kebab_to_camel(name.strip_prefix(':').unwrap_or(name));
+                let prop_name = webui_protocol::attrs::attribute_to_camel(
+                    name.strip_prefix(':').unwrap_or(name),
+                );
                 meta.attr_bindings.push(CompiledAttrBinding::Complex {
                     name: prop_name,
                     value: raw_value,
@@ -2959,46 +2936,27 @@ mod tests {
     }
 
     #[test]
-    fn test_aria_kebab_to_camel() {
-        // Multi-word ARIA attributes must use the lookup table
-        assert_eq!(kebab_to_camel("aria-describedby"), "ariaDescribedBy");
-        assert_eq!(kebab_to_camel("aria-labelledby"), "ariaLabelledBy");
+    fn test_attribute_to_camel_aria() {
+        use webui_protocol::attrs::attribute_to_camel;
+        assert_eq!(attribute_to_camel("aria-describedby"), "ariaDescribedBy");
+        assert_eq!(attribute_to_camel("aria-labelledby"), "ariaLabelledBy");
         assert_eq!(
-            kebab_to_camel("aria-activedescendant"),
+            attribute_to_camel("aria-activedescendant"),
             "ariaActiveDescendant"
         );
-        assert_eq!(kebab_to_camel("aria-autocomplete"), "ariaAutoComplete");
-        assert_eq!(kebab_to_camel("aria-errormessage"), "ariaErrorMessage");
-        assert_eq!(
-            kebab_to_camel("aria-roledescription"),
-            "ariaRoleDescription"
-        );
-        assert_eq!(kebab_to_camel("aria-valuetext"), "ariaValueText");
-        assert_eq!(kebab_to_camel("aria-posinset"), "ariaPosInSet");
-        assert_eq!(kebab_to_camel("aria-colspan"), "ariaColSpan");
-        assert_eq!(kebab_to_camel("aria-haspopup"), "ariaHasPopup");
-        assert_eq!(kebab_to_camel("aria-keyshortcuts"), "ariaKeyShortcuts");
+        assert_eq!(attribute_to_camel("aria-label"), "ariaLabel");
+        assert_eq!(attribute_to_camel("aria-hidden"), "ariaHidden");
     }
 
     #[test]
-    fn test_aria_single_word_fallback() {
-        // Single-word ARIA attributes work correctly via naive conversion
-        assert_eq!(kebab_to_camel("aria-label"), "ariaLabel");
-        assert_eq!(kebab_to_camel("aria-hidden"), "ariaHidden");
-        assert_eq!(kebab_to_camel("aria-disabled"), "ariaDisabled");
-    }
-
-    #[test]
-    fn test_html_global_attribute_to_property() {
-        assert_eq!(kebab_to_camel("readonly"), "readOnly");
-        assert_eq!(kebab_to_camel("tabindex"), "tabIndex");
-        assert_eq!(kebab_to_camel("accesskey"), "accessKey");
-        assert_eq!(kebab_to_camel("contenteditable"), "contentEditable");
-        assert_eq!(kebab_to_camel("crossorigin"), "crossOrigin");
-        assert_eq!(kebab_to_camel("inputmode"), "inputMode");
-        assert_eq!(kebab_to_camel("maxlength"), "maxLength");
-        assert_eq!(kebab_to_camel("minlength"), "minLength");
-        assert_eq!(kebab_to_camel("novalidate"), "noValidate");
-        assert_eq!(kebab_to_camel("formaction"), "formAction");
+    fn test_attribute_to_camel_html_global() {
+        use webui_protocol::attrs::attribute_to_camel;
+        assert_eq!(attribute_to_camel("readonly"), "readOnly");
+        assert_eq!(attribute_to_camel("tabindex"), "tabIndex");
+        assert_eq!(attribute_to_camel("accesskey"), "accessKey");
+        assert_eq!(attribute_to_camel("contenteditable"), "contentEditable");
+        assert_eq!(attribute_to_camel("inputmode"), "inputMode");
+        assert_eq!(attribute_to_camel("maxlength"), "maxLength");
+        assert_eq!(attribute_to_camel("formaction"), "formAction");
     }
 }

--- a/crates/webui-protocol/src/attrs.rs
+++ b/crates/webui-protocol/src/attrs.rs
@@ -138,6 +138,71 @@ pub fn attribute_to_property(name: &str) -> Option<&'static str> {
     }
 }
 
+/// Convert a camelCase property name to its HTML attribute name.
+///
+/// Checks the irregular attribute lookup table first, then falls back to
+/// generic camelCase → kebab-case conversion (inserting `-` before each
+/// uppercase letter).
+///
+/// # Examples
+/// ```
+/// # use webui_protocol::attrs::camel_to_kebab;
+/// assert_eq!(camel_to_kebab("ariaDescribedBy"), "aria-describedby");
+/// assert_eq!(camel_to_kebab("readOnly"), "readonly");
+/// assert_eq!(camel_to_kebab("totalContacts"), "total-contacts");
+/// ```
+#[must_use]
+pub fn camel_to_kebab(name: &str) -> String {
+    if let Some(attr) = property_to_attribute(name) {
+        return attr.to_string();
+    }
+    let mut result = String::with_capacity(name.len() + 4);
+    for ch in name.chars() {
+        if ch.is_uppercase() && !result.is_empty() {
+            result.push('-');
+            for lc in ch.to_lowercase() {
+                result.push(lc);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+/// Convert an HTML attribute name to its camelCase property name.
+///
+/// Checks the irregular attribute lookup table first, then falls back to
+/// generic kebab-case → camelCase conversion (removing `-` and capitalizing
+/// the following character).
+///
+/// # Examples
+/// ```
+/// # use webui_protocol::attrs::attribute_to_camel;
+/// assert_eq!(attribute_to_camel("aria-describedby"), "ariaDescribedBy");
+/// assert_eq!(attribute_to_camel("readonly"), "readOnly");
+/// assert_eq!(attribute_to_camel("data-title"), "dataTitle");
+/// ```
+#[must_use]
+pub fn attribute_to_camel(name: &str) -> String {
+    if let Some(prop) = attribute_to_property(name) {
+        return prop.to_string();
+    }
+    let mut result = String::with_capacity(name.len());
+    let mut capitalize_next = false;
+    for ch in name.chars() {
+        if ch == '-' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.extend(ch.to_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,6 +331,53 @@ mod tests {
             let attr = property_to_attribute(prop).unwrap();
             let back = attribute_to_property(attr).unwrap();
             assert_eq!(back, prop, "roundtrip failed for {prop}");
+        }
+    }
+
+    #[test]
+    fn camel_to_kebab_irregular() {
+        assert_eq!(camel_to_kebab("ariaDescribedBy"), "aria-describedby");
+        assert_eq!(camel_to_kebab("ariaLabelledBy"), "aria-labelledby");
+        assert_eq!(camel_to_kebab("readOnly"), "readonly");
+        assert_eq!(camel_to_kebab("tabIndex"), "tabindex");
+        assert_eq!(camel_to_kebab("contentEditable"), "contenteditable");
+    }
+
+    #[test]
+    fn camel_to_kebab_regular() {
+        assert_eq!(camel_to_kebab("ariaLabel"), "aria-label");
+        assert_eq!(camel_to_kebab("totalContacts"), "total-contacts");
+        assert_eq!(camel_to_kebab("dataTitle"), "data-title");
+    }
+
+    #[test]
+    fn attribute_to_camel_irregular() {
+        assert_eq!(attribute_to_camel("aria-describedby"), "ariaDescribedBy");
+        assert_eq!(attribute_to_camel("readonly"), "readOnly");
+        assert_eq!(attribute_to_camel("tabindex"), "tabIndex");
+        assert_eq!(attribute_to_camel("contenteditable"), "contentEditable");
+    }
+
+    #[test]
+    fn attribute_to_camel_regular() {
+        assert_eq!(attribute_to_camel("aria-label"), "ariaLabel");
+        assert_eq!(attribute_to_camel("data-title"), "dataTitle");
+    }
+
+    #[test]
+    fn conversion_roundtrip() {
+        let props = [
+            "ariaDescribedBy",
+            "readOnly",
+            "tabIndex",
+            "ariaLabel",
+            "dataTitle",
+            "totalContacts",
+        ];
+        for prop in props {
+            let attr = camel_to_kebab(prop);
+            let back = attribute_to_camel(&attr);
+            assert_eq!(back, prop, "conversion roundtrip failed for {prop}");
         }
     }
 }

--- a/crates/webui-protocol/src/attrs.rs
+++ b/crates/webui-protocol/src/attrs.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Attribute-name ↔ property-name mapping for irregular HTML attributes.
+//!
+//! Some HTML attributes use concatenated lowercase names that do not follow
+//! standard camelCase-to-kebab-case conversion rules. This module provides
+//! lookup tables covering two categories:
+//!
+//! 1. **Multi-word ARIA attributes** — e.g., `aria-describedby` ↔
+//!    `ariaDescribedBy`, per the [ARIAMixin] specification.
+//! 2. **HTML global/element attributes** — e.g., `readonly` ↔ `readOnly`,
+//!    `tabindex` ↔ `tabIndex`.
+//!
+//! [ARIAMixin]: https://w3c.github.io/aria/#ARIAMixin
+
+/// Map a camelCase property name to its HTML attribute.
+///
+/// Returns `None` for names that follow standard camelCase ↔ kebab conversion.
+#[must_use]
+pub fn property_to_attribute(name: &str) -> Option<&'static str> {
+    match name {
+        // --- ARIA (ARIAMixin) ---
+        "ariaActiveDescendant" => Some("aria-activedescendant"),
+        "ariaAutoComplete" => Some("aria-autocomplete"),
+        "ariaBrailleLabel" => Some("aria-braillelabel"),
+        "ariaBrailleRoleDescription" => Some("aria-brailleroledescription"),
+        "ariaColCount" => Some("aria-colcount"),
+        "ariaColIndex" => Some("aria-colindex"),
+        "ariaColIndexText" => Some("aria-colindextext"),
+        "ariaColSpan" => Some("aria-colspan"),
+        "ariaDescribedBy" => Some("aria-describedby"),
+        "ariaDropEffect" => Some("aria-dropeffect"),
+        "ariaErrorMessage" => Some("aria-errormessage"),
+        "ariaFlowTo" => Some("aria-flowto"),
+        "ariaHasPopup" => Some("aria-haspopup"),
+        "ariaKeyShortcuts" => Some("aria-keyshortcuts"),
+        "ariaLabelledBy" => Some("aria-labelledby"),
+        "ariaMultiLine" => Some("aria-multiline"),
+        "ariaMultiSelectable" => Some("aria-multiselectable"),
+        "ariaPosInSet" => Some("aria-posinset"),
+        "ariaReadOnly" => Some("aria-readonly"),
+        "ariaRoleDescription" => Some("aria-roledescription"),
+        "ariaRowCount" => Some("aria-rowcount"),
+        "ariaRowIndex" => Some("aria-rowindex"),
+        "ariaRowIndexText" => Some("aria-rowindextext"),
+        "ariaRowSpan" => Some("aria-rowspan"),
+        "ariaSetSize" => Some("aria-setsize"),
+        "ariaValueMax" => Some("aria-valuemax"),
+        "ariaValueMin" => Some("aria-valuemin"),
+        "ariaValueNow" => Some("aria-valuenow"),
+        "ariaValueText" => Some("aria-valuetext"),
+        // --- HTML global/element attributes ---
+        "accessKey" => Some("accesskey"),
+        "autoCapitalize" => Some("autocapitalize"),
+        "contentEditable" => Some("contenteditable"),
+        "crossOrigin" => Some("crossorigin"),
+        "dirName" => Some("dirname"),
+        "fetchPriority" => Some("fetchpriority"),
+        "formAction" => Some("formaction"),
+        "formEnctype" => Some("formenctype"),
+        "formMethod" => Some("formmethod"),
+        "formNoValidate" => Some("formnovalidate"),
+        "formTarget" => Some("formtarget"),
+        "inputMode" => Some("inputmode"),
+        "isMap" => Some("ismap"),
+        "maxLength" => Some("maxlength"),
+        "minLength" => Some("minlength"),
+        "noModule" => Some("nomodule"),
+        "noValidate" => Some("novalidate"),
+        "readOnly" => Some("readonly"),
+        "referrerPolicy" => Some("referrerpolicy"),
+        "tabIndex" => Some("tabindex"),
+        "useMap" => Some("usemap"),
+        _ => None,
+    }
+}
+
+/// Map an HTML attribute to its camelCase property name.
+///
+/// Inverse of [`property_to_attribute`].
+#[must_use]
+pub fn attribute_to_property(name: &str) -> Option<&'static str> {
+    match name {
+        // --- ARIA (ARIAMixin) ---
+        "aria-activedescendant" => Some("ariaActiveDescendant"),
+        "aria-autocomplete" => Some("ariaAutoComplete"),
+        "aria-braillelabel" => Some("ariaBrailleLabel"),
+        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
+        "aria-colcount" => Some("ariaColCount"),
+        "aria-colindex" => Some("ariaColIndex"),
+        "aria-colindextext" => Some("ariaColIndexText"),
+        "aria-colspan" => Some("ariaColSpan"),
+        "aria-describedby" => Some("ariaDescribedBy"),
+        "aria-dropeffect" => Some("ariaDropEffect"),
+        "aria-errormessage" => Some("ariaErrorMessage"),
+        "aria-flowto" => Some("ariaFlowTo"),
+        "aria-haspopup" => Some("ariaHasPopup"),
+        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
+        "aria-labelledby" => Some("ariaLabelledBy"),
+        "aria-multiline" => Some("ariaMultiLine"),
+        "aria-multiselectable" => Some("ariaMultiSelectable"),
+        "aria-posinset" => Some("ariaPosInSet"),
+        "aria-readonly" => Some("ariaReadOnly"),
+        "aria-roledescription" => Some("ariaRoleDescription"),
+        "aria-rowcount" => Some("ariaRowCount"),
+        "aria-rowindex" => Some("ariaRowIndex"),
+        "aria-rowindextext" => Some("ariaRowIndexText"),
+        "aria-rowspan" => Some("ariaRowSpan"),
+        "aria-setsize" => Some("ariaSetSize"),
+        "aria-valuemax" => Some("ariaValueMax"),
+        "aria-valuemin" => Some("ariaValueMin"),
+        "aria-valuenow" => Some("ariaValueNow"),
+        "aria-valuetext" => Some("ariaValueText"),
+        // --- HTML global/element attributes ---
+        "accesskey" => Some("accessKey"),
+        "autocapitalize" => Some("autoCapitalize"),
+        "contenteditable" => Some("contentEditable"),
+        "crossorigin" => Some("crossOrigin"),
+        "dirname" => Some("dirName"),
+        "fetchpriority" => Some("fetchPriority"),
+        "formaction" => Some("formAction"),
+        "formenctype" => Some("formEnctype"),
+        "formmethod" => Some("formMethod"),
+        "formnovalidate" => Some("formNoValidate"),
+        "formtarget" => Some("formTarget"),
+        "inputmode" => Some("inputMode"),
+        "ismap" => Some("isMap"),
+        "maxlength" => Some("maxLength"),
+        "minlength" => Some("minLength"),
+        "nomodule" => Some("noModule"),
+        "novalidate" => Some("noValidate"),
+        "readonly" => Some("readOnly"),
+        "referrerpolicy" => Some("referrerPolicy"),
+        "tabindex" => Some("tabIndex"),
+        "usemap" => Some("useMap"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aria_property_to_attribute() {
+        assert_eq!(
+            property_to_attribute("ariaDescribedBy"),
+            Some("aria-describedby")
+        );
+        assert_eq!(
+            property_to_attribute("ariaLabelledBy"),
+            Some("aria-labelledby")
+        );
+        assert_eq!(
+            property_to_attribute("ariaActiveDescendant"),
+            Some("aria-activedescendant")
+        );
+        assert_eq!(
+            property_to_attribute("ariaAutoComplete"),
+            Some("aria-autocomplete")
+        );
+        assert_eq!(property_to_attribute("ariaColCount"), Some("aria-colcount"));
+        assert_eq!(property_to_attribute("ariaColSpan"), Some("aria-colspan"));
+        assert_eq!(
+            property_to_attribute("ariaErrorMessage"),
+            Some("aria-errormessage")
+        );
+        assert_eq!(property_to_attribute("ariaHasPopup"), Some("aria-haspopup"));
+        assert_eq!(property_to_attribute("ariaPosInSet"), Some("aria-posinset"));
+        assert_eq!(
+            property_to_attribute("ariaValueText"),
+            Some("aria-valuetext")
+        );
+        assert_eq!(
+            property_to_attribute("ariaBrailleRoleDescription"),
+            Some("aria-brailleroledescription")
+        );
+    }
+
+    #[test]
+    fn aria_attribute_to_property() {
+        assert_eq!(
+            attribute_to_property("aria-describedby"),
+            Some("ariaDescribedBy")
+        );
+        assert_eq!(
+            attribute_to_property("aria-labelledby"),
+            Some("ariaLabelledBy")
+        );
+        assert_eq!(
+            attribute_to_property("aria-activedescendant"),
+            Some("ariaActiveDescendant")
+        );
+        assert_eq!(
+            attribute_to_property("aria-valuetext"),
+            Some("ariaValueText")
+        );
+        assert_eq!(
+            attribute_to_property("aria-roledescription"),
+            Some("ariaRoleDescription")
+        );
+    }
+
+    #[test]
+    fn html_global_property_to_attribute() {
+        assert_eq!(property_to_attribute("readOnly"), Some("readonly"));
+        assert_eq!(property_to_attribute("tabIndex"), Some("tabindex"));
+        assert_eq!(property_to_attribute("accessKey"), Some("accesskey"));
+        assert_eq!(
+            property_to_attribute("contentEditable"),
+            Some("contenteditable")
+        );
+        assert_eq!(property_to_attribute("crossOrigin"), Some("crossorigin"));
+        assert_eq!(property_to_attribute("inputMode"), Some("inputmode"));
+        assert_eq!(property_to_attribute("maxLength"), Some("maxlength"));
+        assert_eq!(property_to_attribute("formAction"), Some("formaction"));
+        assert_eq!(property_to_attribute("noValidate"), Some("novalidate"));
+        assert_eq!(
+            property_to_attribute("referrerPolicy"),
+            Some("referrerpolicy")
+        );
+    }
+
+    #[test]
+    fn html_global_attribute_to_property() {
+        assert_eq!(attribute_to_property("readonly"), Some("readOnly"));
+        assert_eq!(attribute_to_property("tabindex"), Some("tabIndex"));
+        assert_eq!(attribute_to_property("accesskey"), Some("accessKey"));
+        assert_eq!(
+            attribute_to_property("contenteditable"),
+            Some("contentEditable")
+        );
+        assert_eq!(attribute_to_property("maxlength"), Some("maxLength"));
+        assert_eq!(attribute_to_property("formaction"), Some("formAction"));
+    }
+
+    #[test]
+    fn single_word_attrs_return_none() {
+        assert_eq!(property_to_attribute("ariaLabel"), None);
+        assert_eq!(property_to_attribute("ariaHidden"), None);
+        assert_eq!(attribute_to_property("aria-label"), None);
+        assert_eq!(attribute_to_property("aria-hidden"), None);
+    }
+
+    #[test]
+    fn non_aria_non_global_returns_none() {
+        assert_eq!(property_to_attribute("myProp"), None);
+        assert_eq!(attribute_to_property("my-prop"), None);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let props = [
+            "ariaDescribedBy",
+            "ariaLabelledBy",
+            "ariaActiveDescendant",
+            "ariaValueText",
+            "readOnly",
+            "tabIndex",
+            "contentEditable",
+            "maxLength",
+            "formAction",
+        ];
+        for prop in props {
+            let attr = property_to_attribute(prop).unwrap();
+            let back = attribute_to_property(attr).unwrap();
+            assert_eq!(back, prop, "roundtrip failed for {prop}");
+        }
+    }
+}

--- a/crates/webui-protocol/src/attrs.rs
+++ b/crates/webui-protocol/src/attrs.rs
@@ -12,130 +12,101 @@
 //! 2. **HTML global/element attributes** — e.g., `readonly` ↔ `readOnly`,
 //!    `tabindex` ↔ `tabIndex`.
 //!
+//! Both directions are generated from a single list via
+//! [`define_attr_property_mappings!`] so they cannot drift.
+//!
 //! [ARIAMixin]: https://w3c.github.io/aria/#ARIAMixin
 
-/// Map a camelCase property name to its HTML attribute.
-///
-/// Returns `None` for names that follow standard camelCase ↔ kebab conversion.
-#[must_use]
-pub fn property_to_attribute(name: &str) -> Option<&'static str> {
-    match name {
-        // --- ARIA (ARIAMixin) ---
-        "ariaActiveDescendant" => Some("aria-activedescendant"),
-        "ariaAutoComplete" => Some("aria-autocomplete"),
-        "ariaBrailleLabel" => Some("aria-braillelabel"),
-        "ariaBrailleRoleDescription" => Some("aria-brailleroledescription"),
-        "ariaColCount" => Some("aria-colcount"),
-        "ariaColIndex" => Some("aria-colindex"),
-        "ariaColIndexText" => Some("aria-colindextext"),
-        "ariaColSpan" => Some("aria-colspan"),
-        "ariaDescribedBy" => Some("aria-describedby"),
-        "ariaDropEffect" => Some("aria-dropeffect"),
-        "ariaErrorMessage" => Some("aria-errormessage"),
-        "ariaFlowTo" => Some("aria-flowto"),
-        "ariaHasPopup" => Some("aria-haspopup"),
-        "ariaKeyShortcuts" => Some("aria-keyshortcuts"),
-        "ariaLabelledBy" => Some("aria-labelledby"),
-        "ariaMultiLine" => Some("aria-multiline"),
-        "ariaMultiSelectable" => Some("aria-multiselectable"),
-        "ariaPosInSet" => Some("aria-posinset"),
-        "ariaReadOnly" => Some("aria-readonly"),
-        "ariaRoleDescription" => Some("aria-roledescription"),
-        "ariaRowCount" => Some("aria-rowcount"),
-        "ariaRowIndex" => Some("aria-rowindex"),
-        "ariaRowIndexText" => Some("aria-rowindextext"),
-        "ariaRowSpan" => Some("aria-rowspan"),
-        "ariaSetSize" => Some("aria-setsize"),
-        "ariaValueMax" => Some("aria-valuemax"),
-        "ariaValueMin" => Some("aria-valuemin"),
-        "ariaValueNow" => Some("aria-valuenow"),
-        "ariaValueText" => Some("aria-valuetext"),
-        // --- HTML global/element attributes ---
-        "accessKey" => Some("accesskey"),
-        "autoCapitalize" => Some("autocapitalize"),
-        "contentEditable" => Some("contenteditable"),
-        "crossOrigin" => Some("crossorigin"),
-        "dirName" => Some("dirname"),
-        "fetchPriority" => Some("fetchpriority"),
-        "formAction" => Some("formaction"),
-        "formEnctype" => Some("formenctype"),
-        "formMethod" => Some("formmethod"),
-        "formNoValidate" => Some("formnovalidate"),
-        "formTarget" => Some("formtarget"),
-        "inputMode" => Some("inputmode"),
-        "isMap" => Some("ismap"),
-        "maxLength" => Some("maxlength"),
-        "minLength" => Some("minlength"),
-        "noModule" => Some("nomodule"),
-        "noValidate" => Some("novalidate"),
-        "readOnly" => Some("readonly"),
-        "referrerPolicy" => Some("referrerpolicy"),
-        "tabIndex" => Some("tabindex"),
-        "useMap" => Some("usemap"),
-        _ => None,
-    }
+/// Define bidirectional property ↔ attribute lookup functions from a single
+/// list of `(property, attribute)` pairs. This guarantees the two match
+/// statements stay in sync — adding or removing an entry in one direction
+/// automatically applies to the other.
+macro_rules! define_attr_property_mappings {
+    ($( $property:literal => $attribute:literal, )*) => {
+        /// Map a camelCase property name to its HTML attribute.
+        ///
+        /// Returns `None` for names that follow standard camelCase ↔ kebab
+        /// conversion.
+        #[must_use]
+        pub fn property_to_attribute(name: &str) -> Option<&'static str> {
+            match name {
+                $( $property => Some($attribute), )*
+                _ => None,
+            }
+        }
+
+        /// Map an HTML attribute to its camelCase property name.
+        ///
+        /// Inverse of [`property_to_attribute`].
+        #[must_use]
+        pub fn attribute_to_property(name: &str) -> Option<&'static str> {
+            match name {
+                $( $attribute => Some($property), )*
+                _ => None,
+            }
+        }
+
+        /// All `(property, attribute)` pairs for exhaustive testing.
+        #[cfg(test)]
+        const ALL_MAPPINGS: &[(&str, &str)] = &[
+            $( ($property, $attribute), )*
+        ];
+    };
 }
 
-/// Map an HTML attribute to its camelCase property name.
-///
-/// Inverse of [`property_to_attribute`].
-#[must_use]
-pub fn attribute_to_property(name: &str) -> Option<&'static str> {
-    match name {
-        // --- ARIA (ARIAMixin) ---
-        "aria-activedescendant" => Some("ariaActiveDescendant"),
-        "aria-autocomplete" => Some("ariaAutoComplete"),
-        "aria-braillelabel" => Some("ariaBrailleLabel"),
-        "aria-brailleroledescription" => Some("ariaBrailleRoleDescription"),
-        "aria-colcount" => Some("ariaColCount"),
-        "aria-colindex" => Some("ariaColIndex"),
-        "aria-colindextext" => Some("ariaColIndexText"),
-        "aria-colspan" => Some("ariaColSpan"),
-        "aria-describedby" => Some("ariaDescribedBy"),
-        "aria-dropeffect" => Some("ariaDropEffect"),
-        "aria-errormessage" => Some("ariaErrorMessage"),
-        "aria-flowto" => Some("ariaFlowTo"),
-        "aria-haspopup" => Some("ariaHasPopup"),
-        "aria-keyshortcuts" => Some("ariaKeyShortcuts"),
-        "aria-labelledby" => Some("ariaLabelledBy"),
-        "aria-multiline" => Some("ariaMultiLine"),
-        "aria-multiselectable" => Some("ariaMultiSelectable"),
-        "aria-posinset" => Some("ariaPosInSet"),
-        "aria-readonly" => Some("ariaReadOnly"),
-        "aria-roledescription" => Some("ariaRoleDescription"),
-        "aria-rowcount" => Some("ariaRowCount"),
-        "aria-rowindex" => Some("ariaRowIndex"),
-        "aria-rowindextext" => Some("ariaRowIndexText"),
-        "aria-rowspan" => Some("ariaRowSpan"),
-        "aria-setsize" => Some("ariaSetSize"),
-        "aria-valuemax" => Some("ariaValueMax"),
-        "aria-valuemin" => Some("ariaValueMin"),
-        "aria-valuenow" => Some("ariaValueNow"),
-        "aria-valuetext" => Some("ariaValueText"),
-        // --- HTML global/element attributes ---
-        "accesskey" => Some("accessKey"),
-        "autocapitalize" => Some("autoCapitalize"),
-        "contenteditable" => Some("contentEditable"),
-        "crossorigin" => Some("crossOrigin"),
-        "dirname" => Some("dirName"),
-        "fetchpriority" => Some("fetchPriority"),
-        "formaction" => Some("formAction"),
-        "formenctype" => Some("formEnctype"),
-        "formmethod" => Some("formMethod"),
-        "formnovalidate" => Some("formNoValidate"),
-        "formtarget" => Some("formTarget"),
-        "inputmode" => Some("inputMode"),
-        "ismap" => Some("isMap"),
-        "maxlength" => Some("maxLength"),
-        "minlength" => Some("minLength"),
-        "nomodule" => Some("noModule"),
-        "novalidate" => Some("noValidate"),
-        "readonly" => Some("readOnly"),
-        "referrerpolicy" => Some("referrerPolicy"),
-        "tabindex" => Some("tabIndex"),
-        "usemap" => Some("useMap"),
-        _ => None,
-    }
+define_attr_property_mappings! {
+    // --- ARIA (ARIAMixin) ---
+    "ariaActiveDescendant" => "aria-activedescendant",
+    "ariaAutoComplete" => "aria-autocomplete",
+    "ariaBrailleLabel" => "aria-braillelabel",
+    "ariaBrailleRoleDescription" => "aria-brailleroledescription",
+    "ariaColCount" => "aria-colcount",
+    "ariaColIndex" => "aria-colindex",
+    "ariaColIndexText" => "aria-colindextext",
+    "ariaColSpan" => "aria-colspan",
+    "ariaDescribedBy" => "aria-describedby",
+    "ariaDropEffect" => "aria-dropeffect",
+    "ariaErrorMessage" => "aria-errormessage",
+    "ariaFlowTo" => "aria-flowto",
+    "ariaHasPopup" => "aria-haspopup",
+    "ariaKeyShortcuts" => "aria-keyshortcuts",
+    "ariaLabelledBy" => "aria-labelledby",
+    "ariaMultiLine" => "aria-multiline",
+    "ariaMultiSelectable" => "aria-multiselectable",
+    "ariaPosInSet" => "aria-posinset",
+    "ariaReadOnly" => "aria-readonly",
+    "ariaRoleDescription" => "aria-roledescription",
+    "ariaRowCount" => "aria-rowcount",
+    "ariaRowIndex" => "aria-rowindex",
+    "ariaRowIndexText" => "aria-rowindextext",
+    "ariaRowSpan" => "aria-rowspan",
+    "ariaSetSize" => "aria-setsize",
+    "ariaValueMax" => "aria-valuemax",
+    "ariaValueMin" => "aria-valuemin",
+    "ariaValueNow" => "aria-valuenow",
+    "ariaValueText" => "aria-valuetext",
+    // --- HTML global/element attributes ---
+    "accessKey" => "accesskey",
+    "autoCapitalize" => "autocapitalize",
+    "contentEditable" => "contenteditable",
+    "crossOrigin" => "crossorigin",
+    "dirName" => "dirname",
+    "fetchPriority" => "fetchpriority",
+    "formAction" => "formaction",
+    "formEnctype" => "formenctype",
+    "formMethod" => "formmethod",
+    "formNoValidate" => "formnovalidate",
+    "formTarget" => "formtarget",
+    "inputMode" => "inputmode",
+    "isMap" => "ismap",
+    "maxLength" => "maxlength",
+    "minLength" => "minlength",
+    "noModule" => "nomodule",
+    "noValidate" => "novalidate",
+    "readOnly" => "readonly",
+    "referrerPolicy" => "referrerpolicy",
+    "tabIndex" => "tabindex",
+    "useMap" => "usemap",
 }
 
 /// Convert a camelCase property name to its HTML attribute name.
@@ -208,96 +179,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn aria_property_to_attribute() {
-        assert_eq!(
-            property_to_attribute("ariaDescribedBy"),
-            Some("aria-describedby")
-        );
-        assert_eq!(
-            property_to_attribute("ariaLabelledBy"),
-            Some("aria-labelledby")
-        );
-        assert_eq!(
-            property_to_attribute("ariaActiveDescendant"),
-            Some("aria-activedescendant")
-        );
-        assert_eq!(
-            property_to_attribute("ariaAutoComplete"),
-            Some("aria-autocomplete")
-        );
-        assert_eq!(property_to_attribute("ariaColCount"), Some("aria-colcount"));
-        assert_eq!(property_to_attribute("ariaColSpan"), Some("aria-colspan"));
-        assert_eq!(
-            property_to_attribute("ariaErrorMessage"),
-            Some("aria-errormessage")
-        );
-        assert_eq!(property_to_attribute("ariaHasPopup"), Some("aria-haspopup"));
-        assert_eq!(property_to_attribute("ariaPosInSet"), Some("aria-posinset"));
-        assert_eq!(
-            property_to_attribute("ariaValueText"),
-            Some("aria-valuetext")
-        );
-        assert_eq!(
-            property_to_attribute("ariaBrailleRoleDescription"),
-            Some("aria-brailleroledescription")
-        );
+    fn exhaustive_property_to_attribute() {
+        for &(prop, attr) in ALL_MAPPINGS {
+            assert_eq!(
+                property_to_attribute(prop),
+                Some(attr),
+                "property_to_attribute({prop}) should be {attr}"
+            );
+        }
     }
 
     #[test]
-    fn aria_attribute_to_property() {
-        assert_eq!(
-            attribute_to_property("aria-describedby"),
-            Some("ariaDescribedBy")
-        );
-        assert_eq!(
-            attribute_to_property("aria-labelledby"),
-            Some("ariaLabelledBy")
-        );
-        assert_eq!(
-            attribute_to_property("aria-activedescendant"),
-            Some("ariaActiveDescendant")
-        );
-        assert_eq!(
-            attribute_to_property("aria-valuetext"),
-            Some("ariaValueText")
-        );
-        assert_eq!(
-            attribute_to_property("aria-roledescription"),
-            Some("ariaRoleDescription")
-        );
+    fn exhaustive_attribute_to_property() {
+        for &(prop, attr) in ALL_MAPPINGS {
+            assert_eq!(
+                attribute_to_property(attr),
+                Some(prop),
+                "attribute_to_property({attr}) should be {prop}"
+            );
+        }
     }
 
     #[test]
-    fn html_global_property_to_attribute() {
-        assert_eq!(property_to_attribute("readOnly"), Some("readonly"));
-        assert_eq!(property_to_attribute("tabIndex"), Some("tabindex"));
-        assert_eq!(property_to_attribute("accessKey"), Some("accesskey"));
-        assert_eq!(
-            property_to_attribute("contentEditable"),
-            Some("contenteditable")
-        );
-        assert_eq!(property_to_attribute("crossOrigin"), Some("crossorigin"));
-        assert_eq!(property_to_attribute("inputMode"), Some("inputmode"));
-        assert_eq!(property_to_attribute("maxLength"), Some("maxlength"));
-        assert_eq!(property_to_attribute("formAction"), Some("formaction"));
-        assert_eq!(property_to_attribute("noValidate"), Some("novalidate"));
-        assert_eq!(
-            property_to_attribute("referrerPolicy"),
-            Some("referrerpolicy")
-        );
-    }
-
-    #[test]
-    fn html_global_attribute_to_property() {
-        assert_eq!(attribute_to_property("readonly"), Some("readOnly"));
-        assert_eq!(attribute_to_property("tabindex"), Some("tabIndex"));
-        assert_eq!(attribute_to_property("accesskey"), Some("accessKey"));
-        assert_eq!(
-            attribute_to_property("contenteditable"),
-            Some("contentEditable")
-        );
-        assert_eq!(attribute_to_property("maxlength"), Some("maxLength"));
-        assert_eq!(attribute_to_property("formaction"), Some("formAction"));
+    fn exhaustive_roundtrip() {
+        for &(prop, _) in ALL_MAPPINGS {
+            let attr = camel_to_kebab(prop);
+            let back = attribute_to_camel(&attr);
+            assert_eq!(back, prop, "roundtrip failed for {prop}");
+        }
     }
 
     #[test]
@@ -309,38 +218,9 @@ mod tests {
     }
 
     #[test]
-    fn non_aria_non_global_returns_none() {
+    fn non_mapped_returns_none() {
         assert_eq!(property_to_attribute("myProp"), None);
         assert_eq!(attribute_to_property("my-prop"), None);
-    }
-
-    #[test]
-    fn roundtrip() {
-        let props = [
-            "ariaDescribedBy",
-            "ariaLabelledBy",
-            "ariaActiveDescendant",
-            "ariaValueText",
-            "readOnly",
-            "tabIndex",
-            "contentEditable",
-            "maxLength",
-            "formAction",
-        ];
-        for prop in props {
-            let attr = property_to_attribute(prop).unwrap();
-            let back = attribute_to_property(attr).unwrap();
-            assert_eq!(back, prop, "roundtrip failed for {prop}");
-        }
-    }
-
-    #[test]
-    fn camel_to_kebab_irregular() {
-        assert_eq!(camel_to_kebab("ariaDescribedBy"), "aria-describedby");
-        assert_eq!(camel_to_kebab("ariaLabelledBy"), "aria-labelledby");
-        assert_eq!(camel_to_kebab("readOnly"), "readonly");
-        assert_eq!(camel_to_kebab("tabIndex"), "tabindex");
-        assert_eq!(camel_to_kebab("contentEditable"), "contenteditable");
     }
 
     #[test]
@@ -351,33 +231,8 @@ mod tests {
     }
 
     #[test]
-    fn attribute_to_camel_irregular() {
-        assert_eq!(attribute_to_camel("aria-describedby"), "ariaDescribedBy");
-        assert_eq!(attribute_to_camel("readonly"), "readOnly");
-        assert_eq!(attribute_to_camel("tabindex"), "tabIndex");
-        assert_eq!(attribute_to_camel("contenteditable"), "contentEditable");
-    }
-
-    #[test]
     fn attribute_to_camel_regular() {
         assert_eq!(attribute_to_camel("aria-label"), "ariaLabel");
         assert_eq!(attribute_to_camel("data-title"), "dataTitle");
-    }
-
-    #[test]
-    fn conversion_roundtrip() {
-        let props = [
-            "ariaDescribedBy",
-            "readOnly",
-            "tabIndex",
-            "ariaLabel",
-            "dataTitle",
-            "totalContacts",
-        ];
-        for prop in props {
-            let attr = camel_to_kebab(prop);
-            let back = attribute_to_camel(&attr);
-            assert_eq!(back, prop, "conversion roundtrip failed for {prop}");
-        }
     }
 }

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -17,6 +17,9 @@ use thiserror::Error;
 /// Plugin-specific protocol helpers for framework hydration metadata.
 pub mod plugin;
 
+/// Attribute-name ↔ property-name mapping for irregular HTML attributes.
+pub mod attrs;
+
 /// Generated protobuf types from `proto/webui.proto`.
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/webui.rs"));

--- a/packages/webui-framework/src/decorators.test.ts
+++ b/packages/webui-framework/src/decorators.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { toKebabCase } from './decorators.js';
+
+describe('toKebabCase', () => {
+  test('converts multi-word ARIA properties to correct attribute names', () => {
+    assert.equal(toKebabCase('ariaDescribedBy'), 'aria-describedby');
+    assert.equal(toKebabCase('ariaLabelledBy'), 'aria-labelledby');
+    assert.equal(toKebabCase('ariaActiveDescendant'), 'aria-activedescendant');
+    assert.equal(toKebabCase('ariaAutoComplete'), 'aria-autocomplete');
+    assert.equal(toKebabCase('ariaColCount'), 'aria-colcount');
+    assert.equal(toKebabCase('ariaColIndex'), 'aria-colindex');
+    assert.equal(toKebabCase('ariaColIndexText'), 'aria-colindextext');
+    assert.equal(toKebabCase('ariaColSpan'), 'aria-colspan');
+    assert.equal(toKebabCase('ariaDropEffect'), 'aria-dropeffect');
+    assert.equal(toKebabCase('ariaErrorMessage'), 'aria-errormessage');
+    assert.equal(toKebabCase('ariaFlowTo'), 'aria-flowto');
+    assert.equal(toKebabCase('ariaHasPopup'), 'aria-haspopup');
+    assert.equal(toKebabCase('ariaKeyShortcuts'), 'aria-keyshortcuts');
+    assert.equal(toKebabCase('ariaMultiLine'), 'aria-multiline');
+    assert.equal(toKebabCase('ariaMultiSelectable'), 'aria-multiselectable');
+    assert.equal(toKebabCase('ariaPosInSet'), 'aria-posinset');
+    assert.equal(toKebabCase('ariaReadOnly'), 'aria-readonly');
+    assert.equal(toKebabCase('ariaRoleDescription'), 'aria-roledescription');
+    assert.equal(toKebabCase('ariaRowCount'), 'aria-rowcount');
+    assert.equal(toKebabCase('ariaRowIndex'), 'aria-rowindex');
+    assert.equal(toKebabCase('ariaRowIndexText'), 'aria-rowindextext');
+    assert.equal(toKebabCase('ariaRowSpan'), 'aria-rowspan');
+    assert.equal(toKebabCase('ariaSetSize'), 'aria-setsize');
+    assert.equal(toKebabCase('ariaValueMax'), 'aria-valuemax');
+    assert.equal(toKebabCase('ariaValueMin'), 'aria-valuemin');
+    assert.equal(toKebabCase('ariaValueNow'), 'aria-valuenow');
+    assert.equal(toKebabCase('ariaValueText'), 'aria-valuetext');
+    assert.equal(toKebabCase('ariaBrailleLabel'), 'aria-braillelabel');
+    assert.equal(
+      toKebabCase('ariaBrailleRoleDescription'),
+      'aria-brailleroledescription',
+    );
+  });
+
+  test('single-word ARIA properties use fallback conversion', () => {
+    assert.equal(toKebabCase('ariaLabel'), 'aria-label');
+    assert.equal(toKebabCase('ariaHidden'), 'aria-hidden');
+    assert.equal(toKebabCase('ariaDisabled'), 'aria-disabled');
+    assert.equal(toKebabCase('ariaChecked'), 'aria-checked');
+  });
+
+  test('non-ARIA properties use standard camelCase-to-kebab', () => {
+    assert.equal(toKebabCase('myProp'), 'my-prop');
+    assert.equal(toKebabCase('totalContacts'), 'total-contacts');
+    assert.equal(toKebabCase('dataTitle'), 'data-title');
+  });
+});

--- a/packages/webui-framework/src/decorators.test.ts
+++ b/packages/webui-framework/src/decorators.test.ts
@@ -49,6 +49,30 @@ describe('toKebabCase', () => {
     assert.equal(toKebabCase('ariaChecked'), 'aria-checked');
   });
 
+  test('converts HTML global/element properties to correct attribute names', () => {
+    assert.equal(toKebabCase('readOnly'), 'readonly');
+    assert.equal(toKebabCase('tabIndex'), 'tabindex');
+    assert.equal(toKebabCase('accessKey'), 'accesskey');
+    assert.equal(toKebabCase('contentEditable'), 'contenteditable');
+    assert.equal(toKebabCase('crossOrigin'), 'crossorigin');
+    assert.equal(toKebabCase('inputMode'), 'inputmode');
+    assert.equal(toKebabCase('maxLength'), 'maxlength');
+    assert.equal(toKebabCase('minLength'), 'minlength');
+    assert.equal(toKebabCase('noValidate'), 'novalidate');
+    assert.equal(toKebabCase('formAction'), 'formaction');
+    assert.equal(toKebabCase('formEnctype'), 'formenctype');
+    assert.equal(toKebabCase('formMethod'), 'formmethod');
+    assert.equal(toKebabCase('formNoValidate'), 'formnovalidate');
+    assert.equal(toKebabCase('formTarget'), 'formtarget');
+    assert.equal(toKebabCase('isMap'), 'ismap');
+    assert.equal(toKebabCase('useMap'), 'usemap');
+    assert.equal(toKebabCase('noModule'), 'nomodule');
+    assert.equal(toKebabCase('autoCapitalize'), 'autocapitalize');
+    assert.equal(toKebabCase('dirName'), 'dirname');
+    assert.equal(toKebabCase('fetchPriority'), 'fetchpriority');
+    assert.equal(toKebabCase('referrerPolicy'), 'referrerpolicy');
+  });
+
   test('non-ARIA properties use standard camelCase-to-kebab', () => {
     assert.equal(toKebabCase('myProp'), 'my-prop');
     assert.equal(toKebabCase('totalContacts'), 'total-contacts');

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -22,7 +22,7 @@
  * 2. HTML global/element attributes — concatenated lowercase attribute names
  *    with camelCase property counterparts (e.g., `readOnly` → `readonly`).
  */
-const propertyToAttribute: Record<string, string> = {
+const propertyToAttribute: Record<string, string> = Object.assign(Object.create(null) as Record<string, string>, {
   // --- ARIA (ARIAMixin) ---
   ariaActiveDescendant: 'aria-activedescendant',
   ariaAutoComplete: 'aria-autocomplete',
@@ -75,7 +75,7 @@ const propertyToAttribute: Record<string, string> = {
   referrerPolicy: 'referrerpolicy',
   tabIndex: 'tabindex',
   useMap: 'usemap',
-};
+});
 
 /** Convert camelCase to kebab-case for attribute reflection. */
 export function toKebabCase(str: string): string {

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -13,14 +13,17 @@
 // ---------------------------------------------------------------------------
 
 /**
- * Map of ARIA camelCase property names to their HTML attribute names.
+ * Map of camelCase property names to their HTML attribute names.
  *
- * Multi-word ARIA attributes use concatenated lowercase after `aria-`
- * (e.g., `aria-describedby`), which doesn't match standard camelCase-to-kebab
- * conversion. This table covers every multi-word ARIA attribute in the
- * ARIAMixin specification.
+ * Covers two categories of irregular mappings:
+ *
+ * 1. Multi-word ARIA attributes — concatenated lowercase after `aria-`
+ *    (e.g., `ariaDescribedBy` → `aria-describedby`), per the ARIAMixin spec.
+ * 2. HTML global/element attributes — concatenated lowercase attribute names
+ *    with camelCase property counterparts (e.g., `readOnly` → `readonly`).
  */
-const ariaPropertyToAttribute: Record<string, string> = {
+const propertyToAttribute: Record<string, string> = {
+  // --- ARIA (ARIAMixin) ---
   ariaActiveDescendant: 'aria-activedescendant',
   ariaAutoComplete: 'aria-autocomplete',
   ariaBrailleLabel: 'aria-braillelabel',
@@ -50,6 +53,28 @@ const ariaPropertyToAttribute: Record<string, string> = {
   ariaValueMin: 'aria-valuemin',
   ariaValueNow: 'aria-valuenow',
   ariaValueText: 'aria-valuetext',
+  // --- HTML global/element attributes ---
+  accessKey: 'accesskey',
+  autoCapitalize: 'autocapitalize',
+  contentEditable: 'contenteditable',
+  crossOrigin: 'crossorigin',
+  dirName: 'dirname',
+  fetchPriority: 'fetchpriority',
+  formAction: 'formaction',
+  formEnctype: 'formenctype',
+  formMethod: 'formmethod',
+  formNoValidate: 'formnovalidate',
+  formTarget: 'formtarget',
+  inputMode: 'inputmode',
+  isMap: 'ismap',
+  maxLength: 'maxlength',
+  minLength: 'minlength',
+  noModule: 'nomodule',
+  noValidate: 'novalidate',
+  readOnly: 'readonly',
+  referrerPolicy: 'referrerpolicy',
+  tabIndex: 'tabindex',
+  useMap: 'usemap',
 };
 
 /**
@@ -60,7 +85,7 @@ const ariaPropertyToAttribute: Record<string, string> = {
  * the naive `aria-described-by`.
  */
 export function toKebabCase(str: string): string {
-  if (str in ariaPropertyToAttribute) return ariaPropertyToAttribute[str];
+  if (str in propertyToAttribute) return propertyToAttribute[str];
   return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -77,16 +77,10 @@ const propertyToAttribute: Record<string, string> = {
   useMap: 'usemap',
 };
 
-/**
- * Convert camelCase to kebab-case for attribute reflection.
- *
- * Multi-word ARIA properties are handled via a lookup table so that
- * `ariaDescribedBy` correctly maps to `aria-describedby` rather than
- * the naive `aria-described-by`.
- */
+/** Convert camelCase to kebab-case for attribute reflection. */
 export function toKebabCase(str: string): string {
-  if (str in propertyToAttribute) return propertyToAttribute[str];
-  return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+  const mapped = propertyToAttribute[str];
+  return mapped ?? str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 
 /**

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -12,8 +12,55 @@
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Convert camelCase to kebab-case for attribute reflection. */
-function toKebabCase(str: string): string {
+/**
+ * Map of ARIA camelCase property names to their HTML attribute names.
+ *
+ * Multi-word ARIA attributes use concatenated lowercase after `aria-`
+ * (e.g., `aria-describedby`), which doesn't match standard camelCase-to-kebab
+ * conversion. This table covers every multi-word ARIA attribute in the
+ * ARIAMixin specification.
+ */
+const ariaPropertyToAttribute: Record<string, string> = {
+  ariaActiveDescendant: 'aria-activedescendant',
+  ariaAutoComplete: 'aria-autocomplete',
+  ariaBrailleLabel: 'aria-braillelabel',
+  ariaBrailleRoleDescription: 'aria-brailleroledescription',
+  ariaColCount: 'aria-colcount',
+  ariaColIndex: 'aria-colindex',
+  ariaColIndexText: 'aria-colindextext',
+  ariaColSpan: 'aria-colspan',
+  ariaDescribedBy: 'aria-describedby',
+  ariaDropEffect: 'aria-dropeffect',
+  ariaErrorMessage: 'aria-errormessage',
+  ariaFlowTo: 'aria-flowto',
+  ariaHasPopup: 'aria-haspopup',
+  ariaKeyShortcuts: 'aria-keyshortcuts',
+  ariaLabelledBy: 'aria-labelledby',
+  ariaMultiLine: 'aria-multiline',
+  ariaMultiSelectable: 'aria-multiselectable',
+  ariaPosInSet: 'aria-posinset',
+  ariaReadOnly: 'aria-readonly',
+  ariaRoleDescription: 'aria-roledescription',
+  ariaRowCount: 'aria-rowcount',
+  ariaRowIndex: 'aria-rowindex',
+  ariaRowIndexText: 'aria-rowindextext',
+  ariaRowSpan: 'aria-rowspan',
+  ariaSetSize: 'aria-setsize',
+  ariaValueMax: 'aria-valuemax',
+  ariaValueMin: 'aria-valuemin',
+  ariaValueNow: 'aria-valuenow',
+  ariaValueText: 'aria-valuetext',
+};
+
+/**
+ * Convert camelCase to kebab-case for attribute reflection.
+ *
+ * Multi-word ARIA properties are handled via a lookup table so that
+ * `ariaDescribedBy` correctly maps to `aria-describedby` rather than
+ * the naive `aria-described-by`.
+ */
+export function toKebabCase(str: string): string {
+  if (str in ariaPropertyToAttribute) return ariaPropertyToAttribute[str];
   return str.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 


### PR DESCRIPTION
## Summary

HTML attributes that use concatenated lowercase names do not follow standard camelCase-to-kebab-case conversion. This PR adds a lookup table covering two categories:

1. **Multi-word ARIA attributes** (29 entries) — e.g., `ariaDescribedBy` ↔ `aria-describedby`, `ariaActiveDescendant` ↔ `aria-activedescendant`, per the [ARIAMixin](https://w3c.github.io/aria/#ARIAMixin) specification.
2. **HTML global/element attributes** (21 entries) — e.g., `readOnly` ↔ `readonly`, `tabIndex` ↔ `tabindex`, `contentEditable` ↔ `contenteditable`.

Previously, `camel_to_kebab("ariaDescribedBy")` produced `aria-described-by` and `camel_to_kebab("readOnly")` produced `read-only`. Similarly, `component_attr_name("readonly")` returned `readonly` instead of `readOnly`.

## Architecture

The canonical lookup table lives in a single location: `webui_protocol::attrs` (`crates/webui-protocol/src/attrs.rs`). Both `webui-handler` and `webui-parser` already depend on `webui-protocol`, so no new crate dependencies were added. The TypeScript table in `decorators.ts` is a necessary client-side copy.

## Changes

- **Protocol** (`webui-protocol`): New `attrs` module with `property_to_attribute` and `attribute_to_property` lookup functions
- **Handler** (`webui-handler`): `camel_to_kebab`, `convert_hyphen_to_camel_case`, and `component_attr_name` now call `webui_protocol::attrs`
- **Parser** (`webui-parser`): `kebab_to_camel` now calls `webui_protocol::attrs`
- **Framework** (`webui-framework`): `toKebabCase` checks lookup table; exported for testability
- **DESIGN.md**: Document attribute name mapping and single source of truth

## Tests

### Rust (`webui-protocol` — canonical tests)
- All 29 ARIA + 21 HTML global property ↔ attribute conversions
- Single-word attrs correctly return `None`
- Roundtrip correctness

### Rust (`webui-handler` + `webui-parser` — integration)
- Conversion functions produce correct results via the shared table
- `component_attr_name` maps non-hyphenated attrs correctly

### TypeScript (`webui-framework`)
- ARIA, HTML global, single-word, and non-ARIA conversion tests

## Quality Gate

`cargo xtask check` passes (license-headers, fmt, clippy, deny, test, build). The wasm build failure is pre-existing on main.