### PR TITLE
feat(router): support base paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "examples/integration/rust",
     "examples/integration/ssr-performance-showdown",
     "examples/app/commerce/server",
-    "examples/demo/server",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/integration/rust",
     "examples/integration/ssr-performance-showdown",
     "examples/app/commerce/server",
+    "examples/demo/server",
 ]
 resolver = "2"
 
@@ -48,6 +49,7 @@ tree-sitter-language = "0.1.7"
 tree-sitter-html = "0.23.2"
 tree-sitter-css = "0.25.0"
 walkdir = "2.5.0"
+toml = "0.8"
 libc = "0.2.183"
 which = "8.0.2"
 windows = { version = "0.62.2", features = [

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -54,6 +54,12 @@ pub struct ServeArgs {
     /// when the value doesn't point to a file on disk.
     #[arg(long)]
     pub theme: Option<String>,
+
+    /// Base path for sub-path deployment (e.g., `/commerce/`).
+    /// Emits a `<base href>` tag and makes asset paths relative so the
+    /// app can be served behind a reverse proxy under a sub-path.
+    #[arg(long)]
+    pub base_path: Option<String>,
 }
 
 /// Resolved paths for `webui serve`.
@@ -312,6 +318,7 @@ fn run(args: &ServeArgs) -> Result<()> {
         app_dir: paths.app_dir.clone(),
         state_file: paths.state_file.clone(),
         token_css,
+        base_path: args.base_path.clone(),
     };
 
     output::header("WebUI Dev Server");
@@ -390,6 +397,7 @@ fn run(args: &ServeArgs) -> Result<()> {
         api_port: args.api_port,
         plugin: args.app_args.plugin,
         token_css: render_config.token_css,
+        base_path: args.base_path.clone(),
     });
 
     let has_api_proxy = server_context.api_port.is_some();
@@ -472,6 +480,8 @@ struct RenderConfig {
     /// Pre-resolved per-theme CSS strings. Computed once at startup and reused
     /// for every build-and-render cycle (initial + file-watcher rebuilds).
     token_css: Option<HashMap<String, String>>,
+    /// Base path for sub-path deployment (e.g., `/commerce/`).
+    base_path: Option<String>,
 }
 
 /// Result of a build-and-render cycle.
@@ -503,6 +513,15 @@ fn build_and_render(
     // Inject pre-resolved token CSS into state
     if let Some(ref token_css) = config.token_css {
         webui_tokens::inject_token_css(&mut state, token_css);
+    }
+
+    // Inject basePath into state so templates can use {{basePath}}.
+    // Default to "/" when no --base-path is set — relative CSS paths
+    // like "foo.css" need <base href="/"> to resolve correctly on
+    // nested routes (e.g., /contacts/123 → /foo.css, not /contacts/foo.css).
+    if let Value::Object(ref mut map) = state {
+        let bp = config.base_path.as_deref().unwrap_or("/").to_string();
+        map.insert("basePath".into(), Value::String(bp));
     }
 
     // Render to memory
@@ -562,6 +581,8 @@ struct ServerContext {
     plugin: Option<Plugin>,
     /// Pre-resolved token CSS keyed by theme name, injected into state at render time.
     token_css: Option<HashMap<String, String>>,
+    /// Base path for sub-path deployment.
+    base_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -646,6 +667,12 @@ async fn resolve_state(context: &ServerContext, request_path: &str) -> Value {
     // whether state came from a static file or the API server.
     if let Some(ref token_css) = context.token_css {
         webui_tokens::inject_token_css(&mut state, token_css);
+    }
+
+    // Inject basePath into state — default "/" for correct CSS resolution.
+    if let Value::Object(ref mut map) = state {
+        let bp = context.base_path.as_deref().unwrap_or("/").to_string();
+        map.insert("basePath".into(), Value::String(bp));
     }
 
     state
@@ -1194,6 +1221,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: Some(app.path().join("state.json")),
             token_css: None,
+            base_path: None,
         };
         let hmr = PollingHmrBackend::new("/hmr", 1000);
         let BuildRenderResult { html, .. } = build_and_render(&config, Some(&hmr)).unwrap();
@@ -1218,6 +1246,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: Some(app.path().join("state.json")),
             token_css: None,
+            base_path: None,
         };
         let hmr = PollingHmrBackend::new("/hmr", 1000);
         let BuildRenderResult { html, .. } = build_and_render(&config, Some(&hmr)).unwrap();
@@ -1239,6 +1268,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: Some(app.path().join("state.json")),
             token_css: None,
+            base_path: None,
         };
         let BuildRenderResult { html, .. } = build_and_render(&config, None).unwrap();
         assert!(!html.contains("/hmr"));
@@ -1272,6 +1302,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: Some(app.path().join("state.json")),
             token_css: None,
+            base_path: None,
         };
         let hmr = PollingHmrBackend::new("/hmr", 1000);
         let result = build_and_render(&config, Some(&hmr));
@@ -1293,6 +1324,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: None,
             token_css: None,
+            base_path: None,
         };
         let result = build_and_render(&config, None).unwrap();
         assert!(result.html.contains("<h1>Hello</h1>"));
@@ -1313,6 +1345,7 @@ mod tests {
             app_dir: app.path().to_path_buf(),
             state_file: Some(app.path().join("state.json")),
             token_css: None,
+            base_path: None,
         };
         let hmr = PollingHmrBackend::new("/hmr", 1000);
         let result = build_and_render(&config, Some(&hmr));
@@ -1570,6 +1603,7 @@ mod tests {
             app_dir,
             state_file: Some(manifest_dir.join("../../examples/app/hello-world/data/state.json")),
             token_css: None,
+            base_path: None,
         };
         let hmr = PollingHmrBackend::new("/hmr", 1000);
         let BuildRenderResult { html, .. } = build_and_render(&config, Some(&hmr)).unwrap();
@@ -1612,6 +1646,7 @@ mod tests {
             api_port: None,
             plugin: None,
             token_css: None,
+            base_path: None,
         });
 
         let app = actix_test::init_service(

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -6198,7 +6198,7 @@ mod tests {
             .components
             .entry("my-card".to_string())
             .or_default();
-        comp.css_href = "/my-card.css".to_string();
+        comp.css_href = "my-card.css".to_string();
         comp.template = "(function(){})();".to_string();
 
         let state = test_json!({});
@@ -6215,7 +6215,7 @@ mod tests {
         let html = writer.get_content();
 
         let head_end = html.find("</head>").expect("</head> missing");
-        let link_pos = html.find(r#"<link rel="stylesheet" href="/my-card.css">"#);
+        let link_pos = html.find(r#"<link rel="stylesheet" href="my-card.css">"#);
         assert!(
             link_pos.is_some_and(|p| p < head_end),
             "Light DOM Link strategy should emit <link rel=stylesheet> in <head>: {html}"
@@ -6273,14 +6273,14 @@ mod tests {
             .components
             .entry("o-loading-state".to_string())
             .or_default();
-        comp1.css_href = "/o-loading-state.css".to_string();
+        comp1.css_href = "o-loading-state.css".to_string();
         comp1.template = "(function(){})();".to_string();
 
         let comp2 = protocol
             .components
             .entry("my-card".to_string())
             .or_default();
-        comp2.css_href = "/my-card.css".to_string();
+        comp2.css_href = "my-card.css".to_string();
         comp2.template = "(function(){})();".to_string();
 
         let state = test_json!({});
@@ -6301,13 +6301,13 @@ mod tests {
         // Both preload hints must be present with data-webui-ssr-preload attr
         assert!(
             head_section.contains(
-                r#"<link rel="preload" href="/o-loading-state.css" as="style" data-webui-ssr-preload="style">"#
+                r#"<link rel="preload" href="o-loading-state.css" as="style" data-webui-ssr-preload="style">"#
             ),
             "Missing preload for o-loading-state.css in <head>: {html}"
         );
         assert!(
             head_section.contains(
-                r#"<link rel="preload" href="/my-card.css" as="style" data-webui-ssr-preload="style">"#
+                r#"<link rel="preload" href="my-card.css" as="style" data-webui-ssr-preload="style">"#
             ),
             "Missing preload for my-card.css in <head>: {html}"
         );
@@ -6482,7 +6482,7 @@ mod tests {
             .components
             .entry("has-css".to_string())
             .or_default()
-            .css_href = "/has-css.css".to_string();
+            .css_href = "has-css.css".to_string();
 
         let state = test_json!({});
         let mut writer = TestWriter::new();
@@ -6501,7 +6501,7 @@ mod tests {
 
         let html = writer.get_content();
         assert!(
-            html.contains(r#"<link rel="stylesheet" href="/has-css.css">"#),
+            html.contains(r#"<link rel="stylesheet" href="has-css.css">"#),
             "Component with CSS should get a <link rel=stylesheet> in <head>: {html}"
         );
         assert!(

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1846,7 +1846,7 @@ mod tests {
             .entry("my-page".to_string())
             .or_default();
         component.template = "(function(){})();".to_string();
-        component.css_href = "/my-page.css".to_string();
+        component.css_href = "my-page.css".to_string();
         // css is empty — Link strategy stores href, not content
 
         let mut index = ProtocolIndex::new(&protocol);

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -31,7 +31,7 @@ use webui_protocol::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum CssStrategy {
-    /// Emit `<link rel="stylesheet" href="/component.css">` tags (default).
+    /// Emit `<link rel="stylesheet" href="component.css">` tags (default).
     #[default]
     Link,
     /// Embed CSS content in `<style>` tags within the component.
@@ -1765,9 +1765,7 @@ impl HtmlParser {
                 // In light DOM mode, CSS links go in <head> (emitted by handler),
                 // not inside each component template.
                 if css_content.is_some() && self.dom_strategy == DomStrategy::Shadow {
-                    Some(format!(
-                        "<link rel=\"stylesheet\" href=\"/{tag_name}.css\">"
-                    ))
+                    Some(format!("<link rel=\"stylesheet\" href=\"{tag_name}.css\">"))
                 } else {
                     None
                 }
@@ -3442,7 +3440,7 @@ mod tests {
             })
             .collect();
         assert!(
-            raw_text.contains(r#"<link rel="stylesheet" href="/my-card.css">"#),
+            raw_text.contains(r#"<link rel="stylesheet" href="my-card.css">"#),
             "Expected external <link> tag in: {}",
             raw_text
         );

--- a/crates/webui-parser/src/plugin/fast.rs
+++ b/crates/webui-parser/src/plugin/fast.rs
@@ -149,7 +149,7 @@ pub fn generate_f_template(
     let css_injection = match css_strategy {
         CssStrategy::Link => css_content.map(|_| {
             let mut s = String::with_capacity(40 + tag_name.len());
-            s.push_str("<link rel=\"stylesheet\" href=\"/");
+            s.push_str("<link rel=\"stylesheet\" href=\"");
             s.push_str(tag_name);
             s.push_str(".css\">");
             s
@@ -777,7 +777,7 @@ mod tests {
         assert!(html.contains("</f-template>"));
         assert!(html.contains("<template>"));
         assert!(html.contains("</template>"));
-        assert!(html.contains("<link rel=\"stylesheet\" href=\"/my-comp.css\">"));
+        assert!(html.contains("<link rel=\"stylesheet\" href=\"my-comp.css\">"));
         assert!(html.contains("<div>hello</div>"));
     }
 

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -2406,10 +2406,10 @@ mod tests {
     fn test_compiled_template_preserves_link_node_in_static_html() {
         let result = generate_compiled_template(
             "my-comp",
-            r#"<template shadowrootmode="open"><link rel="stylesheet" href="/my-comp.css"><p>hi</p></template>"#,
+            r#"<template shadowrootmode="open"><link rel="stylesheet" href="my-comp.css"><p>hi</p></template>"#,
         );
         assert!(result.contains(r#"rel=\"stylesheet\""#));
-        assert!(result.contains(r#"href=\"/my-comp.css\""#));
+        assert!(result.contains(r#"href=\"my-comp.css\""#));
         assert!(result.contains(r#"<p>hi</p>"#));
         assert!(!result.contains(",css:"));
     }
@@ -2449,13 +2449,13 @@ mod tests {
             .register_component_template(
                 "test-el",
                 &comp,
-                r#"<template shadowrootmode="open"><link rel="stylesheet" href="/test-el.css"><p>hi</p></template>"#,
+                r#"<template shadowrootmode="open"><link rel="stylesheet" href="test-el.css"><p>hi</p></template>"#,
             )
             .unwrap();
         let templates = plugin.take_component_templates();
         assert_eq!(templates.len(), 1);
         assert!(templates[0].1.contains(r#"rel=\"stylesheet\""#));
-        assert!(templates[0].1.contains(r#"href=\"/test-el.css\""#));
+        assert!(templates[0].1.contains(r#"href=\"test-el.css\""#));
         assert!(templates[0].1.contains(r#"<p>hi</p>"#));
     }
 
@@ -2478,7 +2478,7 @@ mod tests {
             .register_component_template(
                 "test-el",
                 &comp,
-                r#"<template shadowrootmode="open"><link rel="stylesheet" href="/test-el.css"><p>hi</p></template>"#,
+                r#"<template shadowrootmode="open"><link rel="stylesheet" href="test-el.css"><p>hi</p></template>"#,
             )
             .unwrap();
         let templates = plugin.take_component_templates();

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -314,7 +314,7 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
             protocol.components.entry(tag).or_default().css = css.trim().to_string();
         } else if is_link {
             let safe_tag = tag.replace(['/', '\\'], "-");
-            let href = format!("/{safe_tag}.css");
+            let href = format!("{safe_tag}.css");
             protocol.components.entry(tag).or_default().css_href = href;
             css_files.push((format!("{safe_tag}.css"), css));
         }
@@ -434,7 +434,7 @@ mod tests {
             .map(|c| c.css_href.as_str())
             .unwrap_or("");
         assert_eq!(
-            href, "/has-css.css",
+            href, "has-css.css",
             "Light×Link component with CSS should have css_href"
         );
 
@@ -464,7 +464,7 @@ mod tests {
 
         let comp = result.protocol.components.get("my-card").unwrap();
         assert_eq!(
-            comp.css_href, "/my-card.css",
+            comp.css_href, "my-card.css",
             "Shadow×Link should set css_href"
         );
 

--- a/crates/webui/src/server.rs
+++ b/crates/webui/src/server.rs
@@ -228,7 +228,7 @@ mod tests {
             .entry("my-page".to_string())
             .or_default();
         comp.template = "(function(){})();".to_string();
-        comp.css_href = "/my-page.css".to_string();
+        comp.css_href = "my-page.css".to_string();
         // No css content — Link strategy
 
         let handler = WebUIHandler::new();

--- a/examples/app/calculator/src/index.html
+++ b/examples/app/calculator/src/index.html
@@ -2,6 +2,7 @@
 <html dir="{{textdirection}}" lang="{{language}}">
 <head>
   <meta charset="utf-8">
+  <base href="{{basePath}}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{title}}</title>
   <style>
@@ -120,6 +121,6 @@
     columns="{{columns}}"
   ></calc-app>
 
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/examples/app/commerce/server/src/app.rs
+++ b/examples/app/commerce/server/src/app.rs
@@ -14,22 +14,13 @@ pub(crate) struct AppState {
     frontend: FrontendRuntime,
     rate_limiter: RateLimiter,
     image_cache: ImageCache,
-    base_path: Option<String>,
+    base_path: String,
 }
 
 impl AppState {
-    pub(crate) fn load(
-        app_root: &Path,
-        css: webui::CssStrategy,
-        base_path: Option<&str>,
-    ) -> Result<Self> {
+    pub(crate) fn load(app_root: &Path, css: webui::CssStrategy, base_path: &str) -> Result<Self> {
         let frontend = FrontendRuntime::load(app_root, css)?;
-        let image_prefix = if base_path.is_some() {
-            "_image/"
-        } else {
-            "/_image/"
-        };
-        let catalog = Catalog::generate(image_prefix);
+        let catalog = Catalog::generate();
         // 60 mutation requests per IP per minute
         let rate_limiter = RateLimiter::new(60, 60);
         let image_cache = ImageCache::load(&app_root.join("images"))?;
@@ -38,8 +29,13 @@ impl AppState {
             frontend,
             rate_limiter,
             image_cache,
-            base_path: base_path.map(String::from),
+            base_path: base_path.to_string(),
         })
+    }
+
+    #[must_use]
+    pub(crate) fn base_path(&self) -> &str {
+        &self.base_path
     }
 
     #[must_use]
@@ -71,11 +67,6 @@ impl AppState {
     pub(crate) fn rate_limiter(&self) -> &RateLimiter {
         &self.rate_limiter
     }
-
-    #[must_use]
-    pub(crate) fn base_path(&self) -> Option<&str> {
-        self.base_path.as_deref()
-    }
 }
 
 #[cfg(test)]
@@ -88,7 +79,7 @@ pub(crate) fn test_state_with_css(css: webui::CssStrategy) -> actix_web::web::Da
     let app_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("server crate should live under the app directory");
-    let state = match AppState::load(app_root, css, None) {
+    let state = match AppState::load(app_root, css, "/") {
         Ok(state) => state,
         Err(error) => panic!("Failed to build the commerce WebUI protocol: {error:#}"),
     };

--- a/examples/app/commerce/server/src/app.rs
+++ b/examples/app/commerce/server/src/app.rs
@@ -14,12 +14,22 @@ pub(crate) struct AppState {
     frontend: FrontendRuntime,
     rate_limiter: RateLimiter,
     image_cache: ImageCache,
+    base_path: Option<String>,
 }
 
 impl AppState {
-    pub(crate) fn load(app_root: &Path, css: webui::CssStrategy) -> Result<Self> {
+    pub(crate) fn load(
+        app_root: &Path,
+        css: webui::CssStrategy,
+        base_path: Option<&str>,
+    ) -> Result<Self> {
         let frontend = FrontendRuntime::load(app_root, css)?;
-        let catalog = Catalog::generate();
+        let image_prefix = if base_path.is_some() {
+            "_image/"
+        } else {
+            "/_image/"
+        };
+        let catalog = Catalog::generate(image_prefix);
         // 60 mutation requests per IP per minute
         let rate_limiter = RateLimiter::new(60, 60);
         let image_cache = ImageCache::load(&app_root.join("images"))?;
@@ -28,6 +38,7 @@ impl AppState {
             frontend,
             rate_limiter,
             image_cache,
+            base_path: base_path.map(String::from),
         })
     }
 
@@ -60,6 +71,11 @@ impl AppState {
     pub(crate) fn rate_limiter(&self) -> &RateLimiter {
         &self.rate_limiter
     }
+
+    #[must_use]
+    pub(crate) fn base_path(&self) -> Option<&str> {
+        self.base_path.as_deref()
+    }
 }
 
 #[cfg(test)]
@@ -72,7 +88,7 @@ pub(crate) fn test_state_with_css(css: webui::CssStrategy) -> actix_web::web::Da
     let app_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("server crate should live under the app directory");
-    let state = match AppState::load(app_root, css) {
+    let state = match AppState::load(app_root, css, None) {
         Ok(state) => state,
         Err(error) => panic!("Failed to build the commerce WebUI protocol: {error:#}"),
     };

--- a/examples/app/commerce/server/src/cart.rs
+++ b/examples/app/commerce/server/src/cart.rs
@@ -496,7 +496,11 @@ mod tests {
     fn cart_state_resolves_prices_from_catalog() {
         let mut cart = StoredCart::default();
         add_item(&mut cart, "acme-t-shirt", "Black", "M", 2);
-        let state = build_cart_state(&cart, &Catalog::generate(), "/product/acme-t-shirt");
+        let state = build_cart_state(
+            &cart,
+            &Catalog::generate("/_image/"),
+            "/product/acme-t-shirt",
+        );
 
         assert_eq!(state.cart_item_count, 2);
         assert!(!state.cart_empty);

--- a/examples/app/commerce/server/src/cart.rs
+++ b/examples/app/commerce/server/src/cart.rs
@@ -496,11 +496,7 @@ mod tests {
     fn cart_state_resolves_prices_from_catalog() {
         let mut cart = StoredCart::default();
         add_item(&mut cart, "acme-t-shirt", "Black", "M", 2);
-        let state = build_cart_state(
-            &cart,
-            &Catalog::generate("/_image/"),
-            "/product/acme-t-shirt",
-        );
+        let state = build_cart_state(&cart, &Catalog::generate(), "/product/acme-t-shirt");
 
         assert_eq!(state.cart_item_count, 2);
         assert!(!state.cart_empty);

--- a/examples/app/commerce/server/src/catalog.rs
+++ b/examples/app/commerce/server/src/catalog.rs
@@ -557,7 +557,7 @@ pub struct Catalog {
 }
 
 impl Catalog {
-    pub fn generate(image_prefix: &str) -> Self {
+    pub fn generate() -> Self {
         let mut products = Vec::with_capacity(PRODUCT_DEFS.len());
         let mut handle_index = HashMap::with_capacity(PRODUCT_DEFS.len());
         let mut category_index = HashMap::with_capacity(CATEGORY_DEFS.len());
@@ -654,12 +654,12 @@ impl Catalog {
                 category: primary_collection.to_string(),
                 gradient,
                 gradient_alt,
-                image_url: format!("{}{}", image_prefix, def.image_url),
-                image_alt_url: format!("{}{}", image_prefix, image_alt_url),
+                image_url: format!("_image/{}", def.image_url),
+                image_alt_url: format!("_image/{}", image_alt_url),
                 gallery_image_urls: def
                     .gallery_image_urls
                     .iter()
-                    .map(|url| format!("{}{}", image_prefix, url))
+                    .map(|url| format!("_image/{}", url))
                     .collect(),
                 available: true,
                 tags,
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[test]
     fn catalog_matches_live_collection_counts() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
 
         assert_eq!(catalog.product_count(), 18);
         assert_eq!(catalog.by_category("bags").len(), 1);
@@ -1079,7 +1079,7 @@ mod tests {
 
     #[test]
     fn product_can_belong_to_multiple_collections() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let product = catalog
             .by_handle("acme-baby-cap")
             .expect("baby cap should exist");
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[test]
     fn products_without_variants_emit_empty_option_groups() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let keyboard = catalog
             .by_handle("acme-mechanical-keyboard")
             .expect("keyboard should exist");
@@ -1120,7 +1120,7 @@ mod tests {
 
     #[test]
     fn home_featured_matches_live_order() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let handles = catalog
             .home_featured()
             .iter()
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn home_carousel_matches_live_order() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let handles = catalog
             .home_carousel()
             .iter()
@@ -1167,7 +1167,7 @@ mod tests {
 
     #[test]
     fn scraped_product_data_is_embedded_in_catalog() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cowboy_hat = catalog
             .by_handle("acme-cowboy-hat")
             .expect("cowboy hat should exist");
@@ -1189,7 +1189,7 @@ mod tests {
 
     #[test]
     fn search_is_case_insensitive_after_indexing() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
 
         let shirts = catalog.search("PRISM");
         let stickers = catalog.search("stickers");

--- a/examples/app/commerce/server/src/catalog.rs
+++ b/examples/app/commerce/server/src/catalog.rs
@@ -557,7 +557,7 @@ pub struct Catalog {
 }
 
 impl Catalog {
-    pub fn generate() -> Self {
+    pub fn generate(image_prefix: &str) -> Self {
         let mut products = Vec::with_capacity(PRODUCT_DEFS.len());
         let mut handle_index = HashMap::with_capacity(PRODUCT_DEFS.len());
         let mut category_index = HashMap::with_capacity(CATEGORY_DEFS.len());
@@ -654,12 +654,12 @@ impl Catalog {
                 category: primary_collection.to_string(),
                 gradient,
                 gradient_alt,
-                image_url: format!("/_image/{}", def.image_url),
-                image_alt_url: format!("/_image/{}", image_alt_url),
+                image_url: format!("{}{}", image_prefix, def.image_url),
+                image_alt_url: format!("{}{}", image_prefix, image_alt_url),
                 gallery_image_urls: def
                     .gallery_image_urls
                     .iter()
-                    .map(|url| format!("/_image/{}", url))
+                    .map(|url| format!("{}{}", image_prefix, url))
                     .collect(),
                 available: true,
                 tags,
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[test]
     fn catalog_matches_live_collection_counts() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
 
         assert_eq!(catalog.product_count(), 18);
         assert_eq!(catalog.by_category("bags").len(), 1);
@@ -1079,7 +1079,7 @@ mod tests {
 
     #[test]
     fn product_can_belong_to_multiple_collections() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let product = catalog
             .by_handle("acme-baby-cap")
             .expect("baby cap should exist");
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[test]
     fn products_without_variants_emit_empty_option_groups() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let keyboard = catalog
             .by_handle("acme-mechanical-keyboard")
             .expect("keyboard should exist");
@@ -1120,7 +1120,7 @@ mod tests {
 
     #[test]
     fn home_featured_matches_live_order() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let handles = catalog
             .home_featured()
             .iter()
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[test]
     fn home_carousel_matches_live_order() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let handles = catalog
             .home_carousel()
             .iter()
@@ -1167,7 +1167,7 @@ mod tests {
 
     #[test]
     fn scraped_product_data_is_embedded_in_catalog() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cowboy_hat = catalog
             .by_handle("acme-cowboy-hat")
             .expect("cowboy hat should exist");
@@ -1189,7 +1189,7 @@ mod tests {
 
     #[test]
     fn search_is_case_insensitive_after_indexing() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
 
         let shirts = catalog.search("PRISM");
         let stickers = catalog.search("stickers");

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -69,13 +69,9 @@ impl FrontendRuntime {
     pub fn render_html(&self, route_path: &str, state: &Value, nonce: &str) -> Result<String> {
         let mut writer = MemoryWriter::with_capacity(16_384);
         let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
+        let opts = RenderOptions::new(&self.entry, route_path).with_nonce(nonce);
         handler
-            .handle(
-                &self.protocol,
-                state,
-                &RenderOptions::new(&self.entry, route_path).with_nonce(nonce),
-                &mut writer,
-            )
+            .handle(&self.protocol, state, &opts, &mut writer)
             .with_context(|| format!("Failed to render HTML for {route_path}"))?;
         Ok(writer.buf)
     }

--- a/examples/app/commerce/server/src/main.rs
+++ b/examples/app/commerce/server/src/main.rs
@@ -48,6 +48,10 @@ struct ApiArgs {
     /// Path to TLS private key PEM file.
     #[arg(long)]
     tls_key: Option<String>,
+
+    /// Base path for sub-path deployment (e.g., `/commerce/`).
+    #[arg(long)]
+    base_path: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -63,7 +67,7 @@ fn main() -> Result<()> {
     };
     let app_root = std::env::current_dir().context("Failed to determine commerce app directory")?;
 
-    let app_state = AppState::load(&app_root, css)?;
+    let app_state = AppState::load(&app_root, css, args.base_path.as_deref())?;
 
     eprintln!(
         "Commerce server: {} products, {} images ({} variants)",

--- a/examples/app/commerce/server/src/main.rs
+++ b/examples/app/commerce/server/src/main.rs
@@ -50,8 +50,9 @@ struct ApiArgs {
     tls_key: Option<String>,
 
     /// Base path for sub-path deployment (e.g., `/commerce/`).
-    #[arg(long)]
-    base_path: Option<String>,
+    /// Injected as `basePath` in template state for `<base href="{{basePath}}">`.
+    #[arg(long, default_value = "/")]
+    base_path: String,
 }
 
 fn main() -> Result<()> {
@@ -67,7 +68,7 @@ fn main() -> Result<()> {
     };
     let app_root = std::env::current_dir().context("Failed to determine commerce app directory")?;
 
-    let app_state = AppState::load(&app_root, css, args.base_path.as_deref())?;
+    let app_state = AppState::load(&app_root, css, &args.base_path)?;
 
     eprintln!(
         "Commerce server: {} products, {} images ({} variants)",

--- a/examples/app/commerce/server/src/security.rs
+++ b/examples/app/commerce/server/src/security.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub(crate) fn security_headers() -> DefaultHeaders {
     DefaultHeaders::new()
         .add(("X-Content-Type-Options", "nosniff"))
-        .add(("X-Frame-Options", "DENY"))
+        .add(("X-Frame-Options", "SAMEORIGIN"))
         .add(("Referrer-Policy", "strict-origin-when-cross-origin"))
         .add((
             "Permissions-Policy",
@@ -39,7 +39,7 @@ pub(crate) fn csp_header(nonce: &str) -> String {
          style-src 'self' 'unsafe-inline'; \
          img-src 'self'; \
          font-src 'self'; \
-         frame-ancestors 'none'"
+         frame-ancestors 'self'"
     )
 }
 

--- a/examples/app/commerce/server/src/server.rs
+++ b/examples/app/commerce/server/src/server.rs
@@ -52,7 +52,7 @@ async fn handle_frontend_request(
     let stable_path = cart::without_cart(context.request_path());
     let cart_state = build_cart_state(&context.cart_read().cart, data.catalog(), &stable_path);
     let is_partial = context.wants_json();
-    let (page_state, image_preloads) = state::build_route_state(&state::RouteStateRequest {
+    let (mut page_state, image_preloads) = state::build_route_state(&state::RouteStateRequest {
         catalog: data.catalog(),
         route_path: context.route_path(),
         params: &route_params,
@@ -61,6 +61,12 @@ async fn handle_frontend_request(
         is_partial,
     })
     .ok_or(ServerError::NotFound)?;
+
+    // Inject basePath into state — default "/" for correct CSS resolution.
+    if let Value::Object(ref mut map) = page_state {
+        let bp = data.base_path().unwrap_or("/");
+        map.insert("basePath".into(), Value::String(bp.to_string()));
+    }
 
     if context.wants_json() {
         return Ok(partial_response(&context, data.get_ref(), &page_state));
@@ -73,7 +79,7 @@ async fn handle_frontend_request(
         .map_err(ServerError::RenderFailed)?;
     Ok(html_response(
         &context,
-        inject_head_preload_tags(html, &image_preloads),
+        inject_head_preload_tags(html, &image_preloads, data.base_path()),
         &nonce,
     ))
 }
@@ -196,12 +202,16 @@ fn html_response(context: &RequestContext, html: String, nonce: &str) -> HttpRes
     builder.body(html)
 }
 
-fn inject_head_preload_tags(mut html: String, image_urls: &[String]) -> String {
+fn inject_head_preload_tags(
+    mut html: String,
+    image_urls: &[String],
+    base_path: Option<&str>,
+) -> String {
     let Some(head_end) = html.find("</head>") else {
         return html;
     };
 
-    let preloads = build_head_preload_tags(image_urls);
+    let preloads = build_head_preload_tags(image_urls, base_path);
     if preloads.is_empty() {
         return html;
     }
@@ -215,15 +225,31 @@ fn inject_head_preload_tags(mut html: String, image_urls: &[String]) -> String {
 /// no custom logic needed here.
 /// The router removes these managed tags on SPA navigations so preloads never
 /// leak across routes.
-fn build_head_preload_tags(image_urls: &[String]) -> String {
+fn build_head_preload_tags(image_urls: &[String], base_path: Option<&str>) -> String {
     let capacity = 80 + image_urls.len() * 120;
     let mut buf = String::with_capacity(capacity);
 
-    buf.push_str(r#"<link rel="modulepreload" href="/index.js" data-webui-ssr-preload="script">"#);
+    // When base_path is set, strip leading `/` so paths are relative
+    // and the browser resolves them against <base href>.
+    let make_relative = base_path.is_some();
+
+    let js_href = if make_relative {
+        "index.js"
+    } else {
+        "/index.js"
+    };
+    buf.push_str("<link rel=\"modulepreload\" href=\"");
+    buf.push_str(js_href);
+    buf.push_str("\" data-webui-ssr-preload=\"script\">");
 
     for (i, url) in image_urls.iter().enumerate() {
         buf.push_str(r#"<link rel="preload" as="image" href=""#);
-        buf.push_str(url);
+        let href = if make_relative {
+            url.strip_prefix('/').unwrap_or(url)
+        } else {
+            url.as_str()
+        };
+        buf.push_str(href);
         if i == 0 {
             buf.push_str(r#"" fetchpriority="high" data-webui-ssr-preload="image">"#);
         } else {

--- a/examples/app/commerce/server/src/server.rs
+++ b/examples/app/commerce/server/src/server.rs
@@ -62,10 +62,12 @@ async fn handle_frontend_request(
     })
     .ok_or(ServerError::NotFound)?;
 
-    // Inject basePath into state — default "/" for correct CSS resolution.
+    // Inject basePath into state for <base href="{{basePath}}">.
     if let Value::Object(ref mut map) = page_state {
-        let bp = data.base_path().unwrap_or("/");
-        map.insert("basePath".into(), Value::String(bp.to_string()));
+        map.insert(
+            "basePath".into(),
+            Value::String(data.base_path().to_string()),
+        );
     }
 
     if context.wants_json() {
@@ -79,7 +81,7 @@ async fn handle_frontend_request(
         .map_err(ServerError::RenderFailed)?;
     Ok(html_response(
         &context,
-        inject_head_preload_tags(html, &image_preloads, data.base_path()),
+        inject_head_preload_tags(html, &image_preloads),
         &nonce,
     ))
 }
@@ -202,16 +204,12 @@ fn html_response(context: &RequestContext, html: String, nonce: &str) -> HttpRes
     builder.body(html)
 }
 
-fn inject_head_preload_tags(
-    mut html: String,
-    image_urls: &[String],
-    base_path: Option<&str>,
-) -> String {
+fn inject_head_preload_tags(mut html: String, image_urls: &[String]) -> String {
     let Some(head_end) = html.find("</head>") else {
         return html;
     };
 
-    let preloads = build_head_preload_tags(image_urls, base_path);
+    let preloads = build_head_preload_tags(image_urls);
     if preloads.is_empty() {
         return html;
     }
@@ -225,31 +223,15 @@ fn inject_head_preload_tags(
 /// no custom logic needed here.
 /// The router removes these managed tags on SPA navigations so preloads never
 /// leak across routes.
-fn build_head_preload_tags(image_urls: &[String], base_path: Option<&str>) -> String {
+fn build_head_preload_tags(image_urls: &[String]) -> String {
     let capacity = 80 + image_urls.len() * 120;
     let mut buf = String::with_capacity(capacity);
 
-    // When base_path is set, strip leading `/` so paths are relative
-    // and the browser resolves them against <base href>.
-    let make_relative = base_path.is_some();
-
-    let js_href = if make_relative {
-        "index.js"
-    } else {
-        "/index.js"
-    };
-    buf.push_str("<link rel=\"modulepreload\" href=\"");
-    buf.push_str(js_href);
-    buf.push_str("\" data-webui-ssr-preload=\"script\">");
+    buf.push_str(r#"<link rel="modulepreload" href="index.js" data-webui-ssr-preload="script">"#);
 
     for (i, url) in image_urls.iter().enumerate() {
         buf.push_str(r#"<link rel="preload" as="image" href=""#);
-        let href = if make_relative {
-            url.strip_prefix('/').unwrap_or(url)
-        } else {
-            url.as_str()
-        };
-        buf.push_str(href);
+        buf.push_str(url);
         if i == 0 {
             buf.push_str(r#"" fetchpriority="high" data-webui-ssr-preload="image">"#);
         } else {
@@ -344,7 +326,7 @@ mod tests {
             html.contains(r#"data-webui-ssr-preload="style""#),
             "Framework should emit CSS preload with data-webui-ssr-preload: {html}"
         );
-        assert!(html.contains(r#"href="/_image/t-shirt-1?w=640&q=75""#));
+        assert!(html.contains(r#"href="_image/t-shirt-1?w=640&q=75""#));
         assert!(
             !html.contains(r#"\"data-webui-ssr-preload\""#),
             "server-only preload tags should not leak into serialized client state"

--- a/examples/app/commerce/server/src/state/mod.rs
+++ b/examples/app/commerce/server/src/state/mod.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn product_state_includes_default_variant_fields() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let mut cart = StoredCart::default();
         add_item(&mut cart, "acme-t-shirt", "Black", "M", 1);
         let cart_state = build_cart_state(&cart, &catalog, "/product/acme-t-shirt");
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn content_routes_only_need_shell_state() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/about");
         let params = std::collections::HashMap::new();
 
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn category_state_includes_current_category_label() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/footware");
         let params =
             std::collections::HashMap::from([("category".to_string(), "footware".to_string())]);
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn partial_response_excludes_shell_state() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/shirts");
         let params =
             std::collections::HashMap::from([("category".to_string(), "shirts".to_string())]);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn home_state_returns_image_preloads() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/");
         let params = std::collections::HashMap::new();
 
@@ -165,7 +165,7 @@ mod tests {
             "home page should preload only the primary hero image"
         );
         assert!(
-            image_preloads[0].contains("/_image/"),
+            image_preloads[0].contains("_image/"),
             "image preloads should reference image proxy"
         );
         assert_eq!(
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn home_partial_returns_no_image_preloads() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/");
         let params = std::collections::HashMap::new();
 
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn product_state_returns_image_preloads() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state =
             build_cart_state(&StoredCart::default(), &catalog, "/product/acme-t-shirt");
         let params =
@@ -233,12 +233,12 @@ mod tests {
             1,
             "product page should preload hero image"
         );
-        assert!(image_preloads[0].contains("/_image/"));
+        assert!(image_preloads[0].contains("_image/"));
     }
 
     #[test]
     fn search_state_returns_image_preloads() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search");
         let params = std::collections::HashMap::new();
 
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn category_state_returns_image_preloads() {
-        let catalog = Catalog::generate("/_image/");
+        let catalog = Catalog::generate();
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/shirts");
         let params =
             std::collections::HashMap::from([("category".to_string(), "shirts".to_string())]);

--- a/examples/app/commerce/server/src/state/mod.rs
+++ b/examples/app/commerce/server/src/state/mod.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn product_state_includes_default_variant_fields() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let mut cart = StoredCart::default();
         add_item(&mut cart, "acme-t-shirt", "Black", "M", 1);
         let cart_state = build_cart_state(&cart, &catalog, "/product/acme-t-shirt");
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn content_routes_only_need_shell_state() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/about");
         let params = std::collections::HashMap::new();
 
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn category_state_includes_current_category_label() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/footware");
         let params =
             std::collections::HashMap::from([("category".to_string(), "footware".to_string())]);
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn partial_response_excludes_shell_state() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/shirts");
         let params =
             std::collections::HashMap::from([("category".to_string(), "shirts".to_string())]);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn home_state_returns_image_preloads() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/");
         let params = std::collections::HashMap::new();
 
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn home_partial_returns_no_image_preloads() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/");
         let params = std::collections::HashMap::new();
 
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn product_state_returns_image_preloads() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state =
             build_cart_state(&StoredCart::default(), &catalog, "/product/acme-t-shirt");
         let params =
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn search_state_returns_image_preloads() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search");
         let params = std::collections::HashMap::new();
 
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn category_state_returns_image_preloads() {
-        let catalog = Catalog::generate();
+        let catalog = Catalog::generate("/_image/");
         let cart_state = build_cart_state(&StoredCart::default(), &catalog, "/search/shirts");
         let params =
             std::collections::HashMap::from([("category".to_string(), "shirts".to_string())]);

--- a/examples/app/commerce/src/index.html
+++ b/examples/app/commerce/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
+  <base href="{{basePath}}">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{storeName}}</title>
   <meta name="description" content="High-performance SSR marketplace powered by WebUI and Rust." />
@@ -173,7 +174,7 @@
     <route path="privacy-policy" component="mp-page-privacy" exact />
     <route path="frequently-asked-questions" component="mp-page-faq" exact />
   </route>
-  <script src="/index.js" type="module"></script>
+  <script src="./index.js" type="module"></script>
 </body>
 
 </html>

--- a/examples/app/commerce/src/molecules/mp-search-bar/mp-search-bar.ts
+++ b/examples/app/commerce/src/molecules/mp-search-bar/mp-search-bar.ts
@@ -5,7 +5,7 @@ import { WebUIElement, attr } from '@microsoft/webui-framework';
 import { Router } from '@microsoft/webui-router';
 
 export class MpSearchBar extends WebUIElement {
-  @attr action = '/search';
+  @attr action = './search';
   @attr query = '';
   @attr placeholder = 'Search for products...';
   @attr variant = 'desktop';

--- a/examples/app/commerce/src/organisms/mp-add-to-cart/mp-add-to-cart.html
+++ b/examples/app/commerce/src/organisms/mp-add-to-cart/mp-add-to-cart.html
@@ -1,4 +1,4 @@
-<form class="add-to-cart-form" action="/cart/add" method="post" @submit="{onSubmit(e)}">
+<form class="add-to-cart-form" action="./cart/add" method="post" @submit="{onSubmit(e)}">
   <input type="hidden" name="handle" value="{{handle}}" />
   <input type="hidden" name="color" value="{{selectedColor}}" />
   <input type="hidden" name="size" value="{{selectedSize}}" />

--- a/examples/app/commerce/src/organisms/mp-add-to-cart/mp-add-to-cart.ts
+++ b/examples/app/commerce/src/organisms/mp-add-to-cart/mp-add-to-cart.ts
@@ -27,7 +27,7 @@ export class MpAddToCart extends WebUIElement {
   }
 
   private async submitCart(): Promise<void> {
-    const response = await fetch('/cart/add', {
+    const response = await fetch('./cart/add', {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/examples/app/commerce/src/organisms/mp-cart-panel/mp-cart-panel.html
+++ b/examples/app/commerce/src/organisms/mp-cart-panel/mp-cart-panel.html
@@ -44,7 +44,7 @@
                 <mp-product-image gradient="{{item.gradient}}" image-url="{{item.imageUrl}}" alt="{{item.title}}" loading="lazy" decoding="async" proxy-width="64" proxy-height="64"></mp-product-image>
               </div>
               <div class="item-info">
-                <a href="/product/{{item.handle}}" class="item-title">{{item.title}}</a>
+                <a href="./product/{{item.handle}}" class="item-title">{{item.title}}</a>
                 <if condition="item.variantLabel">
                   <p class="item-variant">{{item.variantLabel}}</p>
                 </if>
@@ -54,7 +54,7 @@
                   <mp-price value="{{item.price}}" variant="plain" size="sm" currency-code="USD"></mp-price>
                 </div>
                 <div class="qty-control">
-                <form method="post" action="/cart/update" class="qty-form">
+                <form method="post" action="./cart/update" class="qty-form">
                   <input type="hidden" name="handle" value="{{item.handle}}" />
                   <input type="hidden" name="color" value="{{item.color}}" />
                   <input type="hidden" name="size" value="{{item.size}}" />
@@ -67,7 +67,7 @@
                    </button>
                  </form>
                 <span class="qty-count">{{item.quantity}}</span>
-                <form method="post" action="/cart/update" class="qty-form">
+                <form method="post" action="./cart/update" class="qty-form">
                   <input type="hidden" name="handle" value="{{item.handle}}" />
                   <input type="hidden" name="color" value="{{item.color}}" />
                   <input type="hidden" name="size" value="{{item.size}}" />

--- a/examples/app/commerce/src/organisms/mp-cart-panel/mp-cart-panel.ts
+++ b/examples/app/commerce/src/organisms/mp-cart-panel/mp-cart-panel.ts
@@ -58,7 +58,7 @@ export class MpCartPanel extends WebUIElement {
       return;
     }
 
-    await this.submitCartMutation('/cart/update', {
+    await this.submitCartMutation('./cart/update', {
       handle,
       color,
       size,

--- a/examples/app/commerce/src/organisms/mp-category-nav/mp-category-nav.html
+++ b/examples/app/commerce/src/organisms/mp-category-nav/mp-category-nav.html
@@ -9,7 +9,7 @@
           <p class="mobile-link" ?active="{{allActive}}" @click="{closeMobileDropdown()}">All</p>
         </if>
         <if condition="!allActive">
-          <a href="/search" class="mobile-link" @click="{closeMobileDropdown()}">All</a>
+          <a href="./search" class="mobile-link" @click="{closeMobileDropdown()}">All</a>
         </if>
       </li>
       <for each="cat in categories">
@@ -18,7 +18,7 @@
             <p class="mobile-link" ?active="{{cat.active}}" @click="{closeMobileDropdown()}">{{cat.title}}</p>
           </if>
           <if condition="!cat.active">
-            <a href="/search/{{cat.handle}}" class="mobile-link"
+            <a href="./search/{{cat.handle}}" class="mobile-link"
               @click="{closeMobileDropdown()}">{{cat.title}}</a>
           </if>
         </li>
@@ -29,21 +29,21 @@
   <ul class="list desktop-list">
     <li>
       <if condition="allActive">
-        <p class="link" ?active="{{allActive}}" data-handle="" data-href="/search">All</p>
+        <p class="link" ?active="{{allActive}}" data-handle="" data-href="./search">All</p>
       </if>
       <if condition="!allActive">
-        <a href="/search" class="link" data-handle="" data-href="/search">All</a>
+        <a href="./search" class="link" data-handle="" data-href="./search">All</a>
       </if>
     </li>
     <for each="cat in categories">
       <li>
         <if condition="cat.active">
-          <p class="link" ?active="{{cat.active}}" data-handle="{{cat.handle}}" data-href="/search/{{cat.handle}}">{{cat.title}}
+          <p class="link" ?active="{{cat.active}}" data-handle="{{cat.handle}}" data-href="./search/{{cat.handle}}">{{cat.title}}
           </p>
         </if>
         <if condition="!cat.active">
-          <a href="/search/{{cat.handle}}" class="link" data-handle="{{cat.handle}}"
-            data-href="/search/{{cat.handle}}">{{cat.title}}</a>
+          <a href="./search/{{cat.handle}}" class="link" data-handle="{{cat.handle}}"
+            data-href="./search/{{cat.handle}}">{{cat.title}}</a>
         </if>
       </li>
     </for>

--- a/examples/app/commerce/src/organisms/mp-footer/mp-footer.html
+++ b/examples/app/commerce/src/organisms/mp-footer/mp-footer.html
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="footer-upper">
     <div class="footer-brand-col">
-      <a href="/" class="brand-link">
+      <a href="./" class="brand-link">
         <span class="brand-logo">
           <svg
             class="brand-mark"
@@ -17,12 +17,12 @@
       </a>
     </div>
     <nav class="footer-nav">
-      <a href="/" class="nav-link">Home</a>
-      <a href="/about" class="nav-link">About</a>
-      <a href="/terms-conditions" class="nav-link">Terms &amp; Conditions</a>
-      <a href="/shipping-return-policy" class="nav-link">Shipping &amp; Return Policy</a>
-      <a href="/privacy-policy" class="nav-link">Privacy Policy</a>
-      <a href="/frequently-asked-questions" class="nav-link">FAQ</a>
+      <a href="./" class="nav-link">Home</a>
+      <a href="./about" class="nav-link">About</a>
+      <a href="./terms-conditions" class="nav-link">Terms &amp; Conditions</a>
+      <a href="./shipping-return-policy" class="nav-link">Shipping &amp; Return Policy</a>
+      <a href="./privacy-policy" class="nav-link">Privacy Policy</a>
+      <a href="./frequently-asked-questions" class="nav-link">FAQ</a>
     </nav>
     <div class="footer-cta">
       <a

--- a/examples/app/commerce/src/organisms/mp-mobile-menu/mp-mobile-menu.html
+++ b/examples/app/commerce/src/organisms/mp-mobile-menu/mp-mobile-menu.html
@@ -9,13 +9,13 @@
     </button>
   </div>
   <div class="mobile-search">
-    <mp-search-bar variant="mobile" query="{{searchQuery}}" action="/search" placeholder="Search for products..."
+    <mp-search-bar variant="mobile" query="{{searchQuery}}" action="./search" placeholder="Search for products..."
       label="Search for products"></mp-search-bar>
   </div>
   <nav class="menu-nav">
-    <a href="/search" class="menu-link" @click="{closeMenu()}">All</a>
+    <a href="./search" class="menu-link" @click="{closeMenu()}">All</a>
     <for each="cat in navCategories">
-      <a href="/search/{{cat.handle}}" class="menu-link" @click="{closeMenu()}">{{cat.title}}</a>
+      <a href="./search/{{cat.handle}}" class="menu-link" @click="{closeMenu()}">{{cat.title}}</a>
     </for>
   </nav>
 </div>

--- a/examples/app/commerce/src/organisms/mp-navbar/mp-navbar.html
+++ b/examples/app/commerce/src/organisms/mp-navbar/mp-navbar.html
@@ -8,7 +8,7 @@
         <path d="M4 18h16"></path>
       </svg>
     </button>
-    <a href="/" class="logo-link">
+    <a href="./" class="logo-link">
       <div class="logo-square">
         <svg class="logo-mark" xmlns="http://www.w3.org/2000/svg" aria-label="Acme Store logo" viewBox="0 0 32 28">
           <path d="M21.5758 9.75769L16 0L0 28H11.6255L21.5758 9.75769Z"></path>
@@ -18,14 +18,14 @@
       <span class="store-name">ACME STORE</span>
     </a>
     <ul class="nav-links">
-      <li><a href="/search" class="nav-link">All</a></li>
+      <li><a href="./search" class="nav-link">All</a></li>
       <for each="cat in navCategories">
-        <li><a href="/search/{{cat.handle}}" class="nav-link">{{cat.title}}</a></li>
+        <li><a href="./search/{{cat.handle}}" class="nav-link">{{cat.title}}</a></li>
       </for>
     </ul>
   </div>
   <div class="center">
-    <mp-search-bar query="{{searchQuery}}" action="/search" placeholder="Search for products..."
+    <mp-search-bar query="{{searchQuery}}" action="./search" placeholder="Search for products..."
       label="Search for products"></mp-search-bar>
   </div>
   <div class="right">

--- a/examples/app/commerce/src/organisms/mp-navbar/mp-navbar.ts
+++ b/examples/app/commerce/src/organisms/mp-navbar/mp-navbar.ts
@@ -8,7 +8,7 @@ import '#molecules/mp-search-bar/mp-search-bar.js';
 export class MpNavbar extends WebUIElement {
   @attr({ attribute: 'store-name' }) storeName = 'Acme Store';
   @attr({ attribute: 'search-query' }) searchQuery = '';
-  @attr({ attribute: 'cart-href' }) cartHref = '/?cart=open';
+  @attr({ attribute: 'cart-href' }) cartHref = './?cart=open';
   @observable cartItems!: unknown[];
   @observable navCategories: { handle: string; title: string }[] = [];
 

--- a/examples/app/commerce/src/organisms/mp-product-card/mp-product-card.html
+++ b/examples/app/commerce/src/organisms/mp-product-card/mp-product-card.html
@@ -1,4 +1,4 @@
-<a href="/product/{{handle}}" class="card">
+<a href="./product/{{handle}}" class="card">
   <mp-product-image class="media" gradient="{{gradient}}" image-url="{{imageUrl}}" alt="{{title}}" interactive="true"
     loading="{{imageLoading}}" decoding="async" fetch-priority="{{imageFetchPriority}}"
     proxy-width="{{imageWidth}}" proxy-height="{{imageHeight}}"></mp-product-image>

--- a/examples/app/commerce/tests/commerce.spec.ts
+++ b/examples/app/commerce/tests/commerce.spec.ts
@@ -187,10 +187,10 @@ test.describe('client-side navigation', () => {
     const logo = page.locator('mp-navbar .logo-link');
     const cartButton = page.locator('mp-navbar .cart-btn');
 
-    await expect(logo).toHaveAttribute('href', '/');
+    await expect(logo).toHaveAttribute('href', './');
     await cartButton.click();
     await page.locator('mp-cart-panel .close-btn').click();
-    await expect(logo).toHaveAttribute('href', '/');
+    await expect(logo).toHaveAttribute('href', './');
 
     await logo.click();
     await expect(page).toHaveURL('/');

--- a/examples/app/contact-book-manager/src/api.ts
+++ b/examples/app/contact-book-manager/src/api.ts
@@ -5,7 +5,7 @@
  * API client for the contact-book-manager backend.
  */
 
-const API_BASE = '/api';
+const API_BASE = './api';
 
 export interface Contact {
   id: string;

--- a/examples/app/contact-book-manager/src/index.html
+++ b/examples/app/contact-book-manager/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <base href="{{basePath}}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Contact Book</title>
   <style>
@@ -44,7 +45,7 @@
     <route path="groups/:group" component="cb-page-group" exact keep-alive />
   </route>
 
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 
 </html>

--- a/examples/app/contact-book-manager/src/organisms/cb-contact-card/cb-contact-card.html
+++ b/examples/app/contact-book-manager/src/organisms/cb-contact-card/cb-contact-card.html
@@ -1,4 +1,4 @@
-<a class="card" href="/contacts/{{id}}">
+<a class="card" href="./contacts/{{id}}">
   <div class="avatar" style="background-color: {{avatarColor}}">
     <span class="avatar-initials">{{initials}}</span>
   </div>

--- a/examples/app/contact-book-manager/src/organisms/cb-header/cb-header.html
+++ b/examples/app/contact-book-manager/src/organisms/cb-header/cb-header.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 <div class="header-right">
-  <a class="add-btn" href="/contacts/add">
+  <a class="add-btn" href="./contacts/add">
     <span class="add-icon">+</span>
     <span class="add-label">Add Contact</span>
   </a>

--- a/examples/app/contact-book-manager/src/organisms/cb-sidebar/cb-sidebar.html
+++ b/examples/app/contact-book-manager/src/organisms/cb-sidebar/cb-sidebar.html
@@ -1,14 +1,14 @@
 <div class="nav-section">
-  <a class="nav-item" ?data-active="{{page == 'dashboard'}}" data-nav="Dashboard" href="/">
+  <a class="nav-item" ?data-active="{{page == 'dashboard'}}" data-nav="Dashboard" href="./">
     <span class="nav-icon nav-icon-dashboard"></span>
     <span class="nav-label">Dashboard</span>
   </a>
-  <a class="nav-item" ?data-active="{{page == 'contacts'}}" data-nav="All Contacts" href="/contacts">
+  <a class="nav-item" ?data-active="{{page == 'contacts'}}" data-nav="All Contacts" href="./contacts">
     <span class="nav-icon nav-icon-contacts"></span>
     <span class="nav-label">All Contacts</span>
     <span class="nav-count">{{totalContacts}}</span>
   </a>
-  <a class="nav-item" ?data-active="{{page == 'favorites'}}" data-nav="Favorites" href="/favorites">
+  <a class="nav-item" ?data-active="{{page == 'favorites'}}" data-nav="Favorites" href="./favorites">
     <span class="nav-icon nav-icon-favorites"></span>
     <span class="nav-label">Favorites</span>
     <span class="nav-count">{{totalFavorites}}</span>
@@ -19,7 +19,7 @@
   <h3 class="nav-heading">Groups</h3>
   <for each="group in groups">
     <a class="nav-item nav-item-group" ?data-active="{{page == 'group' && activeGroup == group}}" data-nav="{{group}}"
-      href="/groups/{{group}}">
+      href="./groups/{{group}}">
       <span class="nav-icon nav-icon-folder"></span>
       <span class="nav-label">{{group}}</span>
     </a>

--- a/examples/app/hello-world/src/index.html
+++ b/examples/app/hello-world/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <base href="{{basePath}}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WebUI Hello World</title>
   <style>
@@ -81,7 +82,7 @@
     </div>
   </if>
 
-  <script src="/index.js"></script>
+  <script src="./index.js"></script>
 </body>
 
 </html>

--- a/examples/app/routes/server/src/index.ts
+++ b/examples/app/routes/server/src/index.ts
@@ -11,7 +11,7 @@
 import express from 'express';
 
 const app = express();
-const PORT = 3018;
+const PORT = Number(process.env.PORT) || 3018;
 
 // ── Data ─────────────────────────────────────────────────────────
 

--- a/examples/app/routes/src/index.html
+++ b/examples/app/routes/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <base href="{{basePath}}">
   <title>{{title}}</title>
   <style>
     :root {
@@ -119,7 +120,7 @@
     </route>
   </route>
 
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 
 </html>

--- a/examples/app/routes/src/routes-app/routes-app.html
+++ b/examples/app/routes/src/routes-app/routes-app.html
@@ -1,5 +1,5 @@
 <header>
-  <h1><a href="/" class="brand">📚 <span>{{appTitle}}</span></a></h1>
+  <h1><a href="./" class="brand">📚 <span>{{appTitle}}</span></a></h1>
   <button class="counter" @click={onCounterClick()}>🔢 Shell: <span w-ref={counterLabel}>0</span></button>
 </header>
 
@@ -7,7 +7,7 @@
   <h2>Sections</h2>
   <ul>
     <for each="section in sections">
-      <li><a href="/sections/{{section.id}}" ?active="{{section.id == sectionId}}">{{section.icon}} {{section.name}}</a></li>
+      <li><a href="./sections/{{section.id}}" ?active="{{section.id == sectionId}}">{{section.icon}} {{section.name}}</a></li>
     </for>
   </ul>
 </nav>

--- a/examples/app/routes/src/section-page/section-page.html
+++ b/examples/app/routes/src/section-page/section-page.html
@@ -5,7 +5,7 @@
 
 <div class="topics">
   <for each="topic in topics">
-    <a href="/sections/{{sectionId}}/topics/{{topic.id}}" ?active="{{topic.id == topicId}}">{{topic.name}}</a>
+    <a href="./sections/{{sectionId}}/topics/{{topic.id}}" ?active="{{topic.id == topicId}}">{{topic.name}}</a>
   </for>
 </div>
 

--- a/examples/app/routes/src/topic-page/topic-page.html
+++ b/examples/app/routes/src/topic-page/topic-page.html
@@ -8,7 +8,7 @@
 
 <div class="lessons">
   <for each="lesson in lessons">
-    <a href="/sections/{{sectionId}}/topics/{{topicId}}/lessons/{{lesson.id}}" ?active="{{lesson.id == lessonId}}">{{lesson.name}}</a>
+    <a href="./sections/{{sectionId}}/topics/{{topicId}}/lessons/{{lesson.id}}" ?active="{{lesson.id == lessonId}}">{{lesson.name}}</a>
   </for>
 </div>
 

--- a/examples/app/todo-fast/src/index.html
+++ b/examples/app/todo-fast/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <base href="{{basePath}}">
   <title>{{title}}</title>
   <style>
     :root {
@@ -35,7 +36,7 @@
 <body>
   <todo-app title="{{title}}"></todo-app>
 
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 
 </html>

--- a/examples/app/todo-webui/src/index.html
+++ b/examples/app/todo-webui/src/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <base href="{{basePath}}">
   <title>{{title}}</title>
   <style>
     :root {
@@ -71,7 +72,7 @@
 <body>
   <todo-app title="{{title}}"></todo-app>
 
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 
 </html>

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -23,7 +23,20 @@ npm install @microsoft/webui-router
 
 ## Quick Start
 
-**1. Declare nested routes in `index.html`:**
+**1. Add `<base href="/">` in your `<head>`:**
+
+```html
+<head>
+  <meta charset="utf-8">
+  <base href="/">
+</head>
+```
+
+All WebUI apps with routes **must** include `<base href="/">`. Without it, relative asset paths (CSS, JS) break on nested routes — the browser resolves `app.css` against `/contacts/123/` → `/contacts/app.css` instead of `/app.css`.
+
+For sub-path deployments, set the base to the sub-path: `<base href="/my-app/">`.
+
+**2. Declare nested routes in `index.html`:**
 
 ```html
 <body>
@@ -32,7 +45,7 @@ npm install @microsoft/webui-router
     <route path="users" component="user-list" exact />
     <route path="users/:id" component="user-detail" exact />
   </route>
-  <script type="module" src="/index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 ```
 
@@ -154,6 +167,22 @@ export class LiveDashboard extends WebUIElement {
 - Keep-alive components that need fresh data on reactivation
 - Any component that wants full control over its state source
 
+### Base Path (Sub-Path Deployment)
+
+Every WebUI app with routes needs `<base href="/">` in its `<head>` (see Quick Start above). This ensures relative asset paths resolve correctly on nested routes.
+
+For sub-path deployments (e.g., `https://example.com/commerce/`), change it to the sub-path:
+
+```html
+<head>
+  <base href="/commerce/">
+</head>
+```
+
+The `<base>` tag is a core web platform feature. It makes the browser resolve all relative URLs (`<a href>`, `<link href>`, `fetch()`) against the base path. The router detects it at startup and uses it to strip/prepend the prefix on navigation URLs.
+
+When using `webui serve --base-path /commerce/`, the `<base>` tag is emitted automatically.
+
 ### Preload on Hover
 
 Opt-in speculative fetching for instant click navigation:
@@ -265,7 +294,6 @@ Start the router. Call after hydration completes.
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `basePath` | `string` | Prefix for all route URLs (e.g., `"/app"`) |
 | `loaders` | `Record<string, () => Promise<unknown>>` | Lazy-loading map: component tag -> dynamic import |
 | `templateEndpoint` | `string` | URL for `ensureLoaded()` requests (default: `"/_webui/templates"`) |
 | `dev` | `boolean` | Enable development mode warnings |

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -95,7 +95,7 @@ export class WebUIRouter {
     this.started = true;
     this.config = config;
     this.loaders = config.loaders ?? {};
-    this.basePath = config.basePath ?? '';
+    this.basePath = document.querySelector('base')?.getAttribute('href')?.replace(/\/+$/, '') ?? '';
     this.excludePaths = config.excludePaths ?? [];
 
     if (config.cache) {

--- a/packages/webui-router/src/types.ts
+++ b/packages/webui-router/src/types.ts
@@ -22,12 +22,6 @@ declare global {
 /** Configuration passed to `Router.start()`. */
 export interface RouterConfig {
   /**
-   * Base path prepended to all route URLs.
-   * @default ""
-   */
-  basePath?: string;
-
-  /**
    * Optional lazy-loading map: component tag → async loader function.
    *
    * When a route's `component` attribute matches a key in this map, the


### PR DESCRIPTION
We need to enforce web platform base paths when doing nested routes in case people deploy their app in a sub path. This is to make sub directories work.

Updated all the examples to have `<base>` exposed.