### PR TITLE
feat(router): add preload on hover and keep-alive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "microsoft-webui-discovery",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "cbindgen",
  "libc",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "html-escape",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "clap",
  "criterion",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "microsoft-webui-protocol",
  "mockall",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -238,7 +238,7 @@ optional parameters. Exact matches (most literal segments) take precedence over 
 For the WebUI framework path, matched route components do **not** receive route
 state as scalar attributes or `data-state`. Initial SSR state comes from the
 rendered DOM plus hydration markers, and client-side navigations apply fresh
-state through the partial-response `setInitialState(...)` path.
+state through the partial-response `setState(...)` path.
 
 When the handler encounters `Fragment::Outlet`:
 1. Take children from the currently active route.

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -1327,12 +1327,14 @@ mod tests {
                         path: "/search/:category".to_string(),
                         fragment_id: "mp-page-search".to_string(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                     WebUIFragment::route_from(WebUiFragmentRoute {
                         path: "/product/:handle".to_string(),
                         fragment_id: "mp-page-product".to_string(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                 ],

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -270,12 +270,14 @@ fn render_partial_returns_templates_inventory_and_chain() {
                     path: "/search/:category".to_string(),
                     fragment_id: "mp-search-page".to_string(),
                     exact: true,
+                    keep_alive: false,
                     ..Default::default()
                 }),
                 WebUIFragment::route_from(WebUiFragmentRoute {
                     path: "/product/:handle".to_string(),
                     fragment_id: "mp-product-page".to_string(),
                     exact: true,
+                    keep_alive: false,
                     ..Default::default()
                 }),
             ],

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -389,6 +389,9 @@ impl WebUIHandler {
                     context.writer.write(&matched_child.allowed_query)?;
                     context.writer.write("\"")?;
                 }
+                if matched_child.keep_alive {
+                    context.writer.write(" keep-alive")?;
+                }
                 context.writer.write(" active>")?;
 
                 context.writer.write("<")?;
@@ -435,6 +438,9 @@ impl WebUIHandler {
                     context.writer.write(" query=\"")?;
                     context.writer.write(&child.allowed_query)?;
                     context.writer.write("\"")?;
+                }
+                if child.keep_alive {
+                    context.writer.write(" keep-alive")?;
                 }
                 context
                     .writer
@@ -508,6 +514,9 @@ impl WebUIHandler {
             context.writer.write(" query=\"")?;
             context.writer.write(&route_frag.allowed_query)?;
             context.writer.write("\"")?;
+        }
+        if route_frag.keep_alive {
+            context.writer.write(" keep-alive")?;
         }
 
         if is_matched {
@@ -5297,12 +5306,14 @@ mod tests {
                         path: "/".into(),
                         fragment_id: "dash-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                     WebUIFragment::route_from(WebUiFragmentRoute {
                         path: "/contacts/:id".into(),
                         fragment_id: "detail-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                 ],
@@ -5349,10 +5360,13 @@ mod tests {
                             fragment_id: "topic-comp".into(),
                             exact: true,
                             children: vec![],
+                            keep_alive: false,
                             ..Default::default()
                         }],
+                        keep_alive: false,
                         ..Default::default()
                     }],
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },
@@ -6408,15 +6422,18 @@ mod tests {
                             fragment_id: "compose-page".into(),
                             exact: true,
                             allowed_query: "action,to,subject".into(),
+                            keep_alive: false,
                             ..Default::default()
                         },
                         WebUiFragmentRoute {
                             path: "settings".into(),
                             fragment_id: "settings-page".into(),
                             exact: true,
+                            keep_alive: false,
                             ..Default::default()
                         },
                     ],
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -603,6 +603,8 @@ pub struct RouteChainEntry {
     pub exact: bool,
     /// Comma-separated allowlist of query parameters forwarded as attributes.
     pub allowed_query: String,
+    /// When true, the router keeps the component alive across navigations.
+    pub keep_alive: bool,
 }
 
 impl RouteChainEntry {
@@ -628,6 +630,9 @@ impl RouteChainEntry {
                 "allowedQuery".into(),
                 Value::String(self.allowed_query.clone()),
             );
+        }
+        if self.keep_alive {
+            obj.insert("keepAlive".into(), Value::Bool(true));
         }
         Value::Object(obj)
     }
@@ -699,6 +704,7 @@ pub fn collect_route_chain(
                                 params: rm.params.clone(),
                                 exact: route_frag.exact,
                                 allowed_query: route_frag.allowed_query.clone(),
+                                keep_alive: route_frag.keep_alive,
                             });
 
                             let child_route_base = route_matcher::compute_route_base(
@@ -763,6 +769,7 @@ fn collect_chain_from_children(
                 params: rm.params,
                 exact: matched.exact,
                 allowed_query: matched.allowed_query.clone(),
+                keep_alive: matched.keep_alive,
             });
             if !matched.children.is_empty() {
                 let child_base =
@@ -961,12 +968,14 @@ mod tests {
                         path: "/search/:category".into(),
                         fragment_id: "mp-search-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                     WebUIFragment::route_from(WebUiFragmentRoute {
                         path: "/product/:handle".into(),
                         fragment_id: "mp-product-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                 ],
@@ -1043,6 +1052,7 @@ mod tests {
                     path: "/account/*rest".into(),
                     fragment_id: "mp-account-shell".into(),
                     exact: false,
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },
@@ -1056,12 +1066,14 @@ mod tests {
                         path: "/account/profile".into(),
                         fragment_id: "mp-profile-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                     WebUIFragment::route_from(WebUiFragmentRoute {
                         path: "/account/orders/:id".into(),
                         fragment_id: "mp-order-page".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                 ],
@@ -1137,6 +1149,7 @@ mod tests {
                     path: "/search".into(),
                     fragment_id: "mp-search-page".into(),
                     exact: true,
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },
@@ -1211,6 +1224,7 @@ mod tests {
                     path: "/search".into(),
                     fragment_id: "mp-search-page".into(),
                     exact: true,
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },
@@ -1514,6 +1528,7 @@ mod tests {
                         path: "/about".into(),
                         fragment_id: "page-about".into(),
                         exact: true,
+                        keep_alive: false,
                         ..Default::default()
                     }),
                     WebUIFragment::component("cart-panel"),
@@ -1579,6 +1594,7 @@ mod tests {
             params: HashMap::new(),
             exact: true,
             allowed_query: "action,to,subject".into(),
+            keep_alive: false,
         };
         let json = entry.to_json();
         assert_eq!(json["allowedQuery"], "action,to,subject");
@@ -1592,6 +1608,7 @@ mod tests {
             params: HashMap::new(),
             exact: true,
             allowed_query: String::new(),
+            keep_alive: false,
         };
         let json = entry.to_json();
         assert!(
@@ -1615,8 +1632,10 @@ mod tests {
                         fragment_id: "compose-page".into(),
                         exact: true,
                         allowed_query: "action,to".into(),
+                        keep_alive: false,
                         ..Default::default()
                     }],
+                    keep_alive: false,
                     ..Default::default()
                 })],
             },

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -1419,6 +1419,7 @@ impl HtmlParser {
             component: component.clone(),
             exact,
             query,
+            keep_alive: self.has_element_attribute(node, "keep-alive", source)?,
         };
 
         // Validate attributes (component is required)
@@ -1484,6 +1485,7 @@ impl HtmlParser {
             component: component.clone(),
             exact,
             query,
+            keep_alive: self.has_element_attribute(node, "keep-alive", source)?,
         };
 
         route_parser::validate_attributes(&attrs)?;

--- a/crates/webui-parser/src/route_parser.rs
+++ b/crates/webui-parser/src/route_parser.rs
@@ -23,6 +23,8 @@ pub(crate) struct RouteAttributes {
     pub exact: bool,
     /// Comma-separated allowlist of query parameters forwarded as attributes.
     pub query: String,
+    /// When true, the router keeps the component alive across navigations.
+    pub keep_alive: bool,
 }
 
 /// Iteratively extract `:param` and `*splat` tokens from a path template.
@@ -110,6 +112,7 @@ pub(crate) fn build_route_fragment(
         exact: attrs.exact,
         children,
         allowed_query: attrs.query.clone(),
+        keep_alive: attrs.keep_alive,
     }
 }
 

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -66,6 +66,9 @@ message WebUIFragmentRoute {
   // Comma-separated allowlist of query parameters forwarded as attributes.
   // Empty string means no query params are forwarded (deny-by-default).
   string allowed_query = 5;
+  // When true, the router preserves the mounted component instance across
+  // navigations instead of destroying and recreating it. Opt-in per route.
+  bool keep_alive = 6;
 }
 
 // Outlet placeholder — marks where matched child route content renders.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -245,6 +245,7 @@ impl WebUiFragment {
             fragment: Some(web_ui_fragment::Fragment::Route(WebUiFragmentRoute {
                 path: path.into(),
                 fragment_id: fragment_id.into(),
+                keep_alive: false,
                 ..Default::default()
             })),
         }
@@ -787,6 +788,7 @@ mod tests {
                 exact: true,
                 children: Vec::new(),
                 allowed_query: "action,to,subject".to_string(),
+                keep_alive: false,
             })),
         };
         fragments.insert(
@@ -832,6 +834,7 @@ mod tests {
         let route_frag = WebUiFragment {
             fragment: Some(web_ui_fragment::Fragment::Route(WebUiFragmentRoute {
                 path: "/old-path".to_string(),
+                keep_alive: false,
                 ..Default::default()
             })),
         };

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -203,6 +203,8 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 - Omit `exact` on parent routes that have `<outlet />`
 - Path params: `:id` (required), `:query?` (optional), `*path` (catch-all)
 - Query param allowlist: `query="action,to,subject"` — only listed params are set as component attributes (deny-by-default)
+- `keep-alive` — preserves the component across navigations (hidden, not destroyed). Returns instantly with `setState()` on reactivation
+- Preload on hover: `Router.start({ preload: true })` — speculatively fetches route data on link hover for instant click navigation
 
 ### Outlet
 
@@ -281,7 +283,7 @@ MyComponent.define('my-component');
 | `this.$emit(name, detail?)` | Dispatch a CustomEvent that bubbles up |
 | `this.$update()` | Force a reactive update cycle |
 | `this.$flushUpdates()` | Synchronously flush pending updates |
-| `setInitialState(state, params?)` | Populate from router navigation state |
+| `setState(state)` | Populate from router navigation state |
 | `static define(tagName)` | Register as a custom element |
 
 ### Emitting custom events

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -111,6 +111,51 @@ export class ComposePage extends WebUIElement {
 }
 ```
 
+### The `keep-alive` Attribute
+
+Preserve a component's DOM and state across navigations instead of destroying and recreating it:
+
+```html
+<route path="/" component="app-shell">
+  <route path="./" component="mail-view" keep-alive>
+    <route path="" component="inbox-page" exact />
+  </route>
+  <route path="calendar" component="calendar-page" exact keep-alive />
+  <route path="settings" component="settings-page" exact />
+</route>
+```
+
+When navigating from Mail to Calendar and back:
+- **`mail-view` (keep-alive):** Hidden on deactivation, shown instantly on return. The folder pane, email list, and all local state survive the round trip. Fresh server state is applied via `setState()` — only changed data triggers DOM updates.
+- **`settings-page` (no keep-alive):** Destroyed on deactivation, recreated fresh on each visit.
+
+| Behavior | With `keep-alive` | Without |
+|----------|-------------------|---------|
+| Deactivate | `display: none` (stays in DOM) | `display: none` (stays in DOM) |
+| Reactivate | Reuses existing component + `setState()` | Destroys old, creates new component |
+| Local state | Preserved (scroll, input, timers) | Lost |
+| Server state | Applied reactively via `setState()` | Applied on mount |
+
+::: tip When to use
+Use on routes with expensive UI (lists, grids, trees) that users switch between frequently. Leaf routes with simple data-driven content rarely benefit — they're cheap to recreate.
+:::
+
+### Preload on Hover
+
+Opt-in speculative fetching — the router prefetches route data when the user hovers an internal link, so navigation on click is instant:
+
+```ts
+Router.start({ preload: true });
+```
+
+How it works:
+- On mouse hover over an internal `<a>`, the router speculatively calls `fetchPartial()` for that path
+- Templates, CSS, and state are cached (single-entry, 5-second TTL)
+- On click, the cached result is used immediately — no network wait
+- If the user clicks a different link, the cache is discarded and a fresh fetch happens
+
+Only mouse pointers trigger preload — touch taps fire simultaneously with the click event, making speculative fetching pointless.
+
 ## How It Works
 
 ### First Load (SSR)
@@ -268,14 +313,14 @@ When `Accept: application/json`:
   "path": "/users/42",
   "chain": [
     { "component": "app-shell", "path": "/" },
-    { "component": "user-detail", "path": "users/:id", "params": { "id": "42" }, "exact": true }
+    { "component": "user-detail", "path": "users/:id", "params": { "id": "42" }, "exact": true, "keepAlive": true }
   ]
 }
 ```
 
 The `templateStyles` array contains module CSS definition tags for CssStrategy::Module. The client appends these to `<head>` before evaluating template scripts so adopted stylesheets are available. For Link/Style modes, this array is empty.
 
-The `chain` field tells the client router which route components are active at each nesting level. The client uses this to diff against the previous chain and only remount what changed - it does **not** perform route matching itself.
+The `chain` field tells the client router which route components are active at each nesting level. Each entry can include a `keepAlive` boolean flag. The client uses this to diff against the previous chain and only remount what changed - it does **not** perform route matching itself.
 
 ### Full HTML (initial load)
 

--- a/examples/app/commerce/package.json
+++ b/examples/app/commerce/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outdir=dist --format=esm --splitting --sourcemap --minify",
-    "start:client": "esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
+    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --format=esm --splitting --sourcemap --minify",
+    "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
     "start:server": "cargo run -p marketplace-api -- --port 3004 --no-tls --css=link",
     "start": "cargo xtask dev commerce",
     "test": "playwright test",

--- a/examples/app/commerce/src/index.ts
+++ b/examples/app/commerce/src/index.ts
@@ -28,6 +28,7 @@ function onHydrationComplete(): void {
 
   // Start client-side router after hydration — page components lazy-loaded
   Router.start({
+    preload: true,
     loaders: {
       'mp-page-home': () => import('#pages/mp-page-home/mp-page-home.js'),
       'mp-page-search': () => import('#pages/mp-page-search/mp-page-search.js'),

--- a/examples/app/contact-book-manager/package.json
+++ b/examples/app/contact-book-manager/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap ",
-    "start:client": "esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
+    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap ",
+    "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --state ./data/state.json --theme=@microsoft/webui-examples-theme --plugin=webui --servedir ./dist --port 3003 --api-port 3013 --watch",
     "start:api": "esbuild server/api.ts --bundle --platform=node --format=esm --outfile=dist/api.js --packages=external && node dist/api.js",
     "start": "cargo xtask dev contact-book-manager",

--- a/examples/app/contact-book-manager/src/index.html
+++ b/examples/app/contact-book-manager/src/index.html
@@ -36,12 +36,12 @@
 <body>
   <route path="/" component="cb-app">
     <route path="" component="cb-page-dashboard" exact />
-    <route path="contacts" component="cb-page-contacts" exact />
+    <route path="contacts" component="cb-page-contacts" exact keep-alive />
     <route path="contacts/add" component="cb-contact-form" exact />
     <route path="contacts/:id" component="cb-contact-detail" exact />
     <route path="contacts/:id/edit" component="cb-contact-form" exact />
-    <route path="favorites" component="cb-page-favorites" exact />
-    <route path="groups/:group" component="cb-page-group" exact />
+    <route path="favorites" component="cb-page-favorites" exact keep-alive />
+    <route path="groups/:group" component="cb-page-group" exact keep-alive />
   </route>
 
   <script type="module" src="/index.js"></script>

--- a/examples/app/routes/package.json
+++ b/examples/app/routes/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap",
+    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap",
+    "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:api": "cd server && pnpm start",
-    "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --plugin=webui --servedir ./dist --port 3008 --api-port 3018 --watch",
     "start": "cargo xtask dev routes",
     "test": "playwright test",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm -r run build",
+    "build": "pnpm --filter webui-framework --filter webui-router run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm --filter webui-framework --filter webui-router run build",
+    "build": "pnpm --filter @microsoft/webui --filter webui-framework --filter webui-router run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -125,7 +125,7 @@ Base class for framework components.
 | `static define(tagName)` | Register the class as a custom element |
 | `$emit(name, detail?)` | Dispatch a bubbling, composed `CustomEvent` |
 | `$update()` | Force a reactive update (normally called automatically) |
-| `setInitialState(state, params?)` | Populate `@observable` properties from router state |
+| `setState(state)` | Populate `@observable` properties from router/server state |
 | `disconnectedCallback()` | Override for cleanup (global listeners, etc.) |
 
 In most components you do not call `$update()` directly. Property changes through `@observable` and `@attr` trigger updates for you.

--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -286,14 +286,14 @@ export class WebUIElement extends HTMLElement {
     );
   }
 
-  /** Populate @observable properties from router state.
+  /** Populate @observable properties from server or router state.
    *
    * Each property is set through its reactive setter, which coalesces
    * updates into a single pending microtask. We then synchronously
    * flush those pending path updates so the DOM is current before any
    * view-transition snapshot captures it.
    */
-  setInitialState(state: Record<string, unknown>): void {
+  setState(state: Record<string, unknown>): void {
     const names = getObservableNames(this.constructor as Function);
     for (const key of Object.keys(state)) {
       if (names.has(key)) {

--- a/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
+++ b/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
@@ -5,7 +5,7 @@
  * Regression test: complex property bindings (:prop) propagate parent
  * observable changes to child <for> loops.
  *
- * When a parent's @observable array is replaced (e.g. via setInitialState
+ * When a parent's @observable array is replaced (e.g. via setState
  * during SPA navigation), the complex binding `:items="{{items}}"` must
  * push the new array to the child, causing the child's <for> loop to
  * re-render with the updated data.
@@ -79,11 +79,11 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     expect(count).toBe(0);
   });
 
-  test('setInitialState on parent propagates to child for-loop', async ({ page }) => {
+  test('setState on parent propagates to child for-loop', async ({ page }) => {
     // Simulate what the router does during SPA navigation
     await page.evaluate(() => {
       const host = document.querySelector('#host') as any;
-      host.setInitialState({ items: [{ name: 'X' }, { name: 'Y' }] });
+      host.setState({ items: [{ name: 'X' }, { name: 'Y' }] });
     });
 
     await page.waitForFunction(() => {
@@ -103,13 +103,13 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     expect(items).toEqual(['X', 'Y']);
   });
 
-  test('setInitialState propagates to child synchronously (no microtask needed)', async ({ page }) => {
-    // The critical case: after setInitialState, the child DOM must be
+  test('setState propagates to child synchronously (no microtask needed)', async ({ page }) => {
+    // The critical case: after setState, the child DOM must be
     // updated synchronously — no microtask wait. This matters for view
     // transitions which snapshot the DOM right after the sync callback.
     const result = await page.evaluate(() => {
       const host = document.querySelector('#host') as any;
-      host.setInitialState({ items: [{ name: 'Sync1' }, { name: 'Sync2' }, { name: 'Sync3' }] });
+      host.setState({ items: [{ name: 'Sync1' }, { name: 'Sync2' }, { name: 'Sync3' }] });
 
       // Check IMMEDIATELY — no await, no microtask, no setTimeout
       const list = host?.shadowRoot?.querySelector('test-item-list');

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/element.ts
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/element.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { WebUIElement, attr, observable } from '../../../src/index.js';
+
+/**
+ * Child component used inside a <for> loop.
+ * Receives `htmlContent` via @attr — tests whether {{{htmlContent}}}
+ * renders raw HTML after a reactive update (not just SSR).
+ */
+export class TestRawItem extends WebUIElement {
+  @attr name = '';
+  @attr htmlContent = '';
+}
+TestRawItem.define('test-raw-item');
+
+/**
+ * Parent component with a <for> loop of test-raw-item elements.
+ * Reactively updating `items` should re-render child @attr values
+ * and {{{htmlContent}}} should render as raw HTML, not escaped.
+ */
+export class TestRawFor extends WebUIElement {
+  @observable items: Array<{ name: string; htmlContent: string }> = [];
+}
+TestRawFor.define('test-raw-for');

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/raw-html-for-attr.spec.ts
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/raw-html-for-attr.spec.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('raw HTML in @attr inside <for> loop', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/raw-html-for-attr/fixture.html');
+    await page.waitForSelector('test-raw-for');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-raw-for');
+      return el && (el as any).$ready === true;
+    });
+  });
+
+  test('SSR: {{{htmlContent}}} renders raw HTML from @attr', async ({ page }) => {
+    // After SSR + hydration, the body should contain rendered HTML, not escaped tags
+    const body1 = await page.locator('test-raw-item:first-of-type .item-body').innerHTML();
+    expect(body1).toContain('<p>Hello <strong>World</strong></p>');
+    // Ensure it does NOT contain escaped HTML like &lt;p&gt;
+    expect(body1).not.toContain('&lt;');
+  });
+
+  test('SSR: plain {{name}} renders correctly alongside raw HTML', async ({ page }) => {
+    await expect(page.locator('test-raw-item:first-of-type .item-name')).toHaveText('Email 1');
+    await expect(page.locator('test-raw-item:nth-of-type(2) .item-name')).toHaveText('Email 2');
+  });
+
+  test('reactive update: new items render {{{htmlContent}}} as raw HTML', async ({ page }) => {
+    // Reactively replace the items array — simulates SPA navigation
+    await page.evaluate(() => {
+      const el = document.querySelector('test-raw-for') as any;
+      el.items = [
+        { name: 'New 1', htmlContent: '<p>Updated <b>bold</b> text</p>' },
+        { name: 'New 2', htmlContent: '<div class="custom"><span>Rich</span> content</div>' },
+      ];
+    });
+
+    // Wait for reactive update to propagate
+    await page.waitForTimeout(100);
+
+    // Verify the new items render raw HTML, not escaped
+    const body1 = await page.locator('test-raw-item:first-of-type .item-body').innerHTML();
+    expect(body1).toContain('<p>Updated <b>bold</b> text</p>');
+    expect(body1).not.toContain('&lt;');
+
+    const body2 = await page.locator('test-raw-item:nth-of-type(2) .item-body').innerHTML();
+    expect(body2).toContain('<div class="custom"><span>Rich</span> content</div>');
+    expect(body2).not.toContain('&lt;');
+  });
+
+  test('reactive update: names update correctly alongside raw HTML', async ({ page }) => {
+    await page.evaluate(() => {
+      const el = document.querySelector('test-raw-for') as any;
+      el.items = [
+        { name: 'Alice', htmlContent: '<p>Message from Alice</p>' },
+      ];
+    });
+    await page.waitForTimeout(100);
+    await expect(page.locator('test-raw-item .item-name')).toHaveText('Alice');
+  });
+});

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/index.html
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Raw HTML in For Loop with @attr</title>
+</head>
+<body>
+  <test-raw-for></test-raw-for>
+</body>
+</html>

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/test-raw-for/test-raw-for.html
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/test-raw-for/test-raw-for.html
@@ -1,0 +1,3 @@
+<for each="item in items">
+  <test-raw-item name="{{item.name}}" html-content="{{item.htmlContent}}"></test-raw-item>
+</for>

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/test-raw-item/test-raw-item.html
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/src/test-raw-item/test-raw-item.html
@@ -1,0 +1,4 @@
+<div class="item">
+  <span class="item-name">{{name}}</span>
+  <div class="item-body">{{{htmlContent}}}</div>
+</div>

--- a/packages/webui-framework/tests/fixtures/raw-html-for-attr/state.json
+++ b/packages/webui-framework/tests/fixtures/raw-html-for-attr/state.json
@@ -1,0 +1,6 @@
+{
+  "items": [
+    { "name": "Email 1", "htmlContent": "<p>Hello <strong>World</strong></p>" },
+    { "name": "Email 2", "htmlContent": "<p>Test <em>italic</em> and <a href=\"#\">link</a></p>" }
+  ]
+}

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -93,6 +93,19 @@ Navigating from `/settings/profile` to `/settings/billing` only remounts the bil
 
 Without `exact`, a route matches any URL that starts with its path — which is what parent routes need.
 
+### The `keep-alive` Attribute
+
+Preserve a component across navigations instead of destroying and recreating it:
+
+```html
+<route path="./" component="mail-view" keep-alive>
+  <route path="" component="inbox-page" exact />
+</route>
+<route path="calendar" component="calendar-page" exact keep-alive />
+```
+
+When the user navigates away from a `keep-alive` route and returns, the existing component is reused — its DOM and local state (scroll position, input values, timers) survive the round trip. Fresh server state is applied via `setState()`, updating only what changed.
+
 ## API
 
 ### `Router.start(config?)`
@@ -105,6 +118,7 @@ Start the router. Call after hydration completes.
 | `loaders` | `Record<string, () => Promise<unknown>>` | Lazy-loading map: component tag → dynamic import |
 | `templateEndpoint` | `string` | URL for `ensureLoaded()` requests (default: `"/_webui/templates"`) |
 | `dev` | `boolean` | Enable development mode warnings |
+| `preload` | `boolean` | Preload routes on link hover for instant navigation |
 
 ### `Router.navigate(path)`
 

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -435,16 +435,21 @@ describe('WebUIRouter', () => {
     });
 
     test('handleNavigation checks signal.aborted after fetch and inside preload loop', () => {
-      // Verify the architectural contract: handleNavigation has abort gates
+      // Verify the architectural contract: commitWithData has abort gates
       // after fetchPartial and inside the ensureComponentLoaded loop.
       const router = new WebUIRouter();
-      const source = (router as any).handleNavigation.toString() as string;
+      const navSource = (router as any).handleNavigation.toString() as string;
+      const commitSource = (router as any).commitWithData.toString() as string;
 
-      // Count occurrences of signal?.aborted checks
+      // handleNavigation should call fetchPartial
+      const fetchIdx = navSource.indexOf('fetchPartial');
+      assert.ok(fetchIdx > -1, 'fetchPartial should be called in handleNavigation');
+
+      // Count occurrences of signal?.aborted checks in commitWithData
       const abortChecks: number[] = [];
       let searchFrom = 0;
       while (true) {
-        const idx = source.indexOf('signal?.aborted', searchFrom);
+        const idx = commitSource.indexOf('signal?.aborted', searchFrom);
         if (idx === -1) break;
         abortChecks.push(idx);
         searchFrom = idx + 1;
@@ -452,21 +457,13 @@ describe('WebUIRouter', () => {
 
       assert.ok(
         abortChecks.length >= 2,
-        `should have at least 2 abort gates, found ${abortChecks.length}`,
+        `should have at least 2 abort gates in commitWithData, found ${abortChecks.length}`,
       );
 
-      // First gate should be after fetchPartial
-      const fetchIdx = source.indexOf('fetchPartial');
-      assert.ok(fetchIdx > -1, 'fetchPartial should be called');
-      assert.ok(
-        abortChecks[0] > fetchIdx,
-        'first abort gate should be after fetchPartial call',
-      );
-
-      // One of the abort gates should be immediately followed by ensureComponentLoaded
-      // (i.e. inside the preload loop, guarding each iteration).
+      // One of the abort gates should be near ensureComponentLoaded
+      // (i.e. inside the preload section, guarding the preload step).
       const hasPreloadGate = abortChecks.some(pos => {
-        const after = source.substring(pos, pos + 200);
+        const after = commitSource.substring(pos, pos + 400);
         return after.includes('ensureComponentLoaded');
       });
       assert.ok(
@@ -497,7 +494,7 @@ describe('WebUIRouter', () => {
       // behind transition animations. The router must use .updateCallbackDone
       // so the handler resolves after the synchronous DOM commit.
       const router = new WebUIRouter();
-      const source = (router as any).handleNavigation.toString() as string;
+      const source = (router as any).commitWithData.toString() as string;
 
       assert.ok(
         source.includes('updateCallbackDone'),
@@ -517,7 +514,7 @@ describe('WebUIRouter', () => {
       // mid-typing). The router must guard the startViewTransition call with
       // an `isQueryOnlyChange` check so focus is preserved.
       const router = new WebUIRouter();
-      const source = (router as any).handleNavigation.toString() as string;
+      const source = (router as any).commitWithData.toString() as string;
 
       // The view-transition block must be gated on !isQueryOnlyChange
       const transitionIdx = source.indexOf('startViewTransition');
@@ -545,16 +542,16 @@ describe('WebUIRouter', () => {
       // network or import(), the browser's view transition will timeout.
       //
       // This test verifies the architectural contract by inspecting the
-      // handleNavigation source code — the commitNavigation callback passed
+      // commitWithData source code — the commitNavigation callback passed
       // to startViewTransition must not reference fetchPartial or
       // ensureComponentLoaded.
 
       const router = new WebUIRouter();
-      const source = (router as any).handleNavigation.toString() as string;
+      const source = (router as any).commitWithData.toString() as string;
 
       // Find the commitNavigation function body
       const commitStart = source.indexOf('commitNavigation');
-      assert.ok(commitStart > -1, 'handleNavigation should define commitNavigation');
+      assert.ok(commitStart > -1, 'commitWithData should define commitNavigation');
 
       // Find ensureComponentLoaded — it must appear BEFORE commitNavigation
       const ensureIdx = source.indexOf('ensureComponentLoaded');
@@ -565,13 +562,12 @@ describe('WebUIRouter', () => {
         'async work must not be inside the view transition callback',
       );
 
-      // fetchPartial must also appear before commitNavigation
-      const fetchIdx = source.indexOf('fetchPartial');
-      assert.ok(fetchIdx > -1, 'fetchPartial should be called');
+      // fetchPartial must also appear before commitNavigation — but commitWithData
+      // receives data as a parameter, so fetchPartial won't be in this method.
+      // Instead, verify the method signature receives data as a parameter.
       assert.ok(
-        fetchIdx < commitStart,
-        'fetchPartial (async network) must be called BEFORE commitNavigation — ' +
-        'async work must not be inside the view transition callback',
+        source.includes('partialData') || source.includes('data'),
+        'commitWithData receives data as a parameter (fetch happens in caller)',
       );
     });
   });
@@ -659,6 +655,148 @@ describe('WebUIRouter', () => {
         (globalThis as any).document.querySelector = origQuerySelector;
         (globalThis as any).document.head = origHead;
       }
+    });
+  });
+
+  describe('preload on hover', () => {
+    test('speculative fetchPartial does not redirect on HTML response', async () => {
+      const origFetch = (globalThis as any).fetch;
+      const origLocation = (globalThis as any).location;
+      let redirected = false;
+      (globalThis as any).location = {
+        ...origLocation,
+        set href(v: string) { redirected = true; },
+        get href() { return origLocation.href; },
+        get origin() { return origLocation.origin; },
+        get pathname() { return origLocation.pathname; },
+      };
+      (globalThis as any).fetch = async () => ({
+        ok: true,
+        headers: { get: () => 'text/html' },
+        json: async () => ({}),
+      });
+
+      try {
+        const router = new WebUIRouter();
+        const fetchPartial = (router as any).fetchPartial.bind(router) as (
+          path: string,
+          signal?: AbortSignal,
+          speculative?: boolean,
+        ) => Promise<unknown>;
+
+        // Non-speculative should redirect
+        const result1 = await fetchPartial('/login');
+        assert.equal(result1, null);
+        assert.ok(redirected, 'non-speculative HTML response should redirect');
+
+        // Speculative should NOT redirect
+        redirected = false;
+        const result2 = await fetchPartial('/login', undefined, true);
+        assert.equal(result2, null);
+        assert.ok(!redirected, 'speculative HTML response should not redirect');
+      } finally {
+        (globalThis as any).fetch = origFetch;
+        (globalThis as any).location = origLocation;
+      }
+    });
+
+    test('preload cache is consumed on navigation and cleared after use', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      const cachedData = { state: { msg: 'preloaded' }, templates: [], path: '/about', chain: [{ component: 'about-page', path: '/about', params: {} }] };
+      priv.preloadCache = { path: '/about', data: cachedData, ts: Date.now() };
+
+      // handleNavigation reads from preloadCache via requestPath matching
+      // Verify the cache structure is correct
+      assert.equal(priv.preloadCache.path, '/about');
+      assert.deepEqual(priv.preloadCache.data.state, { msg: 'preloaded' });
+
+      // Simulate consumption by clearing
+      const consumed = priv.preloadCache;
+      priv.preloadCache = null;
+      assert.equal(priv.preloadCache, null, 'cache should be cleared after consumption');
+      assert.deepEqual(consumed.data.state, { msg: 'preloaded' });
+    });
+
+    test('stale preload cache (>TTL) is not consumed', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      // Cache entry that is 10 seconds old
+      const staleTs = Date.now() - 10_000;
+      priv.preloadCache = { path: '/about', data: { state: {} }, ts: staleTs };
+
+      // The TTL check: Date.now() - ts < PRELOAD_TTL (5000ms)
+      const isFresh = Date.now() - priv.preloadCache.ts < 5_000;
+      assert.ok(!isFresh, 'cache older than 5s should be considered stale');
+    });
+
+    test('preload generation guard prevents stale cache writes', async () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      // Simulate: preload A starts (gen=1), preload B starts (gen=2),
+      // preload A resolves — should NOT write to cache because gen is stale.
+      priv.preloadGeneration = 0;
+
+      const genA = ++priv.preloadGeneration; // gen=1
+      const genB = ++priv.preloadGeneration; // gen=2
+
+      // A's completion check: gen should not match current
+      assert.notEqual(genA, priv.preloadGeneration, 'stale gen should not match current');
+      assert.equal(genB, priv.preloadGeneration, 'current gen should match');
+    });
+
+    test('destroy clears preload state', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      priv.preloadCache = { path: '/test', data: {}, ts: Date.now() };
+      priv.preloadController = new AbortController();
+      priv.preloadGeneration = 5;
+
+      router.destroy();
+
+      assert.equal(priv.preloadCache, null, 'cache should be cleared');
+      assert.equal(priv.preloadController, null, 'controller should be cleared');
+    });
+
+    test('setupPreloadListeners registers pointermove listener on document', () => {
+      const listeners: Array<{ type: string; handler: unknown }> = [];
+      const origAddEventListener = (globalThis as any).document.addEventListener;
+      const origRemoveEventListener = (globalThis as any).document.removeEventListener;
+      (globalThis as any).document.addEventListener = (type: string, fn: unknown) => {
+        listeners.push({ type, handler: fn });
+      };
+      (globalThis as any).document.removeEventListener = () => {};
+
+      try {
+        const router = new WebUIRouter();
+        (router as any).setupPreloadListeners();
+        assert.ok(
+          listeners.some(l => l.type === 'pointermove'),
+          'should register a pointermove listener on document',
+        );
+      } finally {
+        (globalThis as any).document.addEventListener = origAddEventListener;
+        (globalThis as any).document.removeEventListener = origRemoveEventListener;
+      }
+    });
+
+    test('handleNavigation source checks preloadCache before fetchPartial', () => {
+      const router = new WebUIRouter();
+      const source = (router as any).handleNavigation.toString() as string;
+
+      const cacheIdx = source.indexOf('preloadCache');
+      const fetchIdx = source.indexOf('fetchPartial');
+
+      assert.ok(cacheIdx > -1, 'handleNavigation should reference preloadCache');
+      assert.ok(fetchIdx > -1, 'handleNavigation should reference fetchPartial');
+      assert.ok(
+        cacheIdx < fetchIdx,
+        'preloadCache check should come before fetchPartial call',
+      );
     });
   });
 });

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -146,6 +146,7 @@ export class WebUIRouteElement extends HTMLElement {
   get exact(): boolean { return this.hasAttribute('exact'); }
   get component(): string { return this.getAttribute('component') ?? ''; }
   get isActive(): boolean { return this.hasAttribute('active'); }
+  get keepAlive(): boolean { return this.hasAttribute('keep-alive'); }
   get params(): Record<string, string> { return getRouteParams(this); }
   /** Comma-separated allowlist of query params forwarded as attributes. */
   get query(): string { return this.getAttribute('query') ?? ''; }
@@ -167,6 +168,17 @@ interface RouteChainEntry {
   el?: HTMLElement;
   /** Comma-separated allowlist of query params forwarded as attributes. */
   allowedQuery?: string;
+  /** When true, the component is preserved across navigations instead of re-created. */
+  keepAlive?: boolean;
+}
+
+/** Static route manifest entry — built once at startup from <webui-route> tree. */
+interface RouteManifestEntry {
+  component: string;
+  path: string;
+  exact: boolean;
+  allowedQuery?: string;
+  children: RouteManifestEntry[];
 }
 
 // ── Router ───────────────────────────────────────────────────────
@@ -218,8 +230,8 @@ function applyParamsQueryState(
   }
   queryAttrsMap.set(component, newAttrs);
 
-  if (typeof (component as any).setInitialState === 'function') {
-    (component as any).setInitialState(data.state);
+  if (typeof (component as any).setState === 'function') {
+    (component as any).setState(data.state);
   }
 }
 
@@ -244,6 +256,14 @@ export class WebUIRouter {
   private injectedCss = new Set<string>();
   /** In-memory dedup for injected module style specifiers (avoids DOM queries). */
   private injectedStyles = new Set<string>();
+  /** Monotonic navigation generation — guards against stale async completions. */
+  private navGeneration = 0;
+  /** Cached preload result from a speculative hover fetch. */
+  private preloadCache: { path: string; data: PartialResponse & { inventory?: string }; ts: number } | null = null;
+  /** AbortController for the in-flight preload fetch. */
+  private preloadController: AbortController | null = null;
+  /** Monotonic preload generation — prevents stale hover fetches from overwriting the cache. */
+  private preloadGeneration = 0;
 
   /** The component tag of the currently active leaf route. */
   get activeComponent(): string {
@@ -298,6 +318,10 @@ export class WebUIRouter {
     };
     nav.addEventListener('navigate', handler);
     this.cleanupFns.push(() => nav.removeEventListener('navigate', handler));
+
+    if (config.preload) {
+      this.setupPreloadListeners();
+    }
 
     this.handleNavigation(this.currentTarget());
   }
@@ -485,6 +509,78 @@ export class WebUIRouter {
     this.ssrPreloadsCleared = false;
     this.injectedCss.clear();
     this.injectedStyles.clear();
+    this.preloadCache = null;
+    this.preloadController?.abort();
+    this.preloadController = null;
+  }
+
+  // ── Preload on hover ──────────────────────────────────────────
+
+  /** Maximum age (ms) for a preloaded partial before it's considered stale. */
+  private static readonly PRELOAD_TTL = 5_000;
+
+  /**
+   * Register a delegated `pointerover` listener that speculatively fetches
+   * the JSON partial for internal links on mouse hover.
+   *
+   * Uses `pointermove` (bubbles + composed + fires continuously) because
+   * `pointerover` only fires once when entering a shadow host — subsequent
+   * moves between child elements inside the shadow root don't re-trigger it
+   * at the document level. `pointermove` fires on every position change,
+   * giving us reliable detection across all shadow DOM boundaries.
+   *
+   * The handler is naturally debounced: the `preloadCache` path check
+   * ensures we only fetch once per unique link, and the early returns
+   * for non-anchor targets keep the hot path fast (one `composedPath()`
+   * walk that exits immediately when no `<a>` is found).
+   *
+   * Only mouse pointers trigger preload — touch fires too late to benefit.
+   */
+  private setupPreloadListeners(): void {
+    const onPointerMove = (e: PointerEvent): void => {
+      if (e.pointerType !== 'mouse') return;
+
+      // Walk composedPath to find the nearest <a> — works across shadow boundaries.
+      const anchor = (e.composedPath() as Element[]).find(
+        el => el?.tagName === 'A',
+      ) as HTMLAnchorElement | undefined;
+      if (!anchor) return;
+
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) return;
+
+      let url: URL;
+      try {
+        url = new URL(href, location.href);
+      } catch {
+        return;
+      }
+      if (url.origin !== location.origin) return;
+
+      const target = buildNavigationTarget(url, this.basePath);
+
+      // Skip if already on this path or already cached for it
+      if (target.requestPath === this.currentTarget().requestPath) return;
+      if (this.preloadCache?.path === target.requestPath) return;
+
+      // Abort any in-flight speculative fetch and start a new one
+      this.preloadController?.abort();
+      const controller = new AbortController();
+      this.preloadController = controller;
+      const gen = ++this.preloadGeneration;
+
+      this.fetchPartial(target.requestPath, controller.signal, true)
+        .then(data => {
+          // Only cache if this is still the latest preload request
+          if (data && gen === this.preloadGeneration && !controller.signal.aborted) {
+            this.preloadCache = { path: target.requestPath, data, ts: Date.now() };
+          }
+        })
+        .catch(() => {}); // Speculative — silently discard errors
+    };
+
+    document.addEventListener('pointermove', onPointerMove);
+    this.cleanupFns.push(() => document.removeEventListener('pointermove', onPointerMove));
   }
 
   // ── Route matching ──────────────────────────────────────────────
@@ -520,128 +616,24 @@ export class WebUIRouter {
       }
     } else {
       this.clearSsrPreloads();
-      const partialData = await this.fetchPartial(requestPath, signal);
-      if (!partialData) return;
+      const thisGen = ++this.navGeneration;
 
-      // Bail out if a newer navigation has superseded this one.
-      if (signal?.aborted) return;
-
-      const newChain: RouteChainEntry[] = (partialData.chain ?? []).map(e => ({
-        component: e.component ?? '',
-        path: e.path ?? '',
-        params: e.params ?? {},
-        exact: e.exact,
-        allowedQuery: e.allowedQuery,
-      }));
-
-      if (newChain.length === 0) {
-        console.warn(`[Router] No route matched for path: ${requestPath}`);
-        window.location.href = prependBasePath(requestPath, this.basePath);
-        return;
-      }
-
-      // Pre-load all component modules in parallel before the DOM swap so
-      // the view transition only covers the synchronous mount.
-      // Race against abort so a superseding navigation doesn't wait for
-      // in-flight imports from the aborted one. ensureComponentLoaded
-      // caches module promises, so any work done here is reused by the
-      // winning navigation.
-      if (signal?.aborted) return;
-      const preload = Promise.all(
-        newChain
-          .filter(entry => entry.component)
-          .map(entry => this.ensureComponentLoaded(entry.component)),
-      );
-      if (signal) {
-        const aborted = new Promise<'aborted'>(resolve => {
-          signal.addEventListener('abort', () => resolve('aborted'), { once: true });
-        });
-        const result = await Promise.race([preload.then(() => 'loaded' as const), aborted]);
-        if (result === 'aborted') return;
+      // Use preloaded data if we have a fresh cache hit for this path
+      let partialData: (PartialResponse & { inventory?: string }) | null = null;
+      const cached = this.preloadCache;
+      if (cached && cached.path === requestPath &&
+          Date.now() - cached.ts < WebUIRouter.PRELOAD_TTL) {
+        partialData = cached.data;
+        this.preloadCache = null;
       } else {
-        await preload;
+        // Cancel any in-flight speculative fetch — we're doing a real navigation
+        this.preloadController?.abort();
+        this.preloadCache = null;
+        partialData = await this.fetchPartial(requestPath, signal);
       }
-      if (signal?.aborted) return;
 
-      const changeLevel = this.findChangeLevel(this.activeChain, newChain);
-
-      // When only query params change (same route, different ?sort= etc.),
-      // changeLevel equals chain length so nothing remounts. Detect this
-      // and re-apply state to all components in the chain from the server's
-      // fresh partial response.
-      const isQueryOnlyChange = changeLevel === newChain.length && newChain.length > 0;
-
-      // DOM swap — synchronous, safe inside view transitions.
-      // All async work (fetch, import) is done above.
-      const commitNavigation = (): void => {
-        // Deactivate old chain from leaf up
-        for (let i = this.activeChain.length - 1; i >= changeLevel; i--) {
-          if (this.activeChain[i].el) {
-            deactivateRoute(this.activeChain[i].el!);
-          }
-        }
-
-        // Transfer DOM elements to retained levels
-        for (let i = 0; i < changeLevel; i++) {
-          newChain[i].el = this.activeChain[i].el;
-        }
-
-        // Re-apply state to retained (non-remounted) parent components.
-        if (changeLevel > 0 || isQueryOnlyChange) {
-          const end = isQueryOnlyChange ? newChain.length : changeLevel;
-          for (let i = 0; i < end; i++) {
-            this.applyState(newChain[i], partialData, query);
-          }
-        }
-
-        // Mount from the change level down
-        for (let i = changeLevel; i < newChain.length; i++) {
-          const entry = newChain[i];
-          const oldEntry = i < this.activeChain.length ? this.activeChain[i] : null;
-          const parent = i > 0 ? newChain[i - 1] : null;
-
-          // Same component tag at this level → reuse instance, update state
-          if (
-            oldEntry &&
-            oldEntry.component === entry.component &&
-            oldEntry.el
-          ) {
-            entry.el = oldEntry.el;
-            if (entry.component && partialData) {
-              this.applyState(entry, partialData, query);
-            }
-            activateRoute(entry.el, entry.params);
-            continue;
-          }
-
-          // Different component (or no old entry) → full mount
-          const routeEl = this.findOrCreateRouteElement(parent, entry);
-          entry.el = routeEl;
-
-          if (entry.component && partialData) {
-            this.mountComponent(routeEl, entry.component, partialData, entry.params, query);
-          }
-
-          activateRoute(routeEl, entry.params);
-        }
-
-        this.activeChain = newChain;
-      };
-
-      // DOM swap — wrapped in a view transition when available.
-      // Skip view transitions for query-only changes (issue #235): no
-      // components remount so there is nothing to animate, and the
-      // transition would blur the active element (e.g. search input).
-      // Await updateCallbackDone (not .finished) so the Navigation API
-      // handler resolves as soon as the DOM commit completes, without
-      // waiting for the CSS animation to finish. This allows rapid
-      // navigations to supersede each other without queuing.
-      if (document.startViewTransition && !isQueryOnlyChange) {
-        const transition = document.startViewTransition(commitNavigation);
-        await transition.updateCallbackDone;
-      } else {
-        commitNavigation();
-      }
+      if (!partialData || signal?.aborted || thisGen !== this.navGeneration) return;
+      await this.commitWithData(partialData, requestPath, query, signal, thisGen);
     }
 
     const leaf = this.activeChain[this.activeChain.length - 1];
@@ -669,6 +661,13 @@ export class WebUIRouter {
    * For top-level routes, searches direct children of `<body>`.
    * For nested routes, searches the parent component's render root
    * (shadow root or light DOM).
+   *
+   * When creating a new stub, placement strategy:
+   *  1. Sibling routes: insert next to existing `<webui-route>` elements
+   *     (handles SSR'd shadow roots where `<outlet>` was replaced by routes).
+   *  2. `<outlet>` marker: insert after it (handles freshly created components
+   *     whose f-template still contains `<outlet></outlet>`).
+   *  3. Fallback: append to render root.
    */
   private findOrCreateRouteElement(
     parent: RouteChainEntry | null,
@@ -692,20 +691,45 @@ export class WebUIRouter {
       const compEl = parent.el.querySelector(parent.component);
       if (compEl) {
         const root = renderRoot(compEl);
-        for (const child of root.querySelectorAll(ROUTE_SELECTOR)) {
+        const allRoutes = root.querySelectorAll(ROUTE_SELECTOR);
+
+        // Match by component + path for stronger identity
+        for (const child of allRoutes) {
+          if (child.getAttribute('component') === entry.component &&
+              child.getAttribute('path') === (entry.path || null)) {
+            return child as HTMLElement;
+          }
+        }
+        // Fallback: match by component only (backwards compat)
+        for (const child of allRoutes) {
           if (child.getAttribute('component') === entry.component) {
             return child as HTMLElement;
           }
         }
 
-        // Not found — create in the outlet area of parent component
+        // Not found — create stub and place in the correct container
         const stub = createRouteStub(entry);
+
+        // Strategy 1: use the parent container of existing sibling routes.
+        // In SSR'd shadow roots, <outlet> is replaced by <webui-route> elements
+        // so we infer the outlet container from their parentElement.
+        if (allRoutes.length > 0) {
+          const container = allRoutes[allRoutes.length - 1].parentElement;
+          if (container) {
+            container.appendChild(stub);
+            return stub;
+          }
+        }
+
+        // Strategy 2: insert after the <outlet> marker (f-template components)
         const outletMarker = root.querySelector('outlet');
         if (outletMarker?.parentElement) {
           outletMarker.parentElement.insertBefore(stub, outletMarker.nextSibling);
-        } else {
-          root.appendChild(stub);
+          return stub;
         }
+
+        // Strategy 3: fallback — append to render root
+        root.appendChild(stub);
         return stub;
       }
     }
@@ -750,6 +774,7 @@ export class WebUIRouter {
         exact: isExact(activeEl),
         el: activeEl,
         allowedQuery: activeEl.getAttribute('query') ?? undefined,
+        keepAlive: activeEl.hasAttribute('keep-alive'),
       });
       activateRoute(activeEl, params);
 
@@ -827,7 +852,11 @@ export class WebUIRouter {
 
   // ── Fetch + Mount ──────────────────────────────────────────────
 
-  private async fetchPartial(requestPath: string, signal?: AbortSignal): Promise<(PartialResponse & { inventory?: string }) | null> {
+  private async fetchPartial(
+    requestPath: string,
+    signal?: AbortSignal,
+    speculative?: boolean,
+  ): Promise<(PartialResponse & { inventory?: string }) | null> {
     const fullPath = prependBasePath(requestPath, this.basePath);
     const headers: Record<string, string> = { 'Accept': 'application/json' };
     if (this.inventory) headers['X-WebUI-Inventory'] = this.inventory;
@@ -838,8 +867,8 @@ export class WebUIRouter {
     const contentType = resp.headers.get('content-type') ?? '';
     if (!contentType.includes('application/json')) {
       // Server returned HTML (e.g. login page) instead of JSON partial.
-      // Trigger a full page navigation so the browser handles it.
-      if (signal?.aborted) return null;
+      // Speculative fetches never redirect — just bail out silently.
+      if (speculative || signal?.aborted) return null;
       window.location.href = prependBasePath(requestPath, this.basePath);
       return null;
     }
@@ -888,7 +917,7 @@ export class WebUIRouter {
 
   /**
    * Apply partial state to a mounted route component.
-   * Calls the framework's built-in `setInitialState` which sets
+   * Calls the framework's built-in `setState` which sets
    * `@observable` properties and flushes DOM updates synchronously.
    * Route params are set as HTML attributes for `@attr` reflection.
    * Allowed query params (declared via `query` attr on the route) are
@@ -1006,6 +1035,106 @@ export class WebUIRouter {
   private updateInventory(serverInventory: string): void {
     this.inventory = serverInventory;
   }
+
+  /**
+   * Commit a navigation using server-confirmed data (the standard fetch-first path).
+   * Used both as fallback for first visits and when the server responds within the
+   * optimistic delay budget.
+   */
+  private async commitWithData(
+    partialData: PartialResponse & { inventory?: string },
+    requestPath: string,
+    query: Record<string, string>,
+    signal?: AbortSignal,
+    generation?: number,
+  ): Promise<void> {
+    const newChain: RouteChainEntry[] = (partialData.chain ?? []).map(e => ({
+      component: e.component ?? '',
+      path: e.path ?? '',
+      params: e.params ?? {},
+      exact: e.exact,
+      allowedQuery: e.allowedQuery,
+      keepAlive: e.keepAlive,
+    }));
+
+    if (newChain.length === 0) {
+      console.warn(`[Router] No route matched for path: ${requestPath}`);
+      window.location.href = prependBasePath(requestPath, this.basePath);
+      return;
+    }
+
+    // Pre-load component modules
+    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) return;
+    const preload = Promise.all(
+      newChain
+        .filter(entry => entry.component)
+        .map(entry => this.ensureComponentLoaded(entry.component)),
+    );
+    if (signal) {
+      const aborted = new Promise<'aborted'>(resolve => {
+        signal.addEventListener('abort', () => resolve('aborted'), { once: true });
+      });
+      const result = await Promise.race([preload.then(() => 'loaded' as const), aborted]);
+      if (result === 'aborted') return;
+    } else {
+      await preload;
+    }
+    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) return;
+
+    const changeLevel = this.findChangeLevel(this.activeChain, newChain);
+    const isQueryOnlyChange = changeLevel === newChain.length && newChain.length > 0;
+
+    const commitNavigation = (): void => {
+      // Deactivate old chain from leaf up
+      for (let i = this.activeChain.length - 1; i >= changeLevel; i--) {
+        if (this.activeChain[i].el) deactivateRoute(this.activeChain[i].el!);
+      }
+      for (let i = 0; i < changeLevel; i++) {
+        newChain[i].el = this.activeChain[i].el;
+      }
+      if (changeLevel > 0 || isQueryOnlyChange) {
+        const end = isQueryOnlyChange ? newChain.length : changeLevel;
+        for (let i = 0; i < end; i++) {
+          this.applyState(newChain[i], partialData, query);
+        }
+      }
+      for (let i = changeLevel; i < newChain.length; i++) {
+        const entry = newChain[i];
+        const oldEntry = i < this.activeChain.length ? this.activeChain[i] : null;
+        const parent = i > 0 ? newChain[i - 1] : null;
+        if (oldEntry?.component === entry.component && oldEntry?.el) {
+          entry.el = oldEntry.el;
+          if (entry.component) this.applyState(entry, partialData, query);
+          activateRoute(entry.el, entry.params);
+          continue;
+        }
+        const routeEl = this.findOrCreateRouteElement(parent, entry);
+        entry.el = routeEl;
+        if (entry.component) {
+          // Keep-alive: if the route has keep-alive and already has the correct
+          // component mounted (from a previous visit), reuse it and apply fresh
+          // state instead of destroying and recreating the component.
+          const isKeepAlive = entry.keepAlive || routeEl.hasAttribute('keep-alive');
+          const existingComp = routeEl.firstElementChild;
+          if (isKeepAlive && existingComp?.matches(entry.component)) {
+            applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query);
+          } else {
+            this.mountComponent(routeEl, entry.component, partialData, entry.params, query);
+          }
+        }
+        activateRoute(routeEl, entry.params);
+      }
+      this.activeChain = newChain;
+    };
+
+    if (document.startViewTransition && !isQueryOnlyChange) {
+      const transition = document.startViewTransition(commitNavigation);
+      await transition.updateCallbackDone;
+    } else {
+      commitNavigation();
+    }
+  }
+
 }
 
 /** Singleton router instance. */

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -57,6 +57,23 @@ export interface RouterConfig {
    * ```
    */
   templateEndpoint?: string;
+
+  /**
+   * Preload routes on link hover. When enabled, the router listens for
+   * pointer events on internal `<a>` links and speculatively fetches the
+   * JSON partial response. If the user clicks the link, the cached result
+   * is used instantly — eliminating the navigation fetch latency.
+   *
+   * Only mouse pointers trigger preload (touch taps fire too late to benefit).
+   * The cache holds a single entry with a 5-second TTL.
+   *
+   * @default false
+   * @example
+   * ```ts
+   * Router.start({ preload: true });
+   * ```
+   */
+  preload?: boolean;
 }
 
 /** Detail payload of the `webui:route:navigated` CustomEvent. */


### PR DESCRIPTION
## Description

**Why:** The router lacked two features competitors offer: speculative preloading on hover (TanStack, Next.js, Remix all have it) and keep-alive component preservation. 

**What:** Add preload-on-hover (`Router.start({ preload: true })`) and keep-alive (`<route keep-alive>`) flowing through the same build-time pipeline.

**How:**
- **Preload:** Delegated `pointermove` listener walks `composedPath()` for shadow DOM compatibility, speculatively calls `fetchPartial()` with a 5s TTL cache and monotonic generation guard. Speculative fetches never trigger HTML redirects.
- **Keep-alive:** New `keep_alive` bool on `WebUIFragmentRoute` proto → parser reads `keep-alive` attr → handler emits it on `<webui-route>` → router preserves component instances across navigations.
- Refactored `handleNavigation` into `commitWithData` for cleaner fetch/commit separation.

## Test Plan

- `cargo test --workspace` — 909 Rust tests pass (parser, handler, protocol)
- `pnpm test` in webui-router — 55 unit tests pass
- Playwright E2E — 22 tests (SSR deep links, client nav, history, query params, keep-alive, loaders)
- Manual: hover over links in commerce example → network tab shows speculative fetches
- Drive by change: Added a test raw fixture for the framework to fix regression for raw strings.

## Checklist

- [x] Preload on hover with shadow DOM support
- [x] Keep-alive in proto → parser → handler → router pipeline
- [x] DESIGN.md, routing.md, ai.md, router README updated
- [x] No new `unwrap`/`expect` in library code
- [x] `cargo xtask check` passes (fmt, clippy, deny, test, build)

> **Stack: 1/6**