### PR TITLE
feat(router): streaming partial navigation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -283,19 +283,21 @@ without a server round-trip.
 
 **Client-side navigation:**
 1. On initial load, the router builds the active chain from SSR'd `<webui-route active>` elements.
-2. On navigation, fetches a JSON partial (`Accept: application/json`) from the server.
+2. On navigation, fetches a partial response (`Accept: application/x-ndjson, application/json`) from the server.
 3. The server returns the matched route chain — the client does NOT perform route matching.
 4. Reconciles old vs new chain — finds first changed level.
 5. Mounts components at changed levels, creates `<webui-route>` stubs at outlet positions.
 6. Parent components and their state are preserved.
 
-**Partial response:** The server returns `{ state, templateStyles, templates, inventory, path, chain, cacheTags }`:
-- `state`: route params from all nesting levels injected into API state
+**Partial response:** `render_partial()` returns `{ templateStyles, templates, inventory, path, chain, cacheTags }`. The caller adds application state to the response (e.g. as a top-level `state` field for non-streaming, or as an NDJSON Chunk 2 for streaming):
+- `state`: (added by caller) route-scoped application data — the router applies it to components via `setState()`
 - `templateStyles`: module CSS definition tags (`<style type="module" specifier="...">`) for newly shipped components. Empty array for Link/Style modes. The client appends these to `<head>` before evaluating template scripts so adopted stylesheets are available
 - `templates`: client template script/markup payloads the client doesn't already have (filtered by inventory bitmask). Clean JS IIFEs for the WebUI plugin, `<f-template>` markup for the FAST plugin
 - `inventory`: updated hex bitmask of loaded templates
 - `chain`: matched route chain array — each entry has `component`, `path`, optional `params`, `exact`, `pendingComponent`, `errorComponent`, and `invalidates`
 - `cacheTags`: resolved cache tags from the full route chain (union of all levels, deduplicated). The client tags its cache entry with these values for tag-based invalidation
+
+**NDJSON streaming:** For servers that support it, the partial can be split into two NDJSON lines. Chunk 1 (chain + templates) flushes immediately for instant navigation commit. Chunk 2 (per-component states) arrives when the backend data is ready. The router reads Chunk 1, commits navigation, then applies Chunk 2 states in the background.
 
 **Cache control:** The server can include `cacheControl: { staleTime: number }` in the partial response to override the client's default stale time for this specific route.
 
@@ -311,20 +313,12 @@ without a server round-trip.
 
 | Header | Value | Purpose |
 |--------|-------|---------|
-| `Accept` | `application/json` | Requests JSON partial instead of full HTML |
+| `Accept` | `application/x-ndjson, application/json` | Requests NDJSON streaming or JSON partial instead of full HTML |
 | `X-WebUI-Inventory` | Hex bitmask | Templates already loaded — server skips re-sending them |
-| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a static `loader()` — host server may check if the target leaf is in this list and skip state computation |
-
-**Request headers sent by the client router:**
-
-| Header | Value | Purpose |
-|--------|-------|---------|
-| `Accept` | `application/json` | Requests JSON partial instead of full HTML |
-| `X-WebUI-Inventory` | Hex bitmask | Templates already loaded — server skips re-sending them |
-| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a static `loader()` — host server may check if the target leaf is in this list and skip state computation |
 
 The `chain` field is produced by `render_partial()` in the handler, which walks the
-fragment graph and matches routes at each nesting level. Host servers call this once per partial
+fragment graph and matches routes at each nesting level. The function returns chain + templates
+without state — the caller adds state to the response. Host servers call this once per partial
 response. Available via FFI as `webui_render_partial()` for C/.NET/Node hosts.
 
 **Partial-template selection:** During client navigation, servers derive template names from the
@@ -1220,7 +1214,7 @@ header is at `crates/webui-ffi/include/webui_ffi.h`.
 | `webui_handler_create()` | Create a reusable handler (no plugin). |
 | `webui_handler_create_with_plugin(plugin_id)` | Create a handler with a named plugin (e.g. `"fast"`). Returns `NULL` on error. |
 | `webui_handler_render(handler, data, len, json, entry_id, request_path)` | Render a pre-compiled protocol with route matching. `request_path` controls which route is active. Returns heap-allocated string. |
-| `webui_render_partial(protocol_data, len, state_json, entry_id, request_path, inventory_hex)` | Produce a complete JSON partial response (state, templateStyles, templates, inventory, path, and matched route chain) in a single call. Returns heap-allocated JSON string. |
+| `webui_render_partial(protocol_data, len, entry_id, request_path, inventory_hex)` | Produce a JSON partial response (templateStyles, templates, inventory, path, and matched route chain) in a single call. Caller adds state. Returns heap-allocated JSON string. |
 | `webui_handler_destroy(handler)` | Destroy a handler. `NULL` is a safe no-op. |
 | `webui_free(ptr)` | Free a string returned by any render function. `NULL` is a safe no-op. |
 | `webui_last_error()` | Return per-thread error message. Caller must **not** free. |

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -908,15 +908,18 @@ async fn handle_json_partial(
         .unwrap_or_default()
         .to_string();
 
-    // Build the complete partial response (state, templateStyles, templates, inventory, path, chain)
+    // Build the complete partial response (templateStyles, templates, inventory, path, chain)
     let partial = if let Some(proto) = &protocol {
-        webui_handler::route_handler::render_partial(
+        let mut p = webui_handler::route_handler::render_partial(
             proto,
-            state_data,
             &entry,
             &paths.route_path,
             &client_inv_hex,
-        )
+        );
+        if let Some(obj) = p.as_object_mut() {
+            obj.insert("state".into(), state_data);
+        }
+        p
     } else {
         Value::Object(serde_json::Map::new())
     };

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -513,13 +513,15 @@ pub unsafe extern "C" fn webui_render_partial(
             }
         };
 
-        let result = webui_handler::route_handler::render_partial(
+        let mut result = webui_handler::route_handler::render_partial(
             &protocol,
-            state,
             entry_str,
             request_path_str,
             inv_str,
         );
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("state".into(), state);
+        }
 
         match CString::new(result.to_string()) {
             Ok(s) => s.into_raw(),

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -366,10 +366,10 @@ fn render_partial_returns_templates_inventory_and_chain() {
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("ffi response should be valid json");
 
-        // Should have state, templates, inventory, path, and chain fields
+        // State is at top level (caller adds it), not per-entry in chain
         assert!(
             value.get("state").is_some(),
-            "partial response should contain 'state' field"
+            "partial response should contain top-level 'state' field"
         );
         assert!(value["state"].is_object(), "state should be an object");
         assert_eq!(

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -2045,12 +2045,7 @@ mod tests {
         );
         let protocol = WebUIProtocol::new(fragments);
 
-        let partial = render_partial(
-            &protocol,
-            "index.html",
-            "/email/42",
-            "",
-        );
+        let partial = render_partial(&protocol, "index.html", "/email/42", "");
         let tags = partial["cacheTags"].as_array().unwrap();
         let tag_strings: Vec<&str> = tags.iter().map(|v| v.as_str().unwrap()).collect();
         assert!(

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -567,14 +567,14 @@ fn resolve_tag_templates(templates: &[String], params: &HashMap<String, String>)
     resolved
 }
 
-/// Produce a complete JSON partial response for client-side navigation.
+/// Produce a JSON partial response for client-side navigation.
 ///
-/// Combines route templates, inventory, and matched route chain into a single
-/// JSON value. Host servers include this directly in their response alongside
-/// the application `state`.
+/// Returns the matched route chain, templates, inventory, and cache tags.
+/// **State is not included** — the caller is responsible for adding
+/// application state to the response (e.g. as a top-level `"state"` field
+/// for non-streaming, or as NDJSON Chunk 2 for streaming).
 ///
 /// Returns a `serde_json::Value` object with fields:
-/// - `state`: the application state passed through
 /// - `templateStyles`: module CSS definition tags for inventory-new components (empty for Link/Style)
 /// - `templates`: client template payloads the client doesn't already have (inventory-filtered)
 /// - `inventory`: updated hex bitmask
@@ -584,21 +584,16 @@ fn resolve_tag_templates(templates: &[String], params: &HashMap<String, String>)
 #[must_use]
 pub fn render_partial(
     protocol: &WebUIProtocol,
-    state: Value,
     entry_id: &str,
     request_path: &str,
     inventory_hex: &str,
 ) -> Value {
-    // Filter by inventory — only send components the client doesn't have.
     let (needed_names, updated_inv) =
         get_needed_components_for_request(protocol, entry_id, request_path, inventory_hex);
 
-    // Build the matched route chain
     let mut chain = collect_route_chain(protocol, entry_id, request_path);
 
-    // Resolve cache tags with accumulated params from the full chain.
-    // Each level can reference params from its own level AND all ancestors.
-    // Mutates in place to avoid cloning chain entries.
+    // Resolve cache tags and invalidation templates with accumulated params.
     let mut accumulated_params: HashMap<String, String> = HashMap::new();
     let mut all_resolved_tags: Vec<String> = Vec::new();
 
@@ -611,21 +606,18 @@ pub fn render_partial(
         all_resolved_tags.extend(entry.cache_tags.iter().cloned());
     }
 
-    // Collect templates + CSS using the shared helper
     let tag_refs: Vec<&str> = needed_names.iter().map(|s| s.as_str()).collect();
     let (style_array, tmpl_array) = collect_component_assets(protocol, &tag_refs);
 
     let chain_array = Value::Array(chain.iter().map(RouteChainEntry::to_json).collect());
 
-    let mut result = serde_json::Map::with_capacity(7);
-    result.insert("state".into(), state);
+    let mut result = serde_json::Map::with_capacity(6);
     result.insert("templateStyles".into(), Value::Array(style_array));
     result.insert("templates".into(), Value::Array(tmpl_array));
     result.insert("inventory".into(), Value::String(updated_inv));
     result.insert("path".into(), Value::String(request_path.to_string()));
     result.insert("chain".into(), chain_array);
     if !all_resolved_tags.is_empty() {
-        // Deduplicate while preserving order
         let mut seen = HashSet::new();
         let deduped: Vec<Value> = all_resolved_tags
             .into_iter()
@@ -1476,9 +1468,7 @@ mod tests {
             "(function(){window.__webui_templates['my-page']={h:'<p>page</p>'};})();".to_string();
         component.css = ".page{color:red}".to_string();
 
-        let partial = render_partial(&protocol, serde_json::json!({}), "index.html", "/", "");
-
-        // templateStyles should contain the separated module style tag
+        let partial = render_partial(&protocol, "index.html", "/", "");
         let styles = partial["templateStyles"]
             .as_array()
             .expect("templateStyles should be an array");
@@ -1543,7 +1533,7 @@ mod tests {
         component.css_href = "/my-page.css".to_string();
         // css is empty — Link strategy stores href, not content
 
-        let partial = render_partial(&protocol, serde_json::json!({}), "index.html", "/", "");
+        let partial = render_partial(&protocol, "index.html", "/", "");
         let styles = partial["templateStyles"]
             .as_array()
             .expect("templateStyles should be an array");
@@ -1588,7 +1578,7 @@ mod tests {
                 .to_string();
         // css is empty for Style strategy
 
-        let partial = render_partial(&protocol, serde_json::json!({}), "index.html", "/", "");
+        let partial = render_partial(&protocol, "index.html", "/", "");
         let styles = partial["templateStyles"]
             .as_array()
             .expect("templateStyles should be an array");
@@ -1634,7 +1624,7 @@ mod tests {
         component.template = "(function(){})();".to_string();
         // No CSS — simulates Link or Style mode
 
-        let partial = render_partial(&protocol, serde_json::json!({}), "index.html", "/", "");
+        let partial = render_partial(&protocol, "index.html", "/", "");
         let styles = partial["templateStyles"]
             .as_array()
             .expect("templateStyles should be an array");
@@ -1669,7 +1659,7 @@ mod tests {
         component.css = ".page{color:red}".to_string();
 
         // First call to establish inventory
-        let partial1 = render_partial(&protocol, serde_json::json!({}), "index.html", "/", "");
+        let partial1 = render_partial(&protocol, "index.html", "/", "");
         let inv = partial1["inventory"].as_str().unwrap_or_default();
         assert!(!inv.is_empty());
 
@@ -1677,7 +1667,7 @@ mod tests {
         // because the inventory covers this component.  The SSR handler emits all
         // module style definitions in <head> for inventoried components, so the
         // client already has the CSS definition.
-        let partial2 = render_partial(&protocol, serde_json::json!({}), "index.html", "/", inv);
+        let partial2 = render_partial(&protocol, "index.html", "/", inv);
         let styles = partial2["templateStyles"]
             .as_array()
             .expect("templateStyles should be an array");
@@ -2057,7 +2047,6 @@ mod tests {
 
         let partial = render_partial(
             &protocol,
-            serde_json::json!({}),
             "index.html",
             "/email/42",
             "",

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -160,13 +160,15 @@ pub fn render_partial(
     let state: serde_json::Value = serde_json::from_str(&state_json)
         .map_err(|e| NapiError::from_reason(format!("invalid state JSON: {e}")))?;
 
-    let result = webui_handler::route_handler::render_partial(
+    let mut result = webui_handler::route_handler::render_partial(
         &protocol,
-        state,
         &entry_id,
         &request_path,
         &inventory_hex,
     );
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("state".into(), state);
+    }
 
     serde_json::to_string(&result)
         .map_err(|e| NapiError::from_reason(format!("JSON serialize error: {e}")))

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -132,13 +132,15 @@ pub fn render_partial(
     let state: serde_json::Value = serde_json::from_str(state_json)
         .map_err(|e| JsValue::from_str(&format!("invalid state JSON: {e}")))?;
 
-    let result = webui_handler::route_handler::render_partial(
+    let mut result = webui_handler::route_handler::render_partial(
         &protocol,
-        state,
         entry_id,
         request_path,
         inventory_hex,
     );
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("state".into(), state);
+    }
 
     serde_json::to_string(&result)
         .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))

--- a/crates/webui/src/server.rs
+++ b/crates/webui/src/server.rs
@@ -89,15 +89,15 @@ pub fn serve_request(
 
     if request.accept_json {
         // JSON partial response for client-side navigation.
-        // render_partial() produces the complete response shape including
-        // separated templateStyles and templates arrays.
-        let partial = route_handler::render_partial(
+        let mut partial = route_handler::render_partial(
             protocol,
-            data,
             entry,
             request.path,
             request.inventory_hex,
         );
+        if let Some(obj) = partial.as_object_mut() {
+            obj.insert("state".into(), data);
+        }
         Ok(ServeResponse::Json(partial))
     } else {
         // Full HTML SSR

--- a/crates/webui/src/server.rs
+++ b/crates/webui/src/server.rs
@@ -89,12 +89,8 @@ pub fn serve_request(
 
     if request.accept_json {
         // JSON partial response for client-side navigation.
-        let mut partial = route_handler::render_partial(
-            protocol,
-            entry,
-            request.path,
-            request.inventory_hex,
-        );
+        let mut partial =
+            route_handler::render_partial(protocol, entry, request.path, request.inventory_hex);
         if let Some(obj) = partial.as_object_mut() {
             obj.insert("state".into(), data);
         }

--- a/docs/guide/ai.md
+++ b/docs/guide/ai.md
@@ -233,7 +233,6 @@ All attributes are validated at build time. Referencing a non-existent `pending`
 - `Router.invalidate(path?)` - evict by path or all
 
 **Server headers:**
-- `X-WebUI-Has-Loader` header: comma-separated list of component tags with loaders - host server can skip state computation
 - `X-WebUI-Inventory` header: hex bitmask of loaded templates - server skips re-sending
 
 ### Outlet

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -197,23 +197,18 @@ The router provides four mechanisms for controlling how state flows to your comp
 
 | Need | Mechanism | What happens |
 |------|-----------|-------------|
-| **Server provides all state** | Default (no changes) | `setState(data.state)` on every navigation |
+| **Server provides all state** | Default (no changes) | `setState(state)` on every navigation |
 | **I fetch my own data** | `static loader()` on component | Loader runs pre-commit, result passed to `setState()` |
 | **Preserve local state** | `keep-alive` on route | Params/query attrs updated, `setState()` skipped |
 | **Preserve DOM + refresh data** | `keep-alive` + `static loader()` | DOM preserved, loader result applied via `setState()` |
 
-**Server-side optimization:** The router sends `X-WebUI-Has-Loader` as a comma-separated list of component tags that have loaders (e.g., `X-WebUI-Has-Loader: live-dashboard,mail-view`). The host server does its own route matching and can check whether the target leaf component is in this list. If so, it may skip expensive state computation and return `state: {}`.
-
-> **Note:** The header reflects *previously discovered* loaders — components whose `static loader()` was seen during a prior navigation. The very first navigation to a loader route won't advertise it. This is a best-effort optimization, not an exhaustive manifest.
-
 ```typescript
-// Express example — skip DB query when target component fetches its own data
+// Express example — render_partial returns chain + templates (no state).
+// Caller adds state to the response.
 app.get('*', async (req, res) => {
-  const loaderTags = req.headers['x-webui-has-loader']?.split(',') ?? [];
-  const leafComponent = getMatchedLeafComponent(req.path); // your route matching
-  const skipState = loaderTags.includes(leafComponent);
-  const state = skipState ? {} : await db.getPageState(req.path);
-  const partial = handler.renderPartial(protocol, state, req.path);
+  const state = await db.getPageState(req.path);
+  const partial = handler.renderPartial(protocol, req.path, invHex);
+  partial.state = state;
   res.json(partial);
 });
 ```
@@ -540,7 +535,7 @@ The server handles two request types for each route:
 
 ### JSON Partial (client navigation)
 
-When `Accept: application/json`:
+When `Accept: application/json` or `application/x-ndjson`:
 
 ```json
 {
@@ -566,7 +561,7 @@ When `Accept: application/json`:
 
 | Field | Description |
 |-------|-------------|
-| `state` | Application state for the matched route |
+| `state` | Application state (added by the caller, not by `render_partial`) |
 | `templateStyles` | Module CSS definition tags (empty for Link/Style modes) |
 | `templates` | Client template payloads filtered by inventory bitmask |
 | `inventory` | Updated hex bitmask of loaded templates |
@@ -581,9 +576,8 @@ Each `chain` entry can include: `component`, `path`, `params`, `exact`, `keepAli
 
 | Header | Value | Purpose |
 |--------|-------|---------|
-| `Accept` | `application/json` | Requests JSON partial instead of HTML |
+| `Accept` | `application/x-ndjson, application/json` | Requests NDJSON streaming or JSON partial instead of HTML |
 | `X-WebUI-Inventory` | Hex bitmask | Templates the client already has — server skips re-sending them |
-| `X-WebUI-Has-Loader` | Comma-separated tags | Components with a `static loader()` — server can check if the target leaf is in this list to skip state computation |
 
 ### Full HTML (initial load)
 
@@ -591,22 +585,28 @@ Without `Accept: application/json`, return the full SSR'd page. The handler auto
 
 ### Building the chain
 
-Use `render_partial()` (Rust) or `webui_render_partial()` (FFI) to get the complete partial response - state, templateStyles, templates, inventory, path, and chain - in a single call:
+Use `render_partial()` (Rust) or `webui_render_partial()` (FFI) to get the partial response — chain, templateStyles, templates, inventory, path, and cacheTags. The caller adds application state to the result:
 
 ```rust
-// Rust
-let partial = route_handler::render_partial(&protocol, state, &entry, &path, &inventory_hex);
+// Rust — render_partial returns chain + templates (no state)
+let mut partial = route_handler::render_partial(&protocol, &entry, &path, &inventory_hex);
+// Caller adds state to the response
+if let Some(obj) = partial.as_object_mut() {
+    obj.insert("state".into(), state);
+}
 // partial contains: { "state": {...}, "templateStyles": [...], "templates": [...], "inventory": "...", "path": "...", "chain": [...] }
 ```
 
 ```csharp
 // C#
-string partialJson = handler.RenderPartial(protocol, stateJson, entryId, requestPath, inventoryHex);
+string partialJson = handler.RenderPartial(protocol, entryId, requestPath, inventoryHex);
+// Caller merges state into the JSON before sending
 ```
 
 ```javascript
 // Node.js
-const partialJson = webui.renderPartial(protocol, stateJson, entryId, requestPath, inventoryHex);
+const partialJson = webui.renderPartial(protocol, entryId, requestPath, inventoryHex);
+// Caller adds state before sending
 ```
 
 ### Express Example
@@ -616,9 +616,11 @@ app.get('/users/:id', (req, res) => {
   const state = { name: getUser(req.params.id).name };
 
   if (req.accepts('json')) {
-    // renderPartial() returns the complete response - no assembly required
-    const stateJson = JSON.stringify(state);
-    res.type('json').send(webui.renderPartial(protocol, stateJson, 'index.html', req.path, req.get('X-WebUI-Inventory') ?? ''));
+    // renderPartial() returns chain + templates; caller adds state
+    const inv = req.get('X-WebUI-Inventory') ?? '';
+    const partial = JSON.parse(webui.renderPartial(protocol, 'index.html', req.path, inv));
+    partial.state = state;
+    res.type('json').send(JSON.stringify(partial));
   } else {
     res.type('html').send(handler.render(protocol, state, 'index.html', req.path));
   }

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -727,22 +727,19 @@ Hidden routes use `style="display:none"` inline. If your CSS sets
 
 ```typescript
 // index.ts
-import { TemplateElement } from '@microsoft/fast-html';
 import { Router } from '@microsoft/webui-router';
-import './app-shell.js';
 
-TemplateElement.options({
-  'app-shell': { observerMap: 'all' },
-}).config({
-  hydrationComplete() {
-    Router.start({
-      loaders: {
-        'home-page': () => import('./pages/home-page.js'),
-        'contacts-page': () => import('./pages/contacts-page.js'),
-        'contact-form': () => import('./pages/contact-form.js'),
-        'contact-detail': () => import('./pages/contact-detail.js'),
-      },
-    });
-  },
-}).define({ name: 'f-template' });
+window.addEventListener('webui:hydration-complete', () => {
+  Router.start({
+    loaders: {
+      'home-page': () => import('./pages/home-page.js'),
+      'contacts-page': () => import('./pages/contacts-page.js'),
+      'contact-form': () => import('./pages/contact-form.js'),
+      'contact-detail': () => import('./pages/contact-detail.js'),
+    },
+  });
+});
+
+// Shell component — eagerly loaded (registers custom element, triggers hydration)
+import './app-shell.js';
 ```

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -83,12 +83,8 @@ impl FrontendRuntime {
         inventory_hex: &str,
         state: Value,
     ) -> Value {
-        let mut partial = route_handler::render_partial(
-            &self.protocol,
-            &self.entry,
-            route_path,
-            inventory_hex,
-        );
+        let mut partial =
+            route_handler::render_partial(&self.protocol, &self.entry, route_path, inventory_hex);
         if let Some(obj) = partial.as_object_mut() {
             obj.insert("state".into(), state);
         }

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -83,13 +83,16 @@ impl FrontendRuntime {
         inventory_hex: &str,
         state: Value,
     ) -> Value {
-        route_handler::render_partial(
+        let mut partial = route_handler::render_partial(
             &self.protocol,
-            state,
             &self.entry,
             route_path,
             inventory_hex,
-        )
+        );
+        if let Some(obj) = partial.as_object_mut() {
+            obj.insert("state".into(), state);
+        }
+        partial
     }
 
     #[must_use]

--- a/examples/app/commerce/server/src/server.rs
+++ b/examples/app/commerce/server/src/server.rs
@@ -391,12 +391,13 @@ mod tests {
             Err(error) => panic!("{error}"),
         };
 
-        // Page-specific state present
+        // State is at top level (caller adds it), not per-entry in chain
+        assert!(json.get("state").is_some(), "should have top-level state");
         assert!(json["state"].get("products").is_some());
         assert!(json["state"].get("categories").is_some());
         assert!(json["state"].get("sortOptions").is_some());
 
-        // Shell state excluded from partials
+        // Shell state excluded from page-specific state
         assert!(json["state"].get("storeName").is_none());
         assert!(json["state"].get("cartItems").is_none());
         assert!(json["state"].get("cartItemCount").is_none());

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -459,14 +459,14 @@ On client-side navigation, the router sends:
 
 ```
 GET /users/42
-Accept: application/json
+Accept: application/x-ndjson, application/json
 X-WebUI-Inventory: <hex bitmask>
-X-WebUI-Has-Loader: <comma-separated tags>
 ```
 
 The server should return:
 
-- **`Accept: application/json`** → JSON partial: `{ state, templateStyles, templates, inventory, path, chain, cacheTags, cacheControl }` - returned directly from `renderPartial()`, no assembly required
+- **`Accept: application/x-ndjson`** → NDJSON streaming: Chunk 1 `{ templateStyles, templates, inventory, path, chain, cacheTags }`, Chunk 2 `{ states: [...] }` — or fall back to single JSON
+- **`Accept: application/json`** → JSON partial: `{ state, templateStyles, templates, inventory, path, chain, cacheTags, cacheControl }` — `state` is added by the caller; `render_partial()` returns everything else
 - **Otherwise** → Full SSR'd HTML page
 
 The `chain` field contains the matched route chain with `component`, `path`, `params`, `exact`, `keepAlive`, `pendingComponent`, `errorComponent`, and `invalidates`. The `cacheTags` array contains resolved cache tags from the full chain. The optional `cacheControl` object can override `staleTime` per-response.

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -928,14 +928,12 @@ describe('WebUIRouter', () => {
       }
     });
 
-    test('applyParamsQueryState uses stateOverride when provided', () => {
+    test('mountComponent calls applyParamsQueryState with state', () => {
       const router = new WebUIRouter();
       const source = (router as any).mountComponent.toString() as string;
-
-      // Verify mountComponent passes stateOverride to applyParamsQueryState
       assert.ok(
-        source.includes('stateOverride'),
-        'mountComponent should accept and pass stateOverride',
+        source.includes('applyParamsQueryState'),
+        'mountComponent should call applyParamsQueryState',
       );
     });
 
@@ -956,7 +954,7 @@ describe('WebUIRouter', () => {
   });
 
   describe('keep-alive state preservation', () => {
-    test('applyState skips setState for keep-alive without loader', () => {
+    test('applyState skips setState for keep-alive with null state', () => {
       const router = new WebUIRouter();
       const priv = router as any;
 
@@ -978,11 +976,11 @@ describe('WebUIRouter', () => {
         params: { id: '42' },
         el: mockRouteEl,
         keepAlive: true,
+        state: null,  // null = skip setState
       };
 
-      // Call applyState with empty loader results — keep-alive should skip setState
-      priv.applyState(entry, { state: { server: true }, templates: [], path: '/' }, {}, new Map());
-      assert.ok(!setStateCalled, 'setState must not be called for keep-alive without loader');
+      priv.applyState(entry, {}, new Map());
+      assert.ok(!setStateCalled, 'setState must not be called for keep-alive with null state');
     });
 
     test('applyState calls setState for keep-alive with loader override', () => {
@@ -1007,15 +1005,16 @@ describe('WebUIRouter', () => {
         params: {},
         el: mockRouteEl,
         keepAlive: true,
+        state: null,
       };
       const loaderStates = new Map();
       loaderStates.set('test-comp', { fresh: 'data' });
 
-      priv.applyState(entry, { state: { server: true }, templates: [], path: '/' }, {}, loaderStates);
+      priv.applyState(entry, {}, loaderStates);
       assert.deepEqual(setStateArg, { fresh: 'data' }, 'setState should receive loader override');
     });
 
-    test('applyState calls setState with server state when loader fails', () => {
+    test('applyState uses per-entry state for non-keep-alive', () => {
       const router = new WebUIRouter();
       const priv = router as any;
 
@@ -1025,7 +1024,6 @@ describe('WebUIRouter', () => {
         removeAttribute: () => {},
         setState: (s: unknown) => { setStateArg = s; },
       };
-      // Non-keep-alive route always uses server state
       const mockRouteEl = {
         hasAttribute: () => false,
         getAttribute: () => null,
@@ -1038,47 +1036,16 @@ describe('WebUIRouter', () => {
         params: {},
         el: mockRouteEl as any,
         keepAlive: false,
+        state: { from: 'server' },
       };
 
-      priv.applyState(entry, { state: { from: 'server' }, templates: [], path: '/' }, {}, new Map());
-      assert.deepEqual(setStateArg, { from: 'server' }, 'non-keep-alive should use server state');
+      priv.applyState(entry, {}, new Map());
+      assert.deepEqual(setStateArg, { from: 'server' }, 'non-keep-alive should use per-entry state');
     });
   });
 
-  describe('X-WebUI-Has-Loader header', () => {
-    test('fetchPartial sends comma-separated loader component list', async () => {
-      const origFetch = (globalThis as any).fetch;
-      let capturedHeaders: Record<string, string> = {};
-
-      (globalThis as any).fetch = async (_url: string, opts?: RequestInit) => {
-        capturedHeaders = (opts?.headers as Record<string, string>) ?? {};
-        return {
-          ok: true,
-          headers: { get: () => 'application/json' },
-          json: async () => ({ state: {}, templates: [], path: '/', chain: [] }),
-        };
-      };
-
-      try {
-        const router = new WebUIRouter();
-        const priv = router as any;
-
-        // Simulate: two components discovered to have loaders
-        priv.loaderComponents.add('dash-page');
-        priv.loaderComponents.add('mail-view');
-        priv.loaderHeaderCache = [...priv.loaderComponents].join(',');
-
-        await priv.fetchPartial.call(router, '/test');
-        const header = capturedHeaders['X-WebUI-Has-Loader'];
-        assert.ok(header, 'should send X-WebUI-Has-Loader header');
-        assert.ok(header.includes('dash-page'), 'header should include dash-page');
-        assert.ok(header.includes('mail-view'), 'header should include mail-view');
-      } finally {
-        (globalThis as any).fetch = origFetch;
-      }
-    });
-
-    test('fetchPartial omits X-WebUI-Has-Loader when no loaders discovered', async () => {
+  describe('fetchPartial NDJSON support', () => {
+    test('fetchPartial sends Accept header for both NDJSON and JSON', async () => {
       const origFetch = (globalThis as any).fetch;
       let capturedHeaders: Record<string, string> = {};
 
@@ -1094,52 +1061,17 @@ describe('WebUIRouter', () => {
       try {
         const router = new WebUIRouter();
         await (router as any).fetchPartial.call(router, '/test');
-        assert.equal(
-          capturedHeaders['X-WebUI-Has-Loader'],
-          undefined,
-          'should NOT send header when no loaders are known',
-        );
+        const accept = capturedHeaders['Accept'];
+        assert.ok(accept, 'should send Accept header');
+        assert.ok(accept.includes('application/x-ndjson'), 'Accept should include ndjson');
+        assert.ok(accept.includes('application/json'), 'Accept should include json');
       } finally {
         (globalThis as any).fetch = origFetch;
       }
     });
+  });
 
-    test('resolveLoaders populates loaderComponents set', async () => {
-      const router = new WebUIRouter();
-      const priv = router as any;
-
-      const origGet = (globalThis as any).customElements.get;
-      (globalThis as any).customElements.get = (name: string) => {
-        if (name === 'loader-comp') {
-          return class LoaderComp {
-            static async loader() { return { x: 1 }; }
-          };
-        }
-        return origGet(name);
-      };
-
-      try {
-        await priv.resolveLoaders.call(router,
-          [{ component: 'loader-comp', params: {} }],
-          {},
-        );
-        assert.ok(
-          priv.loaderComponents.has('loader-comp'),
-          'resolveLoaders should add component to loaderComponents set',
-        );
-      } finally {
-        (globalThis as any).customElements.get = origGet;
-      }
-    });
-
-    test('destroy clears loaderComponents', () => {
-      const router = new WebUIRouter();
-      const priv = router as any;
-      priv.loaderComponents.add('some-page');
-      router.destroy();
-      assert.equal(priv.loaderComponents.size, 0, 'destroy should clear loaderComponents');
-    });
-
+  describe('loaderPromises cleanup', () => {
     test('loaderPromises entries are deleted after loader completes', async () => {
       const router = new WebUIRouter();
       const priv = router as any;

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -27,6 +27,19 @@ const LOADER_FAILED = Symbol('LOADER_FAILED');
 /** Shared never-aborted signal for loaders called without an external signal. */
 const NOOP_SIGNAL = new AbortController().signal;
 
+/** Maximum buffered NDJSON line size before aborting the stream (256 KiB). */
+const MAX_NDJSON_BUFFER = 256 * 1024;
+
+/**
+ * Check if a state value is meaningful (non-null, non-empty).
+ * Returns false for null, undefined, or `{}`.
+ */
+function hasState(state?: Record<string, unknown> | null): state is Record<string, unknown> {
+  if (state == null) return false;
+  const keys = Object.keys(state);
+  return keys.length > 0;
+}
+
 /**
  * Get the render root of a component element.
  * Returns shadowRoot if present, otherwise the element itself.
@@ -196,6 +209,13 @@ interface RouteChainEntry {
   errorComponent?: string;
   /** Invalidation tags from the build-time proto (already resolved with params). */
   invalidates?: string[];
+  /**
+   * Per-component state from the server.
+   * - `undefined` → skip setState (preserve component's current state)
+   * - `null` → skip setState (preserve component's current state)
+   * - `{...}` → call setState with this data
+   */
+  state?: Record<string, unknown> | null;
 }
 
 /** Static route manifest entry — built once at startup from <webui-route> tree. */
@@ -211,7 +231,8 @@ interface RouteManifestEntry {
 
 /** JSON partial response from the server. */
 interface PartialResponse {
-  state: Record<string, unknown>;
+  /** Top-level application state (non-streaming responses). */
+  state?: Record<string, unknown>;
   /** Module CSS definitions to append before executing template scripts. */
   templateStyles?: string[];
   templates: string[];
@@ -237,6 +258,8 @@ interface CacheEntry {
   staleTime?: number;
   /** True if this entry came from a speculative preload fetch. */
   preload?: boolean;
+  /** Whether both streaming chunks have been received. */
+  complete: boolean;
 }
 
 /**
@@ -304,14 +327,13 @@ function applyParamsQueryState(
   component: Element,
   routeEl: HTMLElement,
   params: Record<string, string>,
-  data: PartialResponse,
+  state?: Record<string, unknown> | null,
   query?: Record<string, string>,
-  stateOverride?: Record<string, unknown>,
 ): void {
   applyParamsAndQuery(component, routeEl, params, query);
 
-  if (typeof (component as any).setState === 'function') {
-    (component as any).setState(stateOverride ?? data.state);
+  if (hasState(state) && typeof (component as any).setState === 'function') {
+    (component as any).setState(state);
   }
 }
 
@@ -338,10 +360,7 @@ export class WebUIRouter {
   private injectedStyles = new Set<string>();
   /** Monotonic navigation generation — guards against stale async completions. */
   private navGeneration = 0;
-  /** Set of component tags known to have a static loader() method. */
-  private loaderComponents = new Set<string>();
-  /** Cached comma-separated loader header — invalidated when loaderComponents changes. */
-  private loaderHeaderCache = '';
+
   /** Cached current request path — updated on every navigation. Avoids URL allocation in hot paths. */
   private currentRequestPath = '/';
   /** Tagged navigation cache — keyed by requestPath. */
@@ -358,6 +377,10 @@ export class WebUIRouter {
   private pendingTimer: ReturnType<typeof setTimeout> | null = null;
   /** AbortController for the in-flight mutation action. */
   private actionController: AbortController | null = null;
+  /** In-flight deferred state reader from streaming Chunk 2. */
+  private deferredReader: Promise<void> | null = null;
+  /** Generation at which the deferred reader was started. */
+  private deferredGeneration = 0;
   /** Direct reference to mounted pending element for O(1) cleanup. */
   private pendingElement: HTMLElement | null = null;
   /** Direct reference to mounted error element for O(1) cleanup. */
@@ -649,8 +672,7 @@ export class WebUIRouter {
     this.ssrPreloadsCleared = false;
     this.injectedCss.clear();
     this.injectedStyles.clear();
-    this.loaderComponents.clear();
-    this.loaderHeaderCache = '';
+
     this.currentRequestPath = '/';
     this.cache.clear();
     this.tagIndex.clear();
@@ -664,6 +686,7 @@ export class WebUIRouter {
     }
     this.pendingElement = null;
     this.errorElement = null;
+    this.deferredReader = null;
   }
 
   // ── Navigation Cache ──────────────────────────────────────────
@@ -671,10 +694,10 @@ export class WebUIRouter {
   /** Maximum age (ms) for a preloaded partial before it's considered stale. */
   private static readonly PRELOAD_TTL = 5_000;
 
-  /** Look up a cache entry. Returns null if missing or stale. */
+  /** Look up a cache entry. Returns null if missing, stale, or incomplete. */
   private lookupCache(requestPath: string): (PartialResponse & { inventory?: string }) | null {
     const entry = this.cache.get(requestPath);
-    if (!entry) return null;
+    if (!entry || !entry.complete) return null;
 
     const age = Date.now() - entry.ts;
     const staleTime = entry.staleTime ?? this.cacheConfig.staleTime;
@@ -696,6 +719,7 @@ export class WebUIRouter {
     requestPath: string,
     data: PartialResponse & { inventory?: string },
     preload?: boolean,
+    streaming?: boolean,
   ): void {
     const tags = data.cacheTags ?? [];
     const staleTime = data.cacheControl?.staleTime;
@@ -713,7 +737,10 @@ export class WebUIRouter {
       }
     }
 
-    this.cache.set(requestPath, { data, tags, ts: Date.now(), staleTime, preload });
+    this.cache.set(requestPath, {
+      data, tags, ts: Date.now(), staleTime, preload,
+      complete: !preload && !streaming,
+    });
 
     // Build reverse tag index
     for (const tag of tags) {
@@ -1194,10 +1221,18 @@ export class WebUIRouter {
 
       // Store in cache with tags
       if (!cached) {
-        this.storeCacheEntry(requestPath, partialData);
+        // Streaming entries are incomplete until Chunk 2 finishes (has _deferredStates or active reader)
+        const isStreaming = this.deferredReader !== null && this.deferredGeneration === thisGen;
+        this.storeCacheEntry(requestPath, partialData, undefined, isStreaming);
       }
 
       await this.commitWithData(partialData, requestPath, query, signal, thisGen);
+
+      // Apply deferred states from streaming Chunk 2 (if both chunks arrived together)
+      const deferredStates = (partialData as any)._deferredStates;
+      if (deferredStates) {
+        this.applyDeferredStates(deferredStates, requestPath);
+      }
     }
 
     const leaf = this.activeChain[this.activeChain.length - 1];
@@ -1424,39 +1459,220 @@ export class WebUIRouter {
     speculative?: boolean,
   ): Promise<(PartialResponse & { inventory?: string }) | null> {
     const fullPath = prependBasePath(requestPath, this.basePath);
-    const headers: Record<string, string> = { 'Accept': 'application/json' };
+    const headers: Record<string, string> = { 'Accept': 'application/x-ndjson, application/json' };
     if (this.inventory) headers['X-WebUI-Inventory'] = this.inventory;
-
-    // Send the set of component tags that have static loaders. The host
-    // server does its own route matching and can check whether the TARGET
-    // leaf component is in this list. If so, it may skip expensive state
-    // computation and return state: {}.
-    if (this.loaderHeaderCache) {
-      headers['X-WebUI-Has-Loader'] = this.loaderHeaderCache;
-    }
 
     const resp = await fetch(fullPath, { headers, signal });
 
     if (!resp.ok) return null;
 
     const contentType = resp.headers.get('content-type') ?? '';
-    if (!contentType.includes('application/json')) {
-      // Server returned HTML (e.g. login page) instead of JSON partial.
-      // Speculative fetches never redirect — just bail out silently.
+
+    // HTML response (e.g. login page) — redirect
+    if (!contentType.includes('json') && !contentType.includes('ndjson')) {
       if (speculative || signal?.aborted) return null;
       window.location.href = prependBasePath(requestPath, this.basePath);
       return null;
     }
 
+    // Streaming NDJSON response — read Chunk 1, spawn background Chunk 2 reader
+    if (contentType.includes('ndjson') && resp.body) {
+      return this.readStreamingPartial(resp, requestPath, signal, speculative);
+    }
+
+    // Fallback: standard JSON response (non-streaming server)
     const data = await resp.json() as PartialResponse & { inventory?: string };
-
-    // Bail out before applying side effects if this navigation was superseded.
     if (signal?.aborted) return null;
-
-    // Register templates, styles, and CSS using the shared pipeline
     this.registerTemplatesAndStyles(data);
+    this.injectCssLinks(data);
+    return data;
+  }
 
-    // Inject CSS stylesheet links (used by some server implementations)
+  /**
+   * Read a streaming NDJSON partial response.
+   * Returns after Chunk 1 (chain + templates) for immediate navigation commit.
+   * Spawns a background reader for Chunk 2 (deferred per-component state).
+   */
+  private async readStreamingPartial(
+    resp: Response,
+    requestPath: string,
+    signal?: AbortSignal,
+    speculative?: boolean,
+  ): Promise<(PartialResponse & { inventory?: string }) | null> {
+    const reader = resp.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let chunk1: (PartialResponse & { inventory?: string }) | null = null;
+
+    // Read until we get Chunk 1 (has 'chain' field)
+    while (!chunk1) {
+      const { done, value } = await reader.read();
+      if (signal?.aborted) break;
+      if (done) {
+        // Flush remaining buffer on stream end
+        buffer += decoder.decode();
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+
+      if (buffer.length > MAX_NDJSON_BUFFER) {
+        console.warn('[Router] NDJSON buffer exceeded limit, aborting stream');
+        reader.cancel().catch(() => {});
+        return null;
+      }
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop()!; // keep incomplete last line
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const parsed = JSON.parse(line);
+          if (parsed.chain) {
+            chunk1 = parsed;
+          } else if (parsed.states && chunk1) {
+            // Chunk 2 arrived in same read batch — store for post-commit application
+            (chunk1 as any)._deferredStates = parsed.states;
+          }
+        } catch {
+          // Malformed line — skip
+        }
+      }
+    }
+
+    // Process any final incomplete line left in buffer
+    if (!chunk1 && buffer.trim()) {
+      try {
+        const parsed = JSON.parse(buffer);
+        if (parsed.chain) chunk1 = parsed;
+      } catch { /* ignore */ }
+      buffer = '';
+    }
+
+    if (!chunk1 || signal?.aborted) {
+      reader.cancel().catch(() => {});
+      return null;
+    }
+
+    // Register templates/styles from Chunk 1
+    this.registerTemplatesAndStyles(chunk1);
+    this.injectCssLinks(chunk1);
+
+    // Spawn background reader for remaining chunks (Chunk 2 state)
+    const gen = this.navGeneration;
+    this.deferredGeneration = gen;
+    this.deferredReader = this.continueDeferredRead(reader, decoder, buffer, requestPath, gen, signal)
+      .catch((err) => {
+        if (!signal?.aborted) {
+          console.warn('[Router] Deferred state reader failed:', err);
+        }
+      });
+
+    return chunk1;
+  }
+
+  /**
+   * Continue reading the NDJSON stream for Chunk 2 (deferred state).
+   * Runs in the background after Chunk 1 has been committed.
+   */
+  private async continueDeferredRead(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    decoder: TextDecoder,
+    initialBuffer: string,
+    requestPath: string,
+    generation: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    let buffer = initialBuffer;
+    try {
+      while (true) {
+        if (signal?.aborted || generation !== this.navGeneration) {
+          reader.cancel().catch(() => {});
+          return;
+        }
+        const { done, value } = await reader.read();
+        if (done) {
+          // Flush remaining bytes from the decoder
+          buffer += decoder.decode();
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+
+        if (buffer.length > MAX_NDJSON_BUFFER) {
+          console.warn('[Router] NDJSON deferred buffer exceeded limit, aborting');
+          reader.cancel().catch(() => {});
+          return;
+        }
+
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!;
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          if (generation !== this.navGeneration) return; // Stale — stop
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed.states) {
+              this.applyDeferredStates(parsed.states, requestPath);
+            } else if (parsed.error) {
+              console.warn('[Router] Streaming state error:', parsed.error);
+            }
+          } catch {
+            // Malformed line — skip
+          }
+        }
+      }
+
+      // Process final incomplete line
+      if (buffer.trim() && generation === this.navGeneration) {
+        try {
+          const parsed = JSON.parse(buffer);
+          if (parsed.states) {
+            this.applyDeferredStates(parsed.states, requestPath);
+          } else if (parsed.error) {
+            console.warn('[Router] Streaming state error:', parsed.error);
+          }
+        } catch { /* ignore */ }
+      }
+    } finally {
+      // Mark cache entry as complete
+      const cacheEntry = this.cache.get(requestPath);
+      if (cacheEntry) cacheEntry.complete = true;
+    }
+  }
+
+  /**
+   * Apply deferred per-component states from streaming Chunk 2.
+   * States array is matched 1:1 to activeChain entries by position.
+   * null entries are skipped (component keeps current state).
+   */
+  private applyDeferredStates(
+    states: (Record<string, unknown> | null)[],
+    requestPath: string,
+  ): void {
+    if (requestPath !== this.currentRequestPath) return; // Stale
+    for (let i = 0; i < states.length && i < this.activeChain.length; i++) {
+      const state = states[i];
+      if (!hasState(state)) continue;
+      const entry = this.activeChain[i];
+      if (!entry.el || !entry.component) continue;
+
+      // Don't override loader results
+      const ctor = customElements.get(entry.component) as
+        ((new () => HTMLElement) & { loader?: Function }) | undefined;
+      if (ctor && typeof ctor.loader === 'function') continue;
+
+      const compEl = entry.el.querySelector(entry.component);
+      if (compEl && typeof (compEl as any).setState === 'function') {
+        (compEl as any).setState(state);
+      }
+      // Update the chain entry's state for cache consistency
+      entry.state = state;
+    }
+  }
+
+  /** Inject CSS stylesheet links from a partial response. */
+  private injectCssLinks(data: PartialResponse): void {
     if (data.css) {
       for (const href of data.css) {
         if (!this.injectedCss.has(href)) {
@@ -1468,41 +1684,27 @@ export class WebUIRouter {
         }
       }
     }
-
-    return data;
   }
 
   private mountComponent(
     routeEl: HTMLElement,
     componentTag: string,
-    data: PartialResponse,
     params: Record<string, string>,
+    state?: Record<string, unknown> | null,
     query?: Record<string, string>,
-    stateOverride?: Record<string, unknown>,
   ): void {
     const component = document.createElement(componentTag);
     routeEl.textContent = '';
     routeEl.appendChild(component);
-
-    // Component module is pre-loaded and defined before commitNavigation.
-    // connectedCallback fires synchronously on appendChild, populating
-    // the component's light DOM immediately.
-
-    applyParamsQueryState(component, routeEl, params, data, query, stateOverride);
+    applyParamsQueryState(component, routeEl, params, state, query);
   }
 
   /**
-   * Apply partial state to a mounted route component.
-   * Calls the framework's built-in `setState` which sets
-   * `@observable` properties and flushes DOM updates synchronously.
-   * Route params are set as HTML attributes for `@attr` reflection.
-   * Allowed query params (declared via `query` attr on the route) are
-   * also set as attributes; stale ones from the previous navigation
-   * are removed.
+   * Apply state to a mounted route component using per-entry state.
+   * State resolution: loader override > per-entry state > keep-alive preserve.
    */
   private applyState(
     entry: RouteChainEntry,
-    data: PartialResponse,
     query?: Record<string, string>,
     loaderStates?: Map<string, Record<string, unknown> | typeof LOADER_FAILED>,
   ): void {
@@ -1517,16 +1719,21 @@ export class WebUIRouter {
 
     if (isKeepAlive) {
       if (effectiveOverride) {
-        applyParamsQueryState(compEl, entry.el, entry.params, data, query, effectiveOverride);
+        applyParamsQueryState(compEl, entry.el, entry.params, effectiveOverride, query);
       } else if (loaderExists) {
-        // Loader failed → fall back to server state
-        applyParamsQueryState(compEl, entry.el, entry.params, data, query);
+        // Loader failed → fall back to per-entry server state
+        applyParamsQueryState(compEl, entry.el, entry.params, entry.state, query);
+      } else if (hasState(entry.state)) {
+        // Server provided meaningful per-entry state → apply it
+        applyParamsQueryState(compEl, entry.el, entry.params, entry.state, query);
       } else {
-        // No loader → preserve local state
+        // null or empty state → preserve local state, only update attrs
         applyParamsAndQuery(compEl, entry.el, entry.params, query);
       }
     } else {
-      applyParamsQueryState(compEl, entry.el, entry.params, data, query, effectiveOverride);
+      // Non-keep-alive: apply state
+      const stateToApply = effectiveOverride ?? entry.state;
+      applyParamsQueryState(compEl, entry.el, entry.params, stateToApply, query);
     }
   }
 
@@ -1562,7 +1769,7 @@ export class WebUIRouter {
    * static `loader()` are skipped — they use server-provided state.
    *
    * On failure, the loader is skipped with a warning and the component
-   * falls back to `data.state` from the server partial.
+   * falls back to server-provided per-entry state.
    */
   private async resolveLoaders(
     chain: RouteChainEntry[],
@@ -1581,12 +1788,6 @@ export class WebUIRouter {
         (new () => HTMLElement) & { loader?: (ctx: import('./types.js').RouteLoaderContext) => Promise<Record<string, unknown>> }
       ) | undefined;
       if (!ctor || typeof ctor.loader !== 'function') continue;
-
-      // Track this component as having a loader for the X-WebUI-Has-Loader header
-      if (!this.loaderComponents.has(entry.component)) {
-        this.loaderComponents.add(entry.component);
-        this.loaderHeaderCache = [...this.loaderComponents].join(',');
-      }
 
       loaderEntries.push({ component: entry.component, params: entry.params, loaderFn: ctor.loader });
     }
@@ -1711,6 +1912,7 @@ export class WebUIRouter {
     signal?: AbortSignal,
     generation?: number,
   ): Promise<void> {
+    const topState = partialData.state ?? null;
     const newChain: RouteChainEntry[] = (partialData.chain ?? []).map(e => ({
       component: e.component ?? '',
       path: e.path ?? '',
@@ -1721,6 +1923,8 @@ export class WebUIRouter {
       pendingComponent: e.pendingComponent,
       errorComponent: e.errorComponent,
       invalidates: e.invalidates,
+      // Per-entry state (streaming Chunk 2) > top-level state (non-streaming) > null
+      state: e.state ?? topState,
     }));
 
     if (newChain.length === 0) {
@@ -1766,7 +1970,7 @@ export class WebUIRouter {
       if (changeLevel > 0 || isQueryOnlyChange) {
         const end = isQueryOnlyChange ? newChain.length : changeLevel;
         for (let i = 0; i < end; i++) {
-          this.applyState(newChain[i], partialData, query, loaderStates);
+          this.applyState(newChain[i], query, loaderStates);
         }
       }
       for (let i = changeLevel; i < newChain.length; i++) {
@@ -1775,7 +1979,7 @@ export class WebUIRouter {
         const parent = i > 0 ? newChain[i - 1] : null;
         if (oldEntry?.component === entry.component && oldEntry?.el) {
           entry.el = oldEntry.el;
-          if (entry.component) this.applyState(entry, partialData, query, loaderStates);
+          if (entry.component) this.applyState(entry, query, loaderStates);
           activateRoute(entry.el, entry.params);
           continue;
         }
@@ -1783,28 +1987,20 @@ export class WebUIRouter {
         entry.el = routeEl;
         if (entry.component) {
           const override = loaderStates.get(entry.component);
-          // Resolve the effective state override:
-          // - undefined = no loader exists → keep-alive preserves local state
-          // - LOADER_FAILED = loader existed but threw → fall back to server state
-          // - object = loader succeeded → use loader result
           const effectiveOverride = override === LOADER_FAILED ? undefined : override;
-          const loaderExists = override !== undefined;
 
           const isKeepAlive = entry.keepAlive || routeEl.hasAttribute('keep-alive');
           const existingComp = routeEl.firstElementChild;
           if (isKeepAlive && existingComp?.matches(entry.component)) {
-            if (effectiveOverride) {
-              // Loader succeeded → apply fresh data
-              applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query, effectiveOverride);
-            } else if (loaderExists) {
-              // Loader failed → fall back to server state
-              applyParamsQueryState(existingComp, routeEl, entry.params, partialData, query);
+            const stateToApply = effectiveOverride ?? entry.state;
+            if (hasState(stateToApply)) {
+              applyParamsQueryState(existingComp, routeEl, entry.params, stateToApply, query);
             } else {
-              // No loader → preserve local state, only update attrs
               applyParamsAndQuery(existingComp, routeEl, entry.params, query);
             }
           } else {
-            this.mountComponent(routeEl, entry.component, partialData, entry.params, query, effectiveOverride);
+            const stateToApply = effectiveOverride ?? entry.state;
+            this.mountComponent(routeEl, entry.component, entry.params, stateToApply, query);
           }
         }
         activateRoute(routeEl, entry.params);

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -1635,6 +1635,9 @@ export class WebUIRouter {
         } catch { /* ignore */ }
       }
     } finally {
+      // Release the stream lock and clear the deferred reference
+      reader.releaseLock();
+      this.deferredReader = null;
       // Mark cache entry as complete
       const cacheEntry = this.cache.get(requestPath);
       if (cacheEntry) cacheEntry.complete = true;

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -426,27 +426,40 @@ test.describe('route loaders', () => {
     await expect(page.locator('.loader-data')).toContainText('Data fetched by static loader');
   });
 
-  test('X-WebUI-Has-Loader header is sent when leaf has loader', async ({ page }) => {
-    // First navigate to the loader page so the router discovers its loader
-    await page.click('a[href="/loader"]');
-    await expect(page.locator('.source')).toContainText('Source: client-loader');
-
-    // Now navigate again — the router should send the X-WebUI-Has-Loader header
+  test('navigation sends Accept header for NDJSON and JSON', async ({ page }) => {
+    // Navigate to any page and capture the partial request headers
     const [request] = await Promise.all([
       page.waitForRequest(req =>
         req.url().includes('/alpha') &&
-        req.headers()['accept']?.includes('application/json'),
+        req.headers()['accept']?.includes('json'),
       ),
       page.click('a[href="/alpha"]'),
     ]);
 
-    // The header should be present since page-loader was the previous leaf
-    // and it has a static loader. Note: the header signals the PREVIOUS
-    // leaf had a loader, which tells the server the current nav might too.
-    // The actual value depends on whether the router detected loaders.
-    const hasLoaderHeader = request.headers()['x-webui-has-loader'];
-    expect(hasLoaderHeader).toBeDefined();
-    expect(hasLoaderHeader).toContain('page-loader');
+    const accept = request.headers()['accept'];
+    expect(accept).toContain('application/x-ndjson');
+    expect(accept).toContain('application/json');
+  });
+
+  test('partial response does not include state (caller responsibility)', async ({ page }) => {
+    // Intercept the partial request and inspect the response body
+    const partialBody = page.waitForResponse(resp =>
+      resp.url().includes('/alpha') &&
+      resp.request().headers()['accept']?.includes('json'),
+    );
+
+    await page.click('a[href="/alpha"]');
+    const response = await partialBody;
+    const body = await response.json();
+
+    // chain + templates should be present
+    expect(body.chain).toBeDefined();
+    expect(body.templates).toBeDefined();
+    expect(body.inventory).toBeDefined();
+    expect(body.path).toBeDefined();
+
+    // State is added by the caller (the dev server adds it at the top level)
+    expect(body.state).toBeDefined();
   });
 });
 

--- a/xtask/src/process.rs
+++ b/xtask/src/process.rs
@@ -572,12 +572,14 @@ mod sys {
 
             // SAFETY: `info` is a valid, zero-initialised
             // `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` with only `LimitFlags` set.
+            #[allow(clippy::cast_possible_truncation)]
+            let info_size = std::mem::size_of::<ExtendedLimitInfo>() as u32;
             unsafe {
                 SetInformationJobObject(
                     job,
                     JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
                     std::ptr::addr_of!(info).cast(),
-                    std::mem::size_of::<ExtendedLimitInfo>() as u32,
+                    info_size,
                 );
             }
 
@@ -630,12 +632,14 @@ mod sys {
 
             // SAFETY: `info` points to a valid writable buffer of the requested
             // type and `self.0` is a valid job handle.
+            #[allow(clippy::cast_possible_truncation)]
+            let info_size = std::mem::size_of::<BasicAccountingInfo>() as u32;
             let ok = unsafe {
                 QueryInformationJobObject(
                     self.0,
                     JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
                     std::ptr::addr_of_mut!(info).cast(),
-                    std::mem::size_of::<BasicAccountingInfo>() as u32,
+                    info_size,
                     std::ptr::addr_of_mut!(returned_len),
                 )
             };


### PR DESCRIPTION
Split client-side navigation partials into a two-chunk NDJSON stream. Chunk 1 (chain + templates) flushes instantly for immediate navigation commit. Chunk 2 (per-component states) arrives when backend data is ready.

Protocol changes:
- render_partial() no longer takes a state parameter; callers add state to the response themselves (top-level for JSON, Chunk 2 for NDJSON)
- Removed render_partial_chain_only() — merged into render_partial()
- Removed state field from RouteChainEntry (zero per-entry clones)

Router (TypeScript):
- Sends Accept: application/x-ndjson, application/json
- readStreamingPartial() reads Chunk 1, commits navigation, spawns background continueDeferredRead() for Chunk 2
- applyDeferredStates() applies per-component state by chain position
- Falls back to top-level partialData.state for non-streaming servers
- Buffer overflow protection (256KB limit), EOF flush, generation guards
- Streaming cache entries start incomplete, marked complete after Chunk 2
- Removed X-WebUI-Has-Loader header and loaderComponents tracking

All binding crates (FFI, Node, WASM, CLI), examples, docs, and tests updated.

Fixes #261 