### PR TITLE
feat(ffi): Add webui_protocol_tokens FFI function to extract CSS token names

### DIFF
--- a/crates/webui-ffi/include/webui_ffi.h
+++ b/crates/webui-ffi/include/webui_ffi.h
@@ -155,4 +155,20 @@ char *webui_render_component_templates(const uint8_t *protocol_data,
 /// (in which case this function is a no-op).
 void webui_free(char *string_ptr);
 
+/// Extract the CSS token name list from a serialized WebUI protocol.
+///
+/// Returns a heap-allocated newline-delimited string of token names,
+/// e.g. `"colorBrandBackground\nfontSizeBase300"`.
+///
+/// Returns an empty string `""` when the protocol has no tokens.
+/// Returns `NULL` only on error (call [`webui_last_error`] for details).
+///
+/// The caller must free the returned string with [`webui_free`].
+///
+/// # Safety
+///
+/// * `protocol_data` must point to `protocol_len` valid bytes.
+/// * The returned pointer must be freed with [`webui_free`].
+char *webui_protocol_tokens(const uint8_t *protocol_data, uintptr_t protocol_len);
+
 }  // extern "C"

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -680,3 +680,60 @@ pub unsafe extern "C" fn webui_free(string_ptr: *mut c_char) {
         let _ = CString::from_raw(string_ptr);
     }
 }
+
+/// Extract the CSS token name list from a serialized WebUI protocol.
+///
+/// Returns a heap-allocated newline-delimited string of token names,
+/// e.g. `"colorBrandBackground\nfontSizeBase300"`.
+///
+/// Returns an empty string `""` when the protocol has no tokens.
+/// Returns `NULL` only on error (call [`webui_last_error`] for details).
+///
+/// The caller must free the returned string with [`webui_free`].
+///
+/// # Safety
+///
+/// * `protocol_data` must point to `protocol_len` valid bytes.
+/// * The returned pointer must be freed with [`webui_free`].
+#[no_mangle]
+pub unsafe extern "C" fn webui_protocol_tokens(
+    protocol_data: *const u8,
+    protocol_len: usize,
+) -> *mut c_char {
+    clear_last_error();
+
+    match std::panic::catch_unwind(|| {
+        if protocol_data.is_null() {
+            set_last_error("protocol_data is null");
+            return std::ptr::null_mut();
+        }
+
+        // SAFETY: caller guarantees protocol_data points to protocol_len readable bytes.
+        let proto_bytes = unsafe { std::slice::from_raw_parts(protocol_data, protocol_len) };
+
+        let protocol = match WebUIProtocol::from_protobuf(proto_bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                set_last_error(format!("failed to parse protobuf: {e}"));
+                return std::ptr::null_mut();
+            }
+        };
+
+        // join() on an empty vec produces "", which is a valid success result.
+        let joined = protocol.tokens.join("\n");
+
+        match CString::new(joined) {
+            Ok(cs) => cs.into_raw(),
+            Err(e) => {
+                set_last_error(format!("token string contains null byte: {e}"));
+                std::ptr::null_mut()
+            }
+        }
+    }) {
+        Ok(ptr) => ptr,
+        Err(_) => {
+            set_last_error("panic in webui_protocol_tokens");
+            std::ptr::null_mut()
+        }
+    }
+}

--- a/crates/webui-ffi/tests/ffi_test.rs
+++ b/crates/webui-ffi/tests/ffi_test.rs
@@ -18,7 +18,7 @@ use std::ffi::{CStr, CString};
 // against the rlib and call the `pub extern "C"` functions.
 use webui_ffi::{
     webui_free, webui_handler_create, webui_handler_destroy, webui_handler_render,
-    webui_last_error, webui_render, webui_render_partial,
+    webui_last_error, webui_protocol_tokens, webui_render, webui_render_partial,
 };
 use webui_protocol::{FragmentList, WebUIFragment, WebUIProtocol, WebUiFragmentRoute};
 
@@ -496,6 +496,158 @@ fn webui_render_without_parser_returns_null_with_error() {
         assert!(
             err.contains("parser"),
             "error should mention parser feature, got: {err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: webui_protocol_tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn protocol_tokens_empty_vec_returns_empty_string() {
+    // A protocol needs at least one fragment to produce non-zero protobuf bytes.
+    let mut fragments = HashMap::new();
+    fragments.insert(
+        "index.html".to_string(),
+        FragmentList {
+            fragments: vec![WebUIFragment::raw("<p>hello</p>")],
+        },
+    );
+    let protocol = WebUIProtocol::with_tokens(fragments, Vec::new());
+    let bytes = protocol.to_protobuf().expect("serialize");
+    assert!(
+        !bytes.is_empty(),
+        "protobuf with a fragment should be non-empty"
+    );
+
+    unsafe {
+        let ptr = webui_protocol_tokens(bytes.as_ptr(), bytes.len());
+        assert!(
+            !ptr.is_null(),
+            "empty tokens should return non-null empty string"
+        );
+        let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert_eq!(result, "");
+        webui_free(ptr);
+    }
+}
+
+#[test]
+fn protocol_tokens_single_token() {
+    let mut fragments = HashMap::new();
+    fragments.insert(
+        "index.html".to_string(),
+        FragmentList {
+            fragments: vec![WebUIFragment::raw("<p>hello</p>")],
+        },
+    );
+    let protocol = WebUIProtocol::with_tokens(fragments, vec!["colorBrandBackground".to_string()]);
+    let bytes = protocol.to_protobuf().expect("serialize");
+
+    unsafe {
+        let ptr = webui_protocol_tokens(bytes.as_ptr(), bytes.len());
+        assert!(!ptr.is_null());
+        let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert_eq!(result, "colorBrandBackground");
+        webui_free(ptr);
+    }
+}
+
+#[test]
+fn protocol_tokens_multiple_tokens_newline_delimited() {
+    let mut fragments = HashMap::new();
+    fragments.insert(
+        "index.html".to_string(),
+        FragmentList {
+            fragments: vec![WebUIFragment::raw("<p>hello</p>")],
+        },
+    );
+    let protocol = WebUIProtocol::with_tokens(
+        fragments,
+        vec![
+            "colorBrandBackground".to_string(),
+            "fontSizeBase300".to_string(),
+            "spacingHorizontalM".to_string(),
+        ],
+    );
+    let bytes = protocol.to_protobuf().expect("serialize");
+
+    unsafe {
+        let ptr = webui_protocol_tokens(bytes.as_ptr(), bytes.len());
+        assert!(!ptr.is_null());
+        let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert_eq!(
+            result,
+            "colorBrandBackground\nfontSizeBase300\nspacingHorizontalM"
+        );
+        webui_free(ptr);
+    }
+}
+
+#[test]
+fn protocol_tokens_preserves_order_and_duplicates() {
+    let mut fragments = HashMap::new();
+    fragments.insert(
+        "index.html".to_string(),
+        FragmentList {
+            fragments: vec![WebUIFragment::raw("<p>hello</p>")],
+        },
+    );
+    let protocol = WebUIProtocol::with_tokens(
+        fragments,
+        vec!["zeta".to_string(), "alpha".to_string(), "zeta".to_string()],
+    );
+    let bytes = protocol.to_protobuf().expect("serialize");
+
+    unsafe {
+        let ptr = webui_protocol_tokens(bytes.as_ptr(), bytes.len());
+        assert!(!ptr.is_null());
+        let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert_eq!(result, "zeta\nalpha\nzeta");
+        webui_free(ptr);
+    }
+}
+
+#[test]
+fn protocol_tokens_null_data_returns_null() {
+    unsafe {
+        let ptr = webui_protocol_tokens(std::ptr::null(), 0);
+        assert!(ptr.is_null());
+        let err = last_error_string().expect("error should be set for null input");
+        assert!(
+            err.contains("null"),
+            "error should mention null, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn protocol_tokens_zero_length_returns_empty_string() {
+    // A non-null pointer with len 0 should decode as an empty protocol (no tokens).
+    let dummy: u8 = 0;
+    unsafe {
+        let ptr = webui_protocol_tokens(&dummy as *const u8, 0);
+        assert!(
+            !ptr.is_null(),
+            "zero-length input should succeed, not return null"
+        );
+        let result = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert_eq!(result, "");
+        webui_free(ptr);
+    }
+}
+
+#[test]
+fn protocol_tokens_invalid_protobuf_returns_null() {
+    let garbage: &[u8] = &[0xFF, 0xFE, 0xFD];
+    unsafe {
+        let ptr = webui_protocol_tokens(garbage.as_ptr(), garbage.len());
+        assert!(ptr.is_null());
+        let err = last_error_string().expect("error should be set for bad protobuf");
+        assert!(
+            err.contains("protobuf") || err.contains("parse"),
+            "error should mention parse failure, got: {err}"
         );
     }
 }

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -210,6 +210,18 @@ pub fn render_component_templates(
         .map_err(|e| NapiError::from_reason(format!("JSON serialize error: {e}")))
 }
 
+/// Extract the CSS token name list from a compiled protocol.
+///
+/// Returns the tokens as a JavaScript string array, preserving the original
+/// order from the build step.
+#[napi]
+pub fn protocol_tokens(protocol_data: Buffer) -> napi::Result<Vec<String>> {
+    let protocol = WebUIProtocol::from_protobuf(&protocol_data)
+        .map_err(|e| NapiError::from_reason(format!("Protocol decode error: {e}")))?;
+
+    Ok(protocol.tokens)
+}
+
 /// A writer that streams each rendered fragment to a JS callback.
 struct CallbackWriter<'a, 'env> {
     callback: &'a Function<'env, String, ()>,
@@ -535,6 +547,38 @@ mod tests {
     #[test]
     fn test_inspect_invalid_protocol() {
         let result = inspect(napi::bindgen_prelude::Buffer::from(vec![0xFF, 0xFF]));
+        assert!(result.is_err());
+    }
+
+    // ── Tests for protocol_tokens napi export ────────────────────────
+
+    #[test]
+    fn test_protocol_tokens_empty() {
+        let proto = build_protocol("<p>Hello</p>");
+        let tokens = protocol_tokens(napi::bindgen_prelude::Buffer::from(proto)).unwrap();
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn test_protocol_tokens_returns_parsed_tokens() {
+        // Build from a protocol that has CSS tokens via with_tokens constructor.
+        let mut parser = HtmlParser::new();
+        parser.parse("index.html", "<p>Hi</p>").expect("parse");
+        let protocol = WebUIProtocol::with_tokens(
+            parser.into_fragment_records(),
+            vec![
+                "colorBrandBackground".to_string(),
+                "fontSizeBase300".to_string(),
+            ],
+        );
+        let proto = protocol.to_protobuf().expect("encode");
+        let tokens = protocol_tokens(napi::bindgen_prelude::Buffer::from(proto)).unwrap();
+        assert_eq!(tokens, vec!["colorBrandBackground", "fontSizeBase300"]);
+    }
+
+    #[test]
+    fn test_protocol_tokens_invalid_protobuf() {
+        let result = protocol_tokens(napi::bindgen_prelude::Buffer::from(vec![0xFF, 0xFF]));
         assert!(result.is_err());
     }
 }

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -152,6 +152,19 @@ pub fn render_partial(
         .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))
 }
 
+/// Extract the CSS token name list from a protocol JSON string.
+///
+/// Returns a JavaScript array of token name strings, preserving the original
+/// order from the build step.
+#[wasm_bindgen]
+pub fn protocol_tokens(protocol_json: &str) -> Result<JsValue, JsValue> {
+    let protocol: WebUIProtocol = serde_json::from_str(protocol_json)
+        .map_err(|e| JsValue::from_str(&format!("Protocol JSON error: {e}")))?;
+
+    serde_wasm_bindgen::to_value(&protocol.tokens)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
+}
+
 #[wasm_bindgen]
 pub fn render_component_templates(
     protocol_json: &str,
@@ -444,5 +457,34 @@ mod tests {
 
         let result = build_and_render_inner(&files, "{}", "index.html", "/");
         assert_eq!(result.unwrap(), "<h1>Static</h1><p>Content</p>");
+    }
+
+    #[test]
+    fn test_protocol_tokens_empty() {
+        let protocol = WebUIProtocol::new(HashMap::new());
+        let json = serde_json::to_string(&protocol).unwrap();
+        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        assert!(decoded.tokens.is_empty());
+    }
+
+    #[test]
+    fn test_protocol_tokens_roundtrip() {
+        let tokens = vec![
+            "colorBrandBackground".to_string(),
+            "fontSizeBase300".to_string(),
+        ];
+        let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
+        let json = serde_json::to_string(&protocol).unwrap();
+        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.tokens, tokens);
+    }
+
+    #[test]
+    fn test_protocol_tokens_preserves_order() {
+        let tokens = vec!["zeta".to_string(), "alpha".to_string(), "zeta".to_string()];
+        let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
+        let json = serde_json::to_string(&protocol).unwrap();
+        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.tokens, tokens);
     }
 }


### PR DESCRIPTION

Adds webui_protocol_tokens — a new C-compatible FFI function that deserializes a WebUI protocol buffer and returns the CSS token name list as a
newline-delimited, heap-allocated string.

Motivation

Host languages (C#, Go, Python, C++) need to extract CSS design-token names from a compiled WebUI protocol without reaching into Rust internals. This
provides a safe, zero-dependency FFI entry point for that use case.

API contract
```
┌───────────────────────────────┬───────────────────────────────┬─────────────────────────────────┐
│ Input                         │ Return value                  │ webui_last_error                │
├───────────────────────────────┼───────────────────────────────┼─────────────────────────────────┤
│ Valid protocol with tokens    │ "token1\ntoken2\n…"           │ cleared                         │
├───────────────────────────────┼───────────────────────────────┼─────────────────────────────────┤
│ Valid protocol with no tokens │ "" (empty string, non-NULL)   │ cleared                         │
├───────────────────────────────┼───────────────────────────────┼─────────────────────────────────┤
│ Zero-length buffer (non-null) │ "" (empty protocol)           │ cleared                         │
├───────────────────────────────┼───────────────────────────────┼─────────────────────────────────┤
│ NULL pointer                  │ NULL                          │ "protocol_data is null"         │
├───────────────────────────────┼───────────────────────────────┼─────────────────────────────────┤
│ Invalid protobuf bytes        │ NULL                          │ "failed to parse protobuf: …"   │
└───────────────────────────────┴───────────────────────────────┴─────────────────────────────────┘
```
Caller must free the returned string with webui_free.

Changes

 - crates/webui-ffi/src/lib.rs — New webui_protocol_tokens function following existing FFI patterns (catch_unwind, null-check, thread-local error, 
CString ownership transfer).
 - crates/webui-ffi/include/webui_ffi.h — C header declaration with full # Safety documentation.
 - crates/webui-ffi/tests/ffi_test.rs — 7 integration tests:
  - Empty token list → ""
  - Single token
  - Multiple tokens (newline-delimited)
  - Order and duplicates preserved
  - Null pointer → NULL + error
  - Zero-length buffer → "" (valid empty protocol)
  - Invalid protobuf → NULL + error