### PR TITLE
fix(router): skip startViewTransition for query-only navigations

### DIFF
--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -481,6 +481,35 @@ describe('WebUIRouter', () => {
       );
     });
 
+    test('startViewTransition is skipped for query-only navigations', () => {
+      // Regression (issue #235): query-only navigations (e.g. /contacts →
+      // /contacts?q=foo) do not remount any components. Wrapping them in
+      // startViewTransition captures a screenshot and temporarily suppresses
+      // the live DOM, which blurs the active element (search input focus lost
+      // mid-typing). The router must guard the startViewTransition call with
+      // an `isQueryOnlyChange` check so focus is preserved.
+      const router = new WebUIRouter();
+      const source = (router as any).handleNavigation.toString() as string;
+
+      // The view-transition block must be gated on !isQueryOnlyChange
+      const transitionIdx = source.indexOf('startViewTransition');
+      assert.ok(transitionIdx > -1, 'startViewTransition should be referenced');
+
+      // The `if` condition that invokes startViewTransition must also
+      // check isQueryOnlyChange (either before or after the feature check).
+      // We grab the surrounding context to verify the guard is present.
+      const conditionRegion = source.slice(
+        Math.max(0, transitionIdx - 120),
+        transitionIdx + 80,
+      );
+      assert.ok(
+        conditionRegion.includes('isQueryOnlyChange'),
+        'startViewTransition must be guarded by isQueryOnlyChange — ' +
+        'query-only navigations must skip view transitions to preserve focus ' +
+        `(condition region: "${conditionRegion}")`,
+      );
+    });
+
     test('startViewTransition callback does not contain async fetch or import', () => {
       // Regression: the view transition callback must complete synchronously
       // (DOM swap only). Async work (fetch, module load) must happen BEFORE

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -336,11 +336,14 @@ export class WebUIRouter {
       };
 
       // DOM swap — wrapped in a view transition when available.
+      // Skip view transitions for query-only changes (issue #235): no
+      // components remount so there is nothing to animate, and the
+      // transition would blur the active element (e.g. search input).
       // Await updateCallbackDone (not .finished) so the Navigation API
       // handler resolves as soon as the DOM commit completes, without
       // waiting for the CSS animation to finish. This allows rapid
       // navigations to supersede each other without queuing.
-      if (document.startViewTransition) {
+      if (document.startViewTransition && !isQueryOnlyChange) {
         const transition = document.startViewTransition(commitNavigation);
         await transition.updateCallbackDone;
       } else {


### PR DESCRIPTION
When only the query string changes (e.g. /contacts -> /contacts?q=foo), no components are remounted — there is nothing meaningful to animate. The View Transitions API captures a screenshot and temporarily suppresses the live DOM during the transition, which causes the browser to blur any focused element. This is most noticeable on search fields: the user types, the debounce fires, the router navigates, and the input loses focus mid-typing.

Guard the startViewTransition call with an isQueryOnlyChange check so that query-only navigations commit synchronously without a view transition, preserving focus on the active element.

Add a regression test that verifies the guard is present by inspecting the handleNavigation source (consistent with the existing view transition timing tests).

Fixes #235