### PR TITLE
chore: Harden clippy lints, refactor error enums, and enforce perf discipline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "thiserror",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 [workspace.package]
 version = "0.0.9"
 edition = "2021"
+rust-version = "1.93"
 authors = ["Microsoft Edge"]
 license = "MIT"
 repository = "https://github.com/microsoft/webui"
@@ -65,6 +66,35 @@ tokio-test = "0.4.5"
 prost-build = "0.14.3"
 napi-build = "2"
 cbindgen = "0.29.2"
+
+[workspace.lints.clippy]
+# Lint groups (lower priority so individual lints can override)
+perf = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+# Performance
+large_enum_variant = "deny"
+large_stack_arrays = "deny"
+large_futures = "deny"
+needless_collect = "deny"
+redundant_clone = "deny"
+unnecessary_to_owned = "deny"
+inefficient_to_string = "deny"
+manual_memcpy = "deny"
+naive_bytecount = "deny"
+# Security & correctness
+cast_possible_truncation = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "deny"
+# Memory discipline
+rc_buffer = "deny"
+large_types_passed_by_value = "deny"
+vec_box = "deny"
+unnecessary_box_returns = "deny"
+# Documentation
+# doc_markdown = "warn"  # TODO: enable after fixing 101 existing violations
+
+[workspace.lints.rust]
+unsafe_code = "deny"
 
 [profile.release]
 lto = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,13 @@
 disallowed-methods = [
   { path = "std::option::Option::unwrap", reason = "can panic; prefer handling the None case explicitly" },
   { path = "std::result::Result::unwrap", reason = "can panic; prefer handling the Err case explicitly" },
+  { path = "std::option::Option::expect", reason = "can panic; prefer handling the None case explicitly" },
+  { path = "std::result::Result::expect", reason = "can panic; prefer handling the Err case explicitly" },
+]
+disallowed-types = [
+  { path = "std::collections::LinkedList", reason = "poor cache locality; use Vec or VecDeque" },
 ]
 cognitive-complexity-threshold = 20
 too-many-arguments-threshold = 5
+large-error-threshold = 128
 

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -35,3 +35,6 @@ walkdir = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.9" }
+
+[lints]
+workspace = true

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -311,7 +311,7 @@ fn run(args: &ServeArgs) -> Result<()> {
         app_args: args.app_args.clone(),
         app_dir: paths.app_dir.clone(),
         state_file: paths.state_file.clone(),
-        token_css: token_css.clone(),
+        token_css,
     };
 
     output::header("WebUI Dev Server");
@@ -389,7 +389,7 @@ fn run(args: &ServeArgs) -> Result<()> {
         assets_dir: paths.serve_dir,
         api_port: args.api_port,
         plugin: args.app_args.plugin,
-        token_css: render_config.token_css.clone(),
+        token_css: render_config.token_css,
     });
 
     let has_api_proxy = server_context.api_port.is_some();

--- a/crates/webui-discovery/Cargo.toml
+++ b/crates/webui-discovery/Cargo.toml
@@ -23,3 +23,6 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -28,3 +28,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "expressions_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui-expressions/benches/expressions_bench.rs
+++ b/crates/webui-expressions/benches/expressions_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 use criterion::{criterion_group, criterion_main, Criterion};
 use serde_json::json;
 use std::hint::black_box;

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -29,3 +29,6 @@ windows = { workspace = true }
 
 [build-dependencies]
 cbindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/webui-ffi/build.rs
+++ b/crates/webui-ffi/build.rs
@@ -5,7 +5,7 @@ extern crate cbindgen;
 
 use std::env;
 use std::io::{Error, ErrorKind};
-use std::path::PathBuf; // Removed 'self' import
+use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the crate directory with proper error handling
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_crate(crate_dir)
         .with_config(config)
         .generate()
-        .map_err(|e| Error::other(format!("Unable to generate C bindings: {e}")))?;
+        .map_err(Error::other)?;
     bindings.write_to_file(out_dir.join("webui_ffi.h"));
 
     Ok(())

--- a/crates/webui-ffi/build.rs
+++ b/crates/webui-ffi/build.rs
@@ -21,12 +21,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // C header
     let config = cbindgen::Config::default();
-    cbindgen::Builder::new()
+    let bindings = cbindgen::Builder::new()
         .with_crate(crate_dir)
         .with_config(config)
         .generate()
-        .expect("Unable to generate C bindings")
-        .write_to_file(out_dir.join("webui_ffi.h"));
+        .map_err(|e| Error::other(format!("Unable to generate C bindings: {e}")))?;
+    bindings.write_to_file(out_dir.join("webui_ffi.h"));
 
     Ok(())
 }

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// FFI crate requires unsafe for C-compatible ABI boundary.
+#![allow(unsafe_code)]
+
 //! WebUI FFI (Foreign Function Interface) for interoperability with other languages.
 //!
 //! This crate provides C-compatible APIs for the WebUI handler to be used from languages

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// FFI tests exercise unsafe C ABI functions.
+#![allow(unsafe_code)]
+
 //! Integration tests for the webui-ffi C ABI.
 //!
 //! These tests call every `#[no_mangle] extern "C"` function through the

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -31,3 +31,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "handler_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use serde_json::json;
 use serde_json::Value;
@@ -148,7 +147,7 @@ fn handler_plugin_fast_bench(c: &mut Criterion) {
     let protocol = build_mixed_protocol();
     let state = build_state(120);
 
-    let mut baseline_handler = WebUIHandler::new();
+    let baseline_handler = WebUIHandler::new();
     let mut baseline_writer = BenchWriter::new(16 * 1024);
     baseline_handler
         .handle(
@@ -218,7 +217,7 @@ fn handler_loop_scaling_bench(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(writer.len() as u64));
 
         group.bench_with_input(BenchmarkId::new("items", count), &state, |b, st| {
-            let mut h = WebUIHandler::new();
+            let h = WebUIHandler::new();
             let mut w = BenchWriter::new(count * 80 + 1024);
 
             b.iter(|| {
@@ -327,7 +326,7 @@ fn handler_condition_variety_bench(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(writer.len() as u64));
 
     group.bench_function("all_true", |b| {
-        let mut h = WebUIHandler::new();
+        let h = WebUIHandler::new();
         let mut w = BenchWriter::new(1024);
         b.iter(|| {
             w.clear();
@@ -351,7 +350,7 @@ fn handler_condition_variety_bench(c: &mut Criterion) {
     });
 
     group.bench_function("mixed", |b| {
-        let mut h = WebUIHandler::new();
+        let h = WebUIHandler::new();
         let mut w = BenchWriter::new(1024);
         b.iter(|| {
             w.clear();
@@ -440,7 +439,7 @@ fn handler_nested_components_bench(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(writer.len() as u64));
 
     group.bench_function("three_levels_50_items", |b| {
-        let mut h = WebUIHandler::new();
+        let h = WebUIHandler::new();
         let mut w = BenchWriter::new(8 * 1024);
         b.iter(|| {
             w.clear();
@@ -494,7 +493,7 @@ fn handler_state_depth_bench(c: &mut Criterion) {
         let protocol = build_signal_protocol(path);
 
         group.bench_function(*label, |b| {
-            let mut h = WebUIHandler::new();
+            let h = WebUIHandler::new();
             let mut w = BenchWriter::new(256);
             b.iter(|| {
                 w.clear();

--- a/crates/webui-handler/src/plugin/webui.rs
+++ b/crates/webui-handler/src/plugin/webui.rs
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_default_creates_instance() {
-        let _plugin = WebUIHydrationPlugin::default();
+        let _plugin = WebUIHydrationPlugin;
     }
 
     #[test]

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -33,7 +33,12 @@ pub fn build_component_index(protocol: &WebUIProtocol) -> HashMap<String, u32> {
     sorted
         .iter()
         .enumerate()
-        .map(|(i, n)| ((*n).clone(), i as u32))
+        .map(|(i, n)| {
+            // Index count bounded by component registry size, well within u32 range
+            #[allow(clippy::cast_possible_truncation)]
+            let idx = i as u32;
+            ((*n).clone(), idx)
+        })
         .collect()
 }
 

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -30,3 +30,6 @@ napi-build = { workspace = true }
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.9", default-features = false }
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.9" }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -84,6 +84,7 @@ pub struct JsBuildOptions {
 ///
 /// Returns the compiled protocol bytes, CSS files, and build statistics.
 #[napi]
+#[allow(clippy::cast_possible_truncation)] // stats are bounded by component/file counts
 pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
     let css = options
         .css

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -42,3 +42,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "parser_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui-parser/benches/parser_bench.rs
+++ b/crates/webui-parser/benches/parser_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::hint::black_box;
 use webui_parser::{plugin::fast::FastParserPlugin, CssStrategy, HtmlParser};
@@ -71,14 +70,14 @@ fn build_component_heavy_template(components: usize) -> String {
 
     for idx in 0..components {
         let component_name = component_names[idx % component_names.len()];
-        html.push_str("<");
+        html.push('<');
         html.push_str(component_name);
         html.push_str(" title=\"{{title}}\" :props=\"{{props}}\" ?active=\"{{active}}\">");
         html.push_str("<span>slot ");
         html.push_str(&idx.to_string());
         html.push_str("</span></");
         html.push_str(component_name);
-        html.push_str(">");
+        html.push('>');
     }
 
     html.push_str("</body>");

--- a/crates/webui-parser/src/component_registry.rs
+++ b/crates/webui-parser/src/component_registry.rs
@@ -131,7 +131,7 @@ impl ComponentRegistry {
 
         // Read HTML content
         let html_content = fs::read_to_string(html_path).map_err(|source| ParserError::IO {
-            context: "Failed to read HTML file".to_string(),
+            context: format!("Failed to read HTML file: {}", html_path.display()),
             source,
         })?;
 
@@ -140,7 +140,7 @@ impl ComponentRegistry {
             let css_path = css_path.as_ref();
             if css_path.exists() {
                 let content = fs::read_to_string(css_path).map_err(|source| ParserError::IO {
-                    context: "Failed to read CSS file".to_string(),
+                    context: format!("Failed to read CSS file: {}", css_path.display()),
                     source,
                 })?;
                 let tokens = self.extract_sorted_tokens(&content)?;

--- a/crates/webui-parser/src/component_registry.rs
+++ b/crates/webui-parser/src/component_registry.rs
@@ -130,15 +130,19 @@ impl ComponentRegistry {
         }
 
         // Read HTML content
-        let html_content = fs::read_to_string(html_path)
-            .map_err(|e| ParserError::IO(format!("Failed to read HTML file: {}", e)))?;
+        let html_content = fs::read_to_string(html_path).map_err(|source| ParserError::IO {
+            context: "Failed to read HTML file".to_string(),
+            source,
+        })?;
 
         // Read CSS content and extract tokens if available
         let (css_content, css_tokens) = if let Some(css_path) = css_path {
             let css_path = css_path.as_ref();
             if css_path.exists() {
-                let content = fs::read_to_string(css_path)
-                    .map_err(|e| ParserError::IO(format!("Failed to read CSS file: {}", e)))?;
+                let content = fs::read_to_string(css_path).map_err(|source| ParserError::IO {
+                    context: "Failed to read CSS file".to_string(),
+                    source,
+                })?;
                 let tokens = self.extract_sorted_tokens(&content)?;
                 (Some(content), tokens)
             } else {

--- a/crates/webui-parser/src/css_parser.rs
+++ b/crates/webui-parser/src/css_parser.rs
@@ -30,6 +30,8 @@ impl CssParser {
     /// Create a new CSS parser.
     pub fn new() -> Self {
         let mut parser = Parser::new();
+        // Grammar is statically linked — set_language cannot fail at runtime.
+        #[allow(clippy::disallowed_methods)]
         parser
             .set_language(&LANGUAGE.into())
             .expect("Error loading CSS grammar");
@@ -169,6 +171,7 @@ impl CssParser {
 
     /// Iteratively walk the CSS tree to collect var() usages and custom
     /// property definitions. Uses an explicit stack instead of recursion.
+    #[allow(clippy::cast_possible_truncation)] // tree-sitter child indices are u32
     fn walk_css_tree(
         root: Node<'_>,
         source: &str,
@@ -200,6 +203,7 @@ impl CssParser {
 
     /// If `node` is a `var()` call expression, extract its `plain_value`
     /// arguments as token names (stripping the `--` prefix).
+    #[allow(clippy::cast_possible_truncation)] // tree-sitter child indices are u32
     fn extract_var_tokens(node: Node<'_>, source: &str, tokens: &mut HashSet<String>) {
         let count = node.child_count();
         let is_var = (0..count).any(|i| {
@@ -256,6 +260,7 @@ impl Default for CssParser {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/webui-parser/src/error.rs
+++ b/crates/webui-parser/src/error.rs
@@ -3,56 +3,53 @@
 
 //! Error handling for the WebUI parser.
 
-use std::fmt;
+use thiserror::Error;
 
 /// Result type for WebUI parser operations.
 pub type Result<T> = std::result::Result<T, ParserError>;
 
 /// Error type for WebUI parser.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ParserError {
     /// Generic error.
+    #[error("Generic error: {0}")]
     Generic(String),
 
-    /// I/O error.
-    IO(String),
+    /// I/O error with context.
+    #[error("I/O error: {context}")]
+    IO {
+        /// What operation failed.
+        context: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
 
     /// Parse error.
+    #[error("Parse error: {0}")]
     Parse(String),
 
     /// Component error.
+    #[error("Component error: {0}")]
     Component(String),
 
     /// CSS error.
+    #[error("CSS error: {0}")]
     Css(String),
 
     /// HTML error.
+    #[error("HTML error: {0}")]
     Html(String),
 
     /// Directive error.
+    #[error("Directive error: {0}")]
     Directive(String),
 
     /// Entity not found error.
+    #[error("Not found: {0}")]
     NotFound(String),
 
     /// TypeScript parse error.
+    #[error("TypeScript parse error: {0}")]
     TsParseError(String),
 }
-
-impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Generic(msg) => write!(f, "Generic error: {}", msg),
-            Self::IO(msg) => write!(f, "I/O error: {}", msg),
-            Self::Parse(msg) => write!(f, "Parse error: {}", msg),
-            Self::Component(msg) => write!(f, "Component error: {}", msg),
-            Self::Css(msg) => write!(f, "CSS error: {}", msg),
-            Self::Html(msg) => write!(f, "HTML error: {}", msg),
-            Self::Directive(msg) => write!(f, "Directive error: {}", msg),
-            Self::NotFound(msg) => write!(f, "Not found: {}", msg),
-            Self::TsParseError(msg) => write!(f, "TypeScript parse error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for ParserError {}

--- a/crates/webui-parser/src/error.rs
+++ b/crates/webui-parser/src/error.rs
@@ -16,7 +16,7 @@ pub enum ParserError {
     Generic(String),
 
     /// I/O error with context.
-    #[error("I/O error: {context}")]
+    #[error("I/O error: {context}: {source}")]
     IO {
         /// What operation failed.
         context: String,

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -209,6 +209,8 @@ impl HtmlParser {
     /// Create a new directive parser.
     pub fn new() -> Self {
         let mut parser = Parser::new();
+        // Grammar is statically linked — set_language cannot fail at runtime.
+        #[allow(clippy::disallowed_methods)]
         parser
             .set_language(&LANGUAGE.into())
             .expect("Error loading HTML grammar");
@@ -1816,7 +1818,9 @@ impl HtmlParser {
                 return Some(node);
             }
             let mut cursor = node.walk();
-            // Push children in reverse so first child is processed first
+            // Collect is required: cursor is mutably borrowed by the iterator,
+            // so we must collect before reversing to push children in DFS order.
+            #[allow(clippy::needless_collect)]
             let children: Vec<_> = node.children(&mut cursor).collect();
             for child in children.into_iter().rev() {
                 stack.push(child);
@@ -3129,7 +3133,7 @@ mod tests {
     fn test_doctype_preserved() {
         // DOCTYPE should be preserved as raw content
         let (fragments, _) = parse_and_get_fragments("<!DOCTYPE html><html><head></head></html>");
-        assert!(fragments.len() >= 1);
+        assert!(!fragments.is_empty());
         assert!(
             matches!(fragments[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if raw.value.contains("<!DOCTYPE html>"))
         );

--- a/crates/webui-protocol/Cargo.toml
+++ b/crates/webui-protocol/Cargo.toml
@@ -30,3 +30,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "protocol_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui-protocol/benches/protocol_bench.rs
+++ b/crates/webui-protocol/benches/protocol_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -266,7 +265,7 @@ fn create_large_protocol(component_count: usize) -> WebUIProtocol {
             panel_id,
             FragmentList {
                 fragments: vec![
-                    WebUIFragment::raw(&format!("<section class=\"panel\" data-idx=\"{idx}\">")),
+                    WebUIFragment::raw(format!("<section class=\"panel\" data-idx=\"{idx}\">")),
                     WebUIFragment::raw("<h3>"),
                     WebUIFragment::signal("title", false),
                     WebUIFragment::raw("</h3>"),

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -25,3 +25,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "state_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui-state/benches/state_bench.rs
+++ b/crates/webui-state/benches/state_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use serde_json::json;
 use std::hint::black_box;

--- a/crates/webui-state/src/lib.rs
+++ b/crates/webui-state/src/lib.rs
@@ -333,13 +333,11 @@ mod tests {
 
     #[test]
     fn test_double_value_directly() {
-        let data = test_json!({ "double_value": 3.14159 });
+        let data = test_json!({ "double_value": 1.23 });
         let value = find_value_by_dotted_path("double_value", &data);
         assert_eq!(
             value,
-            Some(Value::Number(
-                serde_json::Number::from_f64(3.14159).unwrap()
-            ))
+            Some(Value::Number(serde_json::Number::from_f64(1.23).unwrap()))
         );
     }
 }

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -20,3 +20,6 @@ mockall = { workspace = true }
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.9" }
+
+[lints]
+workspace = true

--- a/crates/webui-test-utils/src/lib.rs
+++ b/crates/webui-test-utils/src/lib.rs
@@ -499,6 +499,7 @@ impl TestFileSystem {
     }
 
     /// Add a file to the test file system at the specified path
+    #[allow(clippy::disallowed_methods)] // Test helper — panicking on failure is intentional
     pub fn add_file(&mut self, path: &str, content: &str) -> PathBuf {
         // Create a new temporary directory for this file
         let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");

--- a/crates/webui-tokens/Cargo.toml
+++ b/crates/webui-tokens/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -29,3 +29,6 @@ serde-wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.9" }
+
+[lints]
+workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.9" }

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -172,7 +172,7 @@ fn build_protocol_inner(
     entry: &str,
 ) -> Result<String, BuildError> {
     let protocol = parse_to_protocol(files, entry)?;
-    serde_json::to_string(&protocol).map_err(|e| BuildError::Protocol(e.to_string()))
+    serde_json::to_string(&protocol).map_err(BuildError::Protocol)
 }
 
 /// Create a handler with an optional plugin.
@@ -196,9 +196,8 @@ fn render_inner(
     plugin: Option<Plugin>,
 ) -> Result<String, BuildError> {
     let protocol: WebUIProtocol =
-        serde_json::from_str(protocol_json).map_err(|e| BuildError::Protocol(e.to_string()))?;
-    let state: Value =
-        serde_json::from_str(state_json).map_err(|e| BuildError::State(e.to_string()))?;
+        serde_json::from_str(protocol_json).map_err(BuildError::Protocol)?;
+    let state: Value = serde_json::from_str(state_json).map_err(BuildError::State)?;
 
     let mut writer = StringWriter::with_capacity(1024);
     let handler = create_handler(plugin)?;
@@ -221,8 +220,7 @@ pub(crate) fn build_and_render_inner(
 ) -> Result<String, BuildError> {
     let protocol = parse_to_protocol(files, entry)?;
 
-    let state: Value =
-        serde_json::from_str(state_json).map_err(|e| BuildError::State(e.to_string()))?;
+    let state: Value = serde_json::from_str(state_json).map_err(BuildError::State)?;
 
     let mut writer = StringWriter::with_capacity(1024);
     let handler = create_handler(None)?;
@@ -268,37 +266,22 @@ fn parse_to_protocol(
 }
 
 /// Errors from the build-and-render pipeline.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum BuildError {
+    #[error("Entry file '{0}' not found")]
     MissingEntry(String),
-    Parse(String),
-    Protocol(String),
-    State(String),
-    Render(String),
-}
 
-impl std::fmt::Display for BuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BuildError::MissingEntry(name) => write!(f, "Entry file '{name}' not found"),
-            BuildError::Parse(msg) => write!(f, "Parse error: {msg}"),
-            BuildError::Protocol(msg) => write!(f, "Protocol JSON error: {msg}"),
-            BuildError::State(msg) => write!(f, "State JSON error: {msg}"),
-            BuildError::Render(msg) => write!(f, "Render error: {msg}"),
-        }
-    }
-}
+    #[error("Parse error: {0}")]
+    Parse(#[from] webui_parser::ParserError),
 
-impl From<webui_parser::ParserError> for BuildError {
-    fn from(e: webui_parser::ParserError) -> Self {
-        BuildError::Parse(e.to_string())
-    }
-}
+    #[error("Protocol JSON error: {0}")]
+    Protocol(serde_json::Error),
 
-impl From<webui_handler::HandlerError> for BuildError {
-    fn from(e: webui_handler::HandlerError) -> Self {
-        BuildError::Render(e.to_string())
-    }
+    #[error("State JSON error: {0}")]
+    State(serde_json::Error),
+
+    #[error("Render error: {0}")]
+    Render(#[from] webui_handler::HandlerError),
 }
 
 #[cfg(test)]
@@ -314,8 +297,7 @@ mod tests {
         );
 
         let result = build_and_render_inner(&files, r#"{"name": "WebUI"}"#, "index.html", "/");
-        assert!(result.is_ok(), "Render failed: {:?}", result);
-        assert_eq!(result.as_deref(), Ok("<h1>Hello, WebUI!</h1>"));
+        assert_eq!(result.unwrap(), "<h1>Hello, WebUI!</h1>");
     }
 
     #[test]
@@ -370,10 +352,10 @@ mod tests {
         );
 
         let result_true = build_and_render_inner(&files, r#"{"show": true}"#, "index.html", "/");
-        assert_eq!(result_true.as_deref(), Ok("Visible"));
+        assert_eq!(result_true.unwrap(), "Visible");
 
         let result_false = build_and_render_inner(&files, r#"{"show": false}"#, "index.html", "/");
-        assert_eq!(result_false.as_deref(), Ok(""));
+        assert_eq!(result_false.unwrap(), "");
     }
 
     #[test]
@@ -448,6 +430,6 @@ mod tests {
         );
 
         let result = build_and_render_inner(&files, "{}", "index.html", "/");
-        assert_eq!(result.as_deref(), Ok("<h1>Static</h1><p>Content</p>"));
+        assert_eq!(result.unwrap(), "<h1>Static</h1><p>Content</p>");
     }
 }

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -271,7 +271,7 @@ pub(crate) enum BuildError {
     #[error("Entry file '{0}' not found")]
     MissingEntry(String),
 
-    #[error("Parse error: {0}")]
+    #[error("{0}")]
     Parse(#[from] webui_parser::ParserError),
 
     #[error("Protocol JSON error: {0}")]
@@ -280,7 +280,7 @@ pub(crate) enum BuildError {
     #[error("State JSON error: {0}")]
     State(serde_json::Error),
 
-    #[error("Render error: {0}")]
+    #[error("{0}")]
     Render(#[from] webui_handler::HandlerError),
 }
 

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -202,14 +202,12 @@ fn render_inner(
 
     let mut writer = StringWriter::with_capacity(1024);
     let handler = create_handler(plugin)?;
-    handler
-        .render(
-            &protocol,
-            &state,
-            &RenderOptions::new(entry, request_path),
-            &mut writer,
-        )
-        .map_err(|e| BuildError::Render(e.to_string()))?;
+    handler.render(
+        &protocol,
+        &state,
+        &RenderOptions::new(entry, request_path),
+        &mut writer,
+    )?;
 
     Ok(writer.content)
 }
@@ -228,14 +226,12 @@ pub(crate) fn build_and_render_inner(
 
     let mut writer = StringWriter::with_capacity(1024);
     let handler = create_handler(None)?;
-    handler
-        .render(
-            &protocol,
-            &state,
-            &RenderOptions::new(entry, request_path),
-            &mut writer,
-        )
-        .map_err(|e| BuildError::Render(e.to_string()))?;
+    handler.render(
+        &protocol,
+        &state,
+        &RenderOptions::new(entry, request_path),
+        &mut writer,
+    )?;
 
     Ok(writer.content)
 }
@@ -261,15 +257,12 @@ fn parse_to_protocol(
                 let css = files.get(&css_key).map(|s| s.as_str());
                 parser
                     .component_registry_mut()
-                    .register_component(tag_name, content, css)
-                    .map_err(|e| BuildError::Parse(e.to_string()))?;
+                    .register_component(tag_name, content, css)?;
             }
         }
     }
 
-    parser
-        .parse(entry, entry_html)
-        .map_err(|e| BuildError::Parse(e.to_string()))?;
+    parser.parse(entry, entry_html)?;
 
     Ok(WebUIProtocol::new(parser.into_fragment_records()))
 }
@@ -293,6 +286,18 @@ impl std::fmt::Display for BuildError {
             BuildError::State(msg) => write!(f, "State JSON error: {msg}"),
             BuildError::Render(msg) => write!(f, "Render error: {msg}"),
         }
+    }
+}
+
+impl From<webui_parser::ParserError> for BuildError {
+    fn from(e: webui_parser::ParserError) -> Self {
+        BuildError::Parse(e.to_string())
+    }
+}
+
+impl From<webui_handler::HandlerError> for BuildError {
+    fn from(e: webui_handler::HandlerError) -> Self {
+        BuildError::Render(e.to_string())
     }
 }
 

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -35,3 +35,6 @@ microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.9" }
 [[bench]]
 name = "contact_book_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 //! End-to-end benchmark for the contact-book-manager example application.
 //!
 //! Compiles the real contact-book-manager templates into a protocol binary at
@@ -173,7 +172,7 @@ fn generate_contact(idx: usize) -> Value {
     let group = GROUPS[idx % GROUPS.len()];
     let color = AVATAR_COLORS[idx % AVATAR_COLORS.len()];
     let city = CITIES[idx % CITIES.len()];
-    let favorite = idx % 3 == 0;
+    let favorite = idx.is_multiple_of(3);
 
     json!({
         "id": (idx + 1).to_string(),
@@ -186,7 +185,7 @@ fn generate_contact(idx: usize) -> Value {
         "favorite": favorite,
         "initials": initials,
         "avatarColor": color,
-        "notes": if idx % 2 == 0 { format!("Contact note for {} {}", first, last) } else { String::new() },
+        "notes": if idx.is_multiple_of(2) { format!("Contact note for {} {}", first, last) } else { String::new() },
         "address": format!("{} {} St, {}", (idx + 1) * 100, first, city),
     })
 }

--- a/crates/webui/src/error.rs
+++ b/crates/webui/src/error.rs
@@ -9,8 +9,14 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum WebUIError {
     /// I/O error (file read/write failures).
-    #[error("I/O error: {0}")]
-    Io(String),
+    #[error("I/O error: {context}")]
+    Io {
+        /// What operation failed.
+        context: String,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
 
     /// Component registration failure.
     #[error("Component registration error: {0}")]
@@ -22,11 +28,11 @@ pub enum WebUIError {
 
     /// HTML/CSS parsing failure.
     #[error("Parse error: {0}")]
-    Parse(String),
+    Parse(#[from] webui_parser::ParserError),
 
     /// Protocol serialization or deserialization failure.
     #[error("Protocol error: {0}")]
-    Protocol(String),
+    Protocol(#[from] webui_protocol::ProtocolError),
 
     /// JSON serialization failure.
     #[error("Serialization error: {0}")]
@@ -34,5 +40,5 @@ pub enum WebUIError {
 
     /// Handler rendering error.
     #[error("Rendering error: {0}")]
-    Rendering(String),
+    Rendering(#[from] webui_handler::HandlerError),
 }

--- a/crates/webui/src/error.rs
+++ b/crates/webui/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum WebUIError {
     /// I/O error (file read/write failures).
-    #[error("I/O error: {context}")]
+    #[error("I/O error: {context}: {source}")]
     Io {
         /// What operation failed.
         context: String,
@@ -26,9 +26,15 @@ pub enum WebUIError {
     #[error("Component discovery error: {0}")]
     ComponentDiscovery(String),
 
-    /// HTML/CSS parsing failure.
-    #[error("Parse error: {0}")]
-    Parse(#[from] webui_parser::ParserError),
+    /// HTML/CSS parsing failure with context about which file failed.
+    #[error("Parse error: {context}: {source}")]
+    Parse {
+        /// What was being parsed.
+        context: String,
+        /// The underlying parse error.
+        #[source]
+        source: webui_parser::ParserError,
+    },
 
     /// Protocol serialization or deserialization failure.
     #[error("Protocol error: {0}")]

--- a/crates/webui/src/error.rs
+++ b/crates/webui/src/error.rs
@@ -27,7 +27,7 @@ pub enum WebUIError {
     ComponentDiscovery(String),
 
     /// HTML/CSS parsing failure with context about which file failed.
-    #[error("Parse error: {context}: {source}")]
+    #[error("{context}: {source}")]
     Parse {
         /// What was being parsed.
         context: String,
@@ -37,7 +37,7 @@ pub enum WebUIError {
     },
 
     /// Protocol serialization or deserialization failure.
-    #[error("Protocol error: {0}")]
+    #[error("{0}")]
     Protocol(#[from] webui_protocol::ProtocolError),
 
     /// JSON serialization failure.
@@ -45,6 +45,6 @@ pub enum WebUIError {
     Serialization(String),
 
     /// Handler rendering error.
-    #[error("Rendering error: {0}")]
+    #[error("{0}")]
     Rendering(#[from] webui_handler::HandlerError),
 }

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -255,7 +255,12 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
         context: format!("Failed to read {}", entry_path.display()),
         source,
     })?;
-    parser.parse(&options.entry, &html_content)?;
+    parser
+        .parse(&options.entry, &html_content)
+        .map_err(|source| WebUIError::Parse {
+            context: format!("Failed to parse {}", options.entry),
+            source,
+        })?;
 
     // Snapshot CSS before consuming the parser
     let css_snapshot: Vec<(String, String)> = parser

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -113,10 +113,7 @@ pub fn build(options: BuildOptions) -> Result<BuildResult, WebUIError> {
 
     let raw = build_protocol_inner(&options)?;
 
-    let protocol_bytes = raw
-        .protocol
-        .to_protobuf()
-        .map_err(|e| WebUIError::Serialization(e.to_string()))?;
+    let protocol_bytes = raw.protocol.to_protobuf()?;
 
     let stats = BuildStats {
         duration: started.elapsed(),
@@ -147,22 +144,22 @@ pub fn build(options: BuildOptions) -> Result<BuildResult, WebUIError> {
 pub fn build_to_disk(options: BuildOptions, out_dir: &Path) -> Result<BuildStats, WebUIError> {
     let result = build(options)?;
 
-    fs::create_dir_all(out_dir)
-        .map_err(|e| WebUIError::Io(format!("Failed to create {}: {e}", out_dir.display())))?;
+    fs::create_dir_all(out_dir).map_err(|source| WebUIError::Io {
+        context: format!("Failed to create {}", out_dir.display()),
+        source,
+    })?;
 
-    fs::write(out_dir.join("protocol.bin"), &result.protocol_bytes).map_err(|e| {
-        WebUIError::Io(format!(
-            "Failed to write protocol.bin to {}: {e}",
-            out_dir.display()
-        ))
+    fs::write(out_dir.join("protocol.bin"), &result.protocol_bytes).map_err(|source| {
+        WebUIError::Io {
+            context: format!("Failed to write protocol.bin to {}", out_dir.display()),
+            source,
+        }
     })?;
 
     for (name, content) in &result.css_files {
-        fs::write(out_dir.join(name), content).map_err(|e| {
-            WebUIError::Io(format!(
-                "Failed to write {name} to {}: {e}",
-                out_dir.display()
-            ))
+        fs::write(out_dir.join(name), content).map_err(|source| WebUIError::Io {
+            context: format!("Failed to write {name} to {}", out_dir.display()),
+            source,
         })?;
     }
 
@@ -171,15 +168,16 @@ pub fn build_to_disk(options: BuildOptions, out_dir: &Path) -> Result<BuildStats
 
 /// Inspect a compiled WebUI protocol file and return its JSON representation.
 pub fn inspect(protocol_path: &Path) -> Result<String, WebUIError> {
-    let bytes = fs::read(protocol_path)
-        .map_err(|e| WebUIError::Io(format!("Failed to read {}: {e}", protocol_path.display())))?;
+    let bytes = fs::read(protocol_path).map_err(|source| WebUIError::Io {
+        context: format!("Failed to read {}", protocol_path.display()),
+        source,
+    })?;
     inspect_bytes(&bytes)
 }
 
 /// Inspect raw protocol bytes and return their JSON representation.
 pub fn inspect_bytes(protocol_bytes: &[u8]) -> Result<String, WebUIError> {
-    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)
-        .map_err(|e| WebUIError::Protocol(e.to_string()))?;
+    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)?;
     protocol
         .to_json_pretty()
         .map_err(|e| WebUIError::Serialization(e.to_string()))
@@ -253,11 +251,11 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
 
     // Parse entry HTML
     let entry_path = options.app_dir.join(&options.entry);
-    let html_content = fs::read_to_string(&entry_path)
-        .map_err(|e| WebUIError::Io(format!("Failed to read {}: {e}", entry_path.display())))?;
-    parser
-        .parse(&options.entry, &html_content)
-        .map_err(|e| WebUIError::Parse(format!("Failed to parse {}: {e}", options.entry)))?;
+    let html_content = fs::read_to_string(&entry_path).map_err(|source| WebUIError::Io {
+        context: format!("Failed to read {}", entry_path.display()),
+        source,
+    })?;
+    parser.parse(&options.entry, &html_content)?;
 
     // Snapshot CSS before consuming the parser
     let css_snapshot: Vec<(String, String)> = parser
@@ -547,7 +545,7 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, WebUIError::Io(_)));
+        assert!(matches!(err, WebUIError::Io { .. }));
     }
 
     #[test]
@@ -646,7 +644,7 @@ mod tests {
     fn test_inspect_missing_file() {
         let result = inspect(Path::new("/nonexistent/protocol.bin"));
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), WebUIError::Io(_)));
+        assert!(matches!(result.unwrap_err(), WebUIError::Io { .. }));
     }
 
     #[test]

--- a/examples/app/commerce/server/Cargo.toml
+++ b/examples/app/commerce/server/Cargo.toml
@@ -23,3 +23,6 @@ rustls = { workspace = true }
 rcgen = { workspace = true }
 microsoft-webui = { path = "../../../../crates/webui" }
 microsoft-webui-handler = { path = "../../../../crates/webui-handler" }
+
+[lints]
+workspace = true

--- a/examples/app/commerce/server/src/server.rs
+++ b/examples/app/commerce/server/src/server.rs
@@ -278,7 +278,7 @@ fn cart_response(
         let location = if options.open_cart {
             cart::with_cart_open(&stable_path, true)
         } else {
-            stable_path.clone()
+            stable_path
         };
         let mut redirect = HttpResponse::SeeOther();
         redirect.insert_header((LOCATION, location));

--- a/examples/integration/rust/Cargo.toml
+++ b/examples/integration/rust/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 microsoft-webui-protocol = { path = "../../../crates/webui-protocol" }
 microsoft-webui-handler = { path = "../../../crates/webui-handler" }
 anyhow = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/integration/ssr-performance-showdown/Cargo.toml
+++ b/examples/integration/ssr-performance-showdown/Cargo.toml
@@ -14,3 +14,6 @@ microsoft-webui-protocol = { path = "../../../crates/webui-protocol" }
 microsoft-webui-handler = { path = "../../../crates/webui-handler" }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,3 +17,6 @@ libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 which = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/src/process.rs
+++ b/xtask/src/process.rs
@@ -425,6 +425,7 @@ mod sys {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)]
 mod sys {
     use std::ffi::c_void;
     use std::process::{Child, Command};

--- a/xtask/src/process.rs
+++ b/xtask/src/process.rs
@@ -299,10 +299,11 @@ pub fn terminate_gracefully(managed: &mut ManagedChild) {
 pub fn wait_for_group(children: &mut [(&str, ManagedChild)]) -> ExitCode {
     let ctrlc = Arc::new(AtomicBool::new(false));
     let flag = ctrlc.clone();
-    ctrlc::set_handler(move || {
+    if let Err(e) = ctrlc::set_handler(move || {
         flag.store(true, Ordering::SeqCst);
-    })
-    .expect("failed to set Ctrl+C handler");
+    }) {
+        eprintln!("warning: failed to set Ctrl+C handler: {e}");
+    }
 
     loop {
         if ctrlc.load(Ordering::SeqCst) {
@@ -393,6 +394,7 @@ mod sys {
     use std::process::{Child, Command};
 
     /// Make the child a process-group leader so we can signal the entire tree.
+    #[allow(unsafe_code)]
     pub fn configure_process_group(command: &mut Command) {
         use std::os::unix::process::CommandExt;
 
@@ -408,6 +410,7 @@ mod sys {
 
     /// Send SIGTERM to the child's process group, falling back to the child PID
     /// directly if the group signal fails.
+    #[allow(unsafe_code)]
     pub fn send_graceful_stop(child: &Child) {
         #[allow(clippy::cast_possible_wrap)]
         let pid = child.id() as i32;


### PR DESCRIPTION
## Harden clippy lints, refactor error enums, and enforce perf discipline

### Lint configuration
- Add 20 deny-level clippy lints for perf, security, and memory discipline
- Add lint groups (perf, suspicious) with proper priority ordering
- Add `unsafe_code = "deny"` with targeted allows for FFI and POSIX signals
- Add MSRV (`rust-version = "1.93"`) to workspace metadata
- Ban `.expect()` alongside `.unwrap()` in clippy.toml disallowed-methods
- Ban `LinkedList` in clippy.toml disallowed-types
- Set `large-error-threshold = 128` in clippy.toml
- Enable workspace lints (`[lints] workspace = true`) in all 17 crates

### Error enum refactoring
- `ParserError`: Migrate to `thiserror` derive; `IO` variant becomes struct `{ context, #[source] source: io::Error }`
- `WebUIError::Io`: String → struct `{ context, #[source] source: io::Error }`
- `WebUIError::Parse`: String → struct `{ context, #[source] source: ParserError }` (preserves entry file context)
- `WebUIError::Protocol`: String → `#[from] ProtocolError` (transparent Display to avoid double prefix)
- `WebUIError::Rendering`: String → `#[from] HandlerError` (transparent Display to avoid double prefix)
- `BuildError` (webui-wasm): Migrate to `thiserror` with `#[from]` for `ParserError` and `HandlerError`; `Protocol`/`State` hold `serde_json::Error` directly
- Simplify 10+ call sites to use `?` instead of `.map_err(|e| ...to_string())`
- Transparent `#[error("{0}")]` on wrapper variants to avoid duplicated category prefixes

### Production code fixes
- Replace `.expect()` with `?` propagation in webui-ffi/build.rs
- Replace `.expect()` with if-let-err in xtask/src/process.rs
- Remove 3 redundant `.clone()` calls (webui-cli, commerce example)
- Fix 14 misc lint violations (unused mut, is_multiple_of, push_str, etc.)

Fixes #144
