### PR TITLE
feat(router): add build-time cache infrastructure with tagged invalidation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -198,14 +198,16 @@ pub struct WebUIFragmentRoute {
 ```
 
 **Cache tags:** Declared via `cache-tags="thread:{threadId},inbox"` on `<route>`. Placeholders
-like `{param}` reference route path parameters and are resolved at render time with actual values.
-The handler includes resolved tags in the JSON partial response `cacheTags` array. The client
-caches responses tagged with these values and uses them for tag-based invalidation.
+like `{param}` reference route path parameters from the current route or any ancestor route,
+and are resolved at render time with actual values. The parser validates placeholders against
+the accumulated params from the full route ancestry at build time. The handler includes resolved
+tags in the JSON partial response `cacheTags` array. The client caches responses tagged with
+these values and uses them for tag-based invalidation.
 
 **Invalidation tags:** Declared via `invalidates="inbox,sent,counts"` on `<route>`. After a
 mutation action (`static action()`) on this route, these tags are auto-invalidated from the
-client cache. Supports `{param}` placeholders. The compiler knows the full invalidation graph —
-developers cannot forget to invalidate related data.
+client cache. Supports `{param}` placeholders (including ancestor params). The compiler knows
+the full invalidation graph - developers cannot forget to invalidate related data.
 
 **Pending component:** Declared via `pending="mail-skeleton"` on `<route>`. The compiler validates
 the component exists at build time. During slow navigations (>150ms), the router mounts this

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -189,8 +189,31 @@ pub struct WebUIFragmentRoute {
     pub exact: bool,                           // Require exact path match
     pub children: Vec<WebUIFragmentRoute>,     // Nested child routes
     pub allowed_query: String,                 // Comma-separated allowlist of query params forwarded as attributes
+    pub keep_alive: bool,                      // Preserve component across navigations
+    pub cache_tags: Vec<String>,               // Cache tag templates (e.g., "thread:{threadId}")
+    pub invalidates: Vec<String>,              // Tags to auto-invalidate after mutation actions
+    pub pending_component: String,             // Component tag for loading UI (build-time validated)
+    pub error_component: String,               // Component tag for error boundary (build-time validated)
 }
 ```
+
+**Cache tags:** Declared via `cache-tags="thread:{threadId},inbox"` on `<route>`. Placeholders
+like `{param}` reference route path parameters and are resolved at render time with actual values.
+The handler includes resolved tags in the JSON partial response `cacheTags` array. The client
+caches responses tagged with these values and uses them for tag-based invalidation.
+
+**Invalidation tags:** Declared via `invalidates="inbox,sent,counts"` on `<route>`. After a
+mutation action (`static action()`) on this route, these tags are auto-invalidated from the
+client cache. Supports `{param}` placeholders. The compiler knows the full invalidation graph —
+developers cannot forget to invalidate related data.
+
+**Pending component:** Declared via `pending="mail-skeleton"` on `<route>`. The compiler validates
+the component exists at build time. During slow navigations (>150ms), the router mounts this
+component as a loading indicator. Skip for keep-alive and cached routes.
+
+**Error component:** Declared via `error="error-page"` on `<route>`. The compiler validates
+the component exists at build time. When a navigation fetch fails, the router mounts this
+component with error details as state (`{ error, status, path }`).
 
 There is no global route registry or route tree — routes are inline in the fragment graph
 via `WebUIFragmentRoute` nesting.
@@ -264,12 +287,31 @@ without a server round-trip.
 5. Mounts components at changed levels, creates `<webui-route>` stubs at outlet positions.
 6. Parent components and their state are preserved.
 
-**Partial response:** The server returns `{ state, templateStyles, templates, inventory, path, chain }`:
+**Partial response:** The server returns `{ state, templateStyles, templates, inventory, path, chain, cacheTags }`:
 - `state`: route params from all nesting levels injected into API state
 - `templateStyles`: module CSS definition tags (`<style type="module" specifier="...">`) for newly shipped components. Empty array for Link/Style modes. The client appends these to `<head>` before evaluating template scripts so adopted stylesheets are available
 - `templates`: client template script/markup payloads the client doesn't already have (filtered by inventory bitmask). Clean JS IIFEs for the WebUI plugin, `<f-template>` markup for the FAST plugin
 - `inventory`: updated hex bitmask of loaded templates
-- `chain`: matched route chain array — each entry has `component`, `path`, optional `params` and `exact`
+- `chain`: matched route chain array — each entry has `component`, `path`, optional `params`, `exact`, `pendingComponent`, `errorComponent`, and `invalidates`
+- `cacheTags`: resolved cache tags from the full route chain (union of all levels, deduplicated). The client tags its cache entry with these values for tag-based invalidation
+
+**Cache control:** The server can include `cacheControl: { staleTime: number }` in the partial response to override the client's default stale time for this specific route.
+
+**Navigation cache:** The client router maintains a tagged navigation cache. Partial responses are stored keyed by request path and tagged with `cacheTags`. On revisit within `staleTime`, the cache is used and the network fetch is skipped. After a mutation action, `Router.invalidateTags()` evicts all entries whose tags overlap with the invalidated tags. Configuration: `Router.start({ cache: { staleTime, gcTime, maxEntries } })`.
+
+**Mutation actions:** Components can declare `static action(ctx: RouteActionContext)` as the write counterpart to `static loader()`. The router intercepts `<form method="post">` submissions, finds the nearest route component's `static action()`, calls it, and auto-invalidates the cache using both the action's returned tags and the route's build-time `invalidates` attribute. This ensures the compiler-declared invalidation graph is always respected — developers cannot forget.
+
+**Pending UI:** Routes with a `pending` attribute show a loading component during slow navigations (>150ms). The pending component is a normal WebUI component — SSR'd and build-time validated. Keep-alive and cached routes skip pending (no delay to show).
+
+**Error boundaries:** Routes with an `error` attribute show an error component when the navigation fetch fails. The error component receives `{ error, status, path }` as state and can call `Router.navigate()` to recover.
+
+**Request headers sent by the client router:**
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Accept` | `application/json` | Requests JSON partial instead of full HTML |
+| `X-WebUI-Inventory` | Hex bitmask | Templates already loaded — server skips re-sending them |
+| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a static `loader()` — host server may check if the target leaf is in this list and skip state computation |
 
 **Request headers sent by the client router:**
 

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -392,6 +392,7 @@ impl WebUIHandler {
                 if matched_child.keep_alive {
                     context.writer.write(" keep-alive")?;
                 }
+                route_renderer::write_route_cache_attrs(context.writer, matched_child)?;
                 context.writer.write(" active>")?;
 
                 context.writer.write("<")?;
@@ -442,6 +443,7 @@ impl WebUIHandler {
                 if child.keep_alive {
                     context.writer.write(" keep-alive")?;
                 }
+                route_renderer::write_route_cache_attrs(context.writer, child)?;
                 context
                     .writer
                     .write(" style=\"display:none\"></webui-route>")?;
@@ -518,6 +520,7 @@ impl WebUIHandler {
         if route_frag.keep_alive {
             context.writer.write(" keep-alive")?;
         }
+        route_renderer::write_route_cache_attrs(context.writer, route_frag)?;
 
         if is_matched {
             context.writer.write(" active>")?;

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -599,42 +599,28 @@ pub fn render_partial(
         get_needed_components_for_request(protocol, entry_id, request_path, inventory_hex);
 
     // Build the matched route chain
-    let chain = collect_route_chain(protocol, entry_id, request_path);
+    let mut chain = collect_route_chain(protocol, entry_id, request_path);
 
     // Resolve cache tags with accumulated params from the full chain.
     // Each level can reference params from its own level AND all ancestors.
+    // Mutates in place to avoid cloning chain entries.
     let mut accumulated_params: HashMap<String, String> = HashMap::new();
     let mut all_resolved_tags: Vec<String> = Vec::new();
-    let mut resolved_chain: Vec<RouteChainEntry> = Vec::with_capacity(chain.len());
 
-    for entry in &chain {
-        // Accumulate params from all levels
+    for entry in &mut chain {
         for (k, v) in &entry.params {
             accumulated_params.insert(k.clone(), v.clone());
         }
-        // Resolve cache tags and invalidates with accumulated params
-        let resolved_tags = resolve_tag_templates(&entry.cache_tags, &accumulated_params);
-        let resolved_invalidates = resolve_tag_templates(&entry.invalidates, &accumulated_params);
-
-        all_resolved_tags.extend(resolved_tags.iter().cloned());
-
-        resolved_chain.push(RouteChainEntry {
-            cache_tags: resolved_tags,
-            invalidates: resolved_invalidates,
-            ..entry.clone()
-        });
+        entry.cache_tags = resolve_tag_templates(&entry.cache_tags, &accumulated_params);
+        entry.invalidates = resolve_tag_templates(&entry.invalidates, &accumulated_params);
+        all_resolved_tags.extend(entry.cache_tags.iter().cloned());
     }
 
     // Collect templates + CSS using the shared helper
     let tag_refs: Vec<&str> = needed_names.iter().map(|s| s.as_str()).collect();
     let (style_array, tmpl_array) = collect_component_assets(protocol, &tag_refs);
 
-    let chain_array = Value::Array(
-        resolved_chain
-            .iter()
-            .map(RouteChainEntry::to_json)
-            .collect(),
-    );
+    let chain_array = Value::Array(chain.iter().map(RouteChainEntry::to_json).collect());
 
     let mut result = serde_json::Map::with_capacity(7);
     result.insert("state".into(), state);

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -543,30 +543,25 @@ fn resolve_tag_templates(templates: &[String], params: &HashMap<String, String>)
             continue;
         }
         let mut result = String::with_capacity(template.len());
-        let mut chars = template.char_indices().peekable();
-        while let Some((i, ch)) = chars.next() {
-            if ch == '{' {
-                if let Some(end) = template[i + 1..].find('}') {
-                    let name = &template[i + 1..i + 1 + end];
-                    if let Some(value) = params.get(name) {
-                        result.push_str(value);
-                    } else {
-                        result.push('{');
-                        result.push_str(name);
-                        result.push('}');
-                    }
-                    // Skip past the closing '}'
-                    let skip_to = i + 1 + end + 1;
-                    while chars.peek().is_some_and(|(idx, _)| *idx < skip_to) {
-                        chars.next();
-                    }
+        let mut rest = template.as_str();
+        while let Some(open) = rest.find('{') {
+            result.push_str(&rest[..open]);
+            rest = &rest[open + 1..];
+            if let Some(close) = rest.find('}') {
+                let name = &rest[..close];
+                if let Some(value) = params.get(name) {
+                    result.push_str(value);
                 } else {
                     result.push('{');
+                    result.push_str(name);
+                    result.push('}');
                 }
+                rest = &rest[close + 1..];
             } else {
-                result.push(ch);
+                result.push('{');
             }
         }
+        result.push_str(rest);
         resolved.push(result);
     }
     resolved

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -260,6 +260,29 @@ fn collect_inventoryable_components(
                             route_base: child_route_base.clone(),
                         });
 
+                        // Include pending/error components in the inventory
+                        // so their templates are available on the client.
+                        if !route_frag.pending_component.is_empty() {
+                            stack.push(QueuedFragment {
+                                id: route_frag.pending_component.clone(),
+                                inventoryable: protocol
+                                    .components
+                                    .get(&route_frag.pending_component)
+                                    .is_some_and(|c| !c.template.is_empty()),
+                                route_base: child_route_base.clone(),
+                            });
+                        }
+                        if !route_frag.error_component.is_empty() {
+                            stack.push(QueuedFragment {
+                                id: route_frag.error_component.clone(),
+                                inventoryable: protocol
+                                    .components
+                                    .get(&route_frag.error_component)
+                                    .is_some_and(|c| !c.template.is_empty()),
+                                route_base: child_route_base.clone(),
+                            });
+                        }
+
                         // Walk nested child routes to find the next matched level.
                         // This mirrors the handler's outlet rendering: match children
                         // against the request path and follow the matched chain.
@@ -327,6 +350,28 @@ fn walk_route_children(
                 .is_some_and(|c| !c.template.is_empty()),
             route_base: child_base.clone(),
         });
+
+        // Include pending/error components in the inventory
+        if !matched.pending_component.is_empty() {
+            stack.push(QueuedFragment {
+                id: matched.pending_component.clone(),
+                inventoryable: protocol
+                    .components
+                    .get(&matched.pending_component)
+                    .is_some_and(|c| !c.template.is_empty()),
+                route_base: child_base.clone(),
+            });
+        }
+        if !matched.error_component.is_empty() {
+            stack.push(QueuedFragment {
+                id: matched.error_component.clone(),
+                inventoryable: protocol
+                    .components
+                    .get(&matched.error_component)
+                    .is_some_and(|c| !c.template.is_empty()),
+                route_base: child_base.clone(),
+            });
+        }
 
         if matched.children.is_empty() {
             break;
@@ -485,6 +530,48 @@ fn collect_params_from_children(
 
 // ── Partial Response ────────────────────────────────────────────────
 
+/// Resolve `{param}` placeholders in a list of tag templates.
+///
+/// Replaces `{paramName}` with the actual value from `params`.
+/// Tags without placeholders are returned as-is. Missing params
+/// result in the placeholder being left unresolved (defensive).
+fn resolve_tag_templates(templates: &[String], params: &HashMap<String, String>) -> Vec<String> {
+    let mut resolved = Vec::with_capacity(templates.len());
+    for template in templates {
+        if !template.contains('{') {
+            resolved.push(template.clone());
+            continue;
+        }
+        let mut result = String::with_capacity(template.len());
+        let mut chars = template.char_indices().peekable();
+        while let Some((i, ch)) = chars.next() {
+            if ch == '{' {
+                if let Some(end) = template[i + 1..].find('}') {
+                    let name = &template[i + 1..i + 1 + end];
+                    if let Some(value) = params.get(name) {
+                        result.push_str(value);
+                    } else {
+                        result.push('{');
+                        result.push_str(name);
+                        result.push('}');
+                    }
+                    // Skip past the closing '}'
+                    let skip_to = i + 1 + end + 1;
+                    while chars.peek().is_some_and(|(idx, _)| *idx < skip_to) {
+                        chars.next();
+                    }
+                } else {
+                    result.push('{');
+                }
+            } else {
+                result.push(ch);
+            }
+        }
+        resolved.push(result);
+    }
+    resolved
+}
+
 /// Produce a complete JSON partial response for client-side navigation.
 ///
 /// Combines route templates, inventory, and matched route chain into a single
@@ -498,6 +585,7 @@ fn collect_params_from_children(
 /// - `inventory`: updated hex bitmask
 /// - `path`: the request path
 /// - `chain`: matched route chain array
+/// - `cacheTags`: resolved cache tags from the full route chain (union of all levels)
 #[must_use]
 pub fn render_partial(
     protocol: &WebUIProtocol,
@@ -513,19 +601,104 @@ pub fn render_partial(
     // Build the matched route chain
     let chain = collect_route_chain(protocol, entry_id, request_path);
 
+    // Resolve cache tags with accumulated params from the full chain.
+    // Each level can reference params from its own level AND all ancestors.
+    let mut accumulated_params: HashMap<String, String> = HashMap::new();
+    let mut all_resolved_tags: Vec<String> = Vec::new();
+    let mut resolved_chain: Vec<RouteChainEntry> = Vec::with_capacity(chain.len());
+
+    for entry in &chain {
+        // Accumulate params from all levels
+        for (k, v) in &entry.params {
+            accumulated_params.insert(k.clone(), v.clone());
+        }
+        // Resolve cache tags and invalidates with accumulated params
+        let resolved_tags = resolve_tag_templates(&entry.cache_tags, &accumulated_params);
+        let resolved_invalidates = resolve_tag_templates(&entry.invalidates, &accumulated_params);
+
+        all_resolved_tags.extend(resolved_tags.iter().cloned());
+
+        resolved_chain.push(RouteChainEntry {
+            cache_tags: resolved_tags,
+            invalidates: resolved_invalidates,
+            ..entry.clone()
+        });
+    }
+
     // Collect templates + CSS using the shared helper
     let tag_refs: Vec<&str> = needed_names.iter().map(|s| s.as_str()).collect();
     let (style_array, tmpl_array) = collect_component_assets(protocol, &tag_refs);
 
-    let chain_array = Value::Array(chain.iter().map(RouteChainEntry::to_json).collect());
+    let chain_array = Value::Array(
+        resolved_chain
+            .iter()
+            .map(RouteChainEntry::to_json)
+            .collect(),
+    );
 
-    let mut result = serde_json::Map::with_capacity(6);
+    let mut result = serde_json::Map::with_capacity(7);
     result.insert("state".into(), state);
     result.insert("templateStyles".into(), Value::Array(style_array));
     result.insert("templates".into(), Value::Array(tmpl_array));
     result.insert("inventory".into(), Value::String(updated_inv));
     result.insert("path".into(), Value::String(request_path.to_string()));
     result.insert("chain".into(), chain_array);
+    if !all_resolved_tags.is_empty() {
+        // Deduplicate while preserving order
+        let mut seen = HashSet::new();
+        let deduped: Vec<Value> = all_resolved_tags
+            .into_iter()
+            .filter(|t| seen.insert(t.clone()))
+            .map(Value::String)
+            .collect();
+        result.insert("cacheTags".into(), Value::Array(deduped));
+    }
+    Value::Object(result)
+}
+
+/// Produce a JSON response for a POST mutation action.
+///
+/// Walks the matched route chain, resolves `invalidates` tag templates
+/// with actual param values, and returns them alongside the application
+/// state. Host servers call this for `POST` requests to route paths.
+///
+/// Returns a `serde_json::Value` object with fields:
+/// - `state`: the application state passed through
+/// - `invalidateTags`: resolved invalidation tags from the matched leaf route
+/// - `path`: the request path
+#[must_use]
+pub fn render_action_response(
+    protocol: &WebUIProtocol,
+    state: Value,
+    entry_id: &str,
+    request_path: &str,
+) -> Value {
+    let chain = collect_route_chain(protocol, entry_id, request_path);
+
+    // Accumulate params across the chain for tag resolution
+    let mut accumulated_params: HashMap<String, String> = HashMap::new();
+    let mut all_invalidates: Vec<String> = Vec::new();
+
+    for entry in &chain {
+        for (k, v) in &entry.params {
+            accumulated_params.insert(k.clone(), v.clone());
+        }
+        let resolved = resolve_tag_templates(&entry.invalidates, &accumulated_params);
+        all_invalidates.extend(resolved);
+    }
+
+    // Deduplicate while preserving order
+    let mut seen = HashSet::new();
+    let deduped: Vec<Value> = all_invalidates
+        .into_iter()
+        .filter(|t| seen.insert(t.clone()))
+        .map(Value::String)
+        .collect();
+
+    let mut result = serde_json::Map::with_capacity(3);
+    result.insert("state".into(), state);
+    result.insert("invalidateTags".into(), Value::Array(deduped));
+    result.insert("path".into(), Value::String(request_path.to_string()));
     Value::Object(result)
 }
 
@@ -605,13 +778,21 @@ pub struct RouteChainEntry {
     pub allowed_query: String,
     /// When true, the router keeps the component alive across navigations.
     pub keep_alive: bool,
+    /// Cache tag templates from the proto (e.g. `["thread:{threadId}", "inbox"]`).
+    pub cache_tags: Vec<String>,
+    /// Invalidation tag templates from the proto.
+    pub invalidates: Vec<String>,
+    /// Component tag name for pending/loading UI.
+    pub pending_component: String,
+    /// Component tag name for error boundary UI.
+    pub error_component: String,
 }
 
 impl RouteChainEntry {
     /// Serialize this entry to a JSON value ready for inclusion in a partial response.
     #[must_use]
     pub fn to_json(&self) -> Value {
-        let mut obj = serde_json::Map::with_capacity(5);
+        let mut obj = serde_json::Map::with_capacity(9);
         obj.insert("component".into(), Value::String(self.component.clone()));
         obj.insert("path".into(), Value::String(self.path.clone()));
         if !self.params.is_empty() {
@@ -633,6 +814,29 @@ impl RouteChainEntry {
         }
         if self.keep_alive {
             obj.insert("keepAlive".into(), Value::Bool(true));
+        }
+        if !self.pending_component.is_empty() {
+            obj.insert(
+                "pendingComponent".into(),
+                Value::String(self.pending_component.clone()),
+            );
+        }
+        if !self.error_component.is_empty() {
+            obj.insert(
+                "errorComponent".into(),
+                Value::String(self.error_component.clone()),
+            );
+        }
+        if !self.invalidates.is_empty() {
+            obj.insert(
+                "invalidates".into(),
+                Value::Array(
+                    self.invalidates
+                        .iter()
+                        .map(|s| Value::String(s.clone()))
+                        .collect(),
+                ),
+            );
         }
         Value::Object(obj)
     }
@@ -705,6 +909,10 @@ pub fn collect_route_chain(
                                 exact: route_frag.exact,
                                 allowed_query: route_frag.allowed_query.clone(),
                                 keep_alive: route_frag.keep_alive,
+                                cache_tags: route_frag.cache_tags.clone(),
+                                invalidates: route_frag.invalidates.clone(),
+                                pending_component: route_frag.pending_component.clone(),
+                                error_component: route_frag.error_component.clone(),
                             });
 
                             let child_route_base = route_matcher::compute_route_base(
@@ -770,6 +978,10 @@ fn collect_chain_from_children(
                 exact: matched.exact,
                 allowed_query: matched.allowed_query.clone(),
                 keep_alive: matched.keep_alive,
+                cache_tags: matched.cache_tags.clone(),
+                invalidates: matched.invalidates.clone(),
+                pending_component: matched.pending_component.clone(),
+                error_component: matched.error_component.clone(),
             });
             if !matched.children.is_empty() {
                 let child_base =
@@ -1595,6 +1807,10 @@ mod tests {
             exact: true,
             allowed_query: "action,to,subject".into(),
             keep_alive: false,
+            cache_tags: Vec::new(),
+            invalidates: Vec::new(),
+            pending_component: String::new(),
+            error_component: String::new(),
         };
         let json = entry.to_json();
         assert_eq!(json["allowedQuery"], "action,to,subject");
@@ -1609,6 +1825,10 @@ mod tests {
             exact: true,
             allowed_query: String::new(),
             keep_alive: false,
+            cache_tags: Vec::new(),
+            invalidates: Vec::new(),
+            pending_component: String::new(),
+            error_component: String::new(),
         };
         let json = entry.to_json();
         assert!(
@@ -1728,5 +1948,251 @@ mod tests {
         let result = render_component_templates(&protocol, &["nonexistent-widget"], "");
         assert_eq!(result["templates"].as_array().unwrap().len(), 0);
         assert_eq!(result["templateStyles"].as_array().unwrap().len(), 0);
+    }
+
+    // ── resolve_tag_templates tests ──────────────────────────────────
+
+    #[test]
+    fn test_resolve_tag_templates_no_placeholders() {
+        let tags = vec!["inbox".to_string(), "counts".to_string()];
+        let params = HashMap::new();
+        let resolved = resolve_tag_templates(&tags, &params);
+        assert_eq!(resolved, vec!["inbox", "counts"]);
+    }
+
+    #[test]
+    fn test_resolve_tag_templates_with_params() {
+        let tags = vec!["thread:{threadId}".to_string(), "inbox".to_string()];
+        let mut params = HashMap::new();
+        params.insert("threadId".to_string(), "42".to_string());
+        let resolved = resolve_tag_templates(&tags, &params);
+        assert_eq!(resolved, vec!["thread:42", "inbox"]);
+    }
+
+    #[test]
+    fn test_resolve_tag_templates_multiple_params() {
+        let tags = vec!["folder:{folderId}:user:{userId}".to_string()];
+        let mut params = HashMap::new();
+        params.insert("folderId".to_string(), "drafts".to_string());
+        params.insert("userId".to_string(), "abc".to_string());
+        let resolved = resolve_tag_templates(&tags, &params);
+        assert_eq!(resolved, vec!["folder:drafts:user:abc"]);
+    }
+
+    #[test]
+    fn test_resolve_tag_templates_missing_param_left_unresolved() {
+        let tags = vec!["thread:{threadId}".to_string()];
+        let params = HashMap::new();
+        let resolved = resolve_tag_templates(&tags, &params);
+        assert_eq!(resolved, vec!["thread:{threadId}"]);
+    }
+
+    // ── Chain entry to_json with new fields ───────────────────────
+
+    #[test]
+    fn test_chain_entry_to_json_includes_new_fields() {
+        let entry = RouteChainEntry {
+            component: "mail-thread".into(),
+            path: "email/:threadId".into(),
+            params: {
+                let mut p = HashMap::new();
+                p.insert("threadId".to_string(), "42".to_string());
+                p
+            },
+            exact: true,
+            allowed_query: String::new(),
+            keep_alive: false,
+            cache_tags: vec!["thread:42".to_string()],
+            invalidates: vec!["inbox".to_string(), "counts".to_string()],
+            pending_component: "mail-skeleton".into(),
+            error_component: "error-page".into(),
+        };
+        let json = entry.to_json();
+        assert_eq!(json["pendingComponent"], "mail-skeleton");
+        assert_eq!(json["errorComponent"], "error-page");
+        let inv = json["invalidates"].as_array().unwrap();
+        assert_eq!(inv.len(), 2);
+        assert_eq!(inv[0], "inbox");
+        assert_eq!(inv[1], "counts");
+    }
+
+    #[test]
+    fn test_chain_entry_to_json_omits_empty_new_fields() {
+        let entry = RouteChainEntry {
+            component: "home-page".into(),
+            path: "/".into(),
+            params: HashMap::new(),
+            exact: true,
+            allowed_query: String::new(),
+            keep_alive: false,
+            cache_tags: Vec::new(),
+            invalidates: Vec::new(),
+            pending_component: String::new(),
+            error_component: String::new(),
+        };
+        let json = entry.to_json();
+        assert!(json.get("pendingComponent").is_none());
+        assert!(json.get("errorComponent").is_none());
+        assert!(json.get("invalidates").is_none());
+    }
+
+    // ── render_partial with cache tags ────────────────────────────
+
+    #[test]
+    fn test_render_partial_includes_resolved_cache_tags() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![WebUiFragmentRoute {
+                        path: "email/:threadId".into(),
+                        fragment_id: "mail-thread".into(),
+                        exact: true,
+                        cache_tags: vec!["thread:{threadId}".to_string(), "inbox".to_string()],
+                        ..Default::default()
+                    }],
+                    cache_tags: vec!["folders".to_string()],
+                    ..Default::default()
+                })],
+            },
+        );
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>App</h1>"), WebUIFragment::outlet()],
+            },
+        );
+        fragments.insert(
+            "mail-thread".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Thread</p>")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+
+        let partial = render_partial(
+            &protocol,
+            serde_json::json!({}),
+            "index.html",
+            "/email/42",
+            "",
+        );
+        let tags = partial["cacheTags"].as_array().unwrap();
+        let tag_strings: Vec<&str> = tags.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(
+            tag_strings.contains(&"folders"),
+            "should contain parent tags"
+        );
+        assert!(
+            tag_strings.contains(&"thread:42"),
+            "should resolve threadId param to 42"
+        );
+        assert!(tag_strings.contains(&"inbox"), "should contain static tags");
+    }
+
+    // ── render_action_response tests ─────────────────────────────
+
+    #[test]
+    fn test_render_action_response_returns_resolved_invalidation_tags() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![WebUiFragmentRoute {
+                        path: "compose".into(),
+                        fragment_id: "compose-page".into(),
+                        exact: true,
+                        invalidates: vec![
+                            "inbox".to_string(),
+                            "sent".to_string(),
+                            "counts".to_string(),
+                        ],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })],
+            },
+        );
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>App</h1>"), WebUIFragment::outlet()],
+            },
+        );
+        fragments.insert(
+            "compose-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Compose</p>")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+
+        let result = render_action_response(
+            &protocol,
+            serde_json::json!({"ok": true}),
+            "index.html",
+            "/compose",
+        );
+
+        let tags = result["invalidateTags"].as_array().unwrap();
+        let tag_strings: Vec<&str> = tags.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(tag_strings, vec!["inbox", "sent", "counts"]);
+        assert_eq!(result["state"]["ok"], true);
+    }
+
+    #[test]
+    fn test_render_action_response_resolves_param_placeholders() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/".into(),
+                    fragment_id: "app-shell".into(),
+                    exact: false,
+                    children: vec![WebUiFragmentRoute {
+                        path: "email/:threadId/reply".into(),
+                        fragment_id: "reply-page".into(),
+                        exact: true,
+                        invalidates: vec!["thread:{threadId}".to_string(), "inbox".to_string()],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })],
+            },
+        );
+        fragments.insert(
+            "app-shell".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<h1>App</h1>"), WebUIFragment::outlet()],
+            },
+        );
+        fragments.insert(
+            "reply-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Reply</p>")],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+
+        let result = render_action_response(
+            &protocol,
+            serde_json::json!({}),
+            "index.html",
+            "/email/42/reply",
+        );
+
+        let tags = result["invalidateTags"].as_array().unwrap();
+        let tag_strings: Vec<&str> = tags.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(tag_strings.contains(&"thread:42"));
+        assert!(tag_strings.contains(&"inbox"));
     }
 }

--- a/crates/webui-handler/src/route_renderer.rs
+++ b/crates/webui-handler/src/route_renderer.rs
@@ -8,7 +8,49 @@
 
 use crate::route_matcher;
 use crate::{ResponseWriter, Result};
-use webui_protocol::{web_ui_fragment::Fragment, WebUIFragment};
+use webui_protocol::{web_ui_fragment::Fragment, WebUIFragment, WebUiFragmentRoute};
+
+/// Write comma-separated items directly to the writer without allocating a joined string.
+fn write_comma_separated(writer: &mut dyn ResponseWriter, items: &[String]) -> Result<()> {
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            writer.write(",")?;
+        }
+        writer.write(item)?;
+    }
+    Ok(())
+}
+
+/// Write cache/invalidation/pending/error attributes for a route fragment.
+///
+/// Shared by `process_route`, `process_outlet` (matched child), and
+/// `process_outlet` (hidden siblings) to avoid divergence.
+pub(crate) fn write_route_cache_attrs(
+    writer: &mut dyn ResponseWriter,
+    route: &WebUiFragmentRoute,
+) -> Result<()> {
+    if !route.cache_tags.is_empty() {
+        writer.write(" cache-tags=\"")?;
+        write_comma_separated(writer, &route.cache_tags)?;
+        writer.write("\"")?;
+    }
+    if !route.invalidates.is_empty() {
+        writer.write(" invalidates=\"")?;
+        write_comma_separated(writer, &route.invalidates)?;
+        writer.write("\"")?;
+    }
+    if !route.pending_component.is_empty() {
+        writer.write(" pending=\"")?;
+        writer.write(&route.pending_component)?;
+        writer.write("\"")?;
+    }
+    if !route.error_component.is_empty() {
+        writer.write(" error=\"")?;
+        writer.write(&route.error_component)?;
+        writer.write("\"")?;
+    }
+    Ok(())
+}
 
 /// Escape HTML special characters in an attribute value and write directly to the writer.
 ///

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -1420,13 +1420,53 @@ impl HtmlParser {
             exact,
             query,
             keep_alive: self.has_element_attribute(node, "keep-alive", source)?,
+            cache_tags: self
+                .get_element_attribute(node, "cache-tags", source)?
+                .map(|v| route_parser::parse_tag_list(&v))
+                .unwrap_or_default(),
+            invalidates: self
+                .get_element_attribute(node, "invalidates", source)?
+                .map(|v| route_parser::parse_tag_list(&v))
+                .unwrap_or_default(),
+            pending_component: self
+                .get_element_attribute(node, "pending", source)?
+                .unwrap_or_default(),
+            error_component: self
+                .get_element_attribute(node, "error", source)?
+                .unwrap_or_default(),
         };
 
         // Validate attributes (component is required)
         route_parser::validate_attributes(&attrs)?;
 
-        // Extract params from path template (validation only)
-        route_parser::extract_params(&path)?;
+        // Extract params from path template and validate
+        let route_params: std::collections::HashSet<String> =
+            route_parser::extract_params(&path)?.into_iter().collect();
+        if !attrs.cache_tags.is_empty() {
+            route_parser::validate_tag_placeholders(
+                &attrs.cache_tags,
+                &route_params,
+                "cache-tags",
+                &path,
+            )?;
+        }
+        if !attrs.invalidates.is_empty() {
+            route_parser::validate_tag_placeholders(
+                &attrs.invalidates,
+                &route_params,
+                "invalidates",
+                &path,
+            )?;
+        }
+
+        // Validate pending component exists in the registry
+        if !attrs.pending_component.is_empty() {
+            self.ensure_route_component_parsed(&attrs.pending_component)?;
+        }
+        // Validate error component exists in the registry
+        if !attrs.error_component.is_empty() {
+            self.ensure_route_component_parsed(&attrs.error_component)?;
+        }
 
         // Ensure the component's template is parsed and registered
         self.ensure_route_component_parsed(&component)?;
@@ -1486,10 +1526,51 @@ impl HtmlParser {
             exact,
             query,
             keep_alive: self.has_element_attribute(node, "keep-alive", source)?,
+            cache_tags: self
+                .get_element_attribute(node, "cache-tags", source)?
+                .map(|v| route_parser::parse_tag_list(&v))
+                .unwrap_or_default(),
+            invalidates: self
+                .get_element_attribute(node, "invalidates", source)?
+                .map(|v| route_parser::parse_tag_list(&v))
+                .unwrap_or_default(),
+            pending_component: self
+                .get_element_attribute(node, "pending", source)?
+                .unwrap_or_default(),
+            error_component: self
+                .get_element_attribute(node, "error", source)?
+                .unwrap_or_default(),
         };
 
         route_parser::validate_attributes(&attrs)?;
-        route_parser::extract_params(&path)?;
+
+        // Extract params from path template and validate
+        let route_params: std::collections::HashSet<String> =
+            route_parser::extract_params(&path)?.into_iter().collect();
+        if !attrs.cache_tags.is_empty() {
+            route_parser::validate_tag_placeholders(
+                &attrs.cache_tags,
+                &route_params,
+                "cache-tags",
+                &path,
+            )?;
+        }
+        if !attrs.invalidates.is_empty() {
+            route_parser::validate_tag_placeholders(
+                &attrs.invalidates,
+                &route_params,
+                "invalidates",
+                &path,
+            )?;
+        }
+
+        // Validate pending/error components exist
+        if !attrs.pending_component.is_empty() {
+            self.ensure_route_component_parsed(&attrs.pending_component)?;
+        }
+        if !attrs.error_component.is_empty() {
+            self.ensure_route_component_parsed(&attrs.error_component)?;
+        }
 
         // Ensure the component's template is parsed
         self.ensure_route_component_parsed(&component)?;

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -1471,8 +1471,10 @@ impl HtmlParser {
         // Ensure the component's template is parsed and registered
         self.ensure_route_component_parsed(&component)?;
 
-        // Recursively parse nested <route> children
-        let children = self.parse_child_routes(node, source)?;
+        // Recursively parse nested <route> children, passing accumulated params
+        let mut all_params = std::collections::HashSet::new();
+        all_params.extend(route_params);
+        let children = self.parse_child_routes(node, source, &all_params)?;
 
         // Flush any pending raw content before the route fragment
         self.flush_raw_buffer(fragments);
@@ -1488,7 +1490,12 @@ impl HtmlParser {
     }
 
     /// Parse nested `<route>` children of a route element.
-    fn parse_child_routes(&mut self, node: Node, source: &str) -> Result<Vec<WebUiFragmentRoute>> {
+    fn parse_child_routes(
+        &mut self,
+        node: Node,
+        source: &str,
+        ancestor_params: &std::collections::HashSet<String>,
+    ) -> Result<Vec<WebUiFragmentRoute>> {
         let mut children = Vec::new();
         let mut cursor = node.walk();
 
@@ -1496,7 +1503,8 @@ impl HtmlParser {
             if child.kind() == "element" {
                 if let Ok(tag) = self.get_element_tag_name(child, source) {
                     if tag == "route" {
-                        let child_route = self.parse_route_as_fragment(child, source)?;
+                        let child_route =
+                            self.parse_route_as_fragment(child, source, ancestor_params)?;
                         children.push(child_route);
                     }
                 }
@@ -1507,7 +1515,12 @@ impl HtmlParser {
     }
 
     /// Parse a `<route>` element into a `WebUiFragmentRoute` (for nesting).
-    fn parse_route_as_fragment(&mut self, node: Node, source: &str) -> Result<WebUiFragmentRoute> {
+    fn parse_route_as_fragment(
+        &mut self,
+        node: Node,
+        source: &str,
+        ancestor_params: &std::collections::HashSet<String>,
+    ) -> Result<WebUiFragmentRoute> {
         let path = self
             .get_element_attribute(node, "path", source)?
             .unwrap_or_default();
@@ -1544,13 +1557,16 @@ impl HtmlParser {
 
         route_parser::validate_attributes(&attrs)?;
 
-        // Extract params from path template and validate
-        let route_params: std::collections::HashSet<String> =
+        // Extract params from path template and validate placeholders
+        // against both this route's own params AND ancestor params
+        let own_params: std::collections::HashSet<String> =
             route_parser::extract_params(&path)?.into_iter().collect();
+        let mut all_params = ancestor_params.clone();
+        all_params.extend(own_params.iter().cloned());
         if !attrs.cache_tags.is_empty() {
             route_parser::validate_tag_placeholders(
                 &attrs.cache_tags,
-                &route_params,
+                &all_params,
                 "cache-tags",
                 &path,
             )?;
@@ -1558,7 +1574,7 @@ impl HtmlParser {
         if !attrs.invalidates.is_empty() {
             route_parser::validate_tag_placeholders(
                 &attrs.invalidates,
-                &route_params,
+                &all_params,
                 "invalidates",
                 &path,
             )?;
@@ -1575,8 +1591,8 @@ impl HtmlParser {
         // Ensure the component's template is parsed
         self.ensure_route_component_parsed(&component)?;
 
-        // Recursively parse nested children
-        let children = self.parse_child_routes(node, source)?;
+        // Recursively parse nested children, passing accumulated params
+        let children = self.parse_child_routes(node, source, &all_params)?;
 
         Ok(route_parser::build_route_fragment(
             &attrs, component, children,

--- a/crates/webui-parser/src/route_parser.rs
+++ b/crates/webui-parser/src/route_parser.rs
@@ -25,6 +25,17 @@ pub(crate) struct RouteAttributes {
     pub query: String,
     /// When true, the router keeps the component alive across navigations.
     pub keep_alive: bool,
+    /// Cache tag templates (e.g. `["thread:{threadId}", "inbox"]`).
+    /// Placeholders like `{param}` are resolved at render time.
+    pub cache_tags: Vec<String>,
+    /// Invalidation tag templates (e.g. `["inbox", "sent"]`).
+    /// After a mutation action, these tags are auto-invalidated.
+    /// Supports `{param}` placeholders resolved at render time.
+    pub invalidates: Vec<String>,
+    /// Component tag name for pending/loading UI.
+    pub pending_component: String,
+    /// Component tag name for error boundary UI.
+    pub error_component: String,
 }
 
 /// Iteratively extract `:param` and `*splat` tokens from a path template.
@@ -100,6 +111,96 @@ pub(crate) fn validate_attributes(attrs: &RouteAttributes) -> Result<()> {
     Ok(())
 }
 
+/// Parse a comma-separated list of cache tags or invalidation tags.
+///
+/// Splits on `,`, trims whitespace, and discards empty entries.
+pub(crate) fn parse_tag_list(raw: &str) -> Vec<String> {
+    let mut tags = Vec::new();
+    for part in raw.split(',') {
+        let trimmed = part.trim();
+        if !trimmed.is_empty() {
+            tags.push(trimmed.to_string());
+        }
+    }
+    tags
+}
+
+/// Extract `{param}` placeholder names from tag templates.
+///
+/// Returns the set of param names referenced in tags like `"thread:{threadId}"`.
+/// Validates that placeholder syntax is well-formed.
+pub(crate) fn extract_tag_placeholders(tags: &[String]) -> Result<HashSet<String>> {
+    let mut placeholders = HashSet::new();
+
+    for tag in tags {
+        let bytes = tag.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+
+        while i < len {
+            if bytes[i] == b'{' {
+                let start = i + 1;
+                let end = tag[start..].find('}').map(|j| start + j);
+                match end {
+                    Some(end_idx) => {
+                        let name = &tag[start..end_idx];
+                        if name.is_empty() {
+                            return Err(ParserError::Directive(format!(
+                                "Empty placeholder '{{}}' in cache tag: {tag}"
+                            )));
+                        }
+                        if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                            return Err(ParserError::Directive(format!(
+                                "Invalid placeholder name '{name}' in cache tag: {tag}"
+                            )));
+                        }
+                        placeholders.insert(name.to_string());
+                        i = end_idx + 1;
+                    }
+                    None => {
+                        return Err(ParserError::Directive(format!(
+                            "Unclosed placeholder '{{' in cache tag: {tag}"
+                        )));
+                    }
+                }
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    Ok(placeholders)
+}
+
+/// Validate that `{param}` placeholders in tags reference actual route params.
+///
+/// `available_params` should include params from this route AND all ancestor routes.
+pub(crate) fn validate_tag_placeholders(
+    tags: &[String],
+    available_params: &HashSet<String>,
+    attr_name: &str,
+    route_path: &str,
+) -> Result<()> {
+    let placeholders = extract_tag_placeholders(tags)?;
+    for name in &placeholders {
+        if !available_params.contains(name) {
+            return Err(ParserError::Directive(format!(
+                "Placeholder '{{{name}}}' in {attr_name} references unknown param \
+                 on route '{route_path}'. Available params: {available}",
+                available = if available_params.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    let mut sorted: Vec<&str> =
+                        available_params.iter().map(|s| s.as_str()).collect();
+                    sorted.sort_unstable();
+                    sorted.join(", ")
+                }
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Build a `WebUiFragmentRoute` from parsed attributes.
 pub(crate) fn build_route_fragment(
     attrs: &RouteAttributes,
@@ -113,6 +214,10 @@ pub(crate) fn build_route_fragment(
         children,
         allowed_query: attrs.query.clone(),
         keep_alive: attrs.keep_alive,
+        cache_tags: attrs.cache_tags.clone(),
+        invalidates: attrs.invalidates.clone(),
+        pending_component: attrs.pending_component.clone(),
+        error_component: attrs.error_component.clone(),
     }
 }
 
@@ -217,5 +322,116 @@ mod tests {
     fn test_extract_params_relative_splat() {
         let params = extract_params("./*rest").unwrap();
         assert_eq!(params, vec!["rest"]);
+    }
+
+    // ── Cache tag parsing tests ──
+
+    #[test]
+    fn test_parse_tag_list_simple() {
+        let tags = parse_tag_list("inbox,counts");
+        assert_eq!(tags, vec!["inbox", "counts"]);
+    }
+
+    #[test]
+    fn test_parse_tag_list_with_placeholders() {
+        let tags = parse_tag_list("thread:{threadId},inbox");
+        assert_eq!(tags, vec!["thread:{threadId}", "inbox"]);
+    }
+
+    #[test]
+    fn test_parse_tag_list_whitespace() {
+        let tags = parse_tag_list(" inbox , counts , drafts ");
+        assert_eq!(tags, vec!["inbox", "counts", "drafts"]);
+    }
+
+    #[test]
+    fn test_parse_tag_list_empty() {
+        let tags = parse_tag_list("");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_parse_tag_list_trailing_comma() {
+        let tags = parse_tag_list("inbox,");
+        assert_eq!(tags, vec!["inbox"]);
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_simple() {
+        let tags = vec!["thread:{threadId}".to_string(), "inbox".to_string()];
+        let placeholders = extract_tag_placeholders(&tags).unwrap();
+        assert_eq!(placeholders.len(), 1);
+        assert!(placeholders.contains("threadId"));
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_multiple() {
+        let tags = vec!["folder:{folderId}".to_string(), "user:{userId}".to_string()];
+        let placeholders = extract_tag_placeholders(&tags).unwrap();
+        assert_eq!(placeholders.len(), 2);
+        assert!(placeholders.contains("folderId"));
+        assert!(placeholders.contains("userId"));
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_none() {
+        let tags = vec!["inbox".to_string(), "counts".to_string()];
+        let placeholders = extract_tag_placeholders(&tags).unwrap();
+        assert!(placeholders.is_empty());
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_unclosed_brace() {
+        let tags = vec!["thread:{threadId".to_string()];
+        assert!(extract_tag_placeholders(&tags).is_err());
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_empty_placeholder() {
+        let tags = vec!["thread:{}".to_string()];
+        assert!(extract_tag_placeholders(&tags).is_err());
+    }
+
+    #[test]
+    fn test_extract_tag_placeholders_invalid_name() {
+        let tags = vec!["thread:{thread-id}".to_string()];
+        assert!(extract_tag_placeholders(&tags).is_err());
+    }
+
+    #[test]
+    fn test_validate_tag_placeholders_valid() {
+        let tags = vec!["thread:{threadId}".to_string(), "inbox".to_string()];
+        let mut params = HashSet::new();
+        params.insert("threadId".to_string());
+        assert!(
+            validate_tag_placeholders(&tags, &params, "cache-tags", "/email/:threadId").is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_tag_placeholders_missing_param() {
+        let tags = vec!["thread:{threadId}".to_string()];
+        let params = HashSet::new();
+        let result = validate_tag_placeholders(&tags, &params, "cache-tags", "/email");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("threadId"),
+            "Error should mention the param: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_tag_placeholders_with_ancestor_params() {
+        let tags = vec![
+            "thread:{threadId}".to_string(),
+            "folder:{folderId}".to_string(),
+        ];
+        let mut params = HashSet::new();
+        params.insert("threadId".to_string());
+        params.insert("folderId".to_string());
+        assert!(
+            validate_tag_placeholders(&tags, &params, "cache-tags", "/email/:threadId").is_ok()
+        );
     }
 }

--- a/crates/webui-protocol/proto/webui.proto
+++ b/crates/webui-protocol/proto/webui.proto
@@ -69,6 +69,19 @@ message WebUIFragmentRoute {
   // When true, the router preserves the mounted component instance across
   // navigations instead of destroying and recreating it. Opt-in per route.
   bool keep_alive = 6;
+  // Cache tag templates for this route (e.g. "thread:{threadId}", "inbox").
+  // Placeholders like {param} are resolved at render time with actual param values.
+  repeated string cache_tags = 7;
+  // Invalidation tag templates (e.g. "inbox", "thread:{threadId}").
+  // After a mutation action on this route, these tags are auto-invalidated.
+  // Supports {param} placeholders resolved at render time.
+  repeated string invalidates = 8;
+  // Component tag name for the pending/loading UI (e.g. "mail-skeleton").
+  // Validated at build time — build fails if the component does not exist.
+  string pending_component = 9;
+  // Component tag name for the error boundary UI (e.g. "error-page").
+  // Validated at build time — build fails if the component does not exist.
+  string error_component = 10;
 }
 
 // Outlet placeholder — marks where matched child route content renders.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -789,6 +789,10 @@ mod tests {
                 children: Vec::new(),
                 allowed_query: "action,to,subject".to_string(),
                 keep_alive: false,
+                cache_tags: vec!["user:{id}".to_string(), "posts".to_string()],
+                invalidates: vec!["posts".to_string(), "counts".to_string()],
+                pending_component: "loading-skeleton".to_string(),
+                error_component: "error-page".to_string(),
             })),
         };
         fragments.insert(

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -198,16 +198,43 @@ In the TypeScript class: `searchInput!: HTMLInputElement;`
 </route>
 ```
 
+**Path & matching:**
 - Child paths are relative to parent (no leading `/`)
 - Use `exact` on leaf routes (no children)
 - Omit `exact` on parent routes that have `<outlet />`
 - Path params: `:id` (required), `:query?` (optional), `*path` (catch-all)
-- Query param allowlist: `query="action,to,subject"` — only listed params are set as component attributes (deny-by-default)
-- `keep-alive` — preserves DOM and local state across navigations (hidden, not destroyed). On reactivation, only param/query attrs are updated — `setState()` is NOT called (preserves scroll, forms, observables)
-- Route loaders: static `loader({ params, query, signal })` on component class — fetches custom data instead of server state. Runs pre-commit. Falls back to server state on failure
+
+**Attributes on `<route>`:**
+
+| Attribute | Example | Description |
+|-----------|---------|-------------|
+| `path` | `"users/:id"` | URL path template (relative to parent) |
+| `component` | `"user-detail"` | Component tag to mount |
+| `exact` | (boolean) | Require exact path match (use on leaf routes) |
+| `query` | `"action,to,subject"` | Allowlist of query params set as component attributes (deny-by-default) |
+| `keep-alive` | (boolean) | Preserve DOM and local state across navigations |
+| `cache-tags` | `"thread:{threadId},inbox"` | Cache tag templates - `{param}` resolved at render time |
+| `invalidates` | `"inbox,sent,counts"` | Tags to auto-invalidate after mutation actions |
+| `pending` | `"loading-skeleton"` | Component for loading UI during slow navigations (>150ms) |
+| `error` | `"error-display"` | Component for error boundary on fetch failure |
+
+All attributes are validated at build time. Referencing a non-existent `pending` or `error` component is a compile error.
+
+**State flow:**
+- `keep-alive` — preserves DOM and local state. On reactivation, only param/query attrs are updated - `setState()` is NOT called
+- Route loaders: `static loader({ params, query, signal })` on component class - fetches custom data instead of server state. Runs pre-commit. Falls back to server state on failure
 - Keep-alive + loader: DOM preserved, loader provides fresh data via `setState()` on reactivation
-- Preload on hover: `Router.start({ preload: true })` — speculatively fetches route data on link hover for instant click navigation
-- `X-WebUI-Has-Loader` header: comma-separated list of component tags with loaders — host server can check if the target leaf is in this list to skip state computation
+- Route actions: `static action({ formData, params, signal })` on component class - handles `<form method="post">`. Returns `{ invalidateTags?, state? }`. Auto-invalidates cache with merged tags
+
+**Cache & preload:**
+- Preload on hover: `Router.start({ preload: true })` - speculatively fetches on link hover
+- Tagged cache: `Router.start({ cache: { staleTime, gcTime, maxEntries } })` - responses cached by path, tagged with `cacheTags`
+- `Router.invalidateTags(tags)` - evict cache entries by tag
+- `Router.invalidate(path?)` - evict by path or all
+
+**Server headers:**
+- `X-WebUI-Has-Loader` header: comma-separated list of component tags with loaders - host server can skip state computation
+- `X-WebUI-Inventory` header: hex bitmask of loaded templates - server skips re-sending
 
 ### Outlet
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -1,6 +1,13 @@
 # Routing
 
-WebUI provides nested SSR routing with client-side navigation. Routes are declared as a tree in `index.html`, components use `<outlet />` to render child routes, and the `@microsoft/webui-router` package handles client-side transitions after the initial SSR.
+WebUI routes are **declared in HTML and compiled at build time**. The Rust compiler parses your `<route>` tree, validates every attribute, and bakes it all into the binary protocol. Cache tags, invalidation graphs, pending states, error boundaries - everything is known before a single request is served.
+
+This means:
+- **Zero runtime JavaScript for routing policy.** Cache semantics, invalidation rules, and loading states are HTML attributes - not framework configuration objects.
+- **Build-time validation.** A typo in `pending="loadnig-skeleton"` is a compile error, not a blank screen in production.
+- **Server and client both know the full graph.** The server resolves cache tags with real param values. The client invalidates by tag after mutations. Neither needs runtime discovery.
+
+At its simplest, routing is three lines of HTML and one line of TypeScript. At its most advanced, it's declarative tagged caching with compiler-enforced invalidation graphs - and everything in between uses the same `<route>` element.
 
 ## Installation
 
@@ -154,9 +161,9 @@ Router.start({ preload: true });
 
 How it works:
 - On mouse hover over an internal `<a>`, the router speculatively calls `fetchPartial()` for that path
-- Templates, CSS, and state are cached (single-entry, 5-second TTL)
-- On click, the cached result is used immediately — no network wait
-- If the user clicks a different link, the cache is discarded and a fresh fetch happens
+- Results are stored in the [tagged cache](#tagged-cache) with a 5-second minimum freshness
+- On click, the cached result is used immediately - no network wait
+- If the user hovers a different link, the previous preload is cancelled and a new one starts
 
 Only mouse pointers trigger preload — touch taps fire simultaneously with the click event, making speculative fetching pointless.
 
@@ -211,6 +218,150 @@ app.get('*', async (req, res) => {
 });
 ```
 
+### Tagged Cache
+
+The router caches partial responses and tags them with server-provided cache tags for precise invalidation. Enable caching at startup:
+
+```typescript
+Router.start({
+  cache: {
+    staleTime: 30_000,   // ms before refetch (default: 0 = disabled)
+    gcTime: 300_000,     // ms before eviction from memory (default: 5 min)
+    maxEntries: 50,      // LRU cap (default: 50)
+  },
+});
+```
+
+Declare cache tags on routes as HTML attributes. Placeholders like `{threadId}` reference route path parameters and are resolved at render time:
+
+```html
+<route path="/" component="mail-app">
+  <route path="./" component="mail-view" keep-alive
+         cache-tags="folders,counts">
+    <route path="" component="inbox-page" exact
+           cache-tags="inbox,counts" />
+    <route path="email/:threadId" component="thread-page" exact
+           cache-tags="thread:{threadId}" />
+  </route>
+</route>
+```
+
+| Behavior | Description |
+|----------|-------------|
+| **Build time** | The Rust compiler validates `{param}` placeholders match actual route params |
+| **Render time** | The handler resolves `thread:{threadId}` to `thread:42` using matched params |
+| **Response** | Resolved tags are included in the `cacheTags` array of the JSON partial |
+| **Client** | The router stores the response keyed by path, tagged with resolved values |
+| **Revisit** | Within `staleTime`, the cached response is used instantly - no network fetch |
+| **Server override** | The server can include `cacheControl: { staleTime: 60000 }` to override per-response |
+
+::: tip Preload + cache interaction
+When `preload: true` is enabled, hover fetches write to the same cache. Preloaded entries get a minimum 5-second freshness window even when `staleTime` is 0 (disabled).
+:::
+
+### Tag-Based Invalidation
+
+Declare which tags a route invalidates after mutations:
+
+```html
+<route path="compose" component="compose-page" exact
+       invalidates="inbox,sent,counts,drafts" />
+
+<route path="email/:threadId/reply" component="reply-page" exact
+       invalidates="thread:{threadId},inbox" />
+```
+
+The compiler builds the full invalidation graph at build time. Developers declare intent in HTML - the framework ensures correctness.
+
+Programmatic invalidation:
+
+```typescript
+Router.invalidateTags(['inbox', 'thread:42']);  // evict by tag
+Router.invalidate('/email/42');                  // evict by path
+Router.invalidate();                             // evict everything
+```
+
+### Mutation Actions
+
+The write counterpart to `static loader()`. Components define `static action()` to handle form submissions, and the router auto-invalidates the cache:
+
+```typescript
+import { WebUIElement } from '@microsoft/webui-framework';
+import type { RouteActionContext, RouteActionResult } from '@microsoft/webui-router';
+
+export class ComposePage extends WebUIElement {
+  static async action({ formData, params, signal }: RouteActionContext): Promise<RouteActionResult> {
+    await fetch('/api/send', { method: 'POST', body: formData, signal });
+    return {
+      invalidateTags: ['sent'],           // merged with route's invalidates attr
+      state: { status: 'Message sent' },  // optimistic UI (optional)
+    };
+  }
+}
+```
+
+The router intercepts `<form method="post">` submissions via a delegated listener:
+
+| Step | What happens |
+|------|-------------|
+| **1. Intercept** | Walks `composedPath()` to find the form and nearest `<webui-route>` (shadow DOM safe) |
+| **2. Guard** | Skips forms with external `action` URLs or `target` other than `_self` |
+| **3. Call** | Invokes `static action({ formData, params, signal })` on the component class |
+| **4. Invalidate** | Merges the action's returned tags with the route's build-time `invalidates` attribute |
+| **5. Update** | Applies optimistic `result.state` via `setState()` if provided |
+| **6. Event** | Dispatches `webui:route:action-complete` on `window` |
+
+### Pending UI
+
+Show a loading component during slow navigations. The component is validated at build time - a typo causes a build error, not a runtime blank screen:
+
+```html
+<route path="inbox" component="inbox-page" exact
+       pending="mail-skeleton" />
+```
+
+| Behavior | Description |
+|----------|-------------|
+| **Threshold** | Pending component appears after 150ms - fast navigations never flash |
+| **Mount** | Rendered in the parent route's outlet area |
+| **Replace** | Real content replaces the skeleton when the fetch completes |
+| **Keep-alive** | Skipped - keep-alive routes activate instantly from the DOM |
+| **Cached** | Skipped - cached navigations have no fetch delay |
+
+Pending components are normal WebUI components - SSR'd, compiled, and part of the protocol. No special API needed.
+
+### Error Boundaries
+
+Show an error component when navigation fails. Like `pending`, the component is validated at build time:
+
+```html
+<route path="dashboard" component="dashboard-page" exact
+       error="error-display" />
+```
+
+The error component receives details as state:
+
+```typescript
+export class ErrorDisplay extends WebUIElement {
+  @observable error = '';    // "Navigation failed"
+  @observable status = 0;    // HTTP status code (0 if network error)
+  @observable path = '';     // the path that failed
+
+  onRetry = () => Router.navigate(this.path);
+}
+```
+
+```html
+<!-- error-display.html -->
+<div class="error">
+  <h2>Something went wrong</h2>
+  <p>{{error}}</p>
+  <button @click="{onRetry()}">Try again</button>
+</div>
+```
+
+If no `error` attribute is declared on the route, the router falls back to its default behavior (`console.warn` + stale content preserved).
+
 ## How It Works
 
 ### First Load (SSR)
@@ -239,8 +390,14 @@ Starts the router. Call after hydration completes.
 
 ```typescript
 Router.start({
-  basePath: '/app',   // optional: prefix for all route URLs
-  loaders: { ... },   // optional: lazy-loading map
+  basePath: '/app',           // prefix for all route URLs
+  loaders: { ... },           // lazy-loading map (component tag → async import)
+  preload: true,              // speculative fetch on link hover
+  cache: {                    // tagged navigation cache
+    staleTime: 30_000,        // ms before refetch (0 = disabled)
+    gcTime: 300_000,          // ms before memory eviction
+    maxEntries: 50,           // LRU cap
+  },
 });
 ```
 
@@ -256,6 +413,31 @@ Router.navigate('/users/42');
 Router.back();
 ```
 
+### `Router.invalidateTags(tags)`
+
+Evict all cache entries whose tags overlap with the given tags:
+
+```typescript
+Router.invalidateTags(['inbox', 'thread:42']);
+```
+
+### `Router.invalidate(path?)`
+
+Evict cache entries by path, or all entries if no path is given:
+
+```typescript
+Router.invalidate('/email/42');  // evict one entry
+Router.invalidate();             // evict everything
+```
+
+### `Router.activeComponent`
+
+The component tag of the currently active leaf route:
+
+```typescript
+console.log(Router.activeComponent); // "user-detail"
+```
+
 ### `Router.activeParams`
 
 The bound parameters of the current route:
@@ -266,21 +448,18 @@ console.log(Router.activeParams); // { id: "42" }
 
 ### `Router.destroy()`
 
-Tears down the router and removes event listeners.
+Tears down the router, removes event listeners, and clears the cache.
 
 ### `Router.gc()`
 
 Release all cached component templates to free memory. Removes all entries from `window.__webui_templates` and clears their inventory bits so the server will re-send them on the next navigation that needs them.
 
 ```typescript
-// Release all non-active templates
 Router.gc();
 ```
 
-The framework's internal template cache is a `WeakMap` keyed by the same meta objects, so its entries become GC-eligible automatically when the template is released.
-
 ::: tip When to use this
-Most apps don't need this - the number of unique component templates is bounded by the route tree (typically 10–30). The server's inventory system already prevents duplicate downloads. Use `gc()` in long-lived SPAs with many routes where memory pressure is a concern.
+Most apps don't need this - the number of unique component templates is bounded by the route tree (typically 10-30). The server's inventory system already prevents duplicate downloads. Use `gc()` in long-lived SPAs with many routes where memory pressure is a concern.
 :::
 
 ## Lazy Loading
@@ -347,7 +526,11 @@ app.get('/_webui/templates', (req, res) => {
 
 ```typescript
 window.addEventListener('webui:route:navigated', (event) => {
-  const { component, params, path } = event.detail;
+  const { component, params, query, path } = event.detail;
+});
+
+window.addEventListener('webui:route:action-complete', (event) => {
+  const { component, invalidatedTags, path } = event.detail;
 });
 ```
 
@@ -362,20 +545,37 @@ When `Accept: application/json`:
 ```json
 {
   "state": { "name": "Alice", "email": "alice@example.com" },
-  "templateStyles": ["<style type=\"module\" specifier=\"user-detail\">.user-detail{display:block}</style>"],
+  "templateStyles": ["<style type=\"module\" specifier=\"user-detail\">...</style>"],
   "templates": ["(function(){var w=window.__webui_templates||...})();"],
   "inventory": "04000400...",
   "path": "/users/42",
   "chain": [
     { "component": "app-shell", "path": "/" },
-    { "component": "user-detail", "path": "users/:id", "params": { "id": "42" }, "exact": true, "keepAlive": true }
-  ]
+    {
+      "component": "user-detail", "path": "users/:id",
+      "params": { "id": "42" }, "exact": true, "keepAlive": true,
+      "pendingComponent": "loading-skeleton",
+      "errorComponent": "error-page",
+      "invalidates": ["user:42", "users"]
+    }
+  ],
+  "cacheTags": ["user:42", "users"],
+  "cacheControl": { "staleTime": 60000 }
 }
 ```
 
-The `templateStyles` array contains module CSS definition tags for CssStrategy::Module. The client appends these to `<head>` before evaluating template scripts so adopted stylesheets are available. For Link/Style modes, this array is empty.
+| Field | Description |
+|-------|-------------|
+| `state` | Application state for the matched route |
+| `templateStyles` | Module CSS definition tags (empty for Link/Style modes) |
+| `templates` | Client template payloads filtered by inventory bitmask |
+| `inventory` | Updated hex bitmask of loaded templates |
+| `path` | The matched request path |
+| `chain` | Matched route chain - one entry per nesting level |
+| `cacheTags` | Resolved cache tags from the full chain (union of all levels) |
+| `cacheControl` | Optional per-response cache overrides |
 
-The `chain` field tells the client router which route components are active at each nesting level. Each entry can include a `keepAlive` boolean flag. The client uses this to diff against the previous chain and only remount what changed - it does **not** perform route matching itself.
+Each `chain` entry can include: `component`, `path`, `params`, `exact`, `keepAlive`, `allowedQuery`, `pendingComponent`, `errorComponent`, and `invalidates`.
 
 **Request headers the router sends:**
 

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -1,6 +1,8 @@
 # @microsoft/webui-router
 
-Client-side router for [WebUI](https://github.com/microsoft/webui) apps with nested route support. Uses the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) to intercept link clicks and loads components on demand — preserving server-rendered content on initial load and fetching JSON partials for subsequent navigations. The server provides the matched route chain; the client does not perform route matching.
+Build-time compiled router for [WebUI](https://github.com/microsoft/webui) apps. Routes, cache tags, invalidation graphs, pending states, and error boundaries are declared as HTML attributes, validated by the Rust compiler, and baked into the binary protocol — zero runtime JavaScript for routing policy.
+
+Uses the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) for client-side transitions. The server provides the matched route chain; the client does not perform route matching.
 
 > 📖 **Full documentation at [microsoft.github.io/webui](https://microsoft.github.io/webui)** — see the [Routing Guide](https://microsoft.github.io/webui/guide/concepts/routing) for setup and usage.
 
@@ -160,20 +162,100 @@ Opt-in speculative fetching for instant click navigation:
 Router.start({ preload: true });
 ```
 
-When enabled, the router prefetches JSON partials (templates, CSS, state) when the user hovers over internal links. On click, the cached result is used immediately. Only mouse pointers trigger preload (5-second TTL, single-entry cache).
+When enabled, the router prefetches JSON partials (templates, CSS, state) when the user hovers over internal links. On click, the cached result is used immediately. Preloaded entries are stored in the [tagged cache](#tagged-cache) with a 5-second minimum freshness. Only mouse pointers trigger preload.
+
+### Tagged Cache
+
+Cache partial responses with server-provided tags for precise invalidation:
+
+```typescript
+Router.start({
+  cache: {
+    staleTime: 30_000,   // ms before refetch (default: 0 = disabled)
+    gcTime: 300_000,     // ms before eviction from memory (default: 5 min)
+    maxEntries: 50,      // LRU cap (default: 50)
+  },
+});
+```
+
+Declare cache tags on routes as HTML attributes:
+
+```html
+<route path="email/:threadId" component="thread-page" exact
+       cache-tags="thread:{threadId},inbox" />
+```
+
+The `{threadId}` placeholder is resolved at render time by the Rust handler. The server includes resolved `cacheTags` in the JSON partial. On revisit within `staleTime`, the cached response is used instantly.
+
+### Tag-Based Invalidation
+
+Declare which tags a route invalidates after mutations:
+
+```html
+<route path="compose" component="compose-page" exact
+       invalidates="inbox,sent,counts,drafts" />
+```
+
+Programmatic invalidation:
+
+```typescript
+Router.invalidateTags(['inbox', 'thread:42']);  // evict by tag
+Router.invalidate('/email/42');                  // evict by path
+Router.invalidate();                             // evict everything
+```
+
+### Mutation Actions
+
+The write counterpart to `static loader()`. The router intercepts `<form method="post">` and auto-invalidates the cache:
+
+```typescript
+import type { RouteActionContext, RouteActionResult } from '@microsoft/webui-router';
+
+export class ComposePage extends WebUIElement {
+  static async action({ formData, params, signal }: RouteActionContext): Promise<RouteActionResult> {
+    await fetch('/api/send', { method: 'POST', body: formData, signal });
+    return {
+      invalidateTags: ['sent'],           // merged with route's invalidates attr
+      state: { status: 'Message sent' },  // optimistic UI (optional)
+    };
+  }
+}
+```
+
+The action's returned tags are merged with the route's build-time `invalidates` attribute. Only same-origin forms are intercepted.
+
+### Pending UI
+
+Show a loading component during slow navigations (>150ms):
+
+```html
+<route path="inbox" component="inbox-page" exact pending="mail-skeleton" />
+```
+
+The `pending` component is validated at build time. Keep-alive and cached routes skip pending.
+
+### Error Boundaries
+
+Show an error component when navigation fails:
+
+```html
+<route path="dashboard" component="dashboard-page" exact error="error-display" />
+```
+
+The error component receives `{ error, status, path }` as state. It can call `Router.navigate()` to retry.
 
 ### Controlling State
 
-The router gives you three levers to control how state flows:
-
 | Need | Mechanism |
 |------|-----------|
-| **Server provides all state** (default) | No changes needed — `setState(data.state)` on every navigation |
-| **I fetch my own data** | Define `static loader()` on the component class |
-| **Preserve local state across navigations** | Add `keep-alive` to the route |
-| **Preserve DOM, but refresh data my way** | `keep-alive` + `static loader()` |
-
-The router also sends `X-WebUI-Has-Loader` as a comma-separated list of component tags that have loaders (e.g., `X-WebUI-Has-Loader: dash-page,mail-view`). The host server can check whether the target leaf component is in this list and skip expensive state computation by returning `state: {}`.
+| **Server provides all state** (default) | No changes needed |
+| **I fetch my own data** | `static loader()` on component class |
+| **Preserve local state** | `keep-alive` on route |
+| **Preserve DOM, refresh data** | `keep-alive` + `static loader()` |
+| **Handle form submissions** | `static action()` on component class |
+| **Cache responses** | `cache` config on `Router.start()` |
+| **Show loading state** | `pending` attr on route |
+| **Handle failures** | `error` attr on route |
 
 ## API
 
@@ -188,6 +270,7 @@ Start the router. Call after hydration completes.
 | `templateEndpoint` | `string` | URL for `ensureLoaded()` requests (default: `"/_webui/templates"`) |
 | `dev` | `boolean` | Enable development mode warnings |
 | `preload` | `boolean` | Preload routes on link hover for instant navigation |
+| `cache` | `CacheConfig` | Tagged navigation cache: `{ staleTime, gcTime, maxEntries }` |
 
 ### `Router.navigate(path)`
 
@@ -248,6 +331,23 @@ The router awaits `transition.updateCallbackDone` (not `.finished`), so rapid na
 
 Navigate back in history.
 
+### `Router.invalidateTags(tags)`
+
+Evict all cache entries whose tags overlap with the given tags:
+
+```typescript
+Router.invalidateTags(['inbox', 'thread:42']);
+```
+
+### `Router.invalidate(path?)`
+
+Evict cache entries by path, or all entries if no path is given:
+
+```typescript
+Router.invalidate('/email/42');  // one entry
+Router.invalidate();             // everything
+```
+
 ### `Router.activeComponent`
 
 Component tag of the active leaf route:
@@ -285,18 +385,25 @@ Router.gc();
 The framework's internal `templateCache` (`WeakMap`) is keyed by the same
 meta objects, so its entries become GC-eligible automatically.
 
-### Navigation Event
+### Navigation Events
 
 Dispatched on `window` after each navigation:
 
 ```typescript
 window.addEventListener('webui:route:navigated', (e) => {
   const { component, params, query, path } = (e as CustomEvent).detail;
-  console.log(`Navigated to ${component}`, params, query);
 });
 ```
 
-> **Note:** `query` contains **all** URL query parameters (unfiltered). Only
+Dispatched after a mutation action completes:
+
+```typescript
+window.addEventListener('webui:route:action-complete', (e) => {
+  const { component, invalidatedTags, path } = (e as CustomEvent).detail;
+});
+```
+
+> **Note:** The `query` in `navigated` contains **all** URL query parameters (unfiltered). Only
 > parameters declared via the `query` attribute on `<route>` are set as DOM
 > attributes — the event exposes the full set for programmatic use.
 
@@ -354,14 +461,15 @@ On client-side navigation, the router sends:
 GET /users/42
 Accept: application/json
 X-WebUI-Inventory: <hex bitmask>
+X-WebUI-Has-Loader: <comma-separated tags>
 ```
 
 The server should return:
 
-- **`Accept: application/json`** → JSON partial: `{ state, templateStyles, templates, inventory, path, chain }` - returned directly from `renderPartial()`, no assembly required
-- **Otherwise** → Full SSR'd HTML page (handler emits a `<meta name="webui-inventory">` tag in `<head>` so the client knows which templates are loaded)
+- **`Accept: application/json`** → JSON partial: `{ state, templateStyles, templates, inventory, path, chain, cacheTags, cacheControl }` - returned directly from `renderPartial()`, no assembly required
+- **Otherwise** → Full SSR'd HTML page
 
-When `templateStyles` is present (CssStrategy::Module), the router appends those module CSS definition tags to `<head>` before evaluating the batched template scripts. The `chain` field contains the matched route chain - the client uses it to diff against the previous chain and only remount what changed. The `X-WebUI-Inventory` header is a bitmask of component templates the client already has - the server uses it to avoid sending duplicate templates.
+The `chain` field contains the matched route chain with `component`, `path`, `params`, `exact`, `keepAlive`, `pendingComponent`, `errorComponent`, and `invalidates`. The `cacheTags` array contains resolved cache tags from the full chain. The optional `cacheControl` object can override `staleTime` per-response.
 
 See the [Routing guide](https://github.com/microsoft/webui/blob/main/docs/guide/concepts/routing.md) for complete server implementation examples.
 

--- a/packages/webui-router/src/index.ts
+++ b/packages/webui-router/src/index.ts
@@ -18,4 +18,12 @@
  */
 
 export { Router, WebUIRouter, WebUIRouteElement } from './router.js';
-export type { RouterConfig, NavigationEvent, RouteLoaderContext } from './types.js';
+export type {
+  RouterConfig,
+  NavigationEvent,
+  RouteLoaderContext,
+  CacheConfig,
+  RouteActionContext,
+  RouteActionResult,
+  ActionCompleteEvent,
+} from './types.js';

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -705,31 +705,31 @@ describe('WebUIRouter', () => {
       const priv = router as any;
 
       const cachedData = { state: { msg: 'preloaded' }, templates: [], path: '/about', chain: [{ component: 'about-page', path: '/about', params: {} }] };
-      priv.preloadCache = { path: '/about', data: cachedData, ts: Date.now() };
+      // Store in unified cache via storeCacheEntry
+      priv.storeCacheEntry('/about', cachedData);
 
-      // handleNavigation reads from preloadCache via requestPath matching
-      // Verify the cache structure is correct
-      assert.equal(priv.preloadCache.path, '/about');
-      assert.deepEqual(priv.preloadCache.data.state, { msg: 'preloaded' });
+      // Verify the cache entry exists
+      const entry = priv.cache.get('/about');
+      assert.ok(entry, 'cache should have entry for /about');
+      assert.deepEqual(entry.data.state, { msg: 'preloaded' });
 
-      // Simulate consumption by clearing
-      const consumed = priv.preloadCache;
-      priv.preloadCache = null;
-      assert.equal(priv.preloadCache, null, 'cache should be cleared after consumption');
-      assert.deepEqual(consumed.data.state, { msg: 'preloaded' });
+      // Simulate consumption by lookupCache + evict
+      const consumed = priv.lookupCache('/about');
+      assert.deepEqual(consumed.state, { msg: 'preloaded' });
+      priv.evictCacheEntry('/about');
+      assert.equal(priv.cache.size, 0, 'cache should be empty after eviction');
     });
 
     test('stale preload cache (>TTL) is not consumed', () => {
       const router = new WebUIRouter();
       const priv = router as any;
 
-      // Cache entry that is 10 seconds old
-      const staleTs = Date.now() - 10_000;
-      priv.preloadCache = { path: '/about', data: { state: {} }, ts: staleTs };
+      // Cache entry that is 10 seconds old — stored directly for test
+      priv.cache.set('/about', { data: { state: {} }, tags: [], ts: Date.now() - 10_000 });
 
-      // The TTL check: Date.now() - ts < PRELOAD_TTL (5000ms)
-      const isFresh = Date.now() - priv.preloadCache.ts < 5_000;
-      assert.ok(!isFresh, 'cache older than 5s should be considered stale');
+      // lookupCache should return null for stale entries
+      const result = priv.lookupCache('/about');
+      assert.equal(result, null, 'cache older than TTL should be considered stale');
     });
 
     test('preload generation guard prevents stale cache writes', async () => {
@@ -752,13 +752,14 @@ describe('WebUIRouter', () => {
       const router = new WebUIRouter();
       const priv = router as any;
 
-      priv.preloadCache = { path: '/test', data: {}, ts: Date.now() };
+      // Store an entry in the unified cache
+      priv.cache.set('/test', { data: {}, tags: [], ts: Date.now() });
       priv.preloadController = new AbortController();
       priv.preloadGeneration = 5;
 
       router.destroy();
 
-      assert.equal(priv.preloadCache, null, 'cache should be cleared');
+      assert.equal(priv.cache.size, 0, 'cache should be cleared');
       assert.equal(priv.preloadController, null, 'controller should be cleared');
     });
 
@@ -784,18 +785,18 @@ describe('WebUIRouter', () => {
       }
     });
 
-    test('handleNavigation source checks preloadCache before fetchPartial', () => {
+    test('handleNavigation source checks cache before fetchPartial', () => {
       const router = new WebUIRouter();
       const source = (router as any).handleNavigation.toString() as string;
 
-      const cacheIdx = source.indexOf('preloadCache');
+      const cacheIdx = source.indexOf('lookupCache');
       const fetchIdx = source.indexOf('fetchPartial');
 
-      assert.ok(cacheIdx > -1, 'handleNavigation should reference preloadCache');
+      assert.ok(cacheIdx > -1, 'handleNavigation should reference lookupCache');
       assert.ok(fetchIdx > -1, 'handleNavigation should reference fetchPartial');
       assert.ok(
         cacheIdx < fetchIdx,
-        'preloadCache check should come before fetchPartial call',
+        'lookupCache check should come before fetchPartial call',
       );
     });
   });

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -15,7 +15,7 @@
  */
 
 import { buildNavigationTarget, prependBasePath, stripBaseFromPathname } from './navigation-path.js';
-import type { RouterConfig, NavigationEvent } from './types.js';
+import type { RouterConfig, NavigationEvent, CacheConfig, RouteActionContext, RouteActionResult, ActionCompleteEvent } from './types.js';
 import type { NavigationTarget } from './navigation-path.js';
 
 const ROUTE_SELECTOR = 'webui-route';
@@ -190,6 +190,12 @@ interface RouteChainEntry {
   allowedQuery?: string;
   /** When true, the component is preserved across navigations instead of re-created. */
   keepAlive?: boolean;
+  /** Component tag for pending/loading UI. */
+  pendingComponent?: string;
+  /** Component tag for error boundary UI. */
+  errorComponent?: string;
+  /** Invalidation tags from the build-time proto (already resolved with params). */
+  invalidates?: string[];
 }
 
 /** Static route manifest entry — built once at startup from <webui-route> tree. */
@@ -213,6 +219,24 @@ interface PartialResponse {
   chain?: RouteChainEntry[];
   /** CSS stylesheet URLs to inject into `<head>` for this route's components. */
   css?: string[];
+  /** Resolved cache tags for this route chain (union of all levels). */
+  cacheTags?: string[];
+  /** Server-provided cache control overrides. */
+  cacheControl?: { staleTime?: number };
+}
+
+/** A single entry in the navigation cache. */
+interface CacheEntry {
+  /** The full partial response data. */
+  data: PartialResponse & { inventory?: string };
+  /** Cache tags associated with this entry (from server response). */
+  tags: string[];
+  /** Timestamp when this entry was stored. */
+  ts: number;
+  /** Server-provided stale time override (ms), or undefined to use config default. */
+  staleTime?: number;
+  /** True if this entry came from a speculative preload fetch. */
+  preload?: boolean;
 }
 
 /**
@@ -320,12 +344,20 @@ export class WebUIRouter {
   private loaderHeaderCache = '';
   /** Cached current request path — updated on every navigation. Avoids URL allocation in hot paths. */
   private currentRequestPath = '/';
-  /** Cached preload result from a speculative hover fetch. */
-  private preloadCache: { path: string; data: PartialResponse & { inventory?: string }; ts: number } | null = null;
+  /** Tagged navigation cache — keyed by requestPath. */
+  private cache = new Map<string, CacheEntry>();
+  /** Reverse index: tag → set of cache keys. Enables O(1) tag invalidation. */
+  private tagIndex = new Map<string, Set<string>>();
+  /** Cache configuration (staleTime/gcTime/maxEntries). */
+  private cacheConfig: Required<CacheConfig> = { staleTime: 0, gcTime: 300_000, maxEntries: 50 };
   /** AbortController for the in-flight preload fetch. */
   private preloadController: AbortController | null = null;
   /** Monotonic preload generation — prevents stale hover fetches from overwriting the cache. */
   private preloadGeneration = 0;
+  /** Pending UI timer handle — cleared on commit or abort. */
+  private pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  /** AbortController for the in-flight mutation action. */
+  private actionController: AbortController | null = null;
 
   /** The component tag of the currently active leaf route. */
   get activeComponent(): string {
@@ -346,6 +378,14 @@ export class WebUIRouter {
     this.config = config;
     this.loaders = config.loaders ?? {};
     this.basePath = config.basePath ?? '';
+
+    if (config.cache) {
+      this.cacheConfig = {
+        staleTime: config.cache.staleTime ?? 0,
+        gcTime: config.cache.gcTime ?? 300_000,
+        maxEntries: config.cache.maxEntries ?? 50,
+      };
+    }
 
     if (!customElements.get(ROUTE_SELECTOR)) {
       customElements.define(ROUTE_SELECTOR, WebUIRouteElement);
@@ -385,6 +425,8 @@ export class WebUIRouter {
       this.setupPreloadListeners();
     }
 
+    this.setupFormInterception();
+
     this.handleNavigation(this.currentTarget());
   }
 
@@ -397,6 +439,38 @@ export class WebUIRouter {
   /** Navigate back. */
   back(): void {
     window.navigation.back();
+  }
+
+  /**
+   * Invalidate all cache entries whose tags overlap with the given tags.
+   * Use after mutations to ensure stale data is evicted.
+   */
+  invalidateTags(tags: string[]): void {
+    if (tags.length === 0) return;
+    const pathsToEvict = new Set<string>();
+    for (const tag of tags) {
+      const paths = this.tagIndex.get(tag);
+      if (paths) {
+        for (const path of paths) pathsToEvict.add(path);
+      }
+    }
+    for (const path of pathsToEvict) {
+      this.evictCacheEntry(path);
+    }
+  }
+
+  /**
+   * Invalidate cache entries by path, or all entries if no path is given.
+   * Escape hatch for cases where tag-based invalidation isn't sufficient.
+   */
+  invalidate(path?: string): void {
+    if (path) {
+      this.evictCacheEntry(path);
+    } else {
+      for (const key of [...this.cache.keys()]) {
+        this.evictCacheEntry(key);
+      }
+    }
   }
 
   /** In-flight ensureLoaded promises — deduplicates concurrent requests. */
@@ -574,15 +648,355 @@ export class WebUIRouter {
     this.loaderComponents.clear();
     this.loaderHeaderCache = '';
     this.currentRequestPath = '/';
-    this.preloadCache = null;
+    this.cache.clear();
+    this.tagIndex.clear();
     this.preloadController?.abort();
     this.preloadController = null;
+    this.actionController?.abort();
+    this.actionController = null;
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
   }
 
-  // ── Preload on hover ──────────────────────────────────────────
+  // ── Navigation Cache ──────────────────────────────────────────
 
   /** Maximum age (ms) for a preloaded partial before it's considered stale. */
   private static readonly PRELOAD_TTL = 5_000;
+
+  /** Look up a cache entry. Returns null if missing or stale. */
+  private lookupCache(requestPath: string): (PartialResponse & { inventory?: string }) | null {
+    const entry = this.cache.get(requestPath);
+    if (!entry) return null;
+
+    const age = Date.now() - entry.ts;
+    const staleTime = entry.staleTime ?? this.cacheConfig.staleTime;
+
+    // Preload entries get a minimum 5s freshness window; normal entries use staleTime as-is
+    const effectiveStaleTime = entry.preload ? Math.max(staleTime, WebUIRouter.PRELOAD_TTL) : staleTime;
+    if (age > effectiveStaleTime) {
+      return null; // Stale — let handleNavigation refetch
+    }
+
+    // LRU: delete + reinsert to move to end (most recently used)
+    this.cache.delete(requestPath);
+    this.cache.set(requestPath, entry);
+    return entry.data;
+  }
+
+  /** Store a partial response in the cache with its tags. */
+  private storeCacheEntry(
+    requestPath: string,
+    data: PartialResponse & { inventory?: string },
+    preload?: boolean,
+  ): void {
+    const tags = data.cacheTags ?? [];
+    const staleTime = data.cacheControl?.staleTime;
+
+    // Clean up old tag-index references before overwriting
+    this.evictCacheEntry(requestPath);
+
+    // Evict LRU entries if at capacity
+    while (this.cache.size >= this.cacheConfig.maxEntries) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) {
+        this.evictCacheEntry(oldest);
+      } else {
+        break;
+      }
+    }
+
+    this.cache.set(requestPath, { data, tags, ts: Date.now(), staleTime, preload });
+
+    // Build reverse tag index
+    for (const tag of tags) {
+      let paths = this.tagIndex.get(tag);
+      if (!paths) {
+        paths = new Set();
+        this.tagIndex.set(tag, paths);
+      }
+      paths.add(requestPath);
+    }
+  }
+
+  /** Evict a single cache entry and clean up its tag index references. */
+  private evictCacheEntry(requestPath: string): void {
+    const entry = this.cache.get(requestPath);
+    if (!entry) return;
+    this.cache.delete(requestPath);
+    for (const tag of entry.tags) {
+      const paths = this.tagIndex.get(tag);
+      if (paths) {
+        paths.delete(requestPath);
+        if (paths.size === 0) this.tagIndex.delete(tag);
+      }
+    }
+  }
+
+  /** Run GC: evict entries older than gcTime. */
+  private gcCache(): void {
+    const now = Date.now();
+    const gcTime = this.cacheConfig.gcTime;
+    for (const [path, entry] of this.cache) {
+      if (now - entry.ts > gcTime) {
+        this.evictCacheEntry(path);
+      }
+    }
+  }
+
+  // ── Form Interception (Mutation Actions) ──────────────────────
+
+  /**
+   * Set up delegated form submission interception.
+   * Intercepts `<form method="post">` submissions, finds the nearest
+   * route component's `static action()`, and auto-invalidates cache.
+   */
+  private setupFormInterception(): void {
+    const onSubmit = (e: SubmitEvent): void => {
+      // Walk composedPath to find the form — works across shadow boundaries
+      const path = e.composedPath();
+      let form: HTMLFormElement | undefined;
+      for (let i = 0; i < path.length; i++) {
+        const el = path[i] as Element;
+        if (el?.tagName === 'FORM' && (el as HTMLFormElement).method?.toLowerCase() === 'post') {
+          form = el as HTMLFormElement;
+          break;
+        }
+      }
+      if (!form) return;
+
+      // Find the nearest ancestor <webui-route> with a component
+      let routeEl: HTMLElement | null = null;
+      for (let i = 0; i < path.length; i++) {
+        const el = path[i] as Element;
+        if (el?.tagName === 'WEBUI-ROUTE' && el.getAttribute('component')) {
+          routeEl = el as HTMLElement;
+          break;
+        }
+      }
+      if (!routeEl) return;
+
+      const componentTag = routeEl.getAttribute('component');
+      if (!componentTag) return;
+
+      // Check if the component has a static action() method
+      const ctor = customElements.get(componentTag) as (
+        (new () => HTMLElement) & { action?: (ctx: RouteActionContext) => Promise<RouteActionResult | void> }
+      ) | undefined;
+      if (!ctor || typeof ctor.action !== 'function') return;
+
+      // Prevent default form submission
+      e.preventDefault();
+
+      const formData = new FormData(form);
+      const params = getRouteParams(routeEl);
+      const controller = new AbortController();
+      this.actionController = controller;
+
+      // Get resolved invalidation tags from the active chain entry
+      // (not from DOM attr which has unresolved {param} templates)
+      const chainEntry = this.activeChain.find(e => e.component === componentTag);
+      const routeInvalidates = chainEntry?.invalidates ?? [];
+
+      ctor.action({ formData, params, signal: controller.signal })
+        .then((result: RouteActionResult | void) => {
+          if (controller.signal.aborted) return;
+
+          // Apply optimistic state if provided
+          if (result?.state) {
+            const compEl = routeEl!.querySelector(componentTag!) as any;
+            if (compEl && typeof compEl.setState === 'function') {
+              compEl.setState(result.state);
+            }
+          }
+
+          // Merge action-returned tags with route's build-time invalidates
+          const allTags = new Set<string>();
+          for (const tag of routeInvalidates) allTags.add(tag);
+          if (result?.invalidateTags) {
+            for (const tag of result.invalidateTags) allTags.add(tag);
+          }
+          const mergedTags = [...allTags];
+
+          // Invalidate cache
+          if (mergedTags.length > 0) {
+            this.invalidateTags(mergedTags);
+          }
+
+          // Dispatch completion event
+          const detail: ActionCompleteEvent = {
+            component: componentTag!,
+            invalidatedTags: mergedTags,
+            path: this.currentRequestPath,
+          };
+          window.dispatchEvent(new CustomEvent('webui:route:action-complete', { detail }));
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          console.error(`[Router] Action failed for <${componentTag}>:`, err);
+        });
+    };
+
+    document.addEventListener('submit', onSubmit);
+    this.cleanupFns.push(() => document.removeEventListener('submit', onSubmit));
+  }
+
+  // ── Pending UI ────────────────────────────────────────────────
+
+  /** Clear the pending UI timer. */
+  private clearPendingTimer(): void {
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+  }
+
+  /**
+   * Find the pending component for a target route.
+   * Walks SSR'd `<webui-route>` stubs looking for ones whose path
+   * could match the target, preferring the deepest match.
+   */
+  private findPendingComponent(requestPath: string): string | null {
+    // Check active chain (parent routes that already have metadata from partial)
+    for (let i = this.activeChain.length - 1; i >= 0; i--) {
+      if (this.activeChain[i].pendingComponent) {
+        return this.activeChain[i].pendingComponent!;
+      }
+    }
+    // Walk SSR'd route stubs scoped to the deepest active leaf's children
+    const leaf = this.activeChain[this.activeChain.length - 1];
+    if (leaf?.el) {
+      const compEl = leaf.el.querySelector(leaf.component);
+      if (compEl) {
+        const root = (compEl as HTMLElement).shadowRoot ?? compEl;
+        for (const el of root.querySelectorAll(ROUTE_SELECTOR)) {
+          const pending = el.getAttribute('pending');
+          if (pending) return pending;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find the error component for a target route.
+   * Same scoping strategy as findPendingComponent.
+   */
+  private findErrorComponent(requestPath: string): string | null {
+    for (let i = this.activeChain.length - 1; i >= 0; i--) {
+      if (this.activeChain[i].errorComponent) {
+        return this.activeChain[i].errorComponent!;
+      }
+    }
+    const leaf = this.activeChain[this.activeChain.length - 1];
+    if (leaf?.el) {
+      const compEl = leaf.el.querySelector(leaf.component);
+      if (compEl) {
+        const root = (compEl as HTMLElement).shadowRoot ?? compEl;
+        for (const el of root.querySelectorAll(ROUTE_SELECTOR)) {
+          const error = el.getAttribute('error');
+          if (error) return error;
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Remove any pending/error elements left over from a previous navigation. */
+  private clearPendingElements(): void {
+    for (const el of document.querySelectorAll('[data-webui-pending]')) {
+      el.remove();
+    }
+    for (const el of document.querySelectorAll('[data-webui-error]')) {
+      el.remove();
+    }
+  }
+
+  /**
+   * Find the target route's `<webui-route>` element in the DOM.
+   * Searches hidden stubs for a route matching the component tag.
+   */
+  private findTargetRouteElement(componentTag: string): HTMLElement | null {
+    // Search SSR'd route stubs for the target component
+    for (const el of document.querySelectorAll(ROUTE_SELECTOR)) {
+      if (el.getAttribute('component') === componentTag) {
+        return el as HTMLElement;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Mount a pending/loading component in the outlet area.
+   * Finds the target route's parent (deepest active leaf) and appends
+   * the pending component in its outlet container.
+   */
+  private mountPendingComponent(componentTag: string): void {
+    // Find the deepest active route's component, then look for the
+    // outlet area to mount the pending component.
+    const leaf = this.activeChain[this.activeChain.length - 1];
+    if (!leaf?.el) return;
+
+    // Don't show pending for keep-alive routes (they activate instantly)
+    if (leaf.keepAlive) return;
+
+    const existing = leaf.el.querySelector(componentTag);
+    if (existing) return; // Already showing
+
+    // Mount inside the leaf's component's outlet area (where child routes go)
+    const compEl = leaf.el.querySelector(leaf.component);
+    if (!compEl) return;
+
+    const root = (compEl as HTMLElement).shadowRoot ?? compEl;
+
+    // Find existing sibling route elements or an outlet marker
+    const siblingRoutes = root.querySelectorAll(ROUTE_SELECTOR);
+    const container = siblingRoutes.length > 0
+      ? siblingRoutes[siblingRoutes.length - 1].parentElement
+      : (root.querySelector('outlet')?.parentElement ?? root);
+    if (!container) return;
+
+    const pending = document.createElement(componentTag);
+    pending.setAttribute('data-webui-pending', '');
+    container.appendChild(pending);
+  }
+
+  /**
+   * Mount an error boundary component in the outlet area.
+   * Passes error details as state.
+   */
+  private mountErrorComponent(
+    componentTag: string,
+    errorState: { error: string; status: number; path: string },
+  ): void {
+    const leaf = this.activeChain[this.activeChain.length - 1];
+    if (!leaf?.el) return;
+
+    const compEl = leaf.el.querySelector(leaf.component);
+    if (!compEl) return;
+
+    const root = (compEl as HTMLElement).shadowRoot ?? compEl;
+
+    // Find existing sibling route elements or an outlet marker
+    const siblingRoutes = root.querySelectorAll(ROUTE_SELECTOR);
+    const container = siblingRoutes.length > 0
+      ? siblingRoutes[siblingRoutes.length - 1].parentElement
+      : (root.querySelector('outlet')?.parentElement ?? root);
+    if (!container) return;
+
+    // Hide all existing route children
+    for (const child of container.querySelectorAll(ROUTE_SELECTOR)) {
+      (child as HTMLElement).style.display = 'none';
+    }
+
+    const errorEl = document.createElement(componentTag);
+    errorEl.setAttribute('data-webui-error', '');
+    container.appendChild(errorEl);
+    if (typeof (errorEl as any).setState === 'function') {
+      (errorEl as any).setState(errorState);
+    }
+  }
 
   /**
    * Register a delegated `pointerover` listener that speculatively fetches
@@ -594,7 +1008,7 @@ export class WebUIRouter {
    * at the document level. `pointermove` fires on every position change,
    * giving us reliable detection across all shadow DOM boundaries.
    *
-   * The handler is naturally debounced: the `preloadCache` path check
+   * The handler is naturally debounced: the cache lookup
    * ensures we only fetch once per unique link, and the early returns
    * for non-anchor targets keep the hot path fast (one `composedPath()`
    * walk that exits immediately when no `<a>` is found).
@@ -628,7 +1042,7 @@ export class WebUIRouter {
 
       // Skip if already on this path or already cached for it
       if (requestPath === this.currentRequestPath) return;
-      if (this.preloadCache?.path === requestPath) return;
+      if (this.cache.has(requestPath)) return;
 
       // Abort any in-flight speculative fetch and start a new one
       this.preloadController?.abort();
@@ -640,7 +1054,7 @@ export class WebUIRouter {
         .then(data => {
           // Only cache if this is still the latest preload request
           if (data && gen === this.preloadGeneration && !controller.signal.aborted) {
-            this.preloadCache = { path: requestPath, data, ts: Date.now() };
+            this.storeCacheEntry(requestPath, data, true);
           }
         })
         .catch(() => {}); // Speculative — silently discard errors
@@ -699,23 +1113,56 @@ export class WebUIRouter {
       }
     } else {
       this.clearSsrPreloads();
+      this.actionController?.abort();
+      this.actionController = null;
+      this.clearPendingElements();
+      this.gcCache();
       const thisGen = ++this.navGeneration;
 
-      // Use preloaded data if we have a fresh cache hit for this path
+      // Check unified cache for a fresh hit
       let partialData: (PartialResponse & { inventory?: string }) | null = null;
-      const cached = this.preloadCache;
-      if (cached && cached.path === requestPath &&
-          Date.now() - cached.ts < WebUIRouter.PRELOAD_TTL) {
-        partialData = cached.data;
-        this.preloadCache = null;
+      const cached = this.lookupCache(requestPath);
+      if (cached) {
+        partialData = cached;
       } else {
         // Cancel any in-flight speculative fetch — we're doing a real navigation
         this.preloadController?.abort();
-        this.preloadCache = null;
+
+        // Pending UI: start a timer. If the fetch takes longer than 150ms,
+        // mount the pending component (if the target route declares one).
+        const pendingTag = this.findPendingComponent(requestPath);
+        if (pendingTag) {
+          this.pendingTimer = setTimeout(() => {
+            this.mountPendingComponent(pendingTag);
+          }, 150);
+        }
+
         partialData = await this.fetchPartial(requestPath, signal);
+        this.clearPendingTimer();
+
+        // Error boundary: if fetch returned null (HTTP error), mount error component
+        if (!partialData && !signal?.aborted && thisGen === this.navGeneration) {
+          const errorTag = this.findErrorComponent(requestPath);
+          if (errorTag) {
+            this.mountErrorComponent(errorTag, {
+              error: 'Navigation failed',
+              status: 0,
+              path: requestPath,
+            });
+            return;
+          }
+          console.warn('[Router] Navigation fetch failed for:', requestPath);
+          return;
+        }
       }
 
       if (!partialData || signal?.aborted || thisGen !== this.navGeneration) return;
+
+      // Store in cache with tags
+      if (!cached) {
+        this.storeCacheEntry(requestPath, partialData);
+      }
+
       await this.commitWithData(partialData, requestPath, query, signal, thisGen);
     }
 
@@ -858,6 +1305,9 @@ export class WebUIRouter {
         el: activeEl,
         allowedQuery: activeEl.getAttribute('query') ?? undefined,
         keepAlive: activeEl.hasAttribute('keep-alive'),
+        pendingComponent: activeEl.getAttribute('pending') ?? undefined,
+        errorComponent: activeEl.getAttribute('error') ?? undefined,
+        invalidates: activeEl.getAttribute('invalidates')?.split(',').map(s => s.trim()).filter(Boolean) ?? undefined,
       });
       activateRoute(activeEl, params);
 
@@ -1234,6 +1684,9 @@ export class WebUIRouter {
       exact: e.exact,
       allowedQuery: e.allowedQuery,
       keepAlive: e.keepAlive,
+      pendingComponent: e.pendingComponent,
+      errorComponent: e.errorComponent,
+      invalidates: e.invalidates,
     }));
 
     if (newChain.length === 0) {

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -358,6 +358,10 @@ export class WebUIRouter {
   private pendingTimer: ReturnType<typeof setTimeout> | null = null;
   /** AbortController for the in-flight mutation action. */
   private actionController: AbortController | null = null;
+  /** Direct reference to mounted pending element for O(1) cleanup. */
+  private pendingElement: HTMLElement | null = null;
+  /** Direct reference to mounted error element for O(1) cleanup. */
+  private errorElement: HTMLElement | null = null;
 
   /** The component tag of the currently active leaf route. */
   get activeComponent(): string {
@@ -658,6 +662,8 @@ export class WebUIRouter {
       clearTimeout(this.pendingTimer);
       this.pendingTimer = null;
     }
+    this.pendingElement = null;
+    this.errorElement = null;
   }
 
   // ── Navigation Cache ──────────────────────────────────────────
@@ -765,6 +771,20 @@ export class WebUIRouter {
         }
       }
       if (!form) return;
+
+      // Only intercept forms without an explicit action or targeting same-origin.
+      // Forms with external action URLs (payment, auth, etc.) must not be hijacked.
+      const formAction = form.action; // resolved absolute URL
+      if (formAction) {
+        try {
+          const actionUrl = new URL(formAction);
+          if (actionUrl.origin !== location.origin) return;
+        } catch {
+          return; // malformed action — don't intercept
+        }
+      }
+      // Forms with a target attribute submit to a different browsing context
+      if (form.target && form.target !== '_self') return;
 
       // Find the nearest ancestor <webui-route> with a component
       let routeEl: HTMLElement | null = null;
@@ -905,11 +925,13 @@ export class WebUIRouter {
 
   /** Remove any pending/error elements left over from a previous navigation. */
   private clearPendingElements(): void {
-    for (const el of document.querySelectorAll('[data-webui-pending]')) {
-      el.remove();
+    if (this.pendingElement) {
+      this.pendingElement.remove();
+      this.pendingElement = null;
     }
-    for (const el of document.querySelectorAll('[data-webui-error]')) {
-      el.remove();
+    if (this.errorElement) {
+      this.errorElement.remove();
+      this.errorElement = null;
     }
   }
 
@@ -960,6 +982,7 @@ export class WebUIRouter {
     const pending = document.createElement(componentTag);
     pending.setAttribute('data-webui-pending', '');
     container.appendChild(pending);
+    this.pendingElement = pending;
   }
 
   /**
@@ -993,6 +1016,7 @@ export class WebUIRouter {
     const errorEl = document.createElement(componentTag);
     errorEl.setAttribute('data-webui-error', '');
     container.appendChild(errorEl);
+    this.errorElement = errorEl;
     if (typeof (errorEl as any).setState === 'function') {
       (errorEl as any).setState(errorState);
     }
@@ -1157,6 +1181,16 @@ export class WebUIRouter {
       }
 
       if (!partialData || signal?.aborted || thisGen !== this.navGeneration) return;
+
+      // Verify response pathname matches request to prevent cache poisoning.
+      // Compare only the pathname (before '?') since the server path omits query strings.
+      if (partialData.path) {
+        const requestPathname = requestPath.split('?')[0];
+        if (partialData.path !== requestPathname && partialData.path !== requestPath) {
+          console.warn(`[Router] Response path mismatch: expected ${requestPathname}, got ${partialData.path}`);
+          return;
+        }
+      }
 
       // Store in cache with tags
       if (!cached) {

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -65,7 +65,6 @@ export interface RouterConfig {
    * is used instantly — eliminating the navigation fetch latency.
    *
    * Only mouse pointers trigger preload (touch taps fire too late to benefit).
-   * The cache holds a single entry with a 5-second TTL.
    *
    * @default false
    * @example
@@ -74,6 +73,21 @@ export interface RouterConfig {
    * ```
    */
   preload?: boolean;
+
+  /**
+   * Navigation cache configuration. When enabled, partial responses are
+   * cached by path and tagged with server-provided cache tags for
+   * tag-based invalidation.
+   *
+   * @default undefined (caching disabled — staleTime defaults to 0)
+   * @example
+   * ```ts
+   * Router.start({
+   *   cache: { staleTime: 30_000, gcTime: 300_000, maxEntries: 50 },
+   * });
+   * ```
+   */
+  cache?: CacheConfig;
 }
 
 /**
@@ -100,5 +114,69 @@ export interface NavigationEvent {
   /** Parsed query-string parameters (e.g. `?action=reply&to=x` → `{ action: 'reply', to: 'x' }`). */
   query: Record<string, string>;
   /** The navigated path, including the query string when present. */
+  path: string;
+}
+
+/** Configuration for the router's navigation cache. */
+export interface CacheConfig {
+  /**
+   * Maximum age (ms) before a cached response is considered stale and refetched.
+   * @default 0 (always fresh — caching disabled)
+   */
+  staleTime?: number;
+  /**
+   * Maximum age (ms) before a cached entry is evicted from memory.
+   * @default 300000 (5 minutes)
+   */
+  gcTime?: number;
+  /**
+   * Maximum number of entries in the cache. Evicts LRU when exceeded.
+   * @default 50
+   */
+  maxEntries?: number;
+}
+
+/**
+ * Context passed to a component's static `action()` method.
+ *
+ * Route actions handle form submissions (the write counterpart to loaders).
+ * The router intercepts `<form method="post">` submissions and calls the
+ * nearest route component's `static action()`.
+ */
+export interface RouteActionContext {
+  /** The submitted form data. */
+  formData: FormData;
+  /** Bound route parameters (e.g. `{ id: '42' }` for `/contacts/:id`). */
+  params: Record<string, string>;
+  /** Abort signal — cancelled if the user navigates away during the action. */
+  signal: AbortSignal;
+}
+
+/**
+ * Result returned from a component's static `action()` method.
+ *
+ * The router uses this to determine what to invalidate and optionally
+ * apply optimistic state updates.
+ */
+export interface RouteActionResult {
+  /**
+   * Tags to invalidate after the action completes.
+   * Merged with the route's `invalidates` attribute (declared at build time).
+   */
+  invalidateTags?: string[];
+  /**
+   * Optimistic state to apply immediately (before server confirmation).
+   * Passed to the component's `setState()`.
+   */
+  state?: Record<string, unknown>;
+}
+
+/** Detail payload of the `webui:route:action-complete` CustomEvent. */
+export interface ActionCompleteEvent {
+  /** The component tag that handled the action. */
+  component: string;
+  /** Tags that were invalidated. */
+  invalidatedTags: string[];
+  /** The route path where the action occurred. */
   path: string;
 }

--- a/packages/webui-router/tests/fixtures/router-app/src/error-display/error-display.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/error-display/error-display.html
@@ -2,5 +2,5 @@
   <h2>Something went wrong</h2>
   <p class="error-message">{{errorMessage}}</p>
   <p class="error-path">Path: {{errorPath}}</p>
-  <button class="retry" onclick="{{onRetry}}">Retry</button>
+  <button class="retry" @click="{onRetry()}">Retry</button>
 </div>

--- a/packages/webui-router/tests/fixtures/router-app/src/error-display/error-display.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/error-display/error-display.html
@@ -1,0 +1,6 @@
+<div class="error-boundary" data-testid="error-display">
+  <h2>Something went wrong</h2>
+  <p class="error-message">{{errorMessage}}</p>
+  <p class="error-path">Path: {{errorPath}}</p>
+  <button class="retry" onclick="{{onRetry}}">Retry</button>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/index.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.html
@@ -19,6 +19,8 @@
     <route path="dialog" component="test-dialog" exact />
     <route path="keepalive" component="page-keepalive" exact keep-alive />
     <route path="loader" component="page-loader" exact />
+    <route path="slow" component="page-slow" exact pending="loading-skeleton" />
+    <route path="failing" component="page-failing" exact error="error-display" />
   </route>
 
   <script type="module" src="/index.js"></script>

--- a/packages/webui-router/tests/fixtures/router-app/src/index.ts
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.ts
@@ -64,6 +64,33 @@ export class PageLoader extends WebUIElement {
 }
 PageLoader.define('page-loader');
 
+// ── Pending UI test: skeleton component ──────────────────────────
+
+export class LoadingSkeleton extends WebUIElement {}
+LoadingSkeleton.define('loading-skeleton');
+
+// ── Pending UI test: slow-loading page component ─────────────────
+
+export class PageSlow extends WebUIElement {}
+PageSlow.define('page-slow');
+
+// ── Error boundary test: error display component ─────────────────
+
+export class ErrorDisplay extends WebUIElement {
+  @observable errorMessage = '';
+  @observable errorPath = '';
+
+  onRetry = (): void => {
+    (window as any).navigation.navigate('/');
+  };
+}
+ErrorDisplay.define('error-display');
+
+// ── Error boundary test: failing page component ──────────────────
+
+export class PageFailing extends WebUIElement {}
+PageFailing.define('page-failing');
+
 // ── Start router after hydration ─────────────────────────────────
 
 window.addEventListener('webui:hydration-complete', () => {
@@ -75,6 +102,10 @@ window.addEventListener('webui:hydration-complete', () => {
       'page-compose': () => Promise.resolve(),
       'page-keepalive': () => Promise.resolve(),
       'page-loader': () => Promise.resolve(),
+      'page-slow': () => Promise.resolve(),
+      'page-failing': () => Promise.resolve(),
+      'loading-skeleton': () => Promise.resolve(),
+      'error-display': () => Promise.resolve(),
     },
   });
 });
@@ -89,6 +120,10 @@ if (performance.getEntriesByName('webui:hydrate:total', 'measure').length > 0) {
       'page-compose': () => Promise.resolve(),
       'page-keepalive': () => Promise.resolve(),
       'page-loader': () => Promise.resolve(),
+      'page-slow': () => Promise.resolve(),
+      'page-failing': () => Promise.resolve(),
+      'loading-skeleton': () => Promise.resolve(),
+      'error-display': () => Promise.resolve(),
     },
   });
 }

--- a/packages/webui-router/tests/fixtures/router-app/src/loading-skeleton/loading-skeleton.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/loading-skeleton/loading-skeleton.html
@@ -1,0 +1,3 @@
+<div class="skeleton" data-testid="loading-skeleton">
+  <p class="skeleton-text">Loading…</p>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/page-failing/page-failing.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/page-failing/page-failing.html
@@ -1,0 +1,4 @@
+<div class="page page-failing" data-testid="page-failing">
+  <h2>Failing Page</h2>
+  <p class="content">This page should never be seen.</p>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/page-slow/page-slow.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/page-slow/page-slow.html
@@ -1,0 +1,4 @@
+<div class="page page-slow" data-testid="page-slow">
+  <h2>Slow Page</h2>
+  <p class="content">This page loaded successfully.</p>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
@@ -9,6 +9,8 @@
     <a href="/compose?action=reply&to=test@example.com&subject=Re: Hello">Compose</a>
     <a href="/keepalive">Keep-Alive</a>
     <a href="/loader">Loader</a>
+    <a href="/slow">Slow</a>
+    <a href="/failing">Failing</a>
   </nav>
 </header>
 <main>

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -20,7 +20,7 @@ test.describe('SSR deep links', () => {
   test('root page renders shell with nav links', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Router Test');
-    await expect(page.locator('nav a')).toHaveCount(8);
+    await expect(page.locator('nav a')).toHaveCount(10);
   });
 
   test('alpha page renders via SSR', async ({ page }) => {
@@ -447,5 +447,122 @@ test.describe('route loaders', () => {
     const hasLoaderHeader = request.headers()['x-webui-has-loader'];
     expect(hasLoaderHeader).toBeDefined();
     expect(hasLoaderHeader).toContain('page-loader');
+  });
+});
+
+test.describe('pending UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+  });
+
+  test('shows pending skeleton during slow navigation then replaces with real content', async ({ page }) => {
+    // Intercept the partial JSON fetch for /slow and delay it by 500ms
+    await page.route('**/slow', async (route) => {
+      const request = route.request();
+      if (request.headers()['accept']?.includes('application/json')) {
+        // Delay the response to trigger pending UI (threshold is 150ms)
+        await new Promise(r => setTimeout(r, 500));
+        await route.continue();
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Navigate to the slow page
+    await page.click('a[href="/slow"]');
+
+    // The loading skeleton element should appear after ~150ms
+    await expect(page.locator('loading-skeleton')).toBeVisible({ timeout: 3000 });
+
+    // After the fetch completes (~500ms), real content should replace the skeleton
+    await expect(page.locator('[data-testid="page-slow"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('h2')).toContainText('Slow Page');
+  });
+
+  test('skips pending for fast navigations', async ({ page }) => {
+    // No fetch delay — navigation should be fast enough to skip pending
+    let skeletonSeen = false;
+
+    // Monitor for the skeleton element
+    page.on('console', (msg) => {
+      if (msg.text().includes('skeleton-mounted')) skeletonSeen = true;
+    });
+
+    await page.evaluate(() => {
+      const observer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          for (const node of m.addedNodes) {
+            if ((node as Element)?.tagName === 'LOADING-SKELETON') {
+              console.log('skeleton-mounted');
+            }
+          }
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+
+    await page.click('a[href="/slow"]');
+    await expect(page.locator('[data-testid="page-slow"]')).toBeVisible({ timeout: 5000 });
+
+    // The skeleton should NOT have appeared for a fast navigation
+    expect(skeletonSeen).toBe(false);
+  });
+});
+
+test.describe('error boundaries', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('route-shell');
+      return el && (el as any).$ready === true;
+    }, null);
+    await page.waitForFunction(
+      () => !!(window as any).navigation,
+      null,
+      { timeout: 5000 },
+    );
+    await page.waitForTimeout(300);
+  });
+
+  test('shows error component when navigation fetch fails', async ({ page }) => {
+    // Intercept the partial JSON fetch for /failing and return a 500 error
+    await page.route('**/failing', async (route) => {
+      const request = route.request();
+      if (request.headers()['accept']?.includes('application/json')) {
+        await route.fulfill({
+          status: 500,
+          contentType: 'text/plain',
+          body: 'Internal Server Error',
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Navigate to the failing page
+    await page.click('a[href="/failing"]');
+
+    // The error display element should be mounted
+    await expect(page.locator('error-display')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('error component does not appear for successful navigations', async ({ page }) => {
+    // Normal navigation to alpha — no error should appear
+    await page.click('a[href="/alpha"]');
+    await expect(page.locator('h2')).toContainText('Alpha Page');
+
+    // Error display should not be in the DOM
+    const errorCount = await page.locator('[data-testid="error-display"]').count();
+    expect(errorCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Description

**Why:** Without a tagged cache, every SPA navigation hits the server — even revisiting a page the user just left. Without mutation actions, form submissions require full-page reloads. Without pending UI, slow navigations show a blank screen. Without error boundaries, a failed fetch leaves the user staring at stale content. These four capabilities are declared as HTML attributes, validated by the Rust compiler, baked into the binary protocol, and available to both server and client — zero runtime JavaScript for cache policy.

**What:** Extend the full build-time pipeline (proto -> parser -> handler -> router) with `cache-tags`, `invalidates`, `pending`, and `error` on `<route>` elements.

**How:**

*Proto:* Four new fields on `WebUIFragmentRoute` — `cache_tags` (tag templates with `{param}` placeholders), `invalidates`, `pending_component`, `error_component`.

*Parser:* Read attributes from `<route>` HTML. Validate `{param}` placeholders reference actual route params. Validate pending/error components exist at build time (build error if not).

*Handler:* `RouteChainEntry` carries new fields. `render_partial()` resolves tags with accumulated chain params. `render_action_response()` returns resolved invalidation tags for POST. SSR emits all new attrs on `<webui-route>`. Extracted `write_route_cache_attrs()` helper eliminating 3x duplication. Fix UTF-8 corruption in tag resolution (`bytes[i] as char` -> `char_indices()`).

*Router:* Tagged cache (`Map` + reverse tag index, LRU, configurable staleTime/gcTime/maxEntries). Preload unified into same cache. `Router.invalidateTags()` / `Router.invalidate()` public API. Form interception -> `static action()` -> auto-invalidate (merges action tags + build-time invalidates, reads resolved tags from chain not DOM). Pending UI (150ms threshold, skip keep-alive/cached). Error boundaries (mount with `{error, status, path}` state). GC wired up. Pending/error cleanup on each navigation. Action abort on nav.

## Test Plan

- `cargo test --workspace` — 909 Rust tests pass (22 new: tag parsing, validation, resolution, action response)
- `pnpm test` unit — 57 TS unit tests pass
- Playwright E2E — 4 new tests (pending skeleton slow/fast, error boundary 500/success)
- `cargo clippy` clean on all changed crates

## Checklist

- [x] Proto schema: 4 new fields (7-10)
- [x] Parser: attr reading, `{param}` validation, component existence check
- [x] Handler: tag resolution, `render_action_response()`, SSR emission, `write_route_cache_attrs()` helper
- [x] Handler: UTF-8 fix (`char_indices()` instead of `bytes[i] as char`)
- [x] Router: tagged cache with reverse tag index and LRU
- [x] Router: form interception with `composedPath()` for shadow DOM
- [x] Router: auto-invalidation merges action tags + build-time invalidates (resolved)
- [x] Router: pending UI (150ms threshold, skip keep-alive/cached)
- [x] Router: error boundaries with `{error, status, path}` state
- [x] Router: `gcCache()` wired to navigation, pending/error cleanup
- [x] Router: action controller aborted on nav, preload TTL scoped
- [x] DESIGN.md updated
- [x] E2E test fixtures and Playwright tests
- [x] No new `unwrap`/`expect` in library code
- [x] No `for..in` loops

> **Stack: 2/2** — depends on #257