### PR TITLE
feat(router): auto-register passive stub elements for unknown route tags

### DIFF
--- a/packages/webui-router/src/loaders.ts
+++ b/packages/webui-router/src/loaders.ts
@@ -21,6 +21,12 @@ export const NOOP_SIGNAL: AbortSignal = new AbortController().signal;
  * configured for this tag and the element isn't already registered,
  * invoke the loader. The promise is cached so each loader runs at
  * most once.
+ *
+ * When no loader exists and the tag is not yet registered, a passive
+ * stub element is auto-defined. This implements the islands
+ * architecture pattern: only interactive components need explicit
+ * class definitions — passive route targets (pages with no client-side
+ * logic) are handled automatically by the framework.
  */
 export async function ensureComponentLoaded(
   tag: string,
@@ -30,7 +36,12 @@ export async function ensureComponentLoaded(
   if (customElements.get(tag)) return;
 
   const loader = loaders[tag];
-  if (!loader) return;
+  if (!loader) {
+    // No loader and not registered — auto-define a passive stub so
+    // the router can create/query this element during SPA navigation.
+    definePassiveStub(tag);
+    return;
+  }
 
   let promise = loaderPromises.get(tag);
   if (!promise) {
@@ -38,6 +49,23 @@ export async function ensureComponentLoaded(
     loaderPromises.set(tag, promise);
   }
   await promise;
+}
+
+/**
+ * Auto-define a passive stub custom element for tags that have no
+ * registered class and no lazy loader.  The stub extends HTMLElement
+ * directly (no hydration, no template, no bindings) and exposes a
+ * no-op `setState()` so the router's `isStateful()` check passes.
+ *
+ * This is the core of the islands architecture: app code only defines
+ * components that need interactivity.  Everything else is server-
+ * rendered static HTML with zero client-side overhead.
+ */
+function definePassiveStub(tag: string): void {
+  if (customElements.get(tag)) return;
+  customElements.define(tag, class extends HTMLElement {
+    setState(_s: Record<string, unknown>): void { /* SSR-only: no-op */ }
+  });
 }
 
 /**

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -1092,6 +1092,65 @@ describe('WebUIRouter', () => {
       assert.equal(loaderPromises.size, 0, 'entry should be deleted after rejection');
     });
   });
+
+  describe('passive stub auto-registration', () => {
+    test('auto-defines a passive HTMLElement stub for unknown tags with no loader', async () => {
+      const tag = 'auto-stub-' + Date.now();
+      const loaders: Record<string, () => Promise<unknown>> = {};
+      const loaderPromises = new Map<string, Promise<void>>();
+
+      // Tag is not registered before the call
+      assert.equal(customElements.get(tag), undefined, 'tag should not be registered initially');
+
+      await ensureComponentLoaded(tag, loaders, loaderPromises);
+
+      // Tag is now registered
+      const ctor = customElements.get(tag);
+      assert.ok(ctor, 'tag should be auto-registered after ensureComponentLoaded');
+    });
+
+    test('auto-defined stub has a no-op setState method', async () => {
+      const tag = 'stub-setstate-' + Date.now();
+      const loaders: Record<string, () => Promise<unknown>> = {};
+      const loaderPromises = new Map<string, Promise<void>>();
+
+      await ensureComponentLoaded(tag, loaders, loaderPromises);
+
+      const ctor = customElements.get(tag) as new () => HTMLElement;
+      const instance = new ctor();
+      assert.equal(typeof (instance as any).setState, 'function', 'stub should have setState');
+
+      // setState should not throw
+      (instance as any).setState({ foo: 'bar' });
+    });
+
+    test('does not auto-define when a loader exists', async () => {
+      const tag = 'has-loader-' + Date.now();
+      let loaderCalled = false;
+      const loaders: Record<string, () => Promise<unknown>> = {
+        [tag]: () => { loaderCalled = true; return Promise.resolve(); },
+      };
+      const loaderPromises = new Map<string, Promise<void>>();
+
+      await ensureComponentLoaded(tag, loaders, loaderPromises);
+
+      assert.ok(loaderCalled, 'loader should have been called');
+    });
+
+    test('does not re-define when tag is already registered', async () => {
+      const tag = 'already-reg-' + Date.now();
+      const original = class extends HTMLElement {};
+      customElements.define(tag, original);
+
+      const loaders: Record<string, () => Promise<unknown>> = {};
+      const loaderPromises = new Map<string, Promise<void>>();
+
+      await ensureComponentLoaded(tag, loaders, loaderPromises);
+
+      // Should still be the original class, not a stub
+      assert.equal(customElements.get(tag), original, 'should not overwrite existing registration');
+    });
+  });
 });
 
 // ── parseQuery unit tests ────────────────────────────────────────


### PR DESCRIPTION
When the router encounters a route component tag that has no customElements registration and no lazy loader, it now auto-defines a passive HTMLElement stub with a no-op setState().

This is the framework-level implementation of the islands architecture: app developers only need to write component classes for interactive elements. Passive route targets (pages with no client-side logic) are handled automatically — no .ts file needed at all.

The stub is defined once per tag name via definePassiveStub() in ensureComponentLoaded(). It satisfies:
- customElements.get(tag) lookups in the router
- document.createElement(tag) for SPA navigation
- isStateful() checks (has setState method)