### PR TITLE
fix(framework): hydrate multi-root conditional blocks correctly

### DIFF
--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -898,21 +898,23 @@ export class WebUIElement extends HTMLElement {
     scope: ScopeFrame | undefined,
   ): TemplateInstance | null {
     const rootTag = this.$rootTag(blockMeta);
-    if (rootTag) {
+    const tplDom = getTemplateDom(blockMeta);
+    if (rootTag && tplDom.children.length === 1) {
+      // Single-root optimisation: hydrate the element in-place (pathStart=1).
       const el = nextElement(condAnchor);
       if (el) {
-        const inst = this.$hydrate(el, blockMeta, getTemplateDom(blockMeta), scope, 1);
+        const inst = this.$hydrate(el, blockMeta, tplDom, scope, 1);
         this.$updateInstance(inst);
         return inst;
       }
       return null;
     }
-    // Text-only conditional: collect nodes between <!--wc--> and <!--/wc-->
+    // Multi-root or text-only conditional: collect nodes between <!--wc--> and <!--/wc-->
     const condNodes = this.$collectBetween(condAnchor, MARKER_COND_END);
     if (condNodes.length === 0) return null;
     const wrapper = document.createElement('div');
     for (let cn = 0; cn < condNodes.length; cn++) wrapper.appendChild(condNodes[cn]);
-    const inst = this.$hydrate(wrapper, blockMeta, getTemplateDom(blockMeta), scope);
+    const inst = this.$hydrate(wrapper, blockMeta, tplDom, scope);
     inst.nodes = childNodesArray(wrapper);
     let afterNode: Node = condAnchor;
     for (let cn = 0; cn < inst.nodes.length; cn++) {

--- a/packages/webui-framework/tests/fixtures/raw-html-conditional/element.ts
+++ b/packages/webui-framework/tests/fixtures/raw-html-conditional/element.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { WebUIElement, observable } from '../../../src/index.js';
+
+export class TestRawHtml extends WebUIElement {
+  @observable expanded = true;
+  @observable name = '';
+  @observable rawHtml = '';
+}
+
+TestRawHtml.define('test-raw-html');

--- a/packages/webui-framework/tests/fixtures/raw-html-conditional/raw-html-conditional.spec.ts
+++ b/packages/webui-framework/tests/fixtures/raw-html-conditional/raw-html-conditional.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('raw HTML inside conditional', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/raw-html-conditional/fixture.html');
+    await page.waitForSelector('test-raw-html');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-raw-html');
+      return el && (el as any).$ready === true;
+    });
+  });
+
+  test('header retains text after hydration when sibling has {{{raw}}}', async ({ page }) => {
+    // After SSR + hydration, the structured header must still contain "Alice",
+    // not the raw HTML body content.
+    await expect(page.locator('test-raw-html .header .name')).toHaveText('Alice');
+  });
+
+  test('raw HTML body renders in its own container', async ({ page }) => {
+    const bodyHtml = await page.locator('test-raw-html .body').innerHTML();
+    expect(bodyHtml).toContain('<p>Hello</p>');
+  });
+
+  test('header does not contain raw HTML body content', async ({ page }) => {
+    const headerHtml = await page.locator('test-raw-html .header').innerHTML();
+    expect(headerHtml).not.toContain('Hello');
+  });
+});

--- a/packages/webui-framework/tests/fixtures/raw-html-conditional/src/index.html
+++ b/packages/webui-framework/tests/fixtures/raw-html-conditional/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Raw HTML in Conditional Fixture</title>
+</head>
+<body>
+  <test-raw-html></test-raw-html>
+</body>
+</html>

--- a/packages/webui-framework/tests/fixtures/raw-html-conditional/src/test-raw-html/test-raw-html.html
+++ b/packages/webui-framework/tests/fixtures/raw-html-conditional/src/test-raw-html/test-raw-html.html
@@ -1,0 +1,4 @@
+<if condition="expanded">
+  <div class="header"><strong class="name">{{name}}</strong></div>
+  <div class="body">{{{rawHtml}}}</div>
+</if>

--- a/packages/webui-framework/tests/fixtures/raw-html-conditional/state.json
+++ b/packages/webui-framework/tests/fixtures/raw-html-conditional/state.json
@@ -1,0 +1,5 @@
+{
+  "expanded": true,
+  "name": "Alice",
+  "rawHtml": "<p>Hello</p>"
+}


### PR DESCRIPTION
## Description:
Assumed any `<if>` block whose static HTML started with an element tag had a single root element.  It grabbed only the first element after the `<!--wc-->` marker via `nextElement()` and hydrated the entire block against it with `pathStart=1`.

For multi-root blocks (e.g. `<div class='header'>...</div><div class='body'> {{{rawHtml}}}</div>)`, every binding resolved relative to that first element.  A `{{{raw}}}` expression whose compiled parent-path pointed at the second root would resolve to the first root instead, causing `rawParent.innerHTML` to overwrite the header content with the body HTML.

The fix adds a `tplDom.children.length === 1` guard so that multi-root blocks fall through to the wrapper path, which collects all nodes between `<!--wc-->` and `<!--/wc-->` and hydrates them as a group.

Performance impact: `getTemplateDom` is already cached per block (`WeakMap`). The `children.length` check is O(1).  The wrapper path only runs for the previously-broken multi-root case. Single-root blocks (the common case) take the same fast path as before.

## Test Plan:
- Added raw-html-conditional fixture (minimal repro):
  - Template: `<if>` with `<div class='header'>{{name}}</div>` sibling to `<div class='body'>{{{rawHtml}}}</div>`
  - 3 tests: header retains text, body renders raw HTML, header does not contain body content
- Ran full framework E2E suite: 98 passed, 2 skipped, 0 failed
- Ran webui-outlook E2E suite: 57 passed, 0 failed

## Checklist:
- [x] Regression fixture added (raw-html-conditional)
- [x] All 98 framework E2E tests pass