### PR TITLE
feat(webui): expose renderComponentTemplates in @microsoft/webui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ packages/*/webui.node
 publish/
 *.nupkg
 .last
+packages/webui/bin/webui
 packages/webui/bin/webui.exe

--- a/crates/webui-handler/README.md
+++ b/crates/webui-handler/README.md
@@ -23,7 +23,7 @@ let result = route_handler::render_component_templates(
 // Returns: { templates: [...], templateStyles: [...], inventory: "..." }
 ```
 
-Available via all bindings: Rust (direct), Node (`renderComponentTemplates`), WASM (`render_component_templates`), FFI (`webui_render_component_templates`).
+Available via all bindings: Rust (direct), Node (`renderComponentTemplates`), WASM (`render_component_templates`), FFI (`webui_render_component_templates`), npm (`@microsoft/webui` — `renderComponentTemplates`).
 
 ## Documentation
 

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -857,5 +857,10 @@ let result = route_handler::render_component_templates(&protocol, &tags, &inv);
 ```
 
 ```javascript
+// Node native addon
 const result = renderComponentTemplates(protocolBuf, JSON.stringify(tags), invHex);
+
+// @microsoft/webui npm package
+import { renderComponentTemplates } from '@microsoft/webui';
+const result = renderComponentTemplates(protocolBuf, ['settings-dialog'], invHex);
 ```

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -231,6 +231,18 @@ Router.start({
 });
 ```
 
+On the server, handle the template endpoint with `renderComponentTemplates`:
+
+```javascript
+import { renderComponentTemplates } from '@microsoft/webui';
+
+app.get('/_webui/templates', (req, res) => {
+  const tags = (req.query.t ?? '').split(',').filter(Boolean);
+  const inv = req.get('X-WebUI-Inventory') ?? '';
+  res.type('json').send(renderComponentTemplates(protocol, tags, inv));
+});
+```
+
 ## Navigation Events
 
 ```typescript

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -85,6 +85,15 @@ console.log(JSON.parse(json));
 
 Produces a JSON partial response for client-side navigation, including state, templates, and route chain.
 
+### `renderComponentTemplates(protocol: Buffer, componentTags: string[], inventoryHex: string): string`
+
+Renders templates and styles for on-demand component loading (used by `Router.ensureLoaded()`). Returns a JSON string with `templateStyles`, `templates`, and `inventory`. Uses the same inventory bitfield as partial navigation to avoid sending duplicates.
+
+```js
+const json = renderComponentTemplates(protocol, ["settings-dialog"], inventoryHex);
+const { templates, templateStyles, inventory } = JSON.parse(json);
+```
+
 ## CLI
 
 The package also includes the `webui` CLI binary:

--- a/packages/webui/bin/webui
+++ b/packages/webui/bin/webui
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "webui: binary not installed. Run 'pnpm build' or reinstall." >&2; exit 1

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -63,6 +63,16 @@ export interface RenderOptions {
   plugin?: string;
 }
 
+/** Response from `renderComponentTemplates()` for on-demand component loading. */
+export interface ComponentTemplatesResponse {
+  /** Module CSS `<style>` strings for the requested components. */
+  templateStyles: string[];
+  /** `<f-template>` HTML strings for the requested components. */
+  templates: string[];
+  /** Updated hex bitmask of loaded component templates. */
+  inventory: string;
+}
+
 /** Complete JSON partial response from the server for client-side navigation. */
 export interface PartialResponse {
   /** Application state for the matched route. */
@@ -102,6 +112,7 @@ interface NativeAddon {
   }): BuildResult;
   inspect(protocolData: Buffer): string;
   renderPartial(protocolData: Buffer, stateJson: string, entryId: string, requestPath: string, inventoryHex: string): string;
+  renderComponentTemplates(protocolData: Buffer, componentTagsJson: string, inventoryHex: string): string;
 }
 
 let addon: NativeAddon | null = null;
@@ -279,6 +290,34 @@ export function renderPartial(
     return native.renderPartial(protocolData, stateJson, entryId, requestPath, inventoryHex);
   }
   throw new Error("[webui] renderPartial() requires the native addon.");
+}
+
+/**
+ * Render component templates and styles for on-demand loading.
+ *
+ * Used by `Router.ensureLoaded()` to fetch templates for components that
+ * are not part of the route tree (e.g., dialogs, popovers). Uses the same
+ * inventory bitfield as partial navigation to avoid sending duplicates.
+ *
+ * Returns a JSON string. Parse with the exported `ComponentTemplatesResponse` type:
+ * ```ts
+ * const resp: ComponentTemplatesResponse = JSON.parse(renderComponentTemplates(...));
+ * ```
+ */
+export function renderComponentTemplates(
+  protocolData: Buffer,
+  componentTags: string[],
+  inventoryHex: string,
+): string {
+  const native = loadAddon();
+  if (native?.renderComponentTemplates) {
+    return native.renderComponentTemplates(
+      protocolData,
+      JSON.stringify(componentTags),
+      inventoryHex,
+    );
+  }
+  throw new Error("[webui] renderComponentTemplates() requires the native addon.");
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/packages/webui/test/integration.test.ts
+++ b/packages/webui/test/integration.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, test, before, after } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { build, render, renderStream, inspect } from '@microsoft/webui';
+import { build, render, renderStream, inspect, renderComponentTemplates } from '@microsoft/webui';
+import type { ComponentTemplatesResponse } from '@microsoft/webui';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -114,5 +115,24 @@ describe('renderStream', () => {
     });
     assert.ok(chunks.length > 0);
     assert.ok(chunks.join('').includes('Hello, Stream!'));
+  });
+});
+
+describe('renderComponentTemplates', () => {
+  test('returns valid response shape', () => {
+    const result = build({ appDir, entry: 'index2.html' });
+    const json = renderComponentTemplates(result.protocol, ['my-card'], '');
+    const parsed: ComponentTemplatesResponse = JSON.parse(json);
+    assert.ok(Array.isArray(parsed.templates));
+    assert.ok(Array.isArray(parsed.templateStyles));
+    assert.equal(typeof parsed.inventory, 'string');
+  });
+
+  test('returns empty arrays for unknown component', () => {
+    const result = build({ appDir });
+    const json = renderComponentTemplates(result.protocol, ['nonexistent-widget'], '');
+    const parsed: ComponentTemplatesResponse = JSON.parse(json);
+    assert.deepEqual(parsed.templates, []);
+    assert.deepEqual(parsed.templateStyles, []);
   });
 });


### PR DESCRIPTION
Add the renderComponentTemplates binding to the @microsoft/webui npm package so Router.ensureLoaded() template endpoints can be served directly from the high-level API.

- Add ComponentTemplatesResponse type and renderComponentTemplates() wrapper in packages/webui/src/index.ts
- Add integration tests for valid response shape and unknown components
- Update README for packages/webui and crates/webui-handler
- Update docs site (ai.md, routing.md) with npm package usage examples