### PR TITLE
fix(router): flaky router preload cache test

### DIFF
--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -705,12 +705,13 @@ describe('WebUIRouter', () => {
       const priv = router as any;
 
       const cachedData = { state: { msg: 'preloaded' }, templates: [], path: '/about', chain: [{ component: 'about-page', path: '/about', params: {} }] };
-      // Store in unified cache via storeCacheEntry
-      priv.storeCacheEntry('/about', cachedData);
+      // Store in unified cache via storeCacheEntry (preload=true for 5s TTL)
+      priv.storeCacheEntry('/about', cachedData, true);
 
-      // Verify the cache entry exists
+      // Mark the entry as complete so lookupCache considers it ready
       const entry = priv.cache.get('/about');
       assert.ok(entry, 'cache should have entry for /about');
+      entry.complete = true;
       assert.deepEqual(entry.data.state, { msg: 'preloaded' });
 
       // Simulate consumption by lookupCache + evict


### PR DESCRIPTION
The "preload cache is consumed" test stored a non-preload entry with default `staleTime: 0`, causing `lookupCache` to immediately consider it stale. Additionally, non-preload entries get `complete: false` from `storeCacheEntry`, so `lookupCache` returned null.

Fix: pass `preload: true` (matches the test intent) and explicitly set `complete = true` after storage so `lookupCache` finds a ready entry.