### PR TITLE
feat(router): parse query params and pass to components as attributes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,6 +188,7 @@ pub struct WebUIFragmentRoute {
     pub fragment_id: String,                   // Fragment containing the route body
     pub exact: bool,                           // Require exact path match
     pub children: Vec<WebUIFragmentRoute>,     // Nested child routes
+    pub allowed_query: String,                 // Comma-separated allowlist of query params forwarded as attributes
 }
 ```
 
@@ -217,8 +218,13 @@ Child paths are relative to their parent (no leading `/`). The HTML nesting IS t
       <route path="lessons/:lessonId" component="lesson-page" exact />
     </route>
   </route>
+  <route path="compose" component="compose-page" query="action,to,subject" exact />
 </route>
 ```
+
+The optional `query` attribute declares which URL query parameters are forwarded as HTML attributes
+on the component (deny-by-default). Routes without `query` forward no query params. Route path
+params always take priority over query params to prevent URL-based attribute injection.
 
 **Route matching:** The handler uses an iterative path template matcher (no regex). Segments are
 compared left-to-right: `:param` binds a value, `*splat` captures remaining segments, `?` marks

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -6311,4 +6311,135 @@ mod tests {
         assert_eq!(component_attr_name("key-hyphen"), "keyHyphen");
         assert_eq!(component_attr_name("simple"), "simple");
     }
+
+    // ── allowed_query SSR emission tests ─────────────────────────────
+
+    fn make_query_route_protocol() -> WebUIProtocol {
+        use webui_protocol::WebUiFragmentRoute;
+
+        let mut fragments = HashMap::new();
+
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![
+                        WebUiFragmentRoute {
+                            path: "compose".into(),
+                            fragment_id: "compose-page".into(),
+                            exact: true,
+                            allowed_query: "action,to,subject".into(),
+                            ..Default::default()
+                        },
+                        WebUiFragmentRoute {
+                            path: "settings".into(),
+                            fragment_id: "settings-page".into(),
+                            exact: true,
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                })],
+            },
+        );
+
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>App</h1>"), WebUIFragment::outlet()],
+            },
+        );
+        fragments.insert(
+            "compose-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Compose</p>")],
+            },
+        );
+        fragments.insert(
+            "settings-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Settings</p>")],
+            },
+        );
+
+        WebUIProtocol::new(fragments)
+    }
+
+    #[test]
+    fn test_matched_route_emits_query_attr() {
+        let protocol = make_query_route_protocol();
+        let state = test_json!({});
+        let handler = WebUIHandler::new();
+        let mut writer = TestWriter::new();
+
+        handler
+            .handle(
+                &protocol,
+                &state,
+                &RenderOptions::new("index.html", "/compose"),
+                &mut writer,
+            )
+            .expect("render failed");
+
+        let html = writer.get_content();
+        assert!(
+            html.contains(r#"query="action,to,subject""#),
+            "matched route with allowed_query should emit query attr: {html}"
+        );
+    }
+
+    #[test]
+    fn test_nonmatched_route_preserves_query_attr() {
+        let protocol = make_query_route_protocol();
+        let state = test_json!({});
+        let handler = WebUIHandler::new();
+        let mut writer = TestWriter::new();
+
+        handler
+            .handle(
+                &protocol,
+                &state,
+                &RenderOptions::new("index.html", "/settings"),
+                &mut writer,
+            )
+            .expect("render failed");
+
+        let html = writer.get_content();
+        // Compose is the non-matched sibling — it should still have query attr
+        assert!(
+            html.contains(r#"query="action,to,subject""#),
+            "hidden route should preserve query attr: {html}"
+        );
+    }
+
+    #[test]
+    fn test_route_without_query_has_no_query_attr() {
+        let protocol = make_query_route_protocol();
+        let state = test_json!({});
+        let handler = WebUIHandler::new();
+        let mut writer = TestWriter::new();
+
+        handler
+            .handle(
+                &protocol,
+                &state,
+                &RenderOptions::new("index.html", "/settings"),
+                &mut writer,
+            )
+            .expect("render failed");
+
+        let html = writer.get_content();
+        // Find the settings route element and verify it has no query attr
+        let settings_idx = html
+            .find(r#"component="settings-page""#)
+            .expect("settings route should exist");
+        let settings_tag = &html[settings_idx.saturating_sub(60)..settings_idx + 40];
+        assert!(
+            !settings_tag.contains("query="),
+            "route without allowed_query should not emit query attr: {settings_tag}"
+        );
+    }
 }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -384,6 +384,11 @@ impl WebUIHandler {
                 if matched_child.exact {
                     context.writer.write(" exact")?;
                 }
+                if !matched_child.allowed_query.is_empty() {
+                    context.writer.write(" query=\"")?;
+                    context.writer.write(&matched_child.allowed_query)?;
+                    context.writer.write("\"")?;
+                }
                 context.writer.write(" active>")?;
 
                 context.writer.write("<")?;
@@ -422,9 +427,18 @@ impl WebUIHandler {
                 }
                 context.writer.write(" component=\"")?;
                 context.writer.write(&child.fragment_id)?;
+                context.writer.write("\"")?;
+                if child.exact {
+                    context.writer.write(" exact")?;
+                }
+                if !child.allowed_query.is_empty() {
+                    context.writer.write(" query=\"")?;
+                    context.writer.write(&child.allowed_query)?;
+                    context.writer.write("\"")?;
+                }
                 context
                     .writer
-                    .write("\" style=\"display:none\"></webui-route>")?;
+                    .write(" style=\"display:none\"></webui-route>")?;
             }
         }
 
@@ -489,6 +503,11 @@ impl WebUIHandler {
         }
         if route_frag.exact {
             context.writer.write(" exact")?;
+        }
+        if !route_frag.allowed_query.is_empty() {
+            context.writer.write(" query=\"")?;
+            context.writer.write(&route_frag.allowed_query)?;
+            context.writer.write("\"")?;
         }
 
         if is_matched {
@@ -5254,8 +5273,11 @@ mod tests {
                             fragment_id: "topic-comp".into(),
                             exact: true,
                             children: vec![],
+                            ..Default::default()
                         }],
+                        ..Default::default()
                     }],
+                    ..Default::default()
                 })],
             },
         );
@@ -5640,7 +5662,7 @@ mod tests {
         let html = writer.get_content();
 
         assert!(
-            html.contains(r#"component="topic-comp" style="display:none">"#),
+            html.contains(r#"component="topic-comp" exact style="display:none">"#),
             "topic should be hidden: {html}"
         );
     }

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -563,13 +563,15 @@ pub struct RouteChainEntry {
     pub params: HashMap<String, String>,
     /// Whether this route requires an exact match.
     pub exact: bool,
+    /// Comma-separated allowlist of query parameters forwarded as attributes.
+    pub allowed_query: String,
 }
 
 impl RouteChainEntry {
     /// Serialize this entry to a JSON value ready for inclusion in a partial response.
     #[must_use]
     pub fn to_json(&self) -> Value {
-        let mut obj = serde_json::Map::with_capacity(4);
+        let mut obj = serde_json::Map::with_capacity(5);
         obj.insert("component".into(), Value::String(self.component.clone()));
         obj.insert("path".into(), Value::String(self.path.clone()));
         if !self.params.is_empty() {
@@ -582,6 +584,12 @@ impl RouteChainEntry {
         }
         if self.exact {
             obj.insert("exact".into(), Value::Bool(true));
+        }
+        if !self.allowed_query.is_empty() {
+            obj.insert(
+                "allowedQuery".into(),
+                Value::String(self.allowed_query.clone()),
+            );
         }
         Value::Object(obj)
     }
@@ -652,6 +660,7 @@ pub fn collect_route_chain(
                                 path: route_frag.path.clone(),
                                 params: rm.params.clone(),
                                 exact: route_frag.exact,
+                                allowed_query: route_frag.allowed_query.clone(),
                             });
 
                             let child_route_base = route_matcher::compute_route_base(
@@ -715,6 +724,7 @@ fn collect_chain_from_children(
                 path: matched.path.clone(),
                 params: rm.params,
                 exact: matched.exact,
+                allowed_query: matched.allowed_query.clone(),
             });
             if !matched.children.is_empty() {
                 let child_base =

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1530,4 +1530,78 @@ mod tests {
             "cart-panel (non-route sibling) should be needed: {needed:?}"
         );
     }
+
+    // ── RouteChainEntry.to_json + allowed_query tests ────────────────
+
+    #[test]
+    fn test_chain_entry_to_json_includes_allowed_query() {
+        let entry = RouteChainEntry {
+            component: "compose-page".into(),
+            path: "compose".into(),
+            params: HashMap::new(),
+            exact: true,
+            allowed_query: "action,to,subject".into(),
+        };
+        let json = entry.to_json();
+        assert_eq!(json["allowedQuery"], "action,to,subject");
+    }
+
+    #[test]
+    fn test_chain_entry_to_json_omits_empty_allowed_query() {
+        let entry = RouteChainEntry {
+            component: "home-page".into(),
+            path: "/".into(),
+            params: HashMap::new(),
+            exact: true,
+            allowed_query: String::new(),
+        };
+        let json = entry.to_json();
+        assert!(
+            json.get("allowedQuery").is_none(),
+            "empty allowed_query should not appear in JSON"
+        );
+    }
+
+    #[test]
+    fn test_collect_route_chain_carries_allowed_query() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![WebUiFragmentRoute {
+                        path: "compose".into(),
+                        fragment_id: "compose-page".into(),
+                        exact: true,
+                        allowed_query: "action,to".into(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })],
+            },
+        );
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>App</h1>"), WebUIFragment::outlet()],
+            },
+        );
+        fragments.insert(
+            "compose-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Compose</p>")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+
+        let chain = collect_route_chain(&protocol, "index.html", "/compose");
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].component, "app-shell");
+        assert!(chain[0].allowed_query.is_empty());
+        assert_eq!(chain[1].component, "compose-page");
+        assert_eq!(chain[1].allowed_query, "action,to");
+    }
 }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -4076,6 +4076,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_route_with_query_allowlist() {
+        let mut parser = HtmlParser::new();
+        let html =
+            r#"<route path="/compose" component="compose-page" query="action,to,subject" exact />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        let records = parser.into_fragment_records();
+        let frags = &records["test.html"].fragments;
+        assert_eq!(frags.len(), 1);
+        match frags[0].fragment.as_ref() {
+            Some(web_ui_fragment::Fragment::Route(r)) => {
+                assert_eq!(r.path, "/compose");
+                assert_eq!(r.fragment_id, "compose-page");
+                assert!(r.exact);
+                assert_eq!(r.allowed_query, "action,to,subject");
+            }
+            other => panic!("expected Fragment::Route, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_route_without_query_has_empty_allowed_query() {
+        let mut parser = HtmlParser::new();
+        let html = r#"<route path="/profile" component="profile-page" exact />"#;
+        parser.parse("test.html", html).expect("parse failed");
+
+        let records = parser.into_fragment_records();
+        let frags = &records["test.html"].fragments;
+        match frags[0].fragment.as_ref() {
+            Some(web_ui_fragment::Fragment::Route(r)) => {
+                assert!(r.allowed_query.is_empty());
+            }
+            other => panic!("expected Fragment::Route, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_outlet_not_captured_by_for_loop() {
         let mut parser = HtmlParser::new();
         let html = r#"<template shadowrootmode="open">

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -1404,10 +1404,15 @@ impl HtmlParser {
 
         let exact = self.has_element_attribute(node, "exact", source)?;
 
+        let query = self
+            .get_element_attribute(node, "query", source)?
+            .unwrap_or_default();
+
         let attrs = route_parser::RouteAttributes {
             path: path.clone(),
             component: component.clone(),
             exact,
+            query,
         };
 
         // Validate attributes (component is required)
@@ -1464,10 +1469,15 @@ impl HtmlParser {
             .unwrap_or_default();
         let exact = self.has_element_attribute(node, "exact", source)?;
 
+        let query = self
+            .get_element_attribute(node, "query", source)?
+            .unwrap_or_default();
+
         let attrs = route_parser::RouteAttributes {
             path: path.clone(),
             component: component.clone(),
             exact,
+            query,
         };
 
         route_parser::validate_attributes(&attrs)?;

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -387,6 +387,11 @@ fn convert_route_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     if tag.contains(" layout") {
         result.push_str(" layout");
     }
+    if let Some(v) = extract_attribute_value(tag, "query") {
+        result.push_str(" query=\"");
+        result.push_str(v);
+        result.push('"');
+    }
     result.push_str(" style=\"display:none\"");
 
     if is_self_closing {

--- a/crates/webui-parser/src/route_parser.rs
+++ b/crates/webui-parser/src/route_parser.rs
@@ -21,6 +21,8 @@ pub(crate) struct RouteAttributes {
     pub path: String,
     pub component: String,
     pub exact: bool,
+    /// Comma-separated allowlist of query parameters forwarded as attributes.
+    pub query: String,
 }
 
 /// Iteratively extract `:param` and `*splat` tokens from a path template.
@@ -107,6 +109,7 @@ pub(crate) fn build_route_fragment(
         fragment_id,
         exact: attrs.exact,
         children,
+        allowed_query: attrs.query.clone(),
     }
 }
 

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -63,6 +63,9 @@ message WebUIFragmentRoute {
   bool exact = 3;
   // Nested child routes rendered at the component's <outlet />.
   repeated WebUIFragmentRoute children = 4;
+  // Comma-separated allowlist of query parameters forwarded as attributes.
+  // Empty string means no query params are forwarded (deny-by-default).
+  string allowed_query = 5;
 }
 
 // Outlet placeholder — marks where matched child route content renders.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -786,7 +786,7 @@ mod tests {
                 fragment_id: "user-posts".to_string(),
                 exact: true,
                 children: Vec::new(),
-                allowed_query: String::new(),
+                allowed_query: "action,to,subject".to_string(),
             })),
         };
         fragments.insert(

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -786,6 +786,7 @@ mod tests {
                 fragment_id: "user-posts".to_string(),
                 exact: true,
                 children: Vec::new(),
+                allowed_query: String::new(),
             })),
         };
         fragments.insert(

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -202,6 +202,7 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 - Use `exact` on leaf routes (no children)
 - Omit `exact` on parent routes that have `<outlet />`
 - Path params: `:id` (required), `:query?` (optional), `*path` (catch-all)
+- Query param allowlist: `query="action,to,subject"` — only listed params are set as component attributes (deny-by-default)
 
 ### Outlet
 

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -387,6 +387,25 @@ Router.start({
 });
 ```
 
+### View Transitions
+
+The router wraps every client-side navigation in `document.startViewTransition()`
+automatically. **Do not** wrap `Router.navigate()` in your own `startViewTransition()`
+— that would double-transition.
+
+To customize the animation, assign `view-transition-name` to elements in your CSS
+and target them with `::view-transition-old()` / `::view-transition-new()`:
+
+```css
+.content-area { view-transition-name: content; }
+
+::view-transition-old(content) { animation: fade-out 100ms ease-out; }
+::view-transition-new(content) { animation: fade-in 150ms ease-in; }
+```
+
+The router awaits `updateCallbackDone` (not `.finished`) so rapid navigations
+supersede each other without queuing.
+
 ## CLI Commands
 
 ### Build

--- a/docs/guide/concepts/directives/route.md
+++ b/docs/guide/concepts/directives/route.md
@@ -66,6 +66,7 @@ Navigating from `/contacts/1` to `/contacts/2` preserves the contacts list - onl
 | `path` | Yes | URL path segment to match (relative to parent) |
 | `component` | Yes | Tag name of the component to render |
 | `exact` | No | Only match when the full path is consumed (no prefix matching) |
+| `query` | No | Comma-separated allowlist of query params forwarded as component attributes (deny-by-default) |
 
 ## Path Parameters
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -85,6 +85,32 @@ Use `exact` on **leaf routes** - routes with no children. Without `exact`, a rou
 
 **Rule of thumb:** If a route has `<outlet />`, don't add `exact`. If it doesn't, add `exact`.
 
+### The `query` Attribute
+
+Declare which URL query parameters are forwarded as HTML attributes on the component:
+
+```html
+<route path="compose" component="compose-page" query="action,to,subject" exact />
+```
+
+Navigating to `/compose?action=reply&to=user@test.com` sets `action` and `to` as attributes on `<compose-page>`. Unlisted params (e.g. `?class=evil`) are silently dropped.
+
+| Behavior | Description |
+|----------|-------------|
+| No `query` attribute | No query params forwarded (deny-by-default) |
+| `query="action,to"` | Only `action` and `to` set as attributes |
+| Collision with path param | Path param wins — query param is skipped |
+
+Declare `@attr` properties in the component to receive them:
+
+```typescript
+export class ComposePage extends WebUIElement {
+  @attr action = '';
+  @attr to = '';
+  @attr subject = '';
+}
+```
+
 ## How It Works
 
 ### First Load (SSR)

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -117,6 +117,31 @@ Programmatic navigation:
 Router.navigate('/users/42');
 ```
 
+### View Transitions
+
+The router automatically uses the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition) when available. On each client-side navigation, the DOM swap is wrapped in `document.startViewTransition()`, giving you a CSS-driven cross-fade between old and new route content with zero extra code.
+
+**Do NOT wrap `Router.navigate()` in your own `startViewTransition()`** — the router already does this internally.
+
+To customize the animation, use `view-transition-name` on specific elements and target them in CSS:
+
+```css
+/* Scope the transition to the reading pane only */
+.route-outlet {
+  view-transition-name: reading-pane;
+}
+
+/* Custom cross-fade for the reading pane */
+::view-transition-old(reading-pane) {
+  animation: fade-out 100ms ease-out;
+}
+::view-transition-new(reading-pane) {
+  animation: fade-in 150ms ease-in;
+}
+```
+
+The router awaits `transition.updateCallbackDone` (not `.finished`), so rapid navigations supersede each other without queuing animations.
+
 ### `Router.back()`
 
 Navigate back in history.
@@ -164,10 +189,14 @@ Dispatched on `window` after each navigation:
 
 ```typescript
 window.addEventListener('webui:route:navigated', (e) => {
-  const { component, params, path } = (e as CustomEvent).detail;
-  console.log(`Navigated to ${component}`, params);
+  const { component, params, query, path } = (e as CustomEvent).detail;
+  console.log(`Navigated to ${component}`, params, query);
 });
 ```
+
+> **Note:** `query` contains **all** URL query parameters (unfiltered). Only
+> parameters declared via the `query` attribute on `<route>` are set as DOM
+> attributes — the event exposes the full set for programmatic use.
 
 ## Route Path Syntax
 
@@ -179,6 +208,41 @@ window.addEventListener('webui:route:navigated', (e) => {
 | `*splat` | `files/*path` | Rest of path → `{ path: "a/b/c" }` |
 
 Paths are relative to the parent route. Use `/` prefix only for the root route.
+
+## Query Parameters
+
+URL query parameters can be forwarded to components as HTML attributes by
+declaring an **allowlist** on the `<route>` element:
+
+```html
+<route path="compose" component="page-compose" query="action,to,subject" exact />
+```
+
+When a user navigates to `/compose?action=reply&to=user@test.com`, only the
+three listed parameters are set as attributes on `<page-compose>`. Any
+unlisted parameter (e.g. `?class=evil&style=display:none`) is silently
+dropped — **deny-by-default**.
+
+### Rules
+
+| Scenario | Behavior |
+|----------|----------|
+| No `query` attribute | No query params forwarded (safe default) |
+| `query="action,to"` | Only `action` and `to` are set as attributes |
+| Collision with route param | Route param wins — query param is skipped |
+| Query-only navigation | Stale attributes from previous query are removed |
+
+### Component usage
+
+Declare `@attr` properties matching the allowed query param names:
+
+```typescript
+export class PageCompose extends WebUIElement {
+  @attr action = '';
+  @attr to = '';
+  @attr subject = '';
+}
+```
 
 ## Server Contract
 

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -7,6 +7,7 @@ import './browser-shim.js';
 import { strict as assert } from 'node:assert';
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import { WebUIRouter } from './router.js';
+import { parseQuery, filterQuery } from './router.js';
 
 // ── Test-only type access ────────────────────────────────────────
 // The router's `inventory` and `activeChain` are private at compile
@@ -603,5 +604,87 @@ describe('WebUIRouter', () => {
         (globalThis as any).document.head = origHead;
       }
     });
+  });
+});
+
+// ── parseQuery unit tests ────────────────────────────────────────
+
+describe('parseQuery', () => {
+  test('returns empty object for paths without query string', () => {
+    assert.deepEqual(parseQuery('/compose'), {});
+    assert.deepEqual(parseQuery('/'), {});
+    assert.deepEqual(parseQuery('/items/42'), {});
+  });
+
+  test('parses single query parameter', () => {
+    assert.deepEqual(parseQuery('/compose?action=reply'), { action: 'reply' });
+  });
+
+  test('parses multiple query parameters', () => {
+    assert.deepEqual(
+      parseQuery('/compose?action=reply&to=test@example.com&subject=Re: Hello'),
+      { action: 'reply', to: 'test@example.com', subject: 'Re: Hello' },
+    );
+  });
+
+  test('decodes percent-encoded values', () => {
+    assert.deepEqual(
+      parseQuery('/compose?subject=Re%3A%20%5Bwebui%5D%20Fix%20bug'),
+      { subject: 'Re: [webui] Fix bug' },
+    );
+  });
+
+  test('handles empty values', () => {
+    assert.deepEqual(parseQuery('/search?q='), { q: '' });
+  });
+
+  test('last value wins for duplicate keys', () => {
+    const result = parseQuery('/search?sort=date&sort=name');
+    assert.equal(result.sort, 'name');
+  });
+
+  test('handles query with no path prefix', () => {
+    assert.deepEqual(parseQuery('/?q=test'), { q: 'test' });
+  });
+});
+
+// ── filterQuery unit tests ───────────────────────────────────────
+
+describe('filterQuery', () => {
+  test('returns empty object when allowlist is null (deny-by-default)', () => {
+    assert.deepEqual(filterQuery({ action: 'reply', evil: 'inject' }, null), {});
+  });
+
+  test('returns empty object when allowlist is empty set', () => {
+    assert.deepEqual(filterQuery({ action: 'reply' }, new Set()), {});
+  });
+
+  test('passes only allowed keys', () => {
+    const allowed = new Set(['action', 'to']);
+    const query = { action: 'reply', to: 'user@test.com', evil: 'inject', style: 'display:none' };
+    assert.deepEqual(filterQuery(query, allowed), { action: 'reply', to: 'user@test.com' });
+  });
+
+  test('excludes keys that collide with route params', () => {
+    const allowed = new Set(['itemId', 'action']);
+    const query = { itemId: 'evil', action: 'reply' };
+    const routeParams = { itemId: '42' };
+    assert.deepEqual(filterQuery(query, allowed, routeParams), { action: 'reply' });
+  });
+
+  test('excludes keys whose kebab form collides with route param kebab form', () => {
+    const allowed = new Set(['item-id', 'action']);
+    const query = { 'item-id': 'evil', action: 'reply' };
+    const routeParams = { itemId: '42' };
+    assert.deepEqual(filterQuery(query, allowed, routeParams), { action: 'reply' });
+  });
+
+  test('returns empty object when query is empty', () => {
+    assert.deepEqual(filterQuery({}, new Set(['action'])), {});
+  });
+
+  test('handles allowed keys not present in query', () => {
+    const allowed = new Set(['action', 'to', 'subject']);
+    assert.deepEqual(filterQuery({ action: 'reply' }, allowed), { action: 'reply' });
   });
 });

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -161,6 +161,7 @@ describe('WebUIRouter', () => {
 
       (globalThis as any).fetch = async () => ({
         ok: true,
+        headers: { get: () => 'application/json' },
         json: async () => ({
           state: {},
           templateStyles: [
@@ -245,6 +246,7 @@ describe('WebUIRouter', () => {
 
       (globalThis as any).fetch = async () => ({
         ok: true,
+        headers: { get: () => 'application/json' },
         json: async () => ({
           state: {},
           templateStyles: [],
@@ -302,7 +304,7 @@ describe('WebUIRouter', () => {
       let capturedSignal: AbortSignal | undefined;
       (globalThis as any).fetch = async (_url: string, opts?: RequestInit) => {
         capturedSignal = opts?.signal as AbortSignal | undefined;
-        return { ok: true, json: async () => ({ state: {}, templates: [], path: '/', chain: [] }) };
+        return { ok: true, headers: { get: () => 'application/json' }, json: async () => ({ state: {}, templates: [], path: '/', chain: [] }) };
       };
 
       try {
@@ -330,6 +332,7 @@ describe('WebUIRouter', () => {
       (globalThis as any).fetch = async (_url: string, _opts?: RequestInit) => {
         return {
           ok: true,
+          headers: { get: () => 'application/json' },
           json: async () => ({
             state: {},
             templates: [
@@ -367,7 +370,7 @@ describe('WebUIRouter', () => {
       const origFetch = (globalThis as any).fetch;
       (globalThis as any).fetch = async (_url: string, opts?: RequestInit) => {
         assert.equal(opts?.signal, undefined, 'signal should be undefined');
-        return { ok: true, json: async () => ({ state: {}, templates: [], path: '/', chain: [] }) };
+        return { ok: true, headers: { get: () => 'application/json' }, json: async () => ({ state: {}, templates: [], path: '/', chain: [] }) };
       };
 
       try {

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -57,6 +57,69 @@ function routeComponent(el: Element): string {
 /** Type-safe route param storage — avoids expando properties on DOM elements. */
 const routeParamsMap = new WeakMap<Element, Record<string, string>>();
 
+/**
+ * Tracks which query-param attribute names (kebab-case) were last applied to
+ * each component element. Used to remove stale attributes when query params
+ * change (e.g. navigating from `?subject=foo` to no `subject`).
+ */
+const queryAttrsMap = new WeakMap<Element, Set<string>>();
+
+/** Parse query-string parameters from a request path (e.g. `/compose?action=reply&to=x`). */
+export function parseQuery(requestPath: string): Record<string, string> {
+  const qIdx = requestPath.indexOf('?');
+  if (qIdx < 0) return {};
+  const query: Record<string, string> = {};
+  const params = new URLSearchParams(requestPath.slice(qIdx));
+  for (const [k, v] of params) {
+    query[k] = v;
+  }
+  return query;
+}
+
+/**
+ * Read the comma-separated `query` allowlist attribute from a `<route>` element.
+ * Returns null if no `query` attribute is present (deny-by-default).
+ */
+function routeAllowedQuery(el: Element): Set<string> | null {
+  const raw = el.getAttribute('query');
+  if (raw == null) return null;
+  const set = new Set<string>();
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim();
+    if (trimmed) set.add(trimmed);
+  }
+  return set;
+}
+
+/**
+ * Filter query params through an allowlist. Returns only key-value pairs
+ * whose keys appear in `allowed`. If `allowed` is null (no `query` attr
+ * on the route), returns an empty object (deny-by-default).
+ *
+ * Keys whose kebab-case form collides with a route param's kebab-case
+ * form are always excluded so that path parameters cannot be overridden
+ * via query string.
+ */
+export function filterQuery(
+  query: Record<string, string>,
+  allowed: Set<string> | null,
+  routeParams?: Record<string, string>,
+): Record<string, string> {
+  if (!allowed) return {};
+  const toKebab = (k: string): string => k.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
+  // Build a set of kebab-cased route param attribute names for collision check
+  const paramAttrNames = routeParams
+    ? new Set(Object.keys(routeParams).map(toKebab))
+    : undefined;
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(query)) {
+    if (allowed.has(k) && !(paramAttrNames && paramAttrNames.has(toKebab(k)))) {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
 function activateRoute(el: HTMLElement, params: Record<string, string>): void {
   routeParamsMap.set(el, params);
   el.setAttribute('active', '');
@@ -82,6 +145,8 @@ export class WebUIRouteElement extends HTMLElement {
   get component(): string { return this.getAttribute('component') ?? ''; }
   get isActive(): boolean { return this.hasAttribute('active'); }
   get params(): Record<string, string> { return getRouteParams(this); }
+  /** Comma-separated allowlist of query params forwarded as attributes. */
+  get query(): string { return this.getAttribute('query') ?? ''; }
 }
 
 // ── Route Chain Types ────────────────────────────────────────────
@@ -98,6 +163,8 @@ interface RouteChainEntry {
   exact?: boolean;
   /** DOM element, populated during mount or SSR chain build. */
   el?: HTMLElement;
+  /** Comma-separated allowlist of query params forwarded as attributes. */
+  allowedQuery?: string;
 }
 
 // ── Router ───────────────────────────────────────────────────────
@@ -228,6 +295,7 @@ export class WebUIRouter {
    */
   private async handleNavigation(target: NavigationTarget, signal?: AbortSignal): Promise<void> {
     const { requestPath } = target;
+    const query = parseQuery(requestPath);
 
     if (this.isInitialNavigation) {
       // Set the flag BEFORE any async work — if a new navigation
@@ -255,6 +323,7 @@ export class WebUIRouter {
         path: e.path ?? '',
         params: e.params ?? {},
         exact: e.exact,
+        allowedQuery: e.allowedQuery,
       }));
 
       if (newChain.length === 0) {
@@ -297,7 +366,7 @@ export class WebUIRouter {
         if (changeLevel > 0 || isQueryOnlyChange) {
           const end = isQueryOnlyChange ? newChain.length : changeLevel;
           for (let i = 0; i < end; i++) {
-            this.applyState(newChain[i], partialData);
+            this.applyState(newChain[i], partialData, query);
           }
         }
 
@@ -315,7 +384,7 @@ export class WebUIRouter {
           ) {
             entry.el = oldEntry.el;
             if (entry.component && partialData) {
-              this.applyState(entry, partialData);
+              this.applyState(entry, partialData, query);
             }
             activateRoute(entry.el, entry.params);
             continue;
@@ -326,7 +395,7 @@ export class WebUIRouter {
           entry.el = routeEl;
 
           if (entry.component && partialData) {
-            this.mountComponent(routeEl, entry.component, partialData, entry.params);
+            this.mountComponent(routeEl, entry.component, partialData, entry.params, query);
           }
 
           activateRoute(routeEl, entry.params);
@@ -352,6 +421,7 @@ export class WebUIRouter {
     const detail: NavigationEvent = {
       component: leaf?.component ?? '',
       params: leaf?.params ?? {},
+      query,
       path: requestPath,
     };
     window.dispatchEvent(new CustomEvent('webui:route:navigated', { detail }));
@@ -448,6 +518,7 @@ export class WebUIRouter {
         params,
         exact: isExact(activeEl),
         el: activeEl,
+        allowedQuery: activeEl.getAttribute('query') ?? undefined,
       });
       activateRoute(activeEl, params);
 
@@ -532,6 +603,14 @@ export class WebUIRouter {
     const resp = await fetch(fullPath, { headers, signal });
 
     if (!resp.ok) return null;
+
+    const contentType = resp.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      // Server returned HTML (e.g. login page) instead of JSON partial.
+      // Trigger a full page navigation so the browser handles it.
+      window.location.href = prependBasePath(requestPath, this.config.basePath ?? '');
+      return null;
+    }
 
     const data = await resp.json() as PartialResponse & { inventory?: string };
 
@@ -629,6 +708,7 @@ export class WebUIRouter {
     componentTag: string,
     data: PartialResponse,
     params: Record<string, string>,
+    query?: Record<string, string>,
   ): void {
     const component = document.createElement(componentTag);
     routeEl.textContent = '';
@@ -644,6 +724,17 @@ export class WebUIRouter {
       component.setAttribute(toKebab(key), value);
     }
 
+    // Set allowed query params as attributes (deny-by-default)
+    const allowed = routeAllowedQuery(routeEl);
+    const filtered = query ? filterQuery(query, allowed, params) : {};
+    const setAttrs = new Set<string>();
+    for (const [key, value] of Object.entries(filtered)) {
+      const attr = toKebab(key);
+      component.setAttribute(attr, value);
+      setAttrs.add(attr);
+    }
+    queryAttrsMap.set(component, setAttrs);
+
     // Set state via the framework's setInitialState (handles @observable + flush)
     if (typeof (component as any).setInitialState === 'function') {
       (component as any).setInitialState(data.state);
@@ -655,8 +746,11 @@ export class WebUIRouter {
    * Calls the framework's built-in `setInitialState` which sets
    * `@observable` properties and flushes DOM updates synchronously.
    * Route params are set as HTML attributes for `@attr` reflection.
+   * Allowed query params (declared via `query` attr on the route) are
+   * also set as attributes; stale ones from the previous navigation
+   * are removed.
    */
-  private applyState(entry: RouteChainEntry, data: PartialResponse): void {
+  private applyState(entry: RouteChainEntry, data: PartialResponse, query?: Record<string, string>): void {
     if (!entry.component || !entry.el) return;
     const compEl = entry.el.querySelector(entry.component) as any;
     if (!compEl) return;
@@ -666,6 +760,27 @@ export class WebUIRouter {
     for (const [key, value] of Object.entries(entry.params)) {
       compEl.setAttribute(toKebab(key), value);
     }
+
+    // Set allowed query params as attributes (deny-by-default)
+    const allowed = routeAllowedQuery(entry.el);
+    const filtered = query ? filterQuery(query, allowed, entry.params) : {};
+    const newAttrs = new Set<string>();
+    for (const [key, value] of Object.entries(filtered)) {
+      const attr = toKebab(key);
+      compEl.setAttribute(attr, value);
+      newAttrs.add(attr);
+    }
+
+    // Remove stale query-param attributes from the previous navigation
+    const prevAttrs = queryAttrsMap.get(compEl);
+    if (prevAttrs) {
+      for (const attr of prevAttrs) {
+        if (!newAttrs.has(attr)) {
+          compEl.removeAttribute(attr);
+        }
+      }
+    }
+    queryAttrsMap.set(compEl, newAttrs);
 
     // Set state via the framework's setInitialState (handles @observable + flush)
     if (typeof compEl.setInitialState === 'function') {

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -64,6 +64,9 @@ const routeParamsMap = new WeakMap<Element, Record<string, string>>();
  */
 const queryAttrsMap = new WeakMap<Element, Set<string>>();
 
+/** Convert a camelCase key to a kebab-case attribute name. */
+const toKebab = (k: string): string => k.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
+
 /** Parse query-string parameters from a request path (e.g. `/compose?action=reply&to=x`). */
 export function parseQuery(requestPath: string): Record<string, string> {
   const qIdx = requestPath.indexOf('?');
@@ -106,7 +109,6 @@ export function filterQuery(
   routeParams?: Record<string, string>,
 ): Record<string, string> {
   if (!allowed) return {};
-  const toKebab = (k: string): string => k.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
   // Build a set of kebab-cased route param attribute names for collision check
   const paramAttrNames = routeParams
     ? new Set(Object.keys(routeParams).map(toKebab))
@@ -608,6 +610,7 @@ export class WebUIRouter {
     if (!contentType.includes('application/json')) {
       // Server returned HTML (e.g. login page) instead of JSON partial.
       // Trigger a full page navigation so the browser handles it.
+      if (signal?.aborted) return null;
       window.location.href = prependBasePath(requestPath, this.config.basePath ?? '');
       return null;
     }
@@ -719,7 +722,6 @@ export class WebUIRouter {
     // the component's light DOM immediately.
 
     // Set route params as attributes (for @attr reflection)
-    const toKebab = (k: string): string => k.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
     for (const [key, value] of Object.entries(params)) {
       component.setAttribute(toKebab(key), value);
     }
@@ -756,7 +758,6 @@ export class WebUIRouter {
     if (!compEl) return;
 
     // Set route params as attributes (for @attr reflection)
-    const toKebab = (k: string): string => k.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
     for (const [key, value] of Object.entries(entry.params)) {
       compEl.setAttribute(toKebab(key), value);
     }

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -50,6 +50,8 @@ export interface RouterConfig {
 export interface NavigationEvent {
   component: string;
   params: Record<string, string>;
+  /** Parsed query-string parameters (e.g. `?action=reply&to=x` → `{ action: 'reply', to: 'x' }`). */
+  query: Record<string, string>;
   /** The navigated path, including the query string when present. */
   path: string;
 }

--- a/packages/webui-router/tests/fixtures/router-app/src/index.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.html
@@ -15,6 +15,7 @@
     <route path="alpha" component="page-alpha" exact />
     <route path="beta" component="page-beta" exact />
     <route path="items/:itemId" component="page-detail" exact />
+    <route path="compose" component="page-compose" query="action,to,subject" exact />
   </route>
 
   <script type="module" src="/index.js"></script>

--- a/packages/webui-router/tests/fixtures/router-app/src/index.ts
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { WebUIElement, observable } from '@microsoft/webui-framework';
+import { WebUIElement, observable, attr } from '@microsoft/webui-framework';
 import { Router } from '@microsoft/webui-router';
 
 // ── Shell component ──────────────────────────────────────────────
@@ -28,6 +28,13 @@ export class PageDetail extends WebUIElement {
 }
 PageDetail.define('page-detail');
 
+export class PageCompose extends WebUIElement {
+  @attr action = '';
+  @attr to = '';
+  @attr subject = '';
+}
+PageCompose.define('page-compose');
+
 // ── Start router after hydration ─────────────────────────────────
 
 window.addEventListener('webui:hydration-complete', () => {
@@ -36,6 +43,7 @@ window.addEventListener('webui:hydration-complete', () => {
       'page-alpha': () => Promise.resolve(),
       'page-beta': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
+      'page-compose': () => Promise.resolve(),
     },
   });
 });
@@ -47,6 +55,7 @@ if (performance.getEntriesByName('webui:hydrate:total', 'measure').length > 0) {
       'page-alpha': () => Promise.resolve(),
       'page-beta': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
+      'page-compose': () => Promise.resolve(),
     },
   });
 }

--- a/packages/webui-router/tests/fixtures/router-app/src/page-compose/page-compose.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/page-compose/page-compose.html
@@ -1,0 +1,6 @@
+<div class="page page-compose">
+  <h2>Compose</h2>
+  <p class="action">Action: {{action}}</p>
+  <p class="to">To: {{to}}</p>
+  <p class="subject">Subject: {{subject}}</p>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
@@ -6,6 +6,7 @@
     <a href="/beta" ?active="{{isBeta}}">Beta</a>
     <a href="/items/1" ?active="{{isItem1}}">Item 1</a>
     <a href="/items/2" ?active="{{isItem2}}">Item 2</a>
+    <a href="/compose?action=reply&to=test@example.com&subject=Re: Hello">Compose</a>
   </nav>
 </header>
 <main>

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -20,7 +20,7 @@ test.describe('SSR deep links', () => {
   test('root page renders shell with nav links', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Router Test');
-    await expect(page.locator('nav a')).toHaveCount(5);
+    await expect(page.locator('nav a')).toHaveCount(6);
   });
 
   test('alpha page renders via SSR', async ({ page }) => {
@@ -162,5 +162,131 @@ test.describe('page reload preservation', () => {
 
     await page.reload();
     await expect(page.locator('h2')).toContainText('Item 99');
+  });
+});
+
+test.describe('query parameter passing', () => {
+  test('SSR renders compose page (query params not available server-side)', async ({ page }) => {
+    await page.goto('/compose?action=reply&to=test@example.com&subject=Re: Hello');
+    await expect(page.locator('h2')).toContainText('Compose');
+  });
+
+  test('client-side navigation passes query params as attributes', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+
+    // Click the compose link with query params
+    await page.locator('nav a[href*="compose"]').click();
+    await expect(page.locator('h2')).toContainText('Compose');
+
+    // Verify query params were set as attributes on the component
+    const action = await page.locator('.action').textContent();
+    expect(action).toContain('reply');
+
+    const to = await page.locator('.to').textContent();
+    expect(to).toContain('test@example.com');
+
+    const subject = await page.locator('.subject').textContent();
+    expect(subject).toContain('Re: Hello');
+  });
+
+  test('navigated event includes query object', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+
+    // Listen for the navigated event
+    const queryPromise = page.evaluate(() => {
+      return new Promise<Record<string, string>>((resolve) => {
+        window.addEventListener('webui:route:navigated', ((e: CustomEvent) => {
+          resolve(e.detail.query);
+        }) as EventListener, { once: true });
+      });
+    });
+
+    await page.locator('nav a[href*="compose"]').click();
+    const query = await queryPromise;
+    expect(query).toEqual({
+      action: 'reply',
+      to: 'test@example.com',
+      subject: 'Re: Hello',
+    });
+  });
+
+  test('unlisted query params are NOT set as attributes (allowlist enforcement)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+
+    // Navigate to compose with both allowed and disallowed query params
+    await page.evaluate(() => {
+      (window as any).navigation.navigate('/compose?action=reply&to=user@test.com&class=evil&style=display:none&id=hijack');
+    });
+    await expect(page.locator('h2')).toContainText('Compose');
+
+    // Allowed params should be set
+    const comp = page.locator('page-compose');
+    await expect(comp).toHaveAttribute('action', 'reply');
+    await expect(comp).toHaveAttribute('to', 'user@test.com');
+
+    // Disallowed params must NOT be set
+    expect(await comp.getAttribute('class')).toBeNull();
+    expect(await comp.getAttribute('style')).toBeNull();
+    expect(await comp.getAttribute('id')).toBeNull();
+  });
+
+  test('navigated event includes ALL query params (unfiltered)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+
+    const queryPromise = page.evaluate(() => {
+      return new Promise<Record<string, string>>((resolve) => {
+        window.addEventListener('webui:route:navigated', ((e: CustomEvent) => {
+          resolve(e.detail.query);
+        }) as EventListener, { once: true });
+      });
+    });
+
+    await page.evaluate(() => {
+      (window as any).navigation.navigate('/compose?action=reply&evil=inject');
+    });
+
+    const query = await queryPromise;
+    // Event should contain ALL params (unfiltered) for JS consumers
+    expect(query).toEqual({ action: 'reply', evil: 'inject' });
   });
 });


### PR DESCRIPTION
- Add parseQuery() helper to extract URLSearchParams from request paths
- Include 'query' field in NavigationEvent dispatched on navigation
- Pass query params as kebab-case attributes on mounted/re-applied components
- Add page-compose fixture with @attr fields for query param testing
- Add 7 unit tests for parseQuery (empty, single, multiple, encoded, dupes)
- Add 3 E2E tests: SSR render, client-side attr flow, navigated event query
- Update router README and docs/guide/ai.md with query param documentation
- All 32 unit tests + 11 E2E tests pass