### PR TITLE
chore: update rustls-webpki 0.103.10 → 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Description

Update `rustls-webpki` from `0.103.10` to `0.103.12` to resolve two security advisories that are failing the `cargo deny` lint gate:

- **RUSTSEC-2026-0098**: Name constraints for URI names were incorrectly accepted
- **RUSTSEC-2026-0099**: Name constraints were accepted for certificates asserting a wildcard name

This vulnerability on `main` is also causing lint failures on these open PRs:

- #241
- #242
- #243

## Test Plan

- `cargo deny check` passes cleanly after the update
- No code changes, only `Cargo.lock` version bump

## Checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I understand and have considered the performance impact of my changes.
