### PR TITLE
chore: bump to 0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "microsoft-webui-discovery",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "cbindgen",
  "libc",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "clap",
  "criterion",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "microsoft-webui-protocol",
  "mockall",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.11", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.11" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.11" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.11" }
+microsoft-webui = { path = "../webui", version = "0.0.12", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.12" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.12" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -35,7 +35,7 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,14 +15,14 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.12" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 libc = { workspace = true }

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.11" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.12" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.12" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 tokio = { workspace = true }
 criterion = { workspace = true }
 

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,17 +18,17 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.11" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui = { path = "../webui", version = "0.0.12" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", default-features = false }
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -20,8 +20,8 @@ fs = ["walkdir"]
 cli = ["clap"]
 
 [dependencies]
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -36,7 +36,7 @@ clap = { workspace = true, optional = true }
 [dev-dependencies]
 mockall = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.11", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui = { path = "../webui", version = "0.0.12", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -44,7 +44,7 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.11" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 mime_guess = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 mockall = { workspace = true }
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui_wasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11", default-features = false }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
@@ -29,7 +29,7 @@ serde-wasm-bindgen = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.11" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 
 [lints]
 workspace = true

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.11" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.12" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 
@@ -29,8 +29,8 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.11" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.11" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.11"
+  "version": "0.0.12"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bump all workspace crate and package versions from 0.0.11 to 0.0.12.

### What's new in 0.0.12

- **webui_handler_set_nonce** FFI function for CSP nonce support (#283)
- Reduced transitive build dependencies for crates.io consumers (#283)
- cargo xtask proto command and proto drift check (#283)

### Changed files

- Root workspace `Cargo.toml` (workspace version)
- All crate `Cargo.toml` files under `crates/`
- All `package.json` files under `packages/`
- `dotnet/Directory.Build.props`
- `Cargo.lock`
