### PR TITLE
fix(framework): trust SSR conditional content during hydration

### DIFF
--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -733,8 +733,18 @@ export class WebUIElement extends HTMLElement {
         }
         if (marker) lastCondMarker = marker;
 
-        if (shown && blockMeta && marker) {
-          condInstance = this.$hydrateCondContent(condAnchor, blockMeta, scope);
+        // SSR hydration: if the marker exists, the server rendered this
+        // conditional — hydrate its content regardless of the current
+        // condition value.  Complex properties from parent bindings may
+        // not have arrived yet (the parent hydrates after children), so
+        // the condition could evaluate to false even though the server
+        // rendered it as true.  Trust the SSR DOM and wire it up; the
+        // condition will re-evaluate correctly once all data is set.
+        const ssrContentPresent = marker && blockMeta && this.$hasContentAfterMarker(condAnchor, MARKER_COND_END);
+        if (blockMeta && (shown || ssrContentPresent)) {
+          if (marker) {
+            condInstance = this.$hydrateCondContent(condAnchor, blockMeta, scope);
+          }
         }
 
         // Collect <!--/wc--> end marker for deferred removal.
@@ -987,6 +997,24 @@ export class WebUIElement extends HTMLElement {
       child = child.nextSibling;
     }
     return null;
+  }
+
+  /**
+   * Check whether there is non-marker content between a conditional
+   * start anchor and its closing marker.  Used during SSR hydration to
+   * detect server-rendered conditional content even when the runtime
+   * condition value has not been set yet (e.g. complex property from a
+   * parent repeat binding that hydrates after its children).
+   */
+  private $hasContentAfterMarker(anchor: Comment, endData: string): boolean {
+    let sibling = anchor.nextSibling;
+    while (sibling) {
+      if (sibling.nodeType === 8 && (sibling as Comment).data === endData) {
+        return false; // reached end marker with no content in between
+      }
+      return true; // any non-end-marker node = content present
+    }
+    return false;
   }
 
   /**

--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -962,9 +962,12 @@ export class WebUIElement extends HTMLElement {
       // Single-root optimisation: hydrate the element in-place (pathStart=1).
       const el = nextElement(condAnchor);
       if (el) {
-        const inst = this.$hydrate(el, blockMeta, tplDom, scope, 1);
-        this.$updateInstance(inst);
-        return inst;
+        // Wire bindings only — do NOT call $updateInstance.  SSR text
+        // nodes already contain correct values; evaluating bindings now
+        // would overwrite them with stale data (e.g. a complex property
+        // from a parent that hasn't hydrated yet).  This is consistent
+        // with $mount which also skips $updateInstance for SSR roots.
+        return this.$hydrate(el, blockMeta, tplDom, scope, 1);
       }
       return null;
     }
@@ -980,7 +983,7 @@ export class WebUIElement extends HTMLElement {
       condAnchor.parentNode?.insertBefore(inst.nodes[cn], afterNode.nextSibling);
       afterNode = inst.nodes[cn];
     }
-    this.$updateInstance(inst);
+    // Same as above — trust SSR DOM, skip binding evaluation.
     return inst;
   }
 

--- a/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
+++ b/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
@@ -124,3 +124,58 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     expect(result.items).toEqual(['Sync1', 'Sync2', 'Sync3']);
   });
 });
+
+test.describe('complex-prop: SSR conditional blocks trust server-rendered content', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/complex-prop/fixture.html');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#host') as any;
+      return el && el.$ready === true;
+    });
+  });
+
+  test('SSR conditional driven by :data is hydrated without duplicates', async ({ page }) => {
+    // The child's <if condition="data.showHeader"> was rendered by SSR
+    // (condData.showHeader=true in state.json). During hydration the child
+    // may not yet have its :data set (parent sets it after child hydrates).
+    // The framework must trust the SSR content and not create a duplicate.
+    const count = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector('test-cond-child');
+      return child?.shadowRoot?.querySelectorAll('.cond-header')?.length;
+    });
+
+    expect(count).toBe(1);
+  });
+
+  test('SSR conditional content has correct text from :data', async ({ page }) => {
+    const text = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector('test-cond-child');
+      return child?.shadowRoot?.querySelector('.cond-header')?.textContent;
+    });
+
+    expect(text).toBe('Hello');
+  });
+
+  test('toggling :data.showHeader to false removes the conditional block', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      host.hideCondHeader();
+    });
+
+    await page.waitForFunction(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector('test-cond-child');
+      return child?.shadowRoot?.querySelectorAll('.cond-header')?.length === 0;
+    }, null, { timeout: 2000 });
+
+    const count = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector('test-cond-child');
+      return child?.shadowRoot?.querySelectorAll('.cond-header')?.length;
+    });
+
+    expect(count).toBe(0);
+  });
+});

--- a/packages/webui-framework/tests/fixtures/complex-prop/element.ts
+++ b/packages/webui-framework/tests/fixtures/complex-prop/element.ts
@@ -7,12 +7,19 @@ export class TestItemList extends WebUIElement {
   @observable items: Array<{ name: string }> = [];
 }
 
+/** Child component with a conditional block driven by a complex :data property. */
+export class TestCondChild extends WebUIElement {
+  @observable data: { showHeader?: boolean; label?: string } = {};
+}
+
 export class TestItemHost extends WebUIElement {
   @observable items: Array<{ name: string }> = [
     { name: 'Alpha' },
     { name: 'Beta' },
     { name: 'Gamma' },
   ];
+
+  @observable condData = { showHeader: true, label: 'Hello' };
 
   replaceItems(): void {
     this.items = [{ name: 'One' }, { name: 'Two' }];
@@ -21,7 +28,12 @@ export class TestItemHost extends WebUIElement {
   clearItems(): void {
     this.items = [];
   }
+
+  hideCondHeader(): void {
+    this.condData = { ...this.condData, showHeader: false };
+  }
 }
 
 TestItemList.define('test-item-list');
+TestCondChild.define('test-cond-child');
 TestItemHost.define('test-item-host');

--- a/packages/webui-framework/tests/fixtures/complex-prop/src/test-cond-child/test-cond-child.html
+++ b/packages/webui-framework/tests/fixtures/complex-prop/src/test-cond-child/test-cond-child.html
@@ -1,0 +1,4 @@
+<if condition="data.showHeader">
+  <div class="cond-header">{{data.label}}</div>
+</if>
+<div class="always">Always visible</div>

--- a/packages/webui-framework/tests/fixtures/complex-prop/src/test-item-host/test-item-host.html
+++ b/packages/webui-framework/tests/fixtures/complex-prop/src/test-item-host/test-item-host.html
@@ -1,5 +1,7 @@
 <div class="controls">
   <button class="replace" @click="{replaceItems()}">Replace</button>
   <button class="clear" @click="{clearItems()}">Clear</button>
+  <button class="hide-cond" @click="{hideCondHeader()}">Hide Header</button>
 </div>
 <test-item-list :items="{{items}}"></test-item-list>
+<test-cond-child :data="{{condData}}"></test-cond-child>

--- a/packages/webui-framework/tests/fixtures/complex-prop/state.json
+++ b/packages/webui-framework/tests/fixtures/complex-prop/state.json
@@ -1,1 +1,1 @@
-{ "items": [{ "name": "Alpha" }, { "name": "Beta" }, { "name": "Gamma" }] }
+{ "items": [{ "name": "Alpha" }, { "name": "Beta" }, { "name": "Gamma" }], "condData": { "showHeader": true, "label": "Hello" } }


### PR DESCRIPTION
When hydrating a conditional block, the framework previously required the runtime condition value to be truthy before wiring up SSR content. This caused duplicate DOM when a condition depended on complex properties (like :data) set by the parent AFTER the child hydrates:

1. SSR renders content (condition was true on server)
2. Child hydrates — complex prop not yet set — condition evaluates false
3. SSR DOM nodes left orphaned (not wired, not removed)
4. Parent sets complex prop — condition becomes true — new nodes created
5. Result: duplicate content visible to the user

Fix: during SSR hydration, if a <!--wc--> marker has content after it (the server rendered the block), hydrate that content regardless of the current condition value. The server was authoritative; the data will arrive from the parent and the condition will reconcile correctly.

Added helper to detect SSR content between conditional markers.