### PR TITLE
refactor(handler) Remove html-escape dependency from webui-handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,6 @@ name = "microsoft-webui-handler"
 version = "0.0.10"
 dependencies = [
  "criterion",
- "html-escape",
  "microsoft-webui-expressions",
  "microsoft-webui-protocol",
  "microsoft-webui-state",

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -21,7 +21,6 @@ microsoft-webui-state = { path = "../webui-state", version = "0.0.10" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-html-escape = { workspace = true }
 
 [dev-dependencies]
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }

--- a/crates/webui-handler/src/html_encode.rs
+++ b/crates/webui-handler/src/html_encode.rs
@@ -1,6 +1,5 @@
-// Copyright (C) Microsoft Corporation. All rights reserved.
-// Use of this source code is governed by a MIT license that can be
-// found in the LICENSE file.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 //! Minimal HTML entity encoding for safe embedding of dynamic values.
 //!
@@ -109,10 +108,7 @@ mod tests {
 
     #[test]
     fn escapes_all_special_chars() {
-        assert_eq!(
-            encode_safe(r#"&<>"'/"#),
-            "&amp;&lt;&gt;&quot;&#x27;&#x2F;"
-        );
+        assert_eq!(encode_safe(r#"&<>"'/"#), "&amp;&lt;&gt;&quot;&#x27;&#x2F;");
     }
 
     #[test]

--- a/crates/webui-handler/src/html_encode.rs
+++ b/crates/webui-handler/src/html_encode.rs
@@ -1,0 +1,186 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+//! Minimal HTML entity encoding for safe embedding of dynamic values.
+//!
+//! A focused, zero-dependency implementation that covers the six characters
+//! needed for XSS prevention in HTML text and attribute contexts.
+
+use std::borrow::Cow;
+
+/// Characters escaped and their replacements:
+///
+/// * `&` → `&amp;`
+/// * `<` → `&lt;`
+/// * `>` → `&gt;`
+/// * `"` → `&quot;`
+/// * `'` → `&#x27;`
+/// * `/` → `&#x2F;`
+///
+/// Returns [`Cow::Borrowed`] when the input contains no characters that need
+/// escaping (zero-allocation fast path).
+pub fn encode_safe(input: &str) -> Cow<'_, str> {
+    let bytes = input.as_bytes();
+
+    // Fast path: find the first byte that needs escaping.
+    let first = bytes
+        .iter()
+        .position(|b| matches!(b, b'&' | b'<' | b'>' | b'"' | b'\'' | b'/'));
+
+    let Some(pos) = first else {
+        return Cow::Borrowed(input);
+    };
+
+    // Slow path: allocate and build the escaped string.
+    let mut out = String::with_capacity(input.len() + 6);
+    out.push_str(&input[..pos]);
+
+    let mut start = pos;
+    for (i, &b) in bytes[pos..].iter().enumerate() {
+        let replacement = match b {
+            b'&' => "&amp;",
+            b'<' => "&lt;",
+            b'>' => "&gt;",
+            b'"' => "&quot;",
+            b'\'' => "&#x27;",
+            b'/' => "&#x2F;",
+            _ => continue,
+        };
+        // Flush the unescaped run before this match.
+        out.push_str(&input[start..pos + i]);
+        out.push_str(replacement);
+        start = pos + i + 1;
+    }
+    // Flush any remaining unescaped tail.
+    out.push_str(&input[start..]);
+
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_escaping_returns_borrowed() {
+        let input = "Hello World 123";
+        let result = encode_safe(input);
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result, "Hello World 123");
+    }
+
+    #[test]
+    fn empty_string_returns_borrowed() {
+        let result = encode_safe("");
+        assert!(matches!(result, Cow::Borrowed(_)));
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn escapes_ampersand() {
+        assert_eq!(encode_safe("a&b"), "a&amp;b");
+    }
+
+    #[test]
+    fn escapes_less_than() {
+        assert_eq!(encode_safe("<script>"), "&lt;script&gt;");
+    }
+
+    #[test]
+    fn escapes_greater_than() {
+        assert_eq!(encode_safe("a>b"), "a&gt;b");
+    }
+
+    #[test]
+    fn escapes_double_quote() {
+        assert_eq!(encode_safe(r#"a"b"#), "a&quot;b");
+    }
+
+    #[test]
+    fn escapes_single_quote() {
+        assert_eq!(encode_safe("a'b"), "a&#x27;b");
+    }
+
+    #[test]
+    fn escapes_forward_slash() {
+        assert_eq!(encode_safe("a/b"), "a&#x2F;b");
+    }
+
+    #[test]
+    fn escapes_all_special_chars() {
+        assert_eq!(
+            encode_safe(r#"&<>"'/"#),
+            "&amp;&lt;&gt;&quot;&#x27;&#x2F;"
+        );
+    }
+
+    #[test]
+    fn preserves_unicode() {
+        assert_eq!(encode_safe("こんにちは"), "こんにちは");
+        assert!(matches!(encode_safe("こんにちは"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn mixed_unicode_and_special() {
+        assert_eq!(encode_safe("日本語&テスト"), "日本語&amp;テスト");
+    }
+
+    #[test]
+    fn escapes_at_start() {
+        assert_eq!(encode_safe("&start"), "&amp;start");
+    }
+
+    #[test]
+    fn escapes_at_end() {
+        assert_eq!(encode_safe("end&"), "end&amp;");
+    }
+
+    #[test]
+    fn multiple_consecutive_escapes() {
+        assert_eq!(encode_safe("&&"), "&amp;&amp;");
+    }
+
+    #[test]
+    fn realistic_nonce() {
+        // CSP nonces are base64 — no special chars expected.
+        let nonce = "YWJjZGVmZ2hpamtsbW5vcA==";
+        let result = encode_safe(nonce);
+        assert!(matches!(result, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn realistic_attribute_value() {
+        assert_eq!(
+            encode_safe("John O'Brien & Associates"),
+            "John O&#x27;Brien &amp; Associates"
+        );
+    }
+
+    #[test]
+    fn realistic_xss_attempt() {
+        assert_eq!(
+            encode_safe("<script>alert('xss')</script>"),
+            "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;&#x2F;script&gt;"
+        );
+    }
+
+    #[test]
+    fn escapes_all_known_special_chars() {
+        // Verify all six special characters are escaped correctly.
+        let test_cases = [
+            ("", ""),
+            ("hello", "hello"),
+            ("&", "&amp;"),
+            ("<", "&lt;"),
+            (">", "&gt;"),
+            ("\"", "&quot;"),
+            ("'", "&#x27;"),
+            ("/", "&#x2F;"),
+            ("a&b<c>d\"e'f/g", "a&amp;b&lt;c&gt;d&quot;e&#x27;f&#x2F;g"),
+        ];
+        for (input, expected) in test_cases {
+            assert_eq!(encode_safe(input), expected, "Failed for input: {input:?}");
+        }
+    }
+}

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -6,6 +6,7 @@
 //! This crate provides functionality to process and render WebUI protocols
 //! into final HTML output based on provided data.
 
+pub mod html_encode;
 pub mod plugin;
 pub mod route_handler;
 pub mod route_matcher;
@@ -736,7 +737,7 @@ impl WebUIHandler {
                 context
                     .writer
                     .write("<meta name=\"webui-nonce\" content=\"")?;
-                context.writer.write(&html_escape::encode_safe(nonce))?;
+                context.writer.write(&crate::html_encode::encode_safe(nonce))?;
                 context.writer.write("\">")?;
             }
 
@@ -902,10 +903,10 @@ impl WebUIHandler {
             }
         } else {
             match value {
-                Value::String(s) => writer.write(&html_escape::encode_safe(s)),
+                Value::String(s) => writer.write(&crate::html_encode::encode_safe(s)),
                 _ => {
                     let s = value.to_string();
-                    writer.write(&html_escape::encode_safe(&s))
+                    writer.write(&crate::html_encode::encode_safe(&s))
                 }
             }
         }
@@ -978,7 +979,7 @@ impl WebUIHandler {
         // Template attribute (mixed static + dynamic)
         if !attr.template.is_empty() {
             let raw_value = self.render_template_attr_value(&attr.template, context)?;
-            let escaped = html_escape::encode_safe(&raw_value);
+            let escaped = crate::html_encode::encode_safe(&raw_value);
             write_attr(context.writer, &attr.name, &escaped)?;
 
             if !attr.attr_skip {
@@ -1017,14 +1018,14 @@ impl WebUIHandler {
                 // markers (data-fe-b-N) match the DOM node structure.
                 match &value {
                     Some(Value::String(s)) => {
-                        write_attr(context.writer, &attr.name, &html_escape::encode_safe(s))?;
+                        write_attr(context.writer, &attr.name, &crate::html_encode::encode_safe(s))?;
                     }
                     Some(Value::Null) | None => {
                         write_attr(context.writer, &attr.name, "")?;
                     }
                     Some(other) => {
                         let s = other.to_string();
-                        write_attr(context.writer, &attr.name, &html_escape::encode_safe(&s))?;
+                        write_attr(context.writer, &attr.name, &crate::html_encode::encode_safe(&s))?;
                     }
                 }
 
@@ -2427,7 +2428,7 @@ mod tests {
 
     #[test]
     fn test_escape_single_quote() {
-        // html_escape::encode_safe escapes ' as &#x27;
+        // crate::html_encode::encode_safe escapes ' as &#x27;
         let result = render_signal("'");
         assert!(
             result == "&#39;" || result == "&#x27;" || result == "'",

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -6,7 +6,7 @@
 //! This crate provides functionality to process and render WebUI protocols
 //! into final HTML output based on provided data.
 
-pub mod html_encode;
+pub(crate) mod html_encode;
 pub mod plugin;
 pub mod route_handler;
 pub mod route_matcher;
@@ -737,7 +737,9 @@ impl WebUIHandler {
                 context
                     .writer
                     .write("<meta name=\"webui-nonce\" content=\"")?;
-                context.writer.write(&crate::html_encode::encode_safe(nonce))?;
+                context
+                    .writer
+                    .write(&crate::html_encode::encode_safe(nonce))?;
                 context.writer.write("\">")?;
             }
 
@@ -1018,14 +1020,22 @@ impl WebUIHandler {
                 // markers (data-fe-b-N) match the DOM node structure.
                 match &value {
                     Some(Value::String(s)) => {
-                        write_attr(context.writer, &attr.name, &crate::html_encode::encode_safe(s))?;
+                        write_attr(
+                            context.writer,
+                            &attr.name,
+                            &crate::html_encode::encode_safe(s),
+                        )?;
                     }
                     Some(Value::Null) | None => {
                         write_attr(context.writer, &attr.name, "")?;
                     }
                     Some(other) => {
                         let s = other.to_string();
-                        write_attr(context.writer, &attr.name, &crate::html_encode::encode_safe(&s))?;
+                        write_attr(
+                            context.writer,
+                            &attr.name,
+                            &crate::html_encode::encode_safe(&s),
+                        )?;
                     }
                 }
 
@@ -2428,12 +2438,11 @@ mod tests {
 
     #[test]
     fn test_escape_single_quote() {
-        // crate::html_encode::encode_safe escapes ' as &#x27;
+        // encode_safe escapes ' as &#x27;
         let result = render_signal("'");
-        assert!(
-            result == "&#39;" || result == "&#x27;" || result == "'",
-            "Expected escaped single quote, got: {}",
-            result
+        assert_eq!(
+            result, "&#x27;",
+            "Expected &#x27; for single quote, got: {result}"
         );
     }
 


### PR DESCRIPTION
 - Adds inline html_encode module with encode_safe() (Cow fast-path, 18 tests)
 - Replaces 6 call sites in the handler
 - Removes html-escape + transitive utf8-width from handler's dependency tree
 - webui-parser retains html-escape for decode_html_entities
 - All 239 tests pass
