### PR TITLE
fix: preserve text content with bindings after void elements

### DIFF
--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -851,8 +851,12 @@ impl HtmlParser {
                     self.add_raw_fragment(">");
                 }
             } else if !has_end {
-                // Void element (no end tag from parser) — just close the opening tag
+                // Void element (no end tag from parser) — just close the opening tag.
+                // Tree-sitter HTML may still attach following content as children
+                // of the void element (e.g., `<br>text {{binding}}`), so we must
+                // process those children to avoid dropping text and bindings.
                 self.add_raw_fragment(">");
+                self.process_content_children(node, source, fragments)?;
             } else {
                 self.add_raw_fragment(">");
 
@@ -4432,6 +4436,25 @@ mod tests {
                 signal_raw("body_start"),
                 signal_raw("body_end"),
                 raw("</body></html>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_text_with_binding_after_void_element() {
+        // Text nodes containing {{binding}} after void elements like <br>
+        // must be preserved. Regression test for content being dropped.
+        let (fragments, _) = parse_and_get_fragments(
+            "Part A: {{value1}}<button>Click</button><br>Part B: {{value2}}<button>Click2</button>",
+        );
+        assert_fragments!(
+            fragments,
+            [
+                raw("Part A: "),
+                signal("value1"),
+                raw("<button>Click</button><br>Part B: "),
+                signal("value2"),
+                raw("<button>Click2</button>"),
             ]
         );
     }


### PR DESCRIPTION
## Description

Fix text nodes and `{{bindings}}` being silently dropped when they follow HTML void elements like `<br>`, `<hr>`, `<img>`, etc.

Tree-sitter HTML parses void elements with following text as children of the void element node. For example, `<br>Part B: {{value2}}` is parsed as a single `element` node where `Part B: {{value2}}` is a `text` child of `<br>`. The parser previously skipped content processing for void elements (since they have no end tag), which caused any text nodes and bindings that tree-sitter attached as children to be silently dropped.

The fix adds `process_content_children()` for void elements, matching the behavior already used for elements with end tags.

**Before:**
```
Input:    Part A: {{value1}}<br>Part B: {{value2}}
Fragments: [raw("Part A: "), signal("value1"), raw("<br>")]
           ❌ "Part B: " and {{value2}} are lost
```

**After:**
```
Input:    Part A: {{value1}}<br>Part B: {{value2}}
Fragments: [raw("Part A: "), signal("value1"), raw("<br>Part B: "), signal("value2")]
           ✅ All content preserved
```

## Test Plan

- Added regression test `test_text_with_binding_after_void_element`
- All 286 existing parser tests continue to pass
- `cargo xtask check` passes (license-headers, fmt, clippy, test)

## Checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I understand and have considered the performance impact of my changes.
