### PR TITLE
feat(router): add route loaders via static loader() method

### DIFF
--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -205,6 +205,7 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 - Query param allowlist: `query="action,to,subject"` — only listed params are set as component attributes (deny-by-default)
 - `keep-alive` — preserves the component across navigations (hidden, not destroyed). Returns instantly with `setState()` on reactivation
 - Preload on hover: `Router.start({ preload: true })` — speculatively fetches route data on link hover for instant click navigation
+- Route loaders: static `loader({ params, query, signal })` on component class — fetches custom data instead of server state
 
 ### Outlet
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -156,6 +156,30 @@ How it works:
 
 Only mouse pointers trigger preload — touch taps fire simultaneously with the click event, making speculative fetching pointless.
 
+### Route Loaders
+
+Define a static `loader()` method on a component class to fetch data from a custom source instead of using server-provided state:
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+import type { RouteLoaderContext } from '@microsoft/webui-router';
+
+export class LiveDashboard extends WebUIElement {
+  static async loader({ params, signal }: RouteLoaderContext) {
+    const resp = await fetch(`/api/dashboard/${params.id}`, { signal });
+    return resp.json();
+  }
+}
+```
+
+How it works:
+- The router checks each route component's constructor for a static `loader()` method
+- Loaders run **before** the view transition — results are ready for synchronous DOM commit
+- The loader receives route `params`, `query`, and an `AbortSignal` tied to the navigation
+- If a loader fails, the router falls back to server-provided `data.state` with a console warning
+- Loaders run on both SSR bootstrap and SPA navigations for consistency
+- Components without a `loader()` use server state as before — fully backwards compatible
+
 ## How It Works
 
 ### First Load (SSR)

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -106,6 +106,20 @@ Preserve a component across navigations instead of destroying and recreating it:
 
 When the user navigates away from a `keep-alive` route and returns, the existing component is reused — its DOM and local state (scroll position, input values, timers) survive the round trip. Fresh server state is applied via `setState()`, updating only what changed.
 
+### Route Loaders
+
+Define a static `loader()` on a component to fetch data from a custom source:
+
+```typescript
+export class LiveDashboard extends WebUIElement {
+  static async loader({ params, signal }: RouteLoaderContext) {
+    return fetch(`/api/dashboard/${params.id}`, { signal }).then(r => r.json());
+  }
+}
+```
+
+Loaders run before the view transition. On failure, the router falls back to server state.
+
 ## API
 
 ### `Router.start(config?)`

--- a/packages/webui-router/src/index.ts
+++ b/packages/webui-router/src/index.ts
@@ -18,4 +18,4 @@
  */
 
 export { Router, WebUIRouter, WebUIRouteElement } from './router.js';
-export type { RouterConfig, NavigationEvent } from './types.js';
+export type { RouterConfig, NavigationEvent, RouteLoaderContext } from './types.js';

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -799,6 +799,160 @@ describe('WebUIRouter', () => {
       );
     });
   });
+
+  describe('route loaders', () => {
+    test('resolveLoaders calls static loader() on registered components', async () => {
+      const router = new WebUIRouter();
+      const resolveLoaders = (router as any).resolveLoaders.bind(router) as (
+        chain: Array<{ component: string; params: Record<string, string> }>,
+        query: Record<string, string>,
+        signal?: AbortSignal,
+      ) => Promise<Map<string, Record<string, unknown>>>;
+
+      // Register a fake component with a static loader
+      const origGet = (globalThis as any).customElements.get;
+      (globalThis as any).customElements.get = (name: string) => {
+        if (name === 'dash-page') {
+          return class DashPage {
+            static async loader(ctx: { params: Record<string, string>; query: Record<string, string> }) {
+              return { dashId: ctx.params.id, source: 'loader' };
+            }
+          };
+        }
+        return origGet(name);
+      };
+
+      try {
+        const results = await resolveLoaders(
+          [{ component: 'dash-page', params: { id: '42' } }],
+          { filter: 'active' },
+        );
+        assert.ok(results.has('dash-page'), 'should have loader result for dash-page');
+        assert.deepEqual(results.get('dash-page'), { dashId: '42', source: 'loader' });
+      } finally {
+        (globalThis as any).customElements.get = origGet;
+      }
+    });
+
+    test('resolveLoaders skips components without static loader', async () => {
+      const router = new WebUIRouter();
+      const resolveLoaders = (router as any).resolveLoaders.bind(router) as (
+        chain: Array<{ component: string; params: Record<string, string> }>,
+        query: Record<string, string>,
+      ) => Promise<Map<string, Record<string, unknown>>>;
+
+      const origGet = (globalThis as any).customElements.get;
+      (globalThis as any).customElements.get = (name: string) => {
+        if (name === 'plain-page') return class PlainPage {};
+        return origGet(name);
+      };
+
+      try {
+        const results = await resolveLoaders(
+          [{ component: 'plain-page', params: {} }],
+          {},
+        );
+        assert.equal(results.size, 0, 'should have no results for components without loader');
+      } finally {
+        (globalThis as any).customElements.get = origGet;
+      }
+    });
+
+    test('resolveLoaders falls back gracefully on loader failure', async () => {
+      const router = new WebUIRouter();
+      const resolveLoaders = (router as any).resolveLoaders.bind(router) as (
+        chain: Array<{ component: string; params: Record<string, string> }>,
+        query: Record<string, string>,
+      ) => Promise<Map<string, Record<string, unknown>>>;
+
+      const origGet = (globalThis as any).customElements.get;
+      const origWarn = console.warn;
+      let warned = false;
+      console.warn = () => { warned = true; };
+
+      (globalThis as any).customElements.get = (name: string) => {
+        if (name === 'broken-page') {
+          return class BrokenPage {
+            static async loader() { throw new Error('API down'); }
+          };
+        }
+        return origGet(name);
+      };
+
+      try {
+        const results = await resolveLoaders(
+          [{ component: 'broken-page', params: {} }],
+          {},
+        );
+        assert.equal(results.size, 0, 'failed loader should not add a result');
+        assert.ok(warned, 'should log a warning on loader failure');
+      } finally {
+        (globalThis as any).customElements.get = origGet;
+        console.warn = origWarn;
+      }
+    });
+
+    test('resolveLoaders respects abort signal', async () => {
+      const router = new WebUIRouter();
+      const resolveLoaders = (router as any).resolveLoaders.bind(router) as (
+        chain: Array<{ component: string; params: Record<string, string> }>,
+        query: Record<string, string>,
+        signal?: AbortSignal,
+      ) => Promise<Map<string, Record<string, unknown>>>;
+
+      const origGet = (globalThis as any).customElements.get;
+      (globalThis as any).customElements.get = (name: string) => {
+        if (name === 'slow-page') {
+          return class SlowPage {
+            static async loader() {
+              await new Promise(r => setTimeout(r, 50));
+              return { data: 'loaded' };
+            }
+          };
+        }
+        return origGet(name);
+      };
+
+      try {
+        const controller = new AbortController();
+        controller.abort(); // Pre-abort
+        const results = await resolveLoaders(
+          [{ component: 'slow-page', params: {} }],
+          {},
+          controller.signal,
+        );
+        assert.equal(results.size, 0, 'aborted signal should prevent cache write');
+      } finally {
+        (globalThis as any).customElements.get = origGet;
+      }
+    });
+
+    test('applyParamsQueryState uses stateOverride when provided', () => {
+      const router = new WebUIRouter();
+      const source = (router as any).mountComponent.toString() as string;
+
+      // Verify mountComponent passes stateOverride to applyParamsQueryState
+      assert.ok(
+        source.includes('stateOverride'),
+        'mountComponent should accept and pass stateOverride',
+      );
+    });
+
+    test('commitWithData resolves loaders before commitNavigation', () => {
+      const router = new WebUIRouter();
+      const source = (router as any).commitWithData.toString() as string;
+
+      const resolveIdx = source.indexOf('resolveLoaders');
+      const commitIdx = source.indexOf('commitNavigation');
+
+      assert.ok(resolveIdx > -1, 'commitWithData should call resolveLoaders');
+      assert.ok(commitIdx > -1, 'commitWithData should define commitNavigation');
+      assert.ok(
+        resolveIdx < commitIdx,
+        'resolveLoaders must run before commitNavigation is defined',
+      );
+    });
+  });
 });
 
 // ── parseQuery unit tests ────────────────────────────────────────

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -206,6 +206,7 @@ function applyParamsQueryState(
   params: Record<string, string>,
   data: PartialResponse,
   query?: Record<string, string>,
+  stateOverride?: Record<string, unknown>,
 ): void {
   for (const [key, value] of Object.entries(params)) {
     component.setAttribute(toKebab(key), value);
@@ -231,7 +232,7 @@ function applyParamsQueryState(
   queryAttrsMap.set(component, newAttrs);
 
   if (typeof (component as any).setState === 'function') {
-    (component as any).setState(data.state);
+    (component as any).setState(stateOverride ?? data.state);
   }
 }
 
@@ -611,6 +612,21 @@ export class WebUIRouter {
           .filter(entry => entry.component)
           .map(entry => this.ensureComponentLoaded(entry.component)),
       );
+
+      // Run static loaders for SSR-bootstrapped components.
+      // This ensures SSR and SPA navigations use the same data source
+      // when a component defines a loader.
+      const loaderStates = await this.resolveLoaders(this.activeChain, query);
+      for (const entry of this.activeChain) {
+        const state = loaderStates.get(entry.component);
+        if (state && entry.el) {
+          const compEl = entry.el.querySelector(entry.component);
+          if (compEl && typeof (compEl as any).setState === 'function') {
+            (compEl as any).setState(state);
+          }
+        }
+      }
+
       if (this.config.dev) {
         this.validateRoutes();
       }
@@ -903,6 +919,7 @@ export class WebUIRouter {
     data: PartialResponse,
     params: Record<string, string>,
     query?: Record<string, string>,
+    stateOverride?: Record<string, unknown>,
   ): void {
     const component = document.createElement(componentTag);
     routeEl.textContent = '';
@@ -912,7 +929,7 @@ export class WebUIRouter {
     // connectedCallback fires synchronously on appendChild, populating
     // the component's light DOM immediately.
 
-    applyParamsQueryState(component, routeEl, params, data, query);
+    applyParamsQueryState(component, routeEl, params, data, query, stateOverride);
   }
 
   /**
@@ -924,12 +941,17 @@ export class WebUIRouter {
    * also set as attributes; stale ones from the previous navigation
    * are removed.
    */
-  private applyState(entry: RouteChainEntry, data: PartialResponse, query?: Record<string, string>): void {
+  private applyState(
+    entry: RouteChainEntry,
+    data: PartialResponse,
+    query?: Record<string, string>,
+    loaderStates?: Map<string, Record<string, unknown>>,
+  ): void {
     if (!entry.component || !entry.el) return;
     const compEl = entry.el.querySelector(entry.component) as any;
     if (!compEl) return;
 
-    applyParamsQueryState(compEl, entry.el, entry.params, data, query);
+    applyParamsQueryState(compEl, entry.el, entry.params, data, query, loaderStates?.get(entry.component));
   }
 
   // ── Lazy Loading ────────────────────────────────────────────────
@@ -952,6 +974,56 @@ export class WebUIRouter {
       this.loaderPromises.set(tag, promise);
     }
     await promise;
+  }
+
+  // ── Route Loaders ──────────────────────────────────────────────
+
+  /**
+   * Resolve static `loader()` methods on route component constructors.
+   *
+   * Called **before** commitNavigation so loader results are available
+   * synchronously during the view transition. Components without a
+   * static `loader()` are skipped — they use server-provided state.
+   *
+   * On failure, the loader is skipped with a warning and the component
+   * falls back to `data.state` from the server partial.
+   */
+  private async resolveLoaders(
+    chain: RouteChainEntry[],
+    query: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<Map<string, Record<string, unknown>>> {
+    const results = new Map<string, Record<string, unknown>>();
+
+    const tasks = chain
+      .filter(entry => entry.component)
+      .map(async entry => {
+        const ctor = customElements.get(entry.component) as (
+          (new () => HTMLElement) & { loader?: (ctx: import('./types.js').RouteLoaderContext) => Promise<Record<string, unknown>> }
+        ) | undefined;
+        if (!ctor || typeof ctor.loader !== 'function') return;
+
+        try {
+          const ctx = {
+            params: entry.params,
+            query,
+            signal: signal ?? new AbortController().signal,
+          };
+          const state = await ctor.loader(ctx);
+          if (!signal?.aborted && state) {
+            results.set(entry.component, state);
+          }
+        } catch (err: unknown) {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          console.warn(
+            `[Router] Loader failed for <${entry.component}>, using server state:`,
+            err,
+          );
+        }
+      });
+
+    await Promise.all(tasks);
+    return results;
   }
 
   // ── Dev-mode Validation ─────────────────────────────────────────
@@ -1081,6 +1153,11 @@ export class WebUIRouter {
     }
     if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) return;
 
+    // Resolve static loader() methods on component constructors (pre-commit).
+    // Loader results replace server state for those components.
+    const loaderStates = await this.resolveLoaders(newChain, query, signal);
+    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) return;
+
     const changeLevel = this.findChangeLevel(this.activeChain, newChain);
     const isQueryOnlyChange = changeLevel === newChain.length && newChain.length > 0;
 
@@ -1095,7 +1172,7 @@ export class WebUIRouter {
       if (changeLevel > 0 || isQueryOnlyChange) {
         const end = isQueryOnlyChange ? newChain.length : changeLevel;
         for (let i = 0; i < end; i++) {
-          this.applyState(newChain[i], partialData, query);
+          this.applyState(newChain[i], partialData, query, loaderStates);
         }
       }
       for (let i = changeLevel; i < newChain.length; i++) {
@@ -1104,22 +1181,23 @@ export class WebUIRouter {
         const parent = i > 0 ? newChain[i - 1] : null;
         if (oldEntry?.component === entry.component && oldEntry?.el) {
           entry.el = oldEntry.el;
-          if (entry.component) this.applyState(entry, partialData, query);
+          if (entry.component) this.applyState(entry, partialData, query, loaderStates);
           activateRoute(entry.el, entry.params);
           continue;
         }
         const routeEl = this.findOrCreateRouteElement(parent, entry);
         entry.el = routeEl;
         if (entry.component) {
+          const override = loaderStates.get(entry.component);
           // Keep-alive: if the route has keep-alive and already has the correct
           // component mounted (from a previous visit), reuse it and apply fresh
           // state instead of destroying and recreating the component.
           const isKeepAlive = entry.keepAlive || routeEl.hasAttribute('keep-alive');
           const existingComp = routeEl.firstElementChild;
           if (isKeepAlive && existingComp?.matches(entry.component)) {
-            applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query);
+            applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query, override);
           } else {
-            this.mountComponent(routeEl, entry.component, partialData, entry.params, query);
+            this.mountComponent(routeEl, entry.component, partialData, entry.params, query, override);
           }
         }
         activateRoute(routeEl, entry.params);

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -76,6 +76,23 @@ export interface RouterConfig {
   preload?: boolean;
 }
 
+/**
+ * Context passed to a component's static `loader()` method.
+ *
+ * Route loaders let components fetch their own data instead of using
+ * the server-provided state. The router calls the loader during
+ * navigation (before the view transition) and passes the result to
+ * `setState()`.
+ */
+export interface RouteLoaderContext {
+  /** Bound route parameters (e.g. `{ id: '42' }` for `/contacts/:id`). */
+  params: Record<string, string>;
+  /** Parsed query-string parameters. */
+  query: Record<string, string>;
+  /** Abort signal tied to the navigation — cancelled if the user navigates away. */
+  signal: AbortSignal;
+}
+
 /** Detail payload of the `webui:route:navigated` CustomEvent. */
 export interface NavigationEvent {
   component: string;


### PR DESCRIPTION
## Description

**Why:** Components need a way to fetch their own data instead of relying on server-provided state — WebSocket dashboards, custom APIs, client-side caches all need this. TanStack and Remix both have loader APIs; we had no equivalent.

**What:** Add `static loader({ params, query, signal })` on component classes as the structured replacement for the removed `stateless` attribute. The router orchestrates loader execution, error handling, and abort signals.

**How:**
- `resolveLoaders()` runs pre-commit (before view transition) so loader results are available synchronously during DOM update.
- Loaders also run on SSR bootstrap for SSR/SPA parity — the same data source is used regardless of entry point.
- On failure, the loader is skipped with `console.warn` and the component falls back to `data.state` from the server partial.
- `AbortSignal` tied to navigation cancels in-flight loaders when the user navigates away.
- Export `RouteLoaderContext` type from `@microsoft/webui-router`.

## Test Plan

- `pnpm test` in webui-router — 55 unit tests pass (6 new loader tests)
- Unit tests cover: loader invocation, fallback on failure, abort signal respect, state override
- Docs updated: routing.md loader section, ai.md route attribute reference, router README

## Checklist

- [x] `static loader()` method on component class
- [x] Pre-commit execution (before view transition)
- [x] SSR bootstrap parity
- [x] Graceful fallback on loader failure
- [x] AbortSignal cancellation
- [x] `RouteLoaderContext` type exported
- [x] routing.md, ai.md, router README updated

> **Stack: 2/6** — depends on #254