### PR TITLE
fix: address ensureLoaded PR review feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packages/*/webui.node
 publish/
 *.nupkg
 .last
+packages/webui/bin/webui.exe

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -538,31 +538,17 @@ pub fn render_component_templates(
     component_tags: &[&str],
     inventory_hex: &str,
 ) -> Value {
+    let requested: HashSet<String> = component_tags.iter().map(|s| s.to_string()).collect();
     let index = build_component_index(protocol);
-    let client_inv = parse_inventory(inventory_hex);
-    let mut updated_inv = client_inv.clone();
+    let (needed, updated_inv) = filter_needed_components(&requested, inventory_hex, &index);
 
-    // Filter out components the client already has
-    let mut needed: Vec<&str> = Vec::with_capacity(component_tags.len());
-    for &tag in component_tags {
-        if let Some(&idx) = index.get(tag) {
-            if has_component(&client_inv, idx) {
-                continue;
-            }
-            set_component(&mut updated_inv, idx);
-        }
-        needed.push(tag);
-    }
-
-    let (style_array, tmpl_array) = collect_component_assets(protocol, &needed);
+    let tag_refs: Vec<&str> = needed.iter().map(|s| s.as_str()).collect();
+    let (style_array, tmpl_array) = collect_component_assets(protocol, &tag_refs);
 
     let mut result = serde_json::Map::with_capacity(3);
     result.insert("templateStyles".into(), Value::Array(style_array));
     result.insert("templates".into(), Value::Array(tmpl_array));
-    result.insert(
-        "inventory".into(),
-        Value::String(encode_inventory(&updated_inv)),
-    );
+    result.insert("inventory".into(), Value::String(updated_inv));
     Value::Object(result)
 }
 
@@ -571,6 +557,7 @@ fn collect_component_assets(protocol: &WebUIProtocol, tags: &[&str]) -> (Vec<Val
     let mut style_array = Vec::new();
     let mut tmpl_array = Vec::new();
 
+    // Sort for deterministic output (reproducible responses, cache keys)
     let mut sorted_tags: Vec<&str> = tags.to_vec();
     sorted_tags.sort_unstable();
 

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -293,7 +293,7 @@ export class WebUIRouter {
     // Batch-fetch missing templates in one request
     if (missing.length > 0) {
       const inv = this.inventory;
-      const fetchPromise = this.fetchComponentTemplates(missing, inv).then(() => {
+      const fetchPromise = this.fetchComponentTemplates(missing, inv).finally(() => {
         for (const tag of missing) this.loadPromises.delete(tag);
       });
       for (const tag of missing) this.loadPromises.set(tag, fetchPromise);
@@ -312,12 +312,15 @@ export class WebUIRouter {
   /**
    * Fetch component templates + CSS from the server and register them.
    * Reuses the same registration logic as fetchPartial.
+   * Throws on network or server errors so callers can handle failures.
    */
   private async fetchComponentTemplates(tags: string[], inventoryHex: string): Promise<void> {
     const endpoint = this.config.templateEndpoint ?? '/_webui/templates';
     const url = `${endpoint}?t=${tags.join(',')}&inv=${encodeURIComponent(inventoryHex)}`;
     const resp = await fetch(url);
-    if (!resp.ok) return;
+    if (!resp.ok) {
+      throw new Error(`[Router] ensureLoaded failed: ${resp.status} ${resp.statusText}`);
+    }
     const data = await resp.json();
 
     // Register using the same pipeline as partial navigation
@@ -368,7 +371,11 @@ export class WebUIRouter {
       }
     }
 
-    // 2. Template registration: execute JS IIFEs / insert DOM templates
+    // 2. Template registration: execute JS IIFEs / insert DOM templates.
+    //    TRUST BOUNDARY: template scripts come from the same-origin server
+    //    that compiled the protocol. The CSP nonce gates script execution.
+    //    If the server endpoint is compromised, this is an XSS vector —
+    //    same risk as the existing fetchPartial pipeline.
     if (data.templates) {
       let scriptBody = '';
       for (const tmpl of data.templates) {
@@ -761,9 +768,9 @@ export class WebUIRouter {
     // Register templates, styles, and CSS using the shared pipeline
     this.registerTemplatesAndStyles(data);
 
-    // Also handle legacy `css` field from older server responses
-    if ((data as unknown as Record<string, unknown>).css) {
-      for (const href of (data as unknown as Record<string, unknown>).css as string[]) {
+    // Inject CSS stylesheet links (used by some server implementations)
+    if (data.css) {
+      for (const href of data.css) {
         if (!document.querySelector(`link[href="${href}"]`)) {
           const link = document.createElement('link');
           link.rel = 'stylesheet';

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -340,7 +340,7 @@ test.describe('ensureLoaded — non-route components', () => {
       return performance.now() - t0;
     });
 
-    // Should be < 5ms (no network round-trip)
+    // Should complete quickly — no network round-trip (< 50ms on CI)
     expect(start).toBeLessThan(50);
   });
 


### PR DESCRIPTION
Fixes issues identified in code review of the `Router.ensureLoaded()` feature.

- **Unknown tags corrupted inventory**: `render_component_templates` pushed tags not in the protocol index to the `needed` list, updating the inventory bitfield for components that don't exist. Now reuses `filter_needed_components` which only includes tags present in the component index.
- **loadPromises leaked on failure**: If `fetchComponentTemplates` rejected (network error), the promise stayed in `loadPromises` forever. Subsequent calls for the same tag would await the rejected promise and silently fail. Changed `.then()` to `.finally()` for cleanup.
- **Silent failure on server error**: `fetchComponentTemplates` returned silently on non-OK responses. Now throws so callers can handle failures.

- **Reuse `filter_needed_components`**: `render_component_templates` no longer hand-rolls its own inventory filter loop — it calls the same shared function that `render_partial` and `get_needed_components` use.
- **Remove brittle type cast**: Replaced `(data as unknown as Record<...>).css` with direct `data.css` access since `css` is already in the `PartialResponse` type.
- **Trust boundary comment**: Added security comment on the script execution pipeline in `registerTemplatesAndStyles` acknowledging the XSS trust boundary.
- **Sort comment**: Documented that `collect_component_assets` sorts tags for deterministic output, not correctness.
- **Test comment fix**: Idempotency test comment now matches the actual 50ms threshold.

## Checklist
- [x] All 211 handler unit tests pass (including 3 ensureLoaded tests)
- [x] All 16 router E2E tests pass (including 3 ensureLoaded tests)
- [x] Router TypeScript builds clean
- [x] Unknown tags no longer corrupt inventory
- [x] Failed fetches clean up loadPromises via .finally()
- [x] Non-OK responses throw instead of silently returning
- [x] No duplicated inventory filtering logic
- [x] No unsafe type casts
- [x] Trust boundary documented
- [x] Test comments accurate