### PR TITLE
feat(ffi): make webui-parser an optional dependency via parser feature

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1218,7 +1218,7 @@ header is at `crates/webui-ffi/include/webui_ffi.h`.
 
 | Function | Description |
 |----------|-------------|
-| `webui_render(html, data_json)` | Parse + render in one call. Returns heap-allocated string (caller frees with `webui_free`). |
+| `webui_render(html, data_json)` | Parse + render in one call (requires `parser` feature; returns `NULL` when absent). Returns heap-allocated string (caller frees with `webui_free`). |
 | `webui_handler_create()` | Create a reusable handler (no plugin). |
 | `webui_handler_create_with_plugin(plugin_id)` | Create a handler with a named plugin (e.g. `"fast"`). Returns `NULL` on error. |
 | `webui_handler_render(handler, data, len, json, entry_id, request_path)` | Render a pre-compiled protocol with route matching. `request_path` controls which route is active. Returns heap-allocated string. |

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -15,9 +15,13 @@ categories = ["api-bindings", "web-programming"]
 name = "webui_ffi"
 crate-type = ["cdylib", "staticlib", "lib"]
 
+[features]
+default = ["parser"]
+parser = ["dep:microsoft-webui-parser"]
+
 [dependencies]
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10", optional = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/webui-ffi/include/webui_ffi.h
+++ b/crates/webui-ffi/include/webui_ffi.h
@@ -81,6 +81,10 @@ char *webui_handler_render(void *handler_ptr,
 /// This is the **recommended entry point** for Go, C#, and Python consumers.
 /// It eliminates the need for callers to deal with protobuf serialisation.
 ///
+/// Requires the `parser` feature (enabled by default). When built without
+/// the `parser` feature, this function always returns `NULL` and sets an
+/// error via [`webui_last_error`].
+///
 /// # Arguments
 ///
 /// * `html`      - Null-terminated UTF-8 string containing the HTML template.

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -37,6 +37,7 @@ use std::os::raw::{c_char, c_void};
 use webui_handler::plugin::fast::FastHydrationPlugin;
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
+#[cfg(feature = "parser")]
 use webui_parser::HtmlParser;
 use webui_protocol::WebUIProtocol;
 
@@ -323,6 +324,10 @@ pub unsafe extern "C" fn webui_handler_render(
 /// This is the **recommended entry point** for Go, C#, and Python consumers.
 /// It eliminates the need for callers to deal with protobuf serialisation.
 ///
+/// Requires the `parser` feature (enabled by default). When built without
+/// the `parser` feature, this function always returns `NULL` and sets an
+/// error via [`webui_last_error`].
+///
 /// # Arguments
 ///
 /// * `html`      - Null-terminated UTF-8 string containing the HTML template.
@@ -349,7 +354,30 @@ pub unsafe extern "C" fn webui_render(
         return std::ptr::null_mut();
     }
 
+    #[cfg(not(feature = "parser"))]
+    {
+        let _ = (html, data_json);
+        set_last_error(
+            "webui_render requires the \"parser\" feature, which was not enabled at build time",
+        );
+        return std::ptr::null_mut();
+    }
+
+    #[cfg(feature = "parser")]
+    match std::panic::catch_unwind(|| webui_render_impl(html, data_json)) {
+        Ok(ptr) => ptr,
+        Err(_) => {
+            set_last_error("panic in webui_render");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Inner implementation of [`webui_render`], compiled only with the `parser` feature.
+#[cfg(feature = "parser")]
+unsafe fn webui_render_impl(html: *const c_char, data_json: *const c_char) -> *mut c_char {
     // --- Extract C strings ---------------------------------------------------
+    // SAFETY: caller (webui_render) already verified non-null.
     let html_str = match CStr::from_ptr(html).to_str() {
         Ok(s) => s,
         Err(e) => {
@@ -358,6 +386,7 @@ pub unsafe extern "C" fn webui_render(
         }
     };
 
+    // SAFETY: caller (webui_render) already verified non-null.
     let data_str = match CStr::from_ptr(data_json).to_str() {
         Ok(s) => s,
         Err(e) => {

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -28,6 +28,7 @@ use webui_protocol::{FragmentList, WebUIFragment, WebUIProtocol, WebUiFragmentRo
 
 /// Call `webui_render` and return a Rust `String`, freeing the C
 /// string afterwards. Panics if the function returns `NULL`.
+#[cfg(feature = "parser")]
 unsafe fn render(html: &str, json: &str) -> String {
     let c_html = CString::new(html).expect("test html should not contain NUL");
     let c_json = CString::new(json).expect("test json should not contain NUL");
@@ -53,9 +54,10 @@ unsafe fn last_error_string() -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: webui_render (happy paths)
+// Tests: webui_render (happy paths) — requires `parser` feature
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "parser")]
 #[test]
 fn simple_html_passthrough() {
     unsafe {
@@ -64,6 +66,7 @@ fn simple_html_passthrough() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn signal_substitution() {
     unsafe {
@@ -72,6 +75,7 @@ fn signal_substitution() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn for_loop() {
     unsafe {
@@ -82,6 +86,7 @@ fn for_loop() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn if_condition_true() {
     unsafe {
@@ -92,6 +97,7 @@ fn if_condition_true() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn if_condition_false() {
     unsafe {
@@ -102,6 +108,7 @@ fn if_condition_false() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn html_escaping() {
     unsafe {
@@ -116,6 +123,7 @@ fn html_escaping() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn raw_signal_unescaped() {
     unsafe {
@@ -126,6 +134,7 @@ fn raw_signal_unescaped() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn empty_data_object() {
     unsafe {
@@ -135,9 +144,10 @@ fn empty_data_object() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: error cases
+// Tests: error cases — webui_render (requires `parser` feature)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "parser")]
 #[test]
 fn null_html_returns_null_and_sets_error() {
     unsafe {
@@ -158,6 +168,7 @@ fn null_html_returns_null_and_sets_error() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn null_json_returns_null_and_sets_error() {
     unsafe {
@@ -170,6 +181,7 @@ fn null_json_returns_null_and_sets_error() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn invalid_json_returns_null_and_sets_error() {
     unsafe {
@@ -186,6 +198,7 @@ fn invalid_json_returns_null_and_sets_error() {
     }
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn successful_call_clears_previous_error() {
     unsafe {
@@ -435,9 +448,10 @@ fn render_partial_returns_templates_inventory_and_chain() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: fixture file
+// Tests: fixture file (requires `parser` feature)
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "parser")]
 #[test]
 fn fixture_file_renders_correctly() {
     let html = include_str!("fixtures/simple.html");
@@ -458,5 +472,30 @@ fn fixture_file_renders_correctly() {
 fn free_string_null_is_safe() {
     unsafe {
         webui_free(std::ptr::null_mut()); // should not crash
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: webui_render without `parser` feature returns error stub
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "parser"))]
+#[test]
+fn webui_render_without_parser_returns_null_with_error() {
+    unsafe {
+        let c_html = CString::new("<p>hi</p>").expect("static string");
+        let c_json = CString::new("{}").expect("static string");
+
+        let ptr = webui_render(c_html.as_ptr(), c_json.as_ptr());
+        assert!(
+            ptr.is_null(),
+            "webui_render should return NULL without parser feature"
+        );
+
+        let err = last_error_string().expect("error should be set without parser feature");
+        assert!(
+            err.contains("parser"),
+            "error should mention parser feature, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add a `parser` Cargo feature flag (enabled by default) to `webui-ffi` that gates the `microsoft-webui-parser` dependency and its tree-sitter native libraries.

## Motivation

Embedders like Chromium only use protobuf-based rendering functions (`webui_handler_render`, `webui_render_partial`, etc.) and don't need the HTML parser or its tree-sitter C native dependencies. This feature flag lets them consume webui-ffi without pulling in `tree-sitter-html` and `tree-sitter-css`.

## Changes

**`crates/webui-ffi/Cargo.toml`**
- Add `[features]` section: `default = ["parser"]`, `parser = ["dep:microsoft-webui-parser"]`
- Make `microsoft-webui-parser` dependency optional

**`crates/webui-ffi/src/lib.rs`**
- Gate `use webui_parser::HtmlParser` with `#[cfg(feature = "parser")]`
- Split `webui_render()` into always-exported shell + `#[cfg(feature = "parser")]` inner impl
- Without parser: returns `NULL` + descriptive error via `webui_last_error()`
- Add `catch_unwind` to `webui_render()` (matching `webui_render_partial` pattern)

**`crates/webui-ffi/tests/ffi_test.rs`**
- Gate parser-dependent tests with `#[cfg(feature = "parser")]`
- Add `#[cfg(not(feature = "parser"))]` test verifying the stub behavior

**`DESIGN.md`**
- Note `parser` feature requirement in FFI function table

## Backward Compatibility

- `default = ["parser"]`  existing consumers get identical behavior
- `webui_render()` C symbol always exported for ABI stability
- Header file (`webui_ffi.h`) unchanged

## How Chromium would consume it

\\\	oml
microsoft-webui-ffi = { version = "0.0.10", default-features = false }
\\\

## Testing

-  `cargo test -p microsoft-webui-ffi`  18 tests pass (default features)
-  `cargo test -p microsoft-webui-ffi --no-default-features`  6 tests pass (no parser)
-  `cargo xtask fmt` / `clippy` / `license-headers` all pass