### PR TITLE
chore: Bump to 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "microsoft-webui-discovery",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "cbindgen",
  "libc",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "criterion",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "microsoft-webui-protocol",
  "mockall",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.10", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.10" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.10" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.10" }
+microsoft-webui = { path = "../webui", version = "0.0.11", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.11" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.11" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.11" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -35,7 +35,7 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,14 +15,14 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.10" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.11" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -20,9 +20,9 @@ default = ["parser"]
 parser = ["dep:microsoft-webui-parser"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 libc = { workspace = true }

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.10" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.10" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.11" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.11" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 tokio = { workspace = true }
 criterion = { workspace = true }
 

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,17 +18,17 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.10" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui = { path = "../webui", version = "0.0.11" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10", default-features = false }
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", default-features = false }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -20,8 +20,8 @@ fs = ["walkdir"]
 cli = ["clap"]
 
 [dependencies]
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -36,7 +36,7 @@ clap = { workspace = true, optional = true }
 [dev-dependencies]
 mockall = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.10", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui = { path = "../webui", version = "0.0.11", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -44,7 +44,7 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.10" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.11" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 mime_guess = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 mockall = { workspace = true }
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui_wasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10", default-features = false }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", default-features = false }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
@@ -29,7 +29,7 @@ serde-wasm-bindgen = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.10" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
 
 [lints]
 workspace = true

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.10" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.11" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 
@@ -29,8 +29,8 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.10" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.10" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.10</Version>
+    <Version>0.0.11</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/examples/app/commerce/package.json
+++ b/examples/app/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/app/commerce/server/Cargo.toml
+++ b/examples/app/commerce/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marketplace-api"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 publish = false
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
d80f7e8b refactor(dev-server): share rebuild loop between webui-press and webui-cli (#276)
58f98362 (feat/edit-page) fix(docs): Wrong publish directory (#275)
8057d179 feat(press): replace VitePress with WebUI Press, a self-hosted SSG (#274)
efedc196 feat(ffi): Add webui_protocol_tokens FFI function to extract CSS token names (#272)
c6a9106d feat(router): support base paths (#271)
ed88206f perf(framework): add component $destroy(), .bind() events, and compEl release (#270)
9916c931 refactor(router): decompose monolithic router into single-responsibility modules (#268)
a75b330f feat(ffi): make webui-parser an optional dependency via parser feature (#269)
101959de refactor(handler) Remove html-escape dependency from webui-handler (#267)
ae9790f8 Fix flaky router preload cache test (#266)
889ccc5e Add CSS preload hints and protocol strategy fields (#265)
c107f81c (main) feat(router): streaming partial navigation (#262)
3f7c909c fix: allow pnpm-style symlinks in npm package resolution (#260)
35ac73ff feat(router): add build-time cache infrastructure with tagged invalidation (#258)
243ee891 perf(router,framework): reduce allocations on hot paths (#257)
465da5cd feat(router): keep-alive preserves state, add X-WebUI-Has-Loader header (#256)
acce3b1d feat(router): add route loaders via static loader() method (#255)
7e7b3912 feat(router): add preload on hover and keep-alive (#254)