### PR TITLE
perf: optimize handler state and route rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,7 +1762,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "marketplace-api"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -443,16 +443,18 @@ pub struct Predicate {
 
 ## State Management (webui-state)
 ### Path Resolution
-The `find_value_by_dotted_path` function provides a high-performance way to query JSON state:
+The `find_value_by_dotted_path_ref` function provides the render-time state lookup contract:
 ```rust
-pub fn find_value_by_dotted_path(path: &str, state: &Value) -> Result<Value, StateError>
+pub fn find_value_by_dotted_path_ref<'a>(path: &str, state: &'a Value) -> Option<Cow<'a, Value>>
 ```
+Existing JSON values are returned as `Cow::Borrowed` so handler and expression hot paths do not clone the state tree. Synthetic values, currently string and array `.length`, are returned as `Cow::Owned`. The owned `find_value_by_dotted_path(path, state) -> Option<Value>` wrapper is retained for API boundaries that must materialize an owned `serde_json::Value`.
+
 ### Requirements
 - Dot notation support (e.g., user.profile.name)
-- Array indexing support (e.g., users.0.name)
-- Special length property support for arrays (e.g., users.length)
-- Nullable path handling
-- Missing path error reporting
+- Special length property support for arrays and strings (e.g., users.length)
+- Numeric array indexes are not resolved by dotted path lookup; loops bind array items by moniker instead
+- Nullable path handling via `Option`
+- Missing paths return `None`; handler text and attribute bindings render empty, and missing condition values evaluate as false
 
 ## Expression Evaluation (webui-expressions)
 ### Core Function

--- a/crates/webui-expressions/src/lib.rs
+++ b/crates/webui-expressions/src/lib.rs
@@ -5,13 +5,15 @@
 //!
 //! This module handles the evaluation of condition expressions in WebUI templates.
 
+use std::borrow::Cow;
+
 use serde_json::Value;
 use thiserror::Error;
 use webui_protocol::{
     condition_expr, ComparisonOperator, CompoundCondition, ConditionExpr, LogicalOperator,
     Predicate,
 };
-use webui_state::find_value_by_dotted_path;
+use webui_state::find_value_by_dotted_path_ref;
 
 /// Error types for expression evaluation.
 #[derive(Debug, Error)]
@@ -39,7 +41,7 @@ pub type Result<T> = std::result::Result<T, ExpressionError>;
 
 /// Evaluate a condition expression with the given state
 pub fn evaluate(condition: &ConditionExpr, state: &Value) -> Result<bool> {
-    evaluate_with_resolver(condition, |path| find_value_by_dotted_path(path, state))
+    evaluate_with_resolver(condition, |path| find_value_by_dotted_path_ref(path, state))
 }
 
 /// Evaluate a condition expression using a custom resolver for value lookups.
@@ -48,9 +50,9 @@ pub fn evaluate(condition: &ConditionExpr, state: &Value) -> Result<bool> {
 /// returns the resolved value. This allows callers to provide merged views
 /// (e.g., local variables overlaid on global state) without cloning the
 /// entire state tree.
-pub fn evaluate_with_resolver<F>(condition: &ConditionExpr, resolver: F) -> Result<bool>
+pub fn evaluate_with_resolver<'a, F>(condition: &ConditionExpr, resolver: F) -> Result<bool>
 where
-    F: Fn(&str) -> Option<Value>,
+    F: Fn(&str) -> Option<Cow<'a, Value>>,
 {
     let (logical_op_count, has_mixed_ops) = count_logical_operators(condition);
 
@@ -109,9 +111,9 @@ fn count_logical_operators(condition: &ConditionExpr) -> (usize, bool) {
 }
 
 // Iterative evaluation of expressions using a resolver closure
-fn evaluate_expr<F>(condition: &ConditionExpr, resolver: &F) -> Result<bool>
+fn evaluate_expr<'a, F>(condition: &ConditionExpr, resolver: &F) -> Result<bool>
 where
-    F: Fn(&str) -> Option<Value>,
+    F: Fn(&str) -> Option<Cow<'a, Value>>,
 {
     match &condition.expr {
         Some(condition_expr::Expr::Predicate(pred)) => evaluate_predicate(pred, resolver),
@@ -125,8 +127,8 @@ where
         Some(condition_expr::Expr::Compound(compound)) => evaluate_compound(compound, resolver),
         Some(condition_expr::Expr::Identifier(id)) => {
             if let Some(val) = resolver(&id.value) {
-                match val {
-                    Value::Bool(b) => Ok(b),
+                match val.as_ref() {
+                    Value::Bool(b) => Ok(*b),
                     Value::Null => Ok(false),
                     Value::Number(n) => Ok(!(n.as_f64() == Some(0.0))),
                     Value::String(s) => Ok(!s.is_empty()),
@@ -143,9 +145,9 @@ where
     }
 }
 
-fn evaluate_compound<F>(compound: &CompoundCondition, resolver: &F) -> Result<bool>
+fn evaluate_compound<'a, F>(compound: &CompoundCondition, resolver: &F) -> Result<bool>
 where
-    F: Fn(&str) -> Option<Value>,
+    F: Fn(&str) -> Option<Cow<'a, Value>>,
 {
     let left = compound.left.as_ref().ok_or_else(|| {
         ExpressionError::Evaluation("Compound missing left expression".to_string())
@@ -178,9 +180,9 @@ where
     }
 }
 
-fn evaluate_predicate<F>(predicate: &Predicate, resolver: &F) -> Result<bool>
+fn evaluate_predicate<'a, F>(predicate: &Predicate, resolver: &F) -> Result<bool>
 where
-    F: Fn(&str) -> Option<Value>,
+    F: Fn(&str) -> Option<Cow<'a, Value>>,
 {
     let left_val = match resolver(&predicate.left) {
         Some(val) => val,
@@ -188,7 +190,7 @@ where
     };
 
     let right_val = if is_literal(&predicate.right) {
-        parse_literal(&predicate.right)?
+        Cow::Owned(parse_literal(&predicate.right)?)
     } else {
         match resolver(&predicate.right) {
             Some(val) => val,
@@ -203,7 +205,7 @@ where
         ))
     })?;
 
-    compare_values(&left_val, &op, &right_val)
+    compare_values(left_val.as_ref(), &op, right_val.as_ref())
 }
 
 // Check if a string is a literal value
@@ -323,6 +325,7 @@ fn extract_number(val: &Value) -> Result<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
     use webui_protocol::{ComparisonOperator, ConditionExpr, LogicalOperator};
     use webui_test_utils::test_json;
 
@@ -599,6 +602,22 @@ mod tests {
             "Expected Ok(true), got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_borrowed_resolver_value() {
+        let condition = ConditionExpr::identifier("flag");
+        let value = Value::Bool(true);
+
+        let result = evaluate_with_resolver(&condition, |path| {
+            if path == "flag" {
+                Some(Cow::Borrowed(&value))
+            } else {
+                None
+            }
+        });
+
+        assert!(matches!(result, Ok(true)));
     }
 
     #[test]

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -14,12 +14,14 @@ pub(crate) mod route_renderer;
 
 use plugin::HandlerPlugin;
 use route_matcher::CompiledRouteCache;
+use serde::Serialize;
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use webui_expressions::{evaluate_with_resolver, ExpressionError};
 use webui_protocol::{web_ui_fragment::Fragment, WebUIFragment, WebUIProtocol};
-use webui_state::find_value_by_dotted_path;
+use webui_state::find_value_by_dotted_path_ref;
 
 /// Error types for the WebUI handler.
 #[derive(Debug, Error)]
@@ -142,6 +144,15 @@ struct WebUIProcessContext<'a> {
     route_chain_index: usize,
 }
 
+struct WebUiBootstrap<'a> {
+    state: &'a Value,
+    chain: &'a [Value],
+    inventory: &'a str,
+    nonce: Option<&'a str>,
+    css_hrefs: &'a [&'a str],
+    style_specs: &'a [&'a str],
+}
+
 /// Get the component attribute name, stripping `:` prefix and converting to camelCase.
 ///
 /// Uses `webui_protocol::attrs::attribute_to_camel` which handles irregular
@@ -173,6 +184,112 @@ fn write_usize(writer: &mut dyn ResponseWriter, mut n: usize) -> Result<()> {
         Ok(s) => writer.write(s),
         Err(_) => writer.write("0"),
     }
+}
+
+fn write_script_safe_json<T>(writer: &mut dyn ResponseWriter, value: &T) -> Result<()>
+where
+    T: Serialize + ?Sized,
+{
+    let mut json = Vec::with_capacity(256);
+    serde_json::to_writer(&mut json, value)
+        .map_err(|error| HandlerError::Rendering(format!("failed to serialize JSON: {error}")))?;
+    let json = std::str::from_utf8(&json)
+        .map_err(|error| HandlerError::Rendering(format!("invalid JSON UTF-8: {error}")))?;
+    write_script_safe_json_str(writer, json)
+}
+
+fn write_script_safe_json_str(writer: &mut dyn ResponseWriter, json: &str) -> Result<()> {
+    let mut start = 0;
+    while start < json.len() {
+        let rest = &json[start..];
+        let Some(offset) = rest.find("</") else {
+            writer.write(rest)?;
+            return Ok(());
+        };
+
+        if offset > 0 {
+            writer.write(&rest[..offset])?;
+        }
+        writer.write("<\\/")?;
+        start += offset + 2;
+    }
+    Ok(())
+}
+
+fn write_json_field_name(
+    writer: &mut dyn ResponseWriter,
+    wrote_field: &mut bool,
+    name: &str,
+) -> Result<()> {
+    if *wrote_field {
+        writer.write(",")?;
+    }
+    *wrote_field = true;
+    writer.write("\"")?;
+    writer.write(name)?;
+    writer.write("\":")
+}
+
+fn write_json_field<T>(
+    writer: &mut dyn ResponseWriter,
+    wrote_field: &mut bool,
+    name: &str,
+    value: &T,
+) -> Result<()>
+where
+    T: Serialize + ?Sized,
+{
+    write_json_field_name(writer, wrote_field, name)?;
+    write_script_safe_json(writer, value)
+}
+
+fn write_webui_bootstrap(
+    writer: &mut dyn ResponseWriter,
+    bootstrap: WebUiBootstrap<'_>,
+) -> Result<()> {
+    let mut wrote_field = false;
+
+    writer.write("{")?;
+    if !bootstrap.chain.is_empty() {
+        write_json_field(writer, &mut wrote_field, "chain", bootstrap.chain)?;
+    }
+    if !bootstrap.css_hrefs.is_empty() {
+        write_json_field(writer, &mut wrote_field, "css", bootstrap.css_hrefs)?;
+    }
+    write_json_field(writer, &mut wrote_field, "inventory", bootstrap.inventory)?;
+    if let Some(nonce) = bootstrap.nonce {
+        write_json_field(writer, &mut wrote_field, "nonce", nonce)?;
+    }
+    write_json_field(writer, &mut wrote_field, "state", bootstrap.state)?;
+    if !bootstrap.style_specs.is_empty() {
+        write_json_field(writer, &mut wrote_field, "styles", bootstrap.style_specs)?;
+    }
+    write_json_field_name(writer, &mut wrote_field, "templates")?;
+    writer.write("{}")?;
+    writer.write("}")
+}
+
+fn resolve_value_from_sources<'ctx, 'state>(
+    path: &str,
+    local_vars: &'ctx HashMap<String, Value>,
+    state: &'state Value,
+) -> Option<Cow<'ctx, Value>>
+where
+    'state: 'ctx,
+{
+    if let Some(first_part) = path.split('.').next() {
+        if let Some(local_value) = local_vars.get(first_part) {
+            if first_part.len() == path.len() {
+                return Some(Cow::Borrowed(local_value));
+            }
+            let remaining = &path[first_part.len() + 1..];
+            if let Some(value) = find_value_by_dotted_path_ref(remaining, local_value) {
+                return Some(value);
+            }
+        }
+    }
+
+    find_value_by_dotted_path_ref(path, state)
 }
 
 impl WebUIHandler {
@@ -365,10 +482,10 @@ impl WebUIHandler {
         let request_segments = route_matcher::split_request_path(&context.request_path);
         let mut best: Option<(usize, route_matcher::RouteMatch)> = None;
         for (idx, child) in children.iter().enumerate() {
-            let resolved = route_matcher::resolve_route_path(&child.path, &context.route_base);
+            let resolved = route_matcher::resolve_route_path_cow(&child.path, &context.route_base);
             if let Some(m) = route_matcher::match_route_cached_with_segments(
                 &mut context.route_cache,
-                &resolved,
+                resolved.as_ref(),
                 &request_segments,
                 child.exact,
             ) {
@@ -611,7 +728,7 @@ impl WebUIHandler {
         let saved_local_vars = std::mem::take(&mut context.local_vars);
         let saved_component_attrs = std::mem::take(&mut context.component_attrs);
 
-        // Component gets accumulated attrs as its local vars
+        // Component gets accumulated attrs as its local vars.
         context.local_vars = saved_component_attrs;
 
         if let Some(p) = &mut context.plugin {
@@ -632,21 +749,8 @@ impl WebUIHandler {
     }
 
     /// Resolve a dotted path value, checking local variables first, then global state.
-    fn resolve_value(&self, path: &str, context: &WebUIProcessContext) -> Option<Value> {
-        // Check local vars first
-        if let Some(first_part) = path.split('.').next() {
-            if let Some(local_value) = context.local_vars.get(first_part) {
-                if first_part.len() == path.len() {
-                    return Some(local_value.clone());
-                }
-                let remaining = &path[first_part.len() + 1..];
-                if let Some(v) = find_value_by_dotted_path(remaining, local_value) {
-                    return Some(v);
-                }
-            }
-        }
-        // Fall back to global state
-        find_value_by_dotted_path(path, context.state)
+    fn resolve_value(&self, path: &str, context: &WebUIProcessContext<'_>) -> Option<Value> {
+        resolve_value_from_sources(path, &context.local_vars, context.state).map(Cow::into_owned)
     }
 
     /// Evaluate a condition expression against the current context.
@@ -662,18 +766,7 @@ impl WebUIHandler {
         let local_vars = &context.local_vars;
         let state = context.state;
         match evaluate_with_resolver(condition, |path| {
-            if let Some(first_part) = path.split('.').next() {
-                if let Some(local_value) = local_vars.get(first_part) {
-                    if first_part.len() == path.len() {
-                        return Some(local_value.clone());
-                    }
-                    let remaining = &path[first_part.len() + 1..];
-                    if let Some(v) = find_value_by_dotted_path(remaining, local_value) {
-                        return Some(v);
-                    }
-                }
-            }
-            find_value_by_dotted_path(path, state)
+            resolve_value_from_sources(path, local_vars, state)
         }) {
             Ok(result) => Ok(result),
             Err(ExpressionError::MissingValue(_)) => Ok(false),
@@ -721,8 +814,8 @@ impl WebUIHandler {
             let saved_value = context.local_vars.insert(item_name.clone(), item);
             self.process_fragment_id(&for_loop.fragment_id, context)?;
             match saved_value {
-                Some(v) => {
-                    context.local_vars.insert(item_name.clone(), v);
+                Some(value) => {
+                    context.local_vars.insert(item_name.clone(), value);
                 }
                 None => {
                     context.local_vars.remove(item_name.as_str());
@@ -818,11 +911,10 @@ impl WebUIHandler {
             let comp_index = crate::route_handler::build_component_index(context.protocol);
 
             // Compute the inventory hex from actually rendered components.
-            let (_, inventory_hex) = crate::route_handler::filter_needed_components(
+            let inventory_hex = crate::route_handler::encode_component_inventory(
                 &context.rendered_components,
-                "",
                 &comp_index,
-            )?;
+            );
 
             // Emit templates for all REACHABLE components on the current route,
             // not just those rendered in this SSR pass. Components inside false
@@ -831,15 +923,12 @@ impl WebUIHandler {
             // round-trip. The graph walker follows conditional and loop branches
             // unconditionally, but only descends into the matched route chain —
             // components on other routes are delivered via SPA partial navigation.
-            let (reachable_names, _) = crate::route_handler::get_needed_components_for_request(
+            let reachable = crate::route_handler::collect_reachable_components_for_request(
                 context.protocol,
                 &context.entry_id,
                 &context.request_path,
-                "",
-                &comp_index,
-            )?;
-            let reachable: std::collections::HashSet<String> =
-                reachable_names.into_iter().collect();
+                &mut context.route_cache,
+            );
 
             // Emit CSS module definitions for reachable-but-unrendered components.
             // Rendered components already got their <style type="module"> inline
@@ -895,18 +984,6 @@ impl WebUIHandler {
             // Single-script reduces HTML parse overhead and ensures all
             // SSR metadata is available atomically before DOMContentLoaded.
 
-            // Build the window.__webui bootstrap object
-            let mut webui_obj = serde_json::Map::new();
-
-            // Templates — empty object so IIFE scripts can write into it
-            webui_obj.insert(
-                "templates".into(),
-                serde_json::Value::Object(serde_json::Map::new()),
-            );
-
-            // State — emitted as window.__webui.state
-            webui_obj.insert("state".into(), context.state.clone());
-
             // Chain
             let chain = crate::route_handler::collect_route_chain(
                 context.protocol,
@@ -914,28 +991,15 @@ impl WebUIHandler {
                 &context.request_path,
                 &mut context.route_cache,
             );
-            if !chain.is_empty() {
-                let chain_json = serde_json::Value::Array(
-                    chain
-                        .iter()
-                        .map(crate::route_handler::RouteChainEntry::to_json)
-                        .collect(),
-                );
-                webui_obj.insert("chain".into(), chain_json);
-            }
-
-            // Inventory
-            webui_obj.insert("inventory".into(), serde_json::Value::String(inventory_hex));
-
-            // Nonce
-            if let Some(ref nonce) = context.nonce {
-                webui_obj.insert("nonce".into(), serde_json::Value::String(nonce.clone()));
-            }
+            let chain_json: Vec<Value> = chain
+                .iter()
+                .map(crate::route_handler::RouteChainEntry::to_json)
+                .collect();
 
             // CSS hrefs emitted during SSR (Link-strategy components)
             let is_link = context.protocol.css_strategy() == webui_protocol::CssStrategy::Link;
+            let mut css_hrefs: Vec<&str> = Vec::new();
             if is_link {
-                let mut css_hrefs: Vec<serde_json::Value> = Vec::new();
                 for name in &reachable {
                     if let Some(href) = context
                         .protocol
@@ -944,30 +1008,22 @@ impl WebUIHandler {
                         .map(|c| c.css_href.as_str())
                         .filter(|h| !h.is_empty())
                     {
-                        css_hrefs.push(serde_json::Value::String(href.to_string()));
+                        css_hrefs.push(href);
                     }
-                }
-                if !css_hrefs.is_empty() {
-                    webui_obj.insert("css".into(), serde_json::Value::Array(css_hrefs));
                 }
             }
 
             // Module style specifiers emitted during SSR
-            {
-                let mut style_specs: Vec<serde_json::Value> = Vec::new();
-                for name in &reachable {
-                    if context
-                        .protocol
-                        .components
-                        .get(name)
-                        .map(|c| !c.css.is_empty())
-                        .unwrap_or(false)
-                    {
-                        style_specs.push(serde_json::Value::String(name.clone()));
-                    }
-                }
-                if !style_specs.is_empty() {
-                    webui_obj.insert("styles".into(), serde_json::Value::Array(style_specs));
+            let mut style_specs: Vec<&str> = Vec::new();
+            for name in &reachable {
+                if context
+                    .protocol
+                    .components
+                    .get(name)
+                    .map(|c| !c.css.is_empty())
+                    .unwrap_or(false)
+                {
+                    style_specs.push(name);
                 }
             }
 
@@ -983,10 +1039,17 @@ impl WebUIHandler {
             // 1. Emit window.__webui bootstrap object (chain, inventory,
             //    nonce, css, styles, state — all in one JSON assignment)
             context.writer.write("window.__webui=")?;
-            let webui_str =
-                serde_json::to_string(&serde_json::Value::Object(webui_obj)).unwrap_or_default();
-            let safe_webui = webui_str.replace("</", "<\\/");
-            context.writer.write(&safe_webui)?;
+            write_webui_bootstrap(
+                context.writer,
+                WebUiBootstrap {
+                    state: context.state,
+                    chain: &chain_json,
+                    inventory: &inventory_hex,
+                    nonce: context.nonce.as_deref(),
+                    css_hrefs: &css_hrefs,
+                    style_specs: &style_specs,
+                },
+            )?;
             context.writer.write(";")?;
 
             // 2. Template IIFEs — write into window.__webui.templates
@@ -6311,7 +6374,6 @@ mod tests {
             ),
             "Missing preload for my-card.css in <head>: {html}"
         );
-
         // No stylesheet links — shadow root handles that
         assert!(
             !head_section.contains(r#"<link rel="stylesheet""#),
@@ -6334,7 +6396,6 @@ mod tests {
                     WebUIFragment::raw("</head><body><my-card>".to_string()),
                     WebUIFragment::component("my-card"),
                     WebUIFragment::raw("</my-card>".to_string()),
-                    WebUIFragment::signal("body_end", true),
                     WebUIFragment::raw("</body></html>".to_string()),
                 ],
             },
@@ -6456,6 +6517,7 @@ mod tests {
                     WebUIFragment::raw("</head><body>".to_string()),
                     WebUIFragment::component("has-css"),
                     WebUIFragment::component("no-css"),
+                    WebUIFragment::signal("body_end", true),
                     WebUIFragment::raw("</body></html>".to_string()),
                 ],
             },

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -48,24 +48,20 @@ impl ProtocolIndex {
 /// `protocol.components`. Components are sorted alphabetically; index =
 /// position in that order.
 pub fn build_component_index(protocol: &WebUIProtocol) -> HashMap<String, u32> {
-    let mut names: HashSet<&String> = HashSet::new();
-    for key in protocol.fragments.keys() {
-        if key.contains('-') {
-            names.insert(key);
-        }
-    }
-    let mut sorted: Vec<&String> = names.into_iter().collect();
+    let mut sorted: Vec<&String> = protocol
+        .fragments
+        .keys()
+        .filter(|key| key.contains('-'))
+        .collect();
     sorted.sort_unstable();
-    sorted
-        .iter()
-        .enumerate()
-        .map(|(i, n)| {
-            // Index count bounded by component registry size, well within u32 range
-            #[allow(clippy::cast_possible_truncation)]
-            let idx = i as u32;
-            ((*n).clone(), idx)
-        })
-        .collect()
+    let mut index = HashMap::with_capacity(sorted.len());
+    for (i, name) in sorted.into_iter().enumerate() {
+        // Index count bounded by component registry size, well within u32 range
+        #[allow(clippy::cast_possible_truncation)]
+        let idx = i as u32;
+        index.insert(name.clone(), idx);
+    }
+    index
 }
 
 /// Check if a component's bit is set in the inventory bitfield.
@@ -122,12 +118,27 @@ pub fn parse_inventory(hex: &str) -> Result<Vec<u8>, HandlerError> {
 
 /// Encode an inventory bitfield as a hex string.
 pub fn encode_inventory(inv: &[u8]) -> String {
-    inv.iter()
-        .fold(String::with_capacity(inv.len() * 2), |mut acc, b| {
-            use std::fmt::Write;
-            let _ = write!(acc, "{b:02x}");
-            acc
-        })
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(inv.len() * 2);
+    for byte in inv {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+/// Encode the inventory bitfield for a known set of rendered components.
+pub(crate) fn encode_component_inventory(
+    component_names: &HashSet<String>,
+    index: &HashMap<String, u32>,
+) -> String {
+    let mut inventory = Vec::new();
+    for name in component_names {
+        if let Some(&idx) = index.get(name.as_str()) {
+            set_component(&mut inventory, idx);
+        }
+    }
+    encode_inventory(&inventory)
 }
 
 /// Walk the protocol fragment graph from `entry_id` and return the names of
@@ -169,6 +180,16 @@ pub fn get_needed_components_for_request(
         &mut CompiledRouteCache::new(),
     );
     filter_needed_components(&component_names, inventory_hex, component_index)
+}
+
+/// Collect all route-reachable inventoryable components for the request path.
+pub(crate) fn collect_reachable_components_for_request(
+    protocol: &WebUIProtocol,
+    entry_id: &str,
+    request_path: &str,
+    cache: &mut CompiledRouteCache,
+) -> HashSet<String> {
+    collect_inventoryable_components(protocol, entry_id, Some(request_path), false, cache)
 }
 
 /// Filter components against the client's inventory bitfield using sequential indices.
@@ -388,10 +409,10 @@ fn select_best_child_route(
     let request_segments = route_matcher::split_request_path(request_path);
     let mut best: Option<(usize, route_matcher::RouteMatch)> = None;
     for (idx, child) in children.iter().enumerate() {
-        let resolved = route_matcher::resolve_route_path(&child.path, route_base);
+        let resolved = route_matcher::resolve_route_path_cow(&child.path, route_base);
         if let Some(m) = route_matcher::match_route_cached_with_segments(
             cache,
-            &resolved,
+            resolved.as_ref(),
             &request_segments,
             child.exact,
         ) {

--- a/crates/webui-handler/src/route_matcher.rs
+++ b/crates/webui-handler/src/route_matcher.rs
@@ -6,6 +6,7 @@
 //! Matches request paths against route path templates without regex.
 //! Supports `:param`, `:param?` (optional), and `*splat` segments.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Result of matching a request path against a route path template.
@@ -284,19 +285,24 @@ pub fn is_relative_path(path: &str) -> bool {
 /// `"./topics/:id"` + `"/sections/1"` → `"/sections/1/topics/:id"`
 /// `"/topics/:id"` + `"/sections/1"` → `"/topics/:id"`
 pub fn resolve_route_path(path: &str, route_base: &str) -> String {
+    resolve_route_path_cow(path, route_base).into_owned()
+}
+
+/// Resolve a route path while borrowing absolute paths that need no changes.
+pub(crate) fn resolve_route_path_cow<'a>(path: &'a str, route_base: &str) -> Cow<'a, str> {
     // An empty path means "match at the parent level" — resolve to base.
     if path.is_empty() {
-        return route_base.to_string();
+        return Cow::Owned(route_base.to_string());
     }
 
     if !is_relative_path(path) {
-        return path.to_string();
+        return Cow::Borrowed(path);
     }
 
     // Strip leading "./" if present
     let relative = path.strip_prefix("./").unwrap_or(path);
     if relative.is_empty() {
-        return route_base.to_string();
+        return Cow::Owned(route_base.to_string());
     }
 
     let mut resolved = String::with_capacity(route_base.len() + relative.len() + 1);
@@ -305,7 +311,7 @@ pub fn resolve_route_path(path: &str, route_base: &str) -> String {
         resolved.push('/');
     }
     resolved.push_str(relative);
-    resolved
+    Cow::Owned(resolved)
 }
 
 /// Compute the new route base from a matched route's consumed request segments.
@@ -313,16 +319,25 @@ pub fn resolve_route_path(path: &str, route_base: &str) -> String {
 /// Given request path `/sections/1/topics/react` and consumed=2,
 /// returns `/sections/1`.
 pub fn compute_route_base(request_path: &str, consumed_segments: usize) -> String {
-    let parts = split_path(request_path);
-    if consumed_segments == 0 || parts.is_empty() {
+    if consumed_segments == 0 {
         return "/".to_string();
     }
 
-    let n = consumed_segments.min(parts.len());
     let mut base = String::with_capacity(request_path.len());
-    for part in &parts[..n] {
+    let mut remaining = consumed_segments;
+    for part in request_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+    {
+        if remaining == 0 {
+            break;
+        }
         base.push('/');
         base.push_str(part);
+        remaining -= 1;
+    }
+    if base.is_empty() {
+        base.push('/');
     }
     base
 }

--- a/crates/webui-handler/src/route_renderer.rs
+++ b/crates/webui-handler/src/route_renderer.rs
@@ -84,10 +84,10 @@ pub(crate) fn find_best_route_match(
 
     for item in fragments {
         if let Some(Fragment::Route(route_frag)) = item.fragment.as_ref() {
-            let resolved_path = route_matcher::resolve_route_path(&route_frag.path, route_base);
+            let resolved_path = route_matcher::resolve_route_path_cow(&route_frag.path, route_base);
             if let Some(m) = route_matcher::match_route_cached_with_segments(
                 cache,
-                &resolved_path,
+                resolved_path.as_ref(),
                 &request_segments,
                 route_frag.exact,
             ) {

--- a/crates/webui-state/src/lib.rs
+++ b/crates/webui-state/src/lib.rs
@@ -3,10 +3,17 @@
 
 extern crate serde_json;
 
+use std::borrow::Cow;
+
 use serde_json::Value;
 
-// Finds a value in a JSON object by a dotted path.
-pub fn find_value_by_dotted_path(path: &str, state: &Value) -> Option<Value> {
+/// Finds a value in a JSON object by dotted path and returns a borrowed value when possible.
+///
+/// Most lookups borrow directly from `state`. Synthetic values such as array
+/// and string `.length` are returned as owned values because they do not exist
+/// in the source JSON tree.
+#[must_use]
+pub fn find_value_by_dotted_path_ref<'a>(path: &str, state: &'a Value) -> Option<Cow<'a, Value>> {
     let mut current_value: &Value = state;
 
     for part in path.split('.') {
@@ -15,16 +22,27 @@ pub fn find_value_by_dotted_path(path: &str, state: &Value) -> Option<Value> {
                 current_value = map.get(part)?;
             }
             Value::Array(arr) if part == "length" => {
-                return Some(Value::Number(serde_json::Number::from(arr.len())));
+                return Some(Cow::Owned(Value::Number(serde_json::Number::from(
+                    arr.len(),
+                ))));
             }
             Value::String(s) if part == "length" => {
-                return Some(Value::Number(serde_json::Number::from(s.len())));
+                return Some(Cow::Owned(Value::Number(serde_json::Number::from(s.len()))));
             }
             _ => return None,
         }
     }
 
-    Some(current_value.clone())
+    Some(Cow::Borrowed(current_value))
+}
+
+/// Finds a value in a JSON object by dotted path and returns an owned value.
+///
+/// Prefer [`find_value_by_dotted_path_ref`] in render-time hot paths so state
+/// values can be borrowed without cloning.
+#[must_use]
+pub fn find_value_by_dotted_path(path: &str, state: &Value) -> Option<Value> {
+    find_value_by_dotted_path_ref(path, state).map(Cow::into_owned)
 }
 
 #[cfg(test)]
@@ -339,5 +357,31 @@ mod tests {
             value,
             Some(Value::Number(serde_json::Number::from_f64(1.23).unwrap()))
         );
+    }
+
+    #[test]
+    fn test_ref_lookup_borrows_existing_value() {
+        let data = test_json!({
+            "user": {
+                "name": "Alice"
+            }
+        });
+        let value = find_value_by_dotted_path_ref("user.name", &data).expect("value");
+        let expected = data
+            .get("user")
+            .and_then(|user| user.get("name"))
+            .expect("expected value");
+
+        assert!(matches!(value, std::borrow::Cow::Borrowed(_)));
+        assert!(std::ptr::eq(value.as_ref(), expected));
+    }
+
+    #[test]
+    fn test_ref_lookup_owns_synthetic_length() {
+        let data = test_json!({ "items": [1, 2, 3] });
+        let value = find_value_by_dotted_path_ref("items.length", &data).expect("value");
+
+        assert!(matches!(value, std::borrow::Cow::Owned(_)));
+        assert_eq!(value.as_ref(), &Value::Number(serde_json::Number::from(3)));
     }
 }


### PR DESCRIPTION
Use borrowed state/expression lookup for read-only evaluation paths and keep handler route work closer to borrowed/indexed data. This avoids cloning existing serde_json::Value nodes for dotted-path resolution, serializes the WebUI bootstrap without building a cloned state object, and reduces route/index allocation churn by borrowing absolute route paths, avoiding temporary segment Vecs, building component indexes directly from sorted fragment keys, and encoding rendered component inventory directly.

Benchmarks:
- Mail Rust original baseline -> current base-href summary:
  - Render/inbox: 0.57 ms -> 0.514 ms P50 (~9.8% faster)
  - Render/folder: 0.58 ms -> 0.526 ms P50 (~9.3% faster)
  - Render/thread: 0.59 ms -> 0.523 ms P50 (~11.4% faster)
  - Render/compose: 0.58 ms -> 0.528 ms P50 (~9.0% faster)
  - Render/search: 0.58 ms -> 0.529 ms P50 (~8.8% faster)
  - Render/calendar: 0.14 ms -> 0.095 ms P50 (~32.1% faster)
  - Render/settings: 0.11 ms -> 0.070 ms P50 (~36.4% faster)
- Route/index pass vs borrowed-buffered bootstrap artifact:
  - Main SSR routes: roughly 0.1-1.7% faster P50
  - Calendar/settings: roughly 6.4-9.5% faster P50
  - Partial response bytes unchanged
- Mail before/after with fixed base href:
  - Average FCP: 44.3 ms -> 41.9 ms (-5.5%)
  - Average LCP: 57.1 ms -> 57.4 ms (+0.6%, within noise)
  - Average JS heap: 3.00 MB -> 3.02 MB (+0.4%)
  - Average tab memory: 147.05 MB -> 147.25 MB (+0.1%)
  - HTML size, inline script size, listeners, and DOM counts unchanged

Validation:
- cargo run --release -p xtask -- check