### PR TITLE
fix(docs) playground broke in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,10 @@ on:
       - 'crates/webui-protocol/**'
       - 'crates/webui-node/**'
       - 'crates/webui-press/**'
+      - 'crates/webui-wasm/**'
       - 'packages/webui/**'
+      - '.github/workflows/docs.yml'
+      - '.github/actions/build/**'
   workflow_dispatch:
 
 jobs:
@@ -24,6 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
+
+      - name: Build WASM playground
+        uses: ./.github/actions/setup-wasm
 
       - name: Build docs
         run: pnpm --filter @webui/docs... build


### PR DESCRIPTION
The docs deploy workflow was missing the WASM build step, so the playground page at /webui/playground/ could not load webui_wasm.js. Regression from before when we introduced the webui ssg