### PR TITLE
test(framework): add composed-root-event regression fixture

### DIFF
--- a/packages/webui-framework/tests/fixtures/composed-root-event/composed-root-event.spec.ts
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/composed-root-event.spec.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('composed root event — custom event pierces shadow DOM', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/composed-root-event/fixture.html');
+    await page.waitForSelector('test-grandparent');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-grandparent');
+      return el && (el as any).$ready === true;
+    });
+  });
+
+  test('grandparent receives composed custom event from grandchild', async ({ page }) => {
+    // Click the "alpha" button inside test-child (nested 2 shadow DOMs deep)
+    await page.locator('test-grandparent test-child[item-id="alpha"] .select-btn').click();
+
+    // The grandparent's @item-selected root handler should fire
+    await expect(page.locator('test-grandparent .result')).toHaveText('alpha');
+  });
+
+  test('grandparent receives event from second grandchild', async ({ page }) => {
+    await page.locator('test-grandparent test-child[item-id="beta"] .select-btn').click();
+    await expect(page.locator('test-grandparent .result')).toHaveText('beta');
+  });
+
+  test('multiple clicks update correctly', async ({ page }) => {
+    await page.locator('test-grandparent test-child[item-id="alpha"] .select-btn').click();
+    await expect(page.locator('test-grandparent .result')).toHaveText('alpha');
+
+    await page.locator('test-grandparent test-child[item-id="beta"] .select-btn').click();
+    await expect(page.locator('test-grandparent .result')).toHaveText('beta');
+  });
+
+  test('event detail contains correct id', async ({ page }) => {
+    await page.locator('test-grandparent test-child[item-id="alpha"] .select-btn').click();
+
+    const detail = await page.evaluate(() => {
+      const el = document.querySelector('test-grandparent') as any;
+      return el?.selectedItem;
+    });
+    expect(detail).toBe('alpha');
+  });
+});

--- a/packages/webui-framework/tests/fixtures/composed-root-event/element.ts
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/element.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { WebUIElement, observable, attr } from '../../../src/index.js';
+
+// Grandchild — emits a composed custom event.
+export class TestChild extends WebUIElement {
+  @attr itemId = '';
+
+  onSelect(): void {
+    this.$emit('item-selected', { id: this.itemId });
+  }
+}
+TestChild.define('test-child');
+
+// Intermediary — just wraps children, no event handling.
+export class TestParent extends WebUIElement {}
+TestParent.define('test-parent');
+
+// Grandparent — listens for composed event via @item-selected on <template>.
+export class TestGrandparent extends WebUIElement {
+  @observable selectedItem = 'none';
+
+  onItemSelected(e: CustomEvent<{ id: string }>): void {
+    this.selectedItem = e.detail.id;
+  }
+}
+TestGrandparent.define('test-grandparent');

--- a/packages/webui-framework/tests/fixtures/composed-root-event/src/index.html
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Composed Root Event Fixture</title>
+</head>
+<body>
+  <test-grandparent></test-grandparent>
+</body>
+</html>

--- a/packages/webui-framework/tests/fixtures/composed-root-event/src/test-child/test-child.html
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/src/test-child/test-child.html
@@ -1,0 +1,1 @@
+<button class="select-btn" @click="{onSelect()}">{{itemId}}</button>

--- a/packages/webui-framework/tests/fixtures/composed-root-event/src/test-grandparent/test-grandparent.html
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/src/test-grandparent/test-grandparent.html
@@ -1,0 +1,4 @@
+<template shadowrootmode="open" @item-selected="{onItemSelected(e)}">
+  <span class="result">{{selectedItem}}</span>
+  <test-parent></test-parent>
+</template>

--- a/packages/webui-framework/tests/fixtures/composed-root-event/src/test-parent/test-parent.html
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/src/test-parent/test-parent.html
@@ -1,0 +1,4 @@
+<div class="list">
+  <test-child item-id="alpha"></test-child>
+  <test-child item-id="beta"></test-child>
+</div>

--- a/packages/webui-framework/tests/fixtures/composed-root-event/state.json
+++ b/packages/webui-framework/tests/fixtures/composed-root-event/state.json
@@ -1,0 +1,3 @@
+{
+  "selectedItem": "none"
+}


### PR DESCRIPTION
Tests that custom events with composed:true from deeply nested shadow DOM components (grandchild → parent → grandparent) correctly reach the grandparent's @event root handler on <template shadowrootmode>.

The fixture has 3 components: test-grandparent (listens via root event), test-parent (passthrough), test-child (emits composed event on click). All 4 tests pass — the framework's correctly handles composed events that pierce shadow boundaries.