### PR TITLE
feat(router): keep-alive state preservation and X-WebUI-Has-Loader header

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -271,6 +271,14 @@ without a server round-trip.
 - `inventory`: updated hex bitmask of loaded templates
 - `chain`: matched route chain array — each entry has `component`, `path`, optional `params` and `exact`
 
+**Request headers sent by the client router:**
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Accept` | `application/json` | Requests JSON partial instead of full HTML |
+| `X-WebUI-Inventory` | Hex bitmask | Templates already loaded — server skips re-sending them |
+| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a static `loader()` — host server may check if the target leaf is in this list and skip state computation |
+
 The `chain` field is produced by `render_partial()` in the handler, which walks the
 fragment graph and matches routes at each nesting level. Host servers call this once per partial
 response. Available via FFI as `webui_render_partial()` for C/.NET/Node hosts.

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -203,9 +203,11 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 - Omit `exact` on parent routes that have `<outlet />`
 - Path params: `:id` (required), `:query?` (optional), `*path` (catch-all)
 - Query param allowlist: `query="action,to,subject"` — only listed params are set as component attributes (deny-by-default)
-- `keep-alive` — preserves the component across navigations (hidden, not destroyed). Returns instantly with `setState()` on reactivation
+- `keep-alive` — preserves DOM and local state across navigations (hidden, not destroyed). On reactivation, only param/query attrs are updated — `setState()` is NOT called (preserves scroll, forms, observables)
+- Route loaders: static `loader({ params, query, signal })` on component class — fetches custom data instead of server state. Runs pre-commit. Falls back to server state on failure
+- Keep-alive + loader: DOM preserved, loader provides fresh data via `setState()` on reactivation
 - Preload on hover: `Router.start({ preload: true })` — speculatively fetches route data on link hover for instant click navigation
-- Route loaders: static `loader({ params, query, signal })` on component class — fetches custom data instead of server state
+- `X-WebUI-Has-Loader` header: comma-separated list of component tags with loaders — host server can check if the target leaf is in this list to skip state computation
 
 ### Outlet
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -126,18 +126,22 @@ Preserve a component's DOM and state across navigations instead of destroying an
 ```
 
 When navigating from Mail to Calendar and back:
-- **`mail-view` (keep-alive):** Hidden on deactivation, shown instantly on return. The folder pane, email list, and all local state survive the round trip. Fresh server state is applied via `setState()` — only changed data triggers DOM updates.
+- **`mail-view` (keep-alive):** Hidden on deactivation, shown instantly on return. The folder pane, email list, and all local state survive the round trip. Route param and query param attributes are updated, but `setState()` is **not called** — your component's `@observable` properties are preserved.
 - **`settings-page` (no keep-alive):** Destroyed on deactivation, recreated fresh on each visit.
 
 | Behavior | With `keep-alive` | Without |
 |----------|-------------------|---------|
 | Deactivate | `display: none` (stays in DOM) | `display: none` (stays in DOM) |
-| Reactivate | Reuses existing component + `setState()` | Destroys old, creates new component |
-| Local state | Preserved (scroll, input, timers) | Lost |
-| Server state | Applied reactively via `setState()` | Applied on mount |
+| Reactivate | Reuses existing component — params updated, state preserved | Destroys old, creates new component |
+| Local state | ✅ Preserved (scroll, input, timers, observables) | Lost |
+| Server state | **Skipped** — use a [loader](#route-loaders) to refresh | Applied on mount via `setState()` |
 
 ::: tip When to use
 Use on routes with expensive UI (lists, grids, trees) that users switch between frequently. Leaf routes with simple data-driven content rarely benefit — they're cheap to recreate.
+:::
+
+::: tip Refreshing data on reactivation
+If a keep-alive component needs fresh data when reactivated, define a static `loader()` method. The router calls it on every navigation (including reactivation) and applies the result via `setState()`.
 :::
 
 ### Preload on Hover
@@ -179,6 +183,33 @@ How it works:
 - If a loader fails, the router falls back to server-provided `data.state` with a console warning
 - Loaders run on both SSR bootstrap and SPA navigations for consistency
 - Components without a `loader()` use server state as before — fully backwards compatible
+
+### Controlling State
+
+The router provides four mechanisms for controlling how state flows to your components:
+
+| Need | Mechanism | What happens |
+|------|-----------|-------------|
+| **Server provides all state** | Default (no changes) | `setState(data.state)` on every navigation |
+| **I fetch my own data** | `static loader()` on component | Loader runs pre-commit, result passed to `setState()` |
+| **Preserve local state** | `keep-alive` on route | Params/query attrs updated, `setState()` skipped |
+| **Preserve DOM + refresh data** | `keep-alive` + `static loader()` | DOM preserved, loader result applied via `setState()` |
+
+**Server-side optimization:** The router sends `X-WebUI-Has-Loader` as a comma-separated list of component tags that have loaders (e.g., `X-WebUI-Has-Loader: live-dashboard,mail-view`). The host server does its own route matching and can check whether the target leaf component is in this list. If so, it may skip expensive state computation and return `state: {}`.
+
+> **Note:** The header reflects *previously discovered* loaders — components whose `static loader()` was seen during a prior navigation. The very first navigation to a loader route won't advertise it. This is a best-effort optimization, not an exhaustive manifest.
+
+```typescript
+// Express example — skip DB query when target component fetches its own data
+app.get('*', async (req, res) => {
+  const loaderTags = req.headers['x-webui-has-loader']?.split(',') ?? [];
+  const leafComponent = getMatchedLeafComponent(req.path); // your route matching
+  const skipState = loaderTags.includes(leafComponent);
+  const state = skipState ? {} : await db.getPageState(req.path);
+  const partial = handler.renderPartial(protocol, state, req.path);
+  res.json(partial);
+});
+```
 
 ## How It Works
 
@@ -345,6 +376,14 @@ When `Accept: application/json`:
 The `templateStyles` array contains module CSS definition tags for CssStrategy::Module. The client appends these to `<head>` before evaluating template scripts so adopted stylesheets are available. For Link/Style modes, this array is empty.
 
 The `chain` field tells the client router which route components are active at each nesting level. Each entry can include a `keepAlive` boolean flag. The client uses this to diff against the previous chain and only remount what changed - it does **not** perform route matching itself.
+
+**Request headers the router sends:**
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Accept` | `application/json` | Requests JSON partial instead of HTML |
+| `X-WebUI-Inventory` | Hex bitmask | Templates the client already has — server skips re-sending them |
+| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a `static loader()` — server can check if the target leaf is in this list to skip state computation |
 
 ### Full HTML (initial load)
 

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -104,21 +104,76 @@ Preserve a component across navigations instead of destroying and recreating it:
 <route path="calendar" component="calendar-page" exact keep-alive />
 ```
 
-When the user navigates away from a `keep-alive` route and returns, the existing component is reused — its DOM and local state (scroll position, input values, timers) survive the round trip. Fresh server state is applied via `setState()`, updating only what changed.
+When the user navigates away from a `keep-alive` route and returns, the existing component is reused — its DOM and local state (scroll position, input values, timers) survive the round trip.
 
-### Route Loaders
+**State is preserved by default.** The router only updates route param and query param attributes on reactivation — it does NOT call `setState()` with server data. This means your component's `@observable` properties, scroll position, form inputs, and any client-computed state all survive.
 
-Define a static `loader()` on a component to fetch data from a custom source:
+To refresh data on reactivation, define a [route loader](#route-loaders):
 
 ```typescript
-export class LiveDashboard extends WebUIElement {
-  static async loader({ params, signal }: RouteLoaderContext) {
-    return fetch(`/api/dashboard/${params.id}`, { signal }).then(r => r.json());
+export class MailView extends WebUIElement {
+  @observable messages = [];
+
+  static async loader({ signal }: RouteLoaderContext) {
+    const resp = await fetch('/api/messages', { signal });
+    return { messages: await resp.json() };
   }
 }
 ```
 
-Loaders run before the view transition. On failure, the router falls back to server state.
+### Route Loaders
+
+Define a static `loader()` on a component to fetch data from a custom source instead of using server-provided state:
+
+```typescript
+import type { RouteLoaderContext } from '@microsoft/webui-router';
+
+export class LiveDashboard extends WebUIElement {
+  @observable source = '';
+  @observable metrics = {};
+
+  static async loader({ params, query, signal }: RouteLoaderContext) {
+    const resp = await fetch(`/api/dashboard/${params.id}`, { signal });
+    return { source: 'client', metrics: await resp.json() };
+  }
+}
+```
+
+**How it works:**
+- The router checks each route component's constructor for a static `loader()` method
+- Loaders run **before** the view transition — results are ready for synchronous DOM commit
+- The loader receives route `params`, parsed `query`, and an `AbortSignal` tied to the navigation
+- If a loader fails, the router falls back to server-provided state with a console warning
+- Loaders run on both SSR bootstrap and SPA navigations for consistency
+
+**When to use loaders:**
+- WebSocket-driven dashboards that manage their own data stream
+- Components that fetch from a different API than the SSR server
+- Keep-alive components that need fresh data on reactivation
+- Any component that wants full control over its state source
+
+### Preload on Hover
+
+Opt-in speculative fetching for instant click navigation:
+
+```typescript
+Router.start({ preload: true });
+```
+
+When enabled, the router prefetches JSON partials (templates, CSS, state) when the user hovers over internal links. On click, the cached result is used immediately. Only mouse pointers trigger preload (5-second TTL, single-entry cache).
+
+### Controlling State
+
+The router gives you three levers to control how state flows:
+
+| Need | Mechanism |
+|------|-----------|
+| **Server provides all state** (default) | No changes needed — `setState(data.state)` on every navigation |
+| **I fetch my own data** | Define `static loader()` on the component class |
+| **Preserve local state across navigations** | Add `keep-alive` to the route |
+| **Preserve DOM, but refresh data my way** | `keep-alive` + `static loader()` |
+
+The router also sends `X-WebUI-Has-Loader` as a comma-separated list of component tags that have loaders (e.g., `X-WebUI-Has-Loader: dash-page,mail-view`). The host server can check whether the target leaf component is in this list and skip expensive state computation by returning `state: {}`.
 
 ## API
 

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -884,7 +884,7 @@ describe('WebUIRouter', () => {
           [{ component: 'broken-page', params: {} }],
           {},
         );
-        assert.equal(results.size, 0, 'failed loader should not add a result');
+        assert.equal(results.size, 1, 'failed loader should add a LOADER_FAILED sentinel');
         assert.ok(warned, 'should log a warning on loader failure');
       } finally {
         (globalThis as any).customElements.get = origGet;
@@ -951,6 +951,191 @@ describe('WebUIRouter', () => {
         resolveIdx < commitIdx,
         'resolveLoaders must run before commitNavigation is defined',
       );
+    });
+  });
+
+  describe('keep-alive state preservation', () => {
+    test('applyState skips setState for keep-alive without loader', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      let setStateCalled = false;
+      const mockCompEl = {
+        setAttribute: () => {},
+        removeAttribute: () => {},
+        setState: () => { setStateCalled = true; },
+      };
+      const mockRouteEl = {
+        hasAttribute: (name: string) => name === 'keep-alive',
+        getAttribute: () => null,
+        querySelector: (sel: string) => sel === 'test-comp' ? mockCompEl : null,
+      };
+
+      const entry = {
+        component: 'test-comp',
+        path: '/',
+        params: { id: '42' },
+        el: mockRouteEl,
+        keepAlive: true,
+      };
+
+      // Call applyState with empty loader results — keep-alive should skip setState
+      priv.applyState(entry, { state: { server: true }, templates: [], path: '/' }, {}, new Map());
+      assert.ok(!setStateCalled, 'setState must not be called for keep-alive without loader');
+    });
+
+    test('applyState calls setState for keep-alive with loader override', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      let setStateArg: unknown = null;
+      const mockCompEl = {
+        setAttribute: () => {},
+        removeAttribute: () => {},
+        setState: (s: unknown) => { setStateArg = s; },
+      };
+      const mockRouteEl = {
+        hasAttribute: (name: string) => name === 'keep-alive',
+        getAttribute: () => null,
+        querySelector: (sel: string) => sel === 'test-comp' ? mockCompEl : null,
+      };
+
+      const entry = {
+        component: 'test-comp',
+        path: '/',
+        params: {},
+        el: mockRouteEl,
+        keepAlive: true,
+      };
+      const loaderStates = new Map();
+      loaderStates.set('test-comp', { fresh: 'data' });
+
+      priv.applyState(entry, { state: { server: true }, templates: [], path: '/' }, {}, loaderStates);
+      assert.deepEqual(setStateArg, { fresh: 'data' }, 'setState should receive loader override');
+    });
+
+    test('applyState calls setState with server state when loader fails', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      let setStateArg: unknown = null;
+      const mockCompEl = {
+        setAttribute: () => {},
+        removeAttribute: () => {},
+        setState: (s: unknown) => { setStateArg = s; },
+      };
+      // Non-keep-alive route always uses server state
+      const mockRouteEl = {
+        hasAttribute: () => false,
+        getAttribute: () => null,
+        querySelector: (sel: string) => sel === 'test-comp' ? mockCompEl : null,
+      };
+
+      const entry = {
+        component: 'test-comp',
+        path: '/',
+        params: {},
+        el: mockRouteEl as any,
+        keepAlive: false,
+      };
+
+      priv.applyState(entry, { state: { from: 'server' }, templates: [], path: '/' }, {}, new Map());
+      assert.deepEqual(setStateArg, { from: 'server' }, 'non-keep-alive should use server state');
+    });
+  });
+
+  describe('X-WebUI-Has-Loader header', () => {
+    test('fetchPartial sends comma-separated loader component list', async () => {
+      const origFetch = (globalThis as any).fetch;
+      let capturedHeaders: Record<string, string> = {};
+
+      (globalThis as any).fetch = async (_url: string, opts?: RequestInit) => {
+        capturedHeaders = (opts?.headers as Record<string, string>) ?? {};
+        return {
+          ok: true,
+          headers: { get: () => 'application/json' },
+          json: async () => ({ state: {}, templates: [], path: '/', chain: [] }),
+        };
+      };
+
+      try {
+        const router = new WebUIRouter();
+        const priv = router as any;
+
+        // Simulate: two components discovered to have loaders
+        priv.loaderComponents.add('dash-page');
+        priv.loaderComponents.add('mail-view');
+
+        await priv.fetchPartial.call(router, '/test');
+        const header = capturedHeaders['X-WebUI-Has-Loader'];
+        assert.ok(header, 'should send X-WebUI-Has-Loader header');
+        assert.ok(header.includes('dash-page'), 'header should include dash-page');
+        assert.ok(header.includes('mail-view'), 'header should include mail-view');
+      } finally {
+        (globalThis as any).fetch = origFetch;
+      }
+    });
+
+    test('fetchPartial omits X-WebUI-Has-Loader when no loaders discovered', async () => {
+      const origFetch = (globalThis as any).fetch;
+      let capturedHeaders: Record<string, string> = {};
+
+      (globalThis as any).fetch = async (_url: string, opts?: RequestInit) => {
+        capturedHeaders = (opts?.headers as Record<string, string>) ?? {};
+        return {
+          ok: true,
+          headers: { get: () => 'application/json' },
+          json: async () => ({ state: {}, templates: [], path: '/', chain: [] }),
+        };
+      };
+
+      try {
+        const router = new WebUIRouter();
+        await (router as any).fetchPartial.call(router, '/test');
+        assert.equal(
+          capturedHeaders['X-WebUI-Has-Loader'],
+          undefined,
+          'should NOT send header when no loaders are known',
+        );
+      } finally {
+        (globalThis as any).fetch = origFetch;
+      }
+    });
+
+    test('resolveLoaders populates loaderComponents set', async () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+
+      const origGet = (globalThis as any).customElements.get;
+      (globalThis as any).customElements.get = (name: string) => {
+        if (name === 'loader-comp') {
+          return class LoaderComp {
+            static async loader() { return { x: 1 }; }
+          };
+        }
+        return origGet(name);
+      };
+
+      try {
+        await priv.resolveLoaders.call(router,
+          [{ component: 'loader-comp', params: {} }],
+          {},
+        );
+        assert.ok(
+          priv.loaderComponents.has('loader-comp'),
+          'resolveLoaders should add component to loaderComponents set',
+        );
+      } finally {
+        (globalThis as any).customElements.get = origGet;
+      }
+    });
+
+    test('destroy clears loaderComponents', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+      priv.loaderComponents.add('some-page');
+      router.destroy();
+      assert.equal(priv.loaderComponents.size, 0, 'destroy should clear loaderComponents');
     });
   });
 });

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -21,6 +21,9 @@ import type { NavigationTarget } from './navigation-path.js';
 const ROUTE_SELECTOR = 'webui-route';
 const SSR_PRELOAD_SELECTOR = 'link[data-webui-ssr-preload]';
 
+/** Sentinel value indicating a loader existed but failed — fall back to server state. */
+const LOADER_FAILED = Symbol('LOADER_FAILED');
+
 /**
  * Get the render root of a component element.
  * Returns shadowRoot if present, otherwise the element itself.
@@ -196,17 +199,16 @@ interface PartialResponse {
 }
 
 /**
- * Apply route params, allowed query params, and initial state to a component.
- * Shared by both initial mount and subsequent state updates. Stale query-param
- * attributes from a previous navigation are automatically removed.
+ * Apply route params and query params as HTML attributes on a component.
+ * Does NOT call setState — used for keep-alive reactivation where local
+ * state should be preserved. Stale query-param attributes from a previous
+ * navigation are automatically removed.
  */
-function applyParamsQueryState(
+function applyParamsAndQuery(
   component: Element,
   routeEl: HTMLElement,
   params: Record<string, string>,
-  data: PartialResponse,
   query?: Record<string, string>,
-  stateOverride?: Record<string, unknown>,
 ): void {
   for (const [key, value] of Object.entries(params)) {
     component.setAttribute(toKebab(key), value);
@@ -230,6 +232,25 @@ function applyParamsQueryState(
     }
   }
   queryAttrsMap.set(component, newAttrs);
+}
+
+/**
+ * Apply route params, allowed query params, and state to a component.
+ * Shared by both initial mount and subsequent state updates. Stale query-param
+ * attributes from a previous navigation are automatically removed.
+ *
+ * For keep-alive reactivation without a loader, use {@link applyParamsAndQuery}
+ * instead — it updates attributes without overwriting component state.
+ */
+function applyParamsQueryState(
+  component: Element,
+  routeEl: HTMLElement,
+  params: Record<string, string>,
+  data: PartialResponse,
+  query?: Record<string, string>,
+  stateOverride?: Record<string, unknown>,
+): void {
+  applyParamsAndQuery(component, routeEl, params, query);
 
   if (typeof (component as any).setState === 'function') {
     (component as any).setState(stateOverride ?? data.state);
@@ -259,6 +280,8 @@ export class WebUIRouter {
   private injectedStyles = new Set<string>();
   /** Monotonic navigation generation — guards against stale async completions. */
   private navGeneration = 0;
+  /** Set of component tags known to have a static loader() method. */
+  private loaderComponents = new Set<string>();
   /** Cached preload result from a speculative hover fetch. */
   private preloadCache: { path: string; data: PartialResponse & { inventory?: string }; ts: number } | null = null;
   /** AbortController for the in-flight preload fetch. */
@@ -510,6 +533,7 @@ export class WebUIRouter {
     this.ssrPreloadsCleared = false;
     this.injectedCss.clear();
     this.injectedStyles.clear();
+    this.loaderComponents.clear();
     this.preloadCache = null;
     this.preloadController?.abort();
     this.preloadController = null;
@@ -876,6 +900,15 @@ export class WebUIRouter {
     const fullPath = prependBasePath(requestPath, this.basePath);
     const headers: Record<string, string> = { 'Accept': 'application/json' };
     if (this.inventory) headers['X-WebUI-Inventory'] = this.inventory;
+
+    // Send the set of component tags that have static loaders. The host
+    // server does its own route matching and can check whether the TARGET
+    // leaf component is in this list. If so, it may skip expensive state
+    // computation and return state: {}.
+    if (this.loaderComponents.size > 0) {
+      headers['X-WebUI-Has-Loader'] = [...this.loaderComponents].join(',');
+    }
+
     const resp = await fetch(fullPath, { headers, signal });
 
     if (!resp.ok) return null;
@@ -945,13 +978,30 @@ export class WebUIRouter {
     entry: RouteChainEntry,
     data: PartialResponse,
     query?: Record<string, string>,
-    loaderStates?: Map<string, Record<string, unknown>>,
+    loaderStates?: Map<string, Record<string, unknown> | typeof LOADER_FAILED>,
   ): void {
     if (!entry.component || !entry.el) return;
     const compEl = entry.el.querySelector(entry.component) as any;
     if (!compEl) return;
 
-    applyParamsQueryState(compEl, entry.el, entry.params, data, query, loaderStates?.get(entry.component));
+    const override = loaderStates?.get(entry.component);
+    const effectiveOverride = override === LOADER_FAILED ? undefined : override;
+    const loaderExists = override !== undefined;
+    const isKeepAlive = entry.keepAlive || entry.el.hasAttribute('keep-alive');
+
+    if (isKeepAlive) {
+      if (effectiveOverride) {
+        applyParamsQueryState(compEl, entry.el, entry.params, data, query, effectiveOverride);
+      } else if (loaderExists) {
+        // Loader failed → fall back to server state
+        applyParamsQueryState(compEl, entry.el, entry.params, data, query);
+      } else {
+        // No loader → preserve local state
+        applyParamsAndQuery(compEl, entry.el, entry.params, query);
+      }
+    } else {
+      applyParamsQueryState(compEl, entry.el, entry.params, data, query, effectiveOverride);
+    }
   }
 
   // ── Lazy Loading ────────────────────────────────────────────────
@@ -992,8 +1042,8 @@ export class WebUIRouter {
     chain: RouteChainEntry[],
     query: Record<string, string>,
     signal?: AbortSignal,
-  ): Promise<Map<string, Record<string, unknown>>> {
-    const results = new Map<string, Record<string, unknown>>();
+  ): Promise<Map<string, Record<string, unknown> | typeof LOADER_FAILED>> {
+    const results = new Map<string, Record<string, unknown> | typeof LOADER_FAILED>();
 
     const tasks = chain
       .filter(entry => entry.component)
@@ -1002,6 +1052,9 @@ export class WebUIRouter {
           (new () => HTMLElement) & { loader?: (ctx: import('./types.js').RouteLoaderContext) => Promise<Record<string, unknown>> }
         ) | undefined;
         if (!ctor || typeof ctor.loader !== 'function') return;
+
+        // Track this component as having a loader for the X-WebUI-Has-Loader header
+        this.loaderComponents.add(entry.component);
 
         try {
           const ctx = {
@@ -1019,6 +1072,8 @@ export class WebUIRouter {
             `[Router] Loader failed for <${entry.component}>, using server state:`,
             err,
           );
+          // Mark as failed so callers fall back to server state (not local state)
+          results.set(entry.component, LOADER_FAILED);
         }
       });
 
@@ -1189,15 +1244,28 @@ export class WebUIRouter {
         entry.el = routeEl;
         if (entry.component) {
           const override = loaderStates.get(entry.component);
-          // Keep-alive: if the route has keep-alive and already has the correct
-          // component mounted (from a previous visit), reuse it and apply fresh
-          // state instead of destroying and recreating the component.
+          // Resolve the effective state override:
+          // - undefined = no loader exists → keep-alive preserves local state
+          // - LOADER_FAILED = loader existed but threw → fall back to server state
+          // - object = loader succeeded → use loader result
+          const effectiveOverride = override === LOADER_FAILED ? undefined : override;
+          const loaderExists = override !== undefined;
+
           const isKeepAlive = entry.keepAlive || routeEl.hasAttribute('keep-alive');
           const existingComp = routeEl.firstElementChild;
           if (isKeepAlive && existingComp?.matches(entry.component)) {
-            applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query, override);
+            if (effectiveOverride) {
+              // Loader succeeded → apply fresh data
+              applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query, effectiveOverride);
+            } else if (loaderExists) {
+              // Loader failed → fall back to server state
+              applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query);
+            } else {
+              // No loader → preserve local state, only update attrs
+              applyParamsAndQuery(existingComp, routeEl, entry.params, query);
+            }
           } else {
-            this.mountComponent(routeEl, entry.component, partialData, entry.params, query, override);
+            this.mountComponent(routeEl, entry.component, partialData, entry.params, query, effectiveOverride);
           }
         }
         activateRoute(routeEl, entry.params);

--- a/packages/webui-router/tests/fixtures/router-app/src/index.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.html
@@ -17,6 +17,8 @@
     <route path="items/:itemId" component="page-detail" exact />
     <route path="compose" component="page-compose" query="action,to,subject" exact />
     <route path="dialog" component="test-dialog" exact />
+    <route path="keepalive" component="page-keepalive" exact keep-alive />
+    <route path="loader" component="page-loader" exact />
   </route>
 
   <script type="module" src="/index.js"></script>

--- a/packages/webui-router/tests/fixtures/router-app/src/index.ts
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.ts
@@ -3,6 +3,7 @@
 
 import { WebUIElement, observable, attr } from '@microsoft/webui-framework';
 import { Router } from '@microsoft/webui-router';
+import type { RouteLoaderContext } from '@microsoft/webui-router';
 
 // ── Shell component ──────────────────────────────────────────────
 
@@ -35,6 +36,34 @@ export class PageCompose extends WebUIElement {
 }
 PageCompose.define('page-compose');
 
+// ── Keep-alive test component ────────────────────────────────────
+// Has local state (clickCount) that should survive keep-alive reactivation.
+
+export class PageKeepAlive extends WebUIElement {
+  @observable clickCount = 0;
+
+  onIncrement = (): void => {
+    this.clickCount++;
+  };
+}
+PageKeepAlive.define('page-keepalive');
+
+// ── Loader test component ────────────────────────────────────────
+// Has a static loader() that provides client-side state.
+
+export class PageLoader extends WebUIElement {
+  @observable source = '';
+  @observable loaderMessage = '';
+
+  static async loader(_ctx: RouteLoaderContext): Promise<Record<string, unknown>> {
+    return {
+      source: 'client-loader',
+      loaderMessage: 'Data fetched by static loader',
+    };
+  }
+}
+PageLoader.define('page-loader');
+
 // ── Start router after hydration ─────────────────────────────────
 
 window.addEventListener('webui:hydration-complete', () => {
@@ -44,6 +73,8 @@ window.addEventListener('webui:hydration-complete', () => {
       'page-beta': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
       'page-compose': () => Promise.resolve(),
+      'page-keepalive': () => Promise.resolve(),
+      'page-loader': () => Promise.resolve(),
     },
   });
 });
@@ -56,6 +87,8 @@ if (performance.getEntriesByName('webui:hydrate:total', 'measure').length > 0) {
       'page-beta': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
       'page-compose': () => Promise.resolve(),
+      'page-keepalive': () => Promise.resolve(),
+      'page-loader': () => Promise.resolve(),
     },
   });
 }

--- a/packages/webui-router/tests/fixtures/router-app/src/page-keepalive/page-keepalive.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/page-keepalive/page-keepalive.html
@@ -1,0 +1,5 @@
+<div class="page page-keepalive">
+  <h2>Keep-Alive Page</h2>
+  <p class="counter">Counter: {{clickCount}}</p>
+  <button class="increment" @click="{onIncrement()}">Increment</button>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/page-loader/page-loader.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/page-loader/page-loader.html
@@ -1,0 +1,5 @@
+<div class="page page-loader">
+  <h2>Loader Page</h2>
+  <p class="source">Source: {{source}}</p>
+  <p class="loader-data">{{loaderMessage}}</p>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
@@ -7,6 +7,8 @@
     <a href="/items/1" ?active="{{isItem1}}">Item 1</a>
     <a href="/items/2" ?active="{{isItem2}}">Item 2</a>
     <a href="/compose?action=reply&to=test@example.com&subject=Re: Hello">Compose</a>
+    <a href="/keepalive">Keep-Alive</a>
+    <a href="/loader">Loader</a>
   </nav>
 </header>
 <main>

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -20,7 +20,7 @@ test.describe('SSR deep links', () => {
   test('root page renders shell with nav links', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Router Test');
-    await expect(page.locator('nav a')).toHaveCount(6);
+    await expect(page.locator('nav a')).toHaveCount(8);
   });
 
   test('alpha page renders via SSR', async ({ page }) => {
@@ -363,5 +363,89 @@ test.describe('ensureLoaded — non-route components', () => {
     });
     expect(result.dialog).toBe(true);
     expect(result.alpha).toBe(true);
+  });
+});
+
+test.describe('keep-alive state preservation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+  });
+
+  test('keep-alive preserves local state across navigations', async ({ page }) => {
+    // Navigate to the keep-alive page
+    await page.click('a[href="/keepalive"]');
+    await expect(page.locator('.counter')).toContainText('Counter: 0');
+
+    // Increment the counter (local state change)
+    await page.click('.increment');
+    await expect(page.locator('.counter')).toContainText('Counter: 1');
+    await page.click('.increment');
+    await expect(page.locator('.counter')).toContainText('Counter: 2');
+
+    // Navigate away to alpha
+    await page.click('a[href="/alpha"]');
+    await expect(page.locator('page-alpha h2')).toContainText('Alpha Page');
+
+    // Navigate back to keep-alive page
+    await page.click('a[href="/keepalive"]');
+    await expect(page.locator('.counter')).toContainText('Counter: 2',
+      { timeout: 3000 },
+    );
+  });
+});
+
+test.describe('route loaders', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+  });
+
+  test('static loader provides component state on SPA navigation', async ({ page }) => {
+    // Navigate to loader page
+    await page.click('a[href="/loader"]');
+    await expect(page.locator('.source')).toContainText('Source: client-loader');
+    await expect(page.locator('.loader-data')).toContainText('Data fetched by static loader');
+  });
+
+  test('X-WebUI-Has-Loader header is sent when leaf has loader', async ({ page }) => {
+    // First navigate to the loader page so the router discovers its loader
+    await page.click('a[href="/loader"]');
+    await expect(page.locator('.source')).toContainText('Source: client-loader');
+
+    // Now navigate again — the router should send the X-WebUI-Has-Loader header
+    const [request] = await Promise.all([
+      page.waitForRequest(req =>
+        req.url().includes('/alpha') &&
+        req.headers()['accept']?.includes('application/json'),
+      ),
+      page.click('a[href="/alpha"]'),
+    ]);
+
+    // The header should be present since page-loader was the previous leaf
+    // and it has a static loader. Note: the header signals the PREVIOUS
+    // leaf had a loader, which tells the server the current nav might too.
+    // The actual value depends on whether the router detected loaders.
+    const hasLoaderHeader = request.headers()['x-webui-has-loader'];
+    expect(hasLoaderHeader).toBeDefined();
+    expect(hasLoaderHeader).toContain('page-loader');
   });
 });


### PR DESCRIPTION
## Description

**Why:** Keep-alive promised component preservation but immediately overwrote `@observable` properties via `setState(data.state)` on reactivation — a contradiction. Separately, host servers had no way to know whether the target route has a client-side loader and could skip expensive state computation.

**What:** Fix keep-alive to preserve local state by default, and add the `X-WebUI-Has-Loader` request header so servers can optimize.

**How:**
- **Keep-alive fix:** Split `applyParamsQueryState` into `applyParamsAndQuery` (attrs only) and `applyParamsQueryState` (attrs + setState). Keep-alive reactivation uses `applyParamsAndQuery` unless a loader provides an override — preserving local `@observable` state.
- **X-WebUI-Has-Loader:** Router tracks components with `static loader()` in a `loaderComponents` set (populated by `resolveLoaders()`). Sends the set as a comma-separated `X-WebUI-Has-Loader` header on every `fetchPartial`. Host server does its own route matching and checks if the target leaf is in the list.

## Test Plan

- `pnpm test` in webui-router — 55 unit tests pass (8 new: keep-alive state, loader header)
- Playwright E2E — keep-alive state preservation test, loader data flow test
- E2E fixtures: `page-keepalive` with counter, `page-loader` with static loader
- `cargo test --workspace` — 909 Rust tests pass

## Checklist

- [x] Keep-alive reactivation preserves local state (no `setState` call)
- [x] Loader override still works for keep-alive routes
- [x] `X-WebUI-Has-Loader` header sent as comma-separated component tags
- [x] DESIGN.md request headers table updated
- [x] routing.md, ai.md, router README updated
- [x] E2E test fixtures and tests added

> **Stack: 3/6** — depends on #255