### PR TITLE
feat: preserve shadowroot* attrs on component template wrapper

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -883,6 +883,17 @@ pub enum CssStrategy {
 
 Set via `parser.set_css_strategy(CssStrategy::Style)`.
 
+#### Shadow DOM `<template>` wrapper
+
+When `DomStrategy::Shadow` is active, the parser wraps each component's content in a declarative shadow DOM `<template>`. The wrapper preserves any `shadowroot`-prefixed attributes the user wrote on their own outer `<template>` and applies these rules:
+
+- **Mode** — the value of `shadowrootmode` (or, if not present, a bare legacy `shadowroot=` attribute) is captured. Both attributes are then **always** emitted on the wrapper as `shadowrootmode="<mode>" shadowroot="<mode>"` (the legacy `shadowroot` attribute is emitted as a paired alias for older browsers / linters that look for either form). When the user supplies neither, the mode defaults to `"open"`.
+- **Other shadow-root attrs** — `shadowrootclonable`, `shadowrootdelegatesfocus`, `shadowrootserializable`, and any other `shadowroot*` attribute is preserved verbatim on the emitted `<template>`.
+- **`shadowrootadoptedstylesheets`** — when the user supplies a value AND the CSS Module strategy would also generate one, the two are **merged** into a single space-separated list (user-supplied specifiers come first in their original order; parser-generated specifiers are appended only if not already present, deduplicated).
+- **Runtime / non-shadowroot user attrs on `<template>`** — `@event`, `:prop`, `?bool`, and any other non-`shadowroot*` attribute on the user's `<template>` is stripped from the emitted wrapper (it is captured by the framework plugin via root-event metadata or simply ignored).
+
+In **FAST plugin** modes (`fast-v2`, `fast-v3`) the same `shadowroot*` attributes are moved to the **outer `<f-template>`** element rather than the inner `<template>` — `<f-template>` is the framework-owned transport element that the FAST runtime consumes, and the inner `<template>` always has all `shadowroot*` attributes stripped so the browser does not auto-activate it as a declarative shadow root inside `<f-template>`. The `shadowrootadoptedstylesheets` merge rule applies the same way on `<f-template>`.
+
 #### Primary Method
 ```rust
 pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<(), ParserError>

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -1808,14 +1808,24 @@ impl HtmlParser {
 
     /// Process component template HTML.
     ///
-    /// - **Shadow DOM** (`DomStrategy::Shadow`): wraps content in
-    ///   `<template shadowrootmode="open">`, preserves `:host` CSS,
-    ///   optionally adds `shadowrootadoptedstylesheets`.
+    /// - **Shadow DOM** (`DomStrategy::Shadow`): wraps content in a
+    ///   `<template>` with declarative-shadow-DOM attributes. Any
+    ///   `shadowroot`-prefixed attributes on the user-supplied wrapping
+    ///   `<template>` (`shadowrootmode`, `shadowrootclonable`,
+    ///   `shadowrootdelegatesfocus`, `shadowrootserializable`,
+    ///   `shadowrootadoptedstylesheets`, or a bare legacy `shadowroot`)
+    ///   are preserved on the emitted wrapper. Both `shadowrootmode` and
+    ///   the legacy `shadowroot` attribute are always emitted as a matching
+    ///   pair (defaulting to `"open"` when the user did not supply a mode).
+    ///   When the parser also generates an adopted-stylesheet specifier
+    ///   (CSS Module strategy), it is merged with the user's
+    ///   `shadowrootadoptedstylesheets` value as a space-separated,
+    ///   de-duplicated list. `:host` CSS is preserved.
     /// - **Light DOM** (`DomStrategy::Light`): strips any existing shadow DOM
     ///   wrapper, outputs plain HTML.
     ///
-    /// In both modes, runtime-only attributes (`@`, `:`, `?`) are stripped
-    /// from the opening `<template>` tag.
+    /// In both modes, runtime-only attributes (`@`, `:`, `?`) and any other
+    /// non-`shadowroot*` attributes on the user's `<template>` are stripped.
     fn process_component_template(
         &mut self,
         html: &str,
@@ -1825,41 +1835,63 @@ impl HtmlParser {
         let trimmed = html.trim();
         let snippet = css_snippet.unwrap_or_default();
 
-        // Extract inner content — strip <template shadowrootmode> wrapper if present
+        // Extract user template attrs (shadowroot*) and inner content.
         let has_template = trimmed.starts_with("<template");
-        let inner = if has_template {
-            let stripped = self.strip_runtime_attrs_from_template(trimmed);
-            if let Some(open_end) = stripped.find('>') {
+        let (user_attrs, inner) = if has_template {
+            let extracted = self.extract_template_attrs(trimmed);
+            let inner_str = if let Some(open_end) = extracted.opening_tag_end {
                 let inner_start = open_end + 1;
-                let inner_end = stripped.rfind("</template>").unwrap_or(stripped.len());
+                let inner_end = trimmed.rfind("</template>").unwrap_or(trimmed.len());
                 if inner_start < inner_end {
-                    stripped[inner_start..inner_end].to_string()
+                    trimmed[inner_start..inner_end].to_string()
                 } else {
                     String::new()
                 }
             } else {
                 trimmed.to_string()
-            }
+            };
+            (extracted, inner_str)
         } else {
-            trimmed.to_string()
+            (ExtractedTemplateAttrs::default(), trimmed.to_string())
         };
 
         match self.dom_strategy {
             DomStrategy::Shadow => {
-                // Re-wrap in shadow DOM template
-                let adopted_attr = adopted_specifier.map(|spec| {
-                    let mut s = String::with_capacity(35 + spec.len());
-                    s.push_str(" shadowrootadoptedstylesheets=\"");
-                    s.push_str(spec);
-                    s.push('"');
-                    s
-                });
-                let adopted_ref = adopted_attr.as_deref().unwrap_or_default();
+                let mode = user_attrs.mode.as_deref().unwrap_or("open");
+                let merged_adopted =
+                    merge_adopted_stylesheets(user_attrs.adopted.as_deref(), adopted_specifier);
 
-                let mut result =
-                    String::with_capacity(45 + adopted_ref.len() + snippet.len() + inner.len());
-                result.push_str("<template shadowrootmode=\"open\"");
-                result.push_str(adopted_ref);
+                let mut adopted_attr = String::new();
+                if let Some(value) = merged_adopted.as_deref() {
+                    adopted_attr.push_str(" shadowrootadoptedstylesheets=\"");
+                    adopted_attr.push_str(value);
+                    adopted_attr.push('"');
+                }
+
+                let other_len: usize = user_attrs
+                    .other_shadowroot_attrs
+                    .iter()
+                    .map(|s| s.len() + 1)
+                    .sum();
+                let mut result = String::with_capacity(
+                    "<template shadowrootmode=\"\" shadowroot=\"\"".len()
+                        + mode.len() * 2
+                        + other_len
+                        + adopted_attr.len()
+                        + snippet.len()
+                        + inner.len()
+                        + "></template>".len(),
+                );
+                result.push_str("<template shadowrootmode=\"");
+                result.push_str(mode);
+                result.push_str("\" shadowroot=\"");
+                result.push_str(mode);
+                result.push('"');
+                for attr in &user_attrs.other_shadowroot_attrs {
+                    result.push(' ');
+                    result.push_str(attr);
+                }
+                result.push_str(&adopted_attr);
                 result.push('>');
                 result.push_str(snippet);
                 result.push_str(&inner);
@@ -1868,10 +1900,10 @@ impl HtmlParser {
             }
             DomStrategy::Light => {
                 // Plain light-DOM output
-                if snippet.is_empty() && adopted_specifier.is_none() {
+                if snippet.is_empty() {
                     return inner;
                 }
-                let mut result = String::with_capacity(snippet.len() + inner.len() + 16);
+                let mut result = String::with_capacity(snippet.len() + inner.len());
                 result.push_str(snippet);
                 result.push_str(&inner);
                 result
@@ -1879,57 +1911,78 @@ impl HtmlParser {
         }
     }
 
-    /// Strip attributes starting with @, :, or ? from the opening template tag.
-    /// Uses tree-sitter to parse the tag and reconstruct it without runtime attrs.
-    fn strip_runtime_attrs_from_template(&mut self, html: &str) -> String {
+    /// Walk the opening `<template ...>` tag once with tree-sitter,
+    /// classifying each attribute and returning the extracted state.
+    ///
+    /// Behavior:
+    /// - Runtime attributes (`@*`, `:*`, `?*`) are dropped.
+    /// - `shadowrootmode="…"` captures the mode value.
+    /// - Bare `shadowroot="…"` (legacy alias) captures the mode if
+    ///   `shadowrootmode` was not present.
+    /// - `shadowrootadoptedstylesheets="…"` captures the value.
+    /// - All other attributes whose name starts with `shadowroot` are
+    ///   preserved verbatim (raw token, including any quoted value).
+    /// - All other attributes are dropped (consistent with the legacy
+    ///   behavior of fully reconstructing the opening tag).
+    fn extract_template_attrs(&mut self, html: &str) -> ExtractedTemplateAttrs {
+        let mut extracted = ExtractedTemplateAttrs::default();
         let tree = match self.parser.parse(html, None) {
             Some(t) => t,
-            None => return html.to_string(),
+            None => return extracted,
         };
 
-        // Find the first start_tag in the tree
         let root = tree.root_node();
-        let start_tag = Self::find_first_node(root, "start_tag");
-        let Some(tag) = start_tag else {
-            return html.to_string();
+        let Some(tag) = Self::find_first_node(root, "start_tag") else {
+            return extracted;
         };
+        extracted.opening_tag_end = Some(tag.end_byte() - 1);
 
-        // Collect byte ranges of runtime attributes to remove
-        let mut removals: Vec<(usize, usize)> = Vec::new();
         let mut cursor = tag.walk();
+        let mut legacy_mode: Option<String> = None;
         for child in tag.named_children(&mut cursor) {
-            if child.kind() == "attribute" {
-                let name_node = child.child(0);
-                if let Some(name) = name_node {
-                    let attr_name = &html[name.start_byte()..name.end_byte()];
-                    if attr_name.starts_with('@')
-                        || attr_name.starts_with(':')
-                        || attr_name.starts_with('?')
-                    {
-                        // Remove the attribute and any leading whitespace
-                        let mut start = child.start_byte();
-                        while start > 0 && html.as_bytes()[start - 1] == b' ' {
-                            start -= 1;
-                        }
-                        removals.push((start, child.end_byte()));
-                    }
-                }
+            if child.kind() != "attribute" {
+                continue;
             }
+            let Some(name_node) = child.child(0) else {
+                continue;
+            };
+            let attr_name = &html[name_node.start_byte()..name_node.end_byte()];
+            if attr_name.starts_with('@')
+                || attr_name.starts_with(':')
+                || attr_name.starts_with('?')
+            {
+                continue;
+            }
+            if !attr_name.starts_with("shadowroot") {
+                continue;
+            }
+
+            let raw = &html[child.start_byte()..child.end_byte()];
+
+            if attr_name == "shadowrootmode" {
+                extracted.mode = Some(extract_attr_value(raw).unwrap_or("open").to_string());
+                continue;
+            }
+            if attr_name == "shadowroot" {
+                // Legacy alias — only used as the mode source if shadowrootmode
+                // was not explicitly set. We do not echo it back as a separate
+                // attribute because it is always re-emitted from the chosen mode.
+                legacy_mode = Some(extract_attr_value(raw).unwrap_or("open").to_string());
+                continue;
+            }
+            if attr_name == "shadowrootadoptedstylesheets" {
+                extracted.adopted = Some(extract_attr_value(raw).unwrap_or("").to_string());
+                continue;
+            }
+            // Any other shadowroot* attr — preserve raw token.
+            extracted.other_shadowroot_attrs.push(raw.to_string());
         }
 
-        if removals.is_empty() {
-            return html.to_string();
+        if extracted.mode.is_none() {
+            extracted.mode = legacy_mode;
         }
 
-        // Rebuild the string, skipping removed ranges
-        let mut result = String::with_capacity(html.len());
-        let mut pos = 0;
-        for (start, end) in &removals {
-            result.push_str(&html[pos..*start]);
-            pos = *end;
-        }
-        result.push_str(&html[pos..]);
-        result
+        extracted
     }
 
     /// Find the first node of a given kind in the tree (iterative BFS).
@@ -1950,6 +2003,75 @@ impl HtmlParser {
         }
         None
     }
+}
+
+/// Captured attribute state from a user-supplied `<template>` opening tag.
+///
+/// Used by [`HtmlParser::extract_template_attrs`] to surface
+/// `shadowroot`-prefixed attributes so they can be re-emitted on the
+/// declarative-shadow-DOM wrapper.
+#[derive(Default, Debug)]
+struct ExtractedTemplateAttrs {
+    /// Value of `shadowrootmode` (or bare legacy `shadowroot`) if the user supplied one.
+    mode: Option<String>,
+    /// Value of `shadowrootadoptedstylesheets` if the user supplied one.
+    adopted: Option<String>,
+    /// Other `shadowroot*` attributes, captured as raw tokens (e.g.
+    /// `shadowrootclonable` or `shadowrootdelegatesfocus="true"`).
+    other_shadowroot_attrs: Vec<String>,
+    /// Byte index of the `>` that closes the opening tag, when present.
+    opening_tag_end: Option<usize>,
+}
+
+/// Merge two `shadowrootadoptedstylesheets` value strings into a single
+/// space-separated, de-duplicated list. Returns `None` when both inputs
+/// are absent (or only contain whitespace). Order is preserved: tokens
+/// from `user` come first (in their original order), then unique tokens
+/// from `parser`.
+fn merge_adopted_stylesheets(user: Option<&str>, parser: Option<&str>) -> Option<String> {
+    let mut tokens: Vec<&str> = Vec::new();
+    if let Some(u) = user {
+        for tok in u.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if let Some(p) = parser {
+        for tok in p.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+    let total: usize = tokens.iter().map(|t| t.len() + 1).sum();
+    let mut out = String::with_capacity(total);
+    for (i, t) in tokens.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(t);
+    }
+    Some(out)
+}
+
+/// Extract the value of an attribute from its raw token (e.g. `name="value"`).
+/// Returns `None` if the token is bare (no `=`) or malformed. The returned
+/// slice excludes surrounding quotes.
+fn extract_attr_value(raw: &str) -> Option<&str> {
+    let eq_pos = raw.find('=')?;
+    let after = &raw[eq_pos + 1..];
+    let trimmed = after.trim_start();
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        return stripped.strip_suffix('"');
+    }
+    if let Some(stripped) = trimmed.strip_prefix('\'') {
+        return stripped.strip_suffix('\'');
+    }
+    Some(trimmed)
 }
 
 #[cfg(test)]
@@ -2238,6 +2360,219 @@ mod tests {
         assert!(
             component_ids.contains(&"my-footer"),
             "app-shell fragments should contain my-footer: {component_ids:?}"
+        );
+    }
+
+    // ── Shadow DOM template attribute preservation ───────────────────
+
+    fn shadow_template_text(records: &WebUIFragmentRecords, name: &str) -> String {
+        records
+            .get(name)
+            .unwrap_or_else(|| panic!("missing stream {name}"))
+            .fragments
+            .iter()
+            .filter_map(|f| match f.fragment.as_ref() {
+                Some(Fragment::Raw(r)) => Some(r.value.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_shadow_dom_default_emits_paired_shadowrootmode_open() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser
+            .component_registry
+            .register_component("my-comp", "<div>X</div>", Some("div{color:red}"))
+            .expect("register");
+        parser.parse("index.html", "<my-comp></my-comp>").ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "my-comp");
+        assert!(
+            template_text.contains(r#"<template shadowrootmode="open" shadowroot="open""#),
+            "default shadow template should emit paired shadowrootmode/shadowroot=\"open\", got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_user_shadowrootmode_closed_is_preserved_paired() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser
+            .component_registry
+            .register_component(
+                "closed-comp",
+                r#"<template shadowrootmode="closed"><div>X</div></template>"#,
+                None,
+            )
+            .expect("register");
+        parser
+            .parse("index.html", "<closed-comp></closed-comp>")
+            .ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "closed-comp");
+        assert!(
+            template_text.contains(r#"<template shadowrootmode="closed" shadowroot="closed""#),
+            "user shadowrootmode=closed must be preserved AND paired with legacy shadowroot, got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_bare_legacy_shadowroot_used_as_mode_source() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser
+            .component_registry
+            .register_component(
+                "legacy-comp",
+                r#"<template shadowroot="closed"><div>X</div></template>"#,
+                None,
+            )
+            .expect("register");
+        parser
+            .parse("index.html", "<legacy-comp></legacy-comp>")
+            .ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "legacy-comp");
+        assert!(
+            template_text.contains(r#"<template shadowrootmode="closed" shadowroot="closed""#),
+            "bare legacy shadowroot=closed should be promoted to shadowrootmode, got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_shadowrootclonable_is_preserved() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser
+            .component_registry
+            .register_component(
+                "clone-comp",
+                r#"<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus="true"><div>X</div></template>"#,
+                None,
+            )
+            .expect("register");
+        parser.parse("index.html", "<clone-comp></clone-comp>").ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "clone-comp");
+        assert!(
+            template_text.contains("shadowrootclonable"),
+            "shadowrootclonable must be preserved, got: {template_text}"
+        );
+        assert!(
+            template_text.contains(r#"shadowrootdelegatesfocus="true""#),
+            "shadowrootdelegatesfocus must be preserved, got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_user_adopted_stylesheets_merged_with_module_strategy() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser.set_css_strategy(CssStrategy::Module);
+        parser
+            .component_registry
+            .register_component(
+                "merge-comp",
+                r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="theme other"><div>X</div></template>"#,
+                Some("div{color:red}"),
+            )
+            .expect("register");
+        parser.parse("index.html", "<merge-comp></merge-comp>").ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "merge-comp");
+        assert!(
+            template_text.contains(r#"shadowrootadoptedstylesheets="theme other merge-comp""#),
+            "user and parser-generated specifiers should be merged in order without duplicates, got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_user_adopted_stylesheets_dedup_against_module_specifier() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser.set_css_strategy(CssStrategy::Module);
+        parser
+            .component_registry
+            .register_component(
+                "dup-comp",
+                r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="theme dup-comp"><div>X</div></template>"#,
+                Some("div{color:red}"),
+            )
+            .expect("register");
+        parser.parse("index.html", "<dup-comp></dup-comp>").ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "dup-comp");
+        assert!(
+            template_text.contains(r#"shadowrootadoptedstylesheets="theme dup-comp""#),
+            "user-supplied 'dup-comp' should not be duplicated by the parser, got: {template_text}"
+        );
+    }
+
+    #[test]
+    fn test_shadow_dom_drops_user_runtime_attrs_on_template() {
+        // @click, :foo, ?bar are runtime/template attrs and must not survive
+        // on the emitted shadow-DOM <template> wrapper.
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        parser
+            .component_registry
+            .register_component(
+                "runtime-comp",
+                r#"<template shadowrootmode="open" @click="{onClick(e)}" :foo="bar" ?bool="cond" data-keep="x"><div>X</div></template>"#,
+                None,
+            )
+            .expect("register");
+        parser
+            .parse("index.html", "<runtime-comp></runtime-comp>")
+            .ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "runtime-comp");
+        let opening = &template_text[..template_text.find('>').expect("> in template open")];
+        assert!(
+            !opening.contains("@click"),
+            "@click must be stripped from the shadow-DOM <template>, got: {opening}"
+        );
+        assert!(
+            !opening.contains(":foo"),
+            ":foo must be stripped from the shadow-DOM <template>, got: {opening}"
+        );
+        assert!(
+            !opening.contains("?bool"),
+            "?bool must be stripped from the shadow-DOM <template>, got: {opening}"
+        );
+        // Non-runtime, non-shadowroot attrs are also stripped (current behaviour).
+        assert!(
+            !opening.contains("data-keep"),
+            "non-shadowroot attrs are stripped from the shadow-DOM <template>, got: {opening}"
+        );
+    }
+
+    #[test]
+    fn test_light_dom_strips_template_wrapper_with_shadowrootmode() {
+        // Light-DOM mode must continue to strip the user's <template> wrapper
+        // entirely regardless of any shadowroot* attributes on it.
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Light);
+        parser
+            .component_registry
+            .register_component(
+                "light-comp",
+                r#"<template shadowrootmode="open"><div>X</div></template>"#,
+                None,
+            )
+            .expect("register");
+        parser.parse("index.html", "<light-comp></light-comp>").ok();
+        let records = parser.into_fragment_records();
+        let template_text = shadow_template_text(&records, "light-comp");
+        assert!(
+            !template_text.contains("<template"),
+            "light-DOM mode must strip <template> wrapper, got: {template_text}"
+        );
+        assert!(
+            template_text.contains("<div>X</div>"),
+            "inner content must be preserved in light-DOM mode, got: {template_text}"
         );
     }
 

--- a/crates/webui-parser/src/plugin/fast_v2.rs
+++ b/crates/webui-parser/src/plugin/fast_v2.rs
@@ -131,6 +131,17 @@ impl ParserPlugin for FastV2ParserPlugin {
 ///
 /// Used by the server to generate templates on demand for route components
 /// that weren't encountered during initial parsing.
+///
+/// Any `shadowroot`-prefixed attributes on the user-supplied wrapping
+/// `<template>` (e.g. `shadowrootmode`, `shadowrootclonable`,
+/// `shadowrootadoptedstylesheets`) are moved onto the outer
+/// `<f-template>` element rather than the inner `<template>`. The inner
+/// `<template>` always has every `shadowroot*` attribute stripped, to
+/// prevent the browser from auto-activating it as a declarative shadow
+/// root inside the f-template body. When CSS Module strategy generates
+/// a `shadowrootadoptedstylesheets` specifier, it is merged with any
+/// user-supplied value (space-separated, de-duplicated) and emitted on
+/// the `<f-template>`.
 pub fn generate_f_template(
     tag_name: &str,
     html_content: &str,
@@ -138,9 +149,34 @@ pub fn generate_f_template(
     css_strategy: CssStrategy,
 ) -> String {
     let mut output = String::with_capacity(256);
+
+    // Pre-scan the user's outer <template> wrapper (if any) to capture
+    // every shadowroot* attribute — these go on <f-template>, not on the
+    // inner <template>. We also capture any user-supplied
+    // shadowrootadoptedstylesheets value so we can merge it with the
+    // parser-generated specifier under CSS Module strategy.
+    let outer = extract_outer_template_shadowroot_attrs(html_content.trim());
+
+    // Emit the <f-template> opening tag with collected shadowroot* attrs
+    // and (under Module strategy) the merged adopted-stylesheets value.
     output.push_str("<f-template name=\"");
     output.push_str(tag_name);
-    output.push_str("\">\n");
+    output.push('"');
+    for attr in &outer.shadowroot_attrs_other {
+        output.push(' ');
+        output.push_str(attr);
+    }
+    let parser_adopted = if css_strategy == CssStrategy::Module && css_content.is_some() {
+        Some(tag_name)
+    } else {
+        None
+    };
+    if let Some(merged) = merge_adopted_stylesheets(outer.adopted.as_deref(), parser_adopted) {
+        output.push_str(" shadowrootadoptedstylesheets=\"");
+        output.push_str(&merged);
+        output.push('"');
+    }
+    output.push_str(">\n");
 
     let converted = convert_btr_to_fast(html_content);
     let trimmed = minify_inter_tag_whitespace(converted.trim());
@@ -165,13 +201,8 @@ pub fn generate_f_template(
     };
 
     if trimmed.starts_with("<template") {
-        if let Some(close_pos) = trimmed.find('>') {
+        if let Some(close_pos) = find_tag_close(&trimmed) {
             output.push_str(&trimmed[..close_pos]);
-            if css_strategy == CssStrategy::Module && css_content.is_some() {
-                output.push_str(" shadowrootadoptedstylesheets=\"");
-                output.push_str(tag_name);
-                output.push('"');
-            }
             output.push('>');
             if let Some(ref injection) = css_injection {
                 output.push_str(injection);
@@ -181,13 +212,7 @@ pub fn generate_f_template(
             output.push_str(&trimmed);
         }
     } else {
-        output.push_str("<template");
-        if css_strategy == CssStrategy::Module && css_content.is_some() {
-            output.push_str(" shadowrootadoptedstylesheets=\"");
-            output.push_str(tag_name);
-            output.push('"');
-        }
-        output.push('>');
+        output.push_str("<template>");
         if let Some(ref injection) = css_injection {
             output.push_str(injection);
         }
@@ -199,6 +224,153 @@ pub fn generate_f_template(
     output
 }
 
+/// Captured `shadowroot*` attribute state from a user-supplied outer
+/// `<template>` wrapper.
+#[derive(Default, Debug)]
+struct OuterTemplateShadowRootAttrs {
+    /// Raw `shadowroot*` attribute tokens to echo back onto the
+    /// `<f-template>` (e.g. `shadowrootmode="open"`,
+    /// `shadowrootclonable`).
+    ///
+    /// Excludes `shadowrootadoptedstylesheets` because that one is
+    /// always handled separately to merge with parser-generated values.
+    shadowroot_attrs_other: Vec<String>,
+    /// Value of `shadowrootadoptedstylesheets`, when present.
+    adopted: Option<String>,
+}
+
+/// Pre-scan the input's outer `<template>` opening tag and collect every
+/// `shadowroot`-prefixed attribute. Returns an empty result when the
+/// input does not start with a `<template>` wrapper or the tag is
+/// malformed. Uses [`find_tag_close`] so values containing an unquoted
+/// `>` (e.g. `data-note="a > b"`) are handled correctly.
+fn extract_outer_template_shadowroot_attrs(html: &str) -> OuterTemplateShadowRootAttrs {
+    let mut out = OuterTemplateShadowRootAttrs::default();
+    if !html.starts_with("<template") {
+        return out;
+    }
+    let Some(close) = find_tag_close(html) else {
+        return out;
+    };
+    // Inner attribute span is between `<template` and the closing `>` (or `/>`).
+    let attr_start = "<template".len();
+    let mut attr_end = close;
+    if attr_end > 0 && html.as_bytes()[attr_end - 1] == b'/' {
+        attr_end -= 1;
+    }
+    if attr_end <= attr_start {
+        return out;
+    }
+    let inner = &html[attr_start..attr_end];
+    let inner_bytes = inner.as_bytes();
+    let inner_len = inner_bytes.len();
+    let mut j = 0;
+    while j < inner_len {
+        if is_whitespace(inner_bytes[j]) {
+            j += 1;
+            continue;
+        }
+        let name_start = j;
+        while j < inner_len && inner_bytes[j] != b'=' && !is_whitespace(inner_bytes[j]) {
+            j += 1;
+        }
+        let name_end = j;
+        let name = &inner[name_start..name_end];
+
+        let value_end = if j < inner_len && inner_bytes[j] == b'=' {
+            j += 1;
+            if j < inner_len && (inner_bytes[j] == b'"' || inner_bytes[j] == b'\'') {
+                let quote = inner_bytes[j];
+                j += 1;
+                while j < inner_len && inner_bytes[j] != quote {
+                    j += 1;
+                }
+                if j < inner_len {
+                    j += 1;
+                }
+            } else {
+                while j < inner_len && !is_whitespace(inner_bytes[j]) {
+                    j += 1;
+                }
+            }
+            j
+        } else {
+            name_end
+        };
+
+        if !name.starts_with("shadowroot") {
+            continue;
+        }
+
+        if name == "shadowrootadoptedstylesheets" {
+            out.adopted = Some(
+                extract_attr_value_raw(&inner[name_start..value_end])
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            continue;
+        }
+
+        // Preserve the raw `name` or `name="value"` token verbatim so
+        // boolean attrs (e.g. `shadowrootclonable`) round-trip correctly.
+        out.shadowroot_attrs_other
+            .push(inner[name_start..value_end].to_string());
+    }
+
+    out
+}
+
+/// Extract the value portion of a raw `name="value"` (or `name='value'`)
+/// attribute token. Returns `None` when no `=` is present (boolean attr)
+/// or the token is malformed. The returned slice excludes surrounding
+/// quotes.
+fn extract_attr_value_raw(raw: &str) -> Option<&str> {
+    let eq_pos = raw.find('=')?;
+    let after = &raw[eq_pos + 1..];
+    let trimmed = after.trim_start();
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        return stripped.strip_suffix('"');
+    }
+    if let Some(stripped) = trimmed.strip_prefix('\'') {
+        return stripped.strip_suffix('\'');
+    }
+    Some(trimmed)
+}
+
+/// Merge two `shadowrootadoptedstylesheets` value strings into a single
+/// space-separated, de-duplicated list. Returns `None` when both inputs
+/// are absent (or only contain whitespace). Tokens from `user` come
+/// first in their original order, then unique tokens from `parser`.
+fn merge_adopted_stylesheets(user: Option<&str>, parser: Option<&str>) -> Option<String> {
+    let mut tokens: Vec<&str> = Vec::new();
+    if let Some(u) = user {
+        for tok in u.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if let Some(p) = parser {
+        for tok in p.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+    let total: usize = tokens.iter().map(|t| t.len() + 1).sum();
+    let mut out = String::with_capacity(total);
+    for (i, t) in tokens.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(t);
+    }
+    Some(out)
+}
+
 /// Convert WebUI Framework template syntax to FAST syntax in HTML content.
 ///
 /// Performs the following transformations without regex:
@@ -207,9 +379,12 @@ pub fn generate_f_template(
 /// - `<for each="EXPR">` → `<f-repeat value="{{EXPR}}">`
 /// - `</for>` → `</f-repeat>`
 /// - `{{expr}}` inside `:attr` complex attribute values → `{expr}`
-/// - Strips `shadowrootmode` attributes from `<template>` tags
-///   (in f-template context, shadowrootmode must be removed to prevent
-///   the browser from auto-activating it as a declarative shadow root)
+/// - Strips every `shadowroot`-prefixed attribute from any `<template>`
+///   tag (e.g. `shadowrootmode`, `shadowrootclonable`,
+///   `shadowrootadoptedstylesheets`). In f-template context the inner
+///   `<template>` must not carry these attributes — they belong on the
+///   outer `<f-template>` element so the browser does not auto-activate
+///   the inner template as a declarative shadow root.
 fn convert_btr_to_fast(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -285,9 +460,11 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
 
     // Check for tags with :attr="{{expr}}" complex attribute values
     if remaining.starts_with("<") {
-        // Strip shadowrootmode from <template> tags
+        // Strip every shadowroot* attr from <template> tags so the inner
+        // template inside an f-template is never auto-activated as a
+        // declarative shadow root by the browser.
         if starts_with_tag_name(remaining, "template") {
-            if let Some(consumed) = strip_shadowrootmode(remaining, result) {
+            if let Some(consumed) = strip_shadowroot_attrs(remaining, result) {
                 return Some(consumed);
             }
         }
@@ -584,24 +761,25 @@ fn minify_inter_tag_whitespace(input: &str) -> String {
     result
 }
 
-/// Strip `shadowrootmode` attribute from a `<template ...>` opening tag.
-/// Returns `Some(bytes_consumed)` if a `<template` tag was found and processed.
-fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
+/// Strip every `shadowroot`-prefixed attribute from a `<template ...>`
+/// opening tag. Returns `Some(bytes_consumed)` if a `<template` tag was
+/// found and processed.
+fn strip_shadowroot_attrs(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find the closing '>' outside of quoted attribute values
     let close = find_tag_close(tag_str)?;
     let tag_content = &tag_str[..=close];
 
-    // Only process if this tag contains shadowrootmode
-    if !tag_content.contains("shadowrootmode") {
+    // Only process if this tag contains any shadowroot* attribute.
+    if !tag_content.contains("shadowroot") {
         return None;
     }
 
-    // Rebuild the tag without the shadowrootmode attribute
+    // Rebuild the tag without any shadowroot* attribute
     result.push_str("<template");
     let attr_start = "<template".len();
     let inner = &tag_content[attr_start..close];
 
-    // Scan through the attributes, skipping shadowrootmode
+    // Scan through the attributes, skipping shadowroot* attrs.
     let inner_bytes = inner.as_bytes();
     let inner_len = inner_bytes.len();
     let mut j = 0;
@@ -624,9 +802,10 @@ fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
         let mut attr_end = j;
         if j < inner_len && inner_bytes[j] == b'=' {
             j += 1; // skip '='
-            if j < inner_len && inner_bytes[j] == b'"' {
+            if j < inner_len && (inner_bytes[j] == b'"' || inner_bytes[j] == b'\'') {
+                let quote = inner_bytes[j];
                 j += 1; // skip opening quote
-                while j < inner_len && inner_bytes[j] != b'"' {
+                while j < inner_len && inner_bytes[j] != quote {
                     j += 1;
                 }
                 if j < inner_len {
@@ -641,8 +820,8 @@ fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
             attr_end = j;
         }
 
-        // Skip the shadowrootmode attribute entirely
-        if attr_name == "shadowrootmode" {
+        // Skip every shadowroot* attribute entirely
+        if attr_name.starts_with("shadowroot") {
             continue;
         }
 
@@ -1116,6 +1295,25 @@ mod tests {
     }
 
     #[test]
+    fn strip_shadowroot_attrs_strips_all_shadowroot_prefixed() {
+        // The renamed strip helper should strip *every* shadowroot* attribute,
+        // not just shadowrootmode. Non-shadowroot attrs are preserved.
+        let input = r#"<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus="true" shadowrootadoptedstylesheets="x" data-keep="y"><div>Hi</div></template>"#;
+        let output = convert_btr_to_fast(input);
+        assert!(!output.contains("shadowrootmode"), "got: {output}");
+        assert!(!output.contains("shadowrootclonable"), "got: {output}");
+        assert!(
+            !output.contains("shadowrootdelegatesfocus"),
+            "got: {output}"
+        );
+        assert!(
+            !output.contains("shadowrootadoptedstylesheets"),
+            "got: {output}"
+        );
+        assert!(output.contains(r#"data-keep="y""#), "got: {output}");
+    }
+
+    #[test]
     fn no_strip_when_no_shadowrootmode() {
         let input = r#"<template foo="bar"><div>Hi</div></template>"#;
         let output = convert_btr_to_fast(input);
@@ -1123,7 +1321,7 @@ mod tests {
     }
 
     #[test]
-    fn component_template_strips_shadowrootmode_from_f_template() {
+    fn component_template_moves_shadowrootmode_to_f_template() {
         let mut plugin = FastV2ParserPlugin::new();
         let comp = make_component(
             "my-comp",
@@ -1137,12 +1335,179 @@ mod tests {
         assert_eq!(templates.len(), 1);
         let (name, html) = &templates[0];
         assert_eq!(name, "my-comp");
-        // f-template content should NOT have shadowrootmode
-        assert!(!html.contains("shadowrootmode"));
-        // But should keep @click (framework attr kept in f-template mode)
+        // shadowrootmode is moved to the OUTER <f-template>...
+        assert!(
+            html.contains("<f-template name=\"my-comp\" shadowrootmode=\"open\">"),
+            "<f-template> should carry shadowrootmode, got: {html}"
+        );
+        // ...and is NOT on the inner <template>.
+        assert!(
+            !html.contains("<template shadowrootmode"),
+            "inner <template> should not carry shadowrootmode, got: {html}"
+        );
+        // And @click is still preserved on the inner template (framework attr).
         assert!(html.contains("@click"));
         // Should have the converted content
         assert!(html.contains("{{title}}"));
+    }
+
+    #[test]
+    fn component_template_carries_user_shadowrootmode_closed() {
+        let mut plugin = FastV2ParserPlugin::new();
+        let comp = make_component(
+            "closed-comp",
+            r#"<template shadowrootmode="closed"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("closed-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"<f-template name="closed-comp" shadowrootmode="closed">"#),
+            "<f-template> should carry user-supplied shadowrootmode value, got: {html}"
+        );
+        assert!(
+            !html.contains("<template shadowrootmode"),
+            "inner <template> should not carry shadowrootmode, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_preserves_other_shadowroot_attrs_on_f_template() {
+        let mut plugin = FastV2ParserPlugin::new();
+        let comp = make_component(
+            "clone-comp",
+            r#"<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus="true"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("clone-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"shadowrootmode="open""#),
+            "<f-template> should carry shadowrootmode, got: {html}"
+        );
+        assert!(
+            html.contains("shadowrootclonable"),
+            "<f-template> should carry shadowrootclonable, got: {html}"
+        );
+        assert!(
+            html.contains(r#"shadowrootdelegatesfocus="true""#),
+            "<f-template> should carry shadowrootdelegatesfocus, got: {html}"
+        );
+        // Inner <template> must not carry any of them.
+        let inner_template_start = html.find("\n<template").expect("inner template");
+        let inner_template_end = html[inner_template_start..]
+            .find('>')
+            .expect("inner template close");
+        let inner_open = &html[inner_template_start..inner_template_start + inner_template_end + 1];
+        assert!(
+            !inner_open.contains("shadowroot"),
+            "inner <template> should not carry any shadowroot* attr, got: {inner_open}"
+        );
+    }
+
+    #[test]
+    fn component_template_default_no_shadowroot_attr_on_f_template_when_not_supplied() {
+        // When the user did NOT supply any shadowroot* attribute, the
+        // <f-template> should not gain one — <f-template> is not itself
+        // declarative shadow DOM and the framework hard-codes
+        // attachShadow({ mode: 'open' }) client-side.
+        let mut plugin = FastV2ParserPlugin::new();
+        let comp = make_component("plain-comp", r#"<div>x</div>"#, None);
+        plugin
+            .register_component_template("plain-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"<f-template name="plain-comp">"#),
+            "<f-template> should not have shadowroot* attrs when user did not supply any, got: {html}"
+        );
+        assert!(
+            !html.contains("shadowroot"),
+            "no shadowroot* attr should be emitted, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_module_css_puts_adopted_stylesheets_on_f_template() {
+        let mut plugin = FastV2ParserPlugin::new();
+        plugin.set_css_strategy(CssStrategy::Module);
+        let comp = make_component(
+            "mod-comp",
+            r#"<template shadowrootmode="open"><div>x</div></template>"#,
+            Some("div { color: blue; }"),
+        );
+        plugin
+            .register_component_template("mod-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // shadowrootadoptedstylesheets is on <f-template>, not on inner <template>.
+        assert!(
+            html.contains(r#"<f-template name="mod-comp" shadowrootmode="open" shadowrootadoptedstylesheets="mod-comp">"#),
+            "<f-template> should carry shadowrootadoptedstylesheets for module CSS strategy, got: {html}"
+        );
+        let inner_template_start = html.find("\n<template").expect("inner template");
+        let inner_close = html[inner_template_start..]
+            .find('>')
+            .expect("inner template close");
+        let inner_open = &html[inner_template_start..inner_template_start + inner_close + 1];
+        assert!(
+            !inner_open.contains("shadowrootadoptedstylesheets"),
+            "inner <template> should not carry shadowrootadoptedstylesheets, got: {inner_open}"
+        );
+    }
+
+    #[test]
+    fn component_template_merges_user_and_module_adopted_stylesheets() {
+        let mut plugin = FastV2ParserPlugin::new();
+        plugin.set_css_strategy(CssStrategy::Module);
+        let comp = make_component(
+            "merge-comp",
+            r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="theme other"><div>x</div></template>"#,
+            Some("div { color: blue; }"),
+        );
+        plugin
+            .register_component_template("merge-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // User specifiers come first (in order), parser-generated `merge-comp` is
+        // appended last, no duplicates.
+        assert!(
+            html.contains(r#"shadowrootadoptedstylesheets="theme other merge-comp""#),
+            "<f-template> should merge user and parser specifiers, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_handles_gt_in_quoted_attr_value() {
+        let mut plugin = FastV2ParserPlugin::new();
+        let comp = make_component(
+            "gt-comp",
+            r#"<template shadowrootmode="open" data-note="a > b"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("gt-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // Outer <f-template> gets shadowrootmode; inner <template> retains data-note.
+        assert!(
+            html.contains(r#"<f-template name="gt-comp" shadowrootmode="open">"#),
+            "<f-template> should carry shadowrootmode even when an attr value contains '>', got: {html}"
+        );
+        assert!(
+            html.contains(r#"data-note="a > b""#),
+            "data-note should be preserved on the inner <template>, got: {html}"
+        );
     }
 
     #[test]
@@ -1248,7 +1613,7 @@ mod tests {
     }
 
     #[test]
-    fn ftemplate_shadow_dom_strips_shadowroot_and_converts_directives() {
+    fn ftemplate_shadow_dom_moves_shadowroot_and_converts_directives() {
         let mut plugin = FastV2ParserPlugin::new();
         let html = r#"<template shadowrootmode="open"><div><if condition="visible">Shown</if><for each="x in list"><span>{{x}}</span></for></div></template>"#;
         let comp = make_component("my-shadow", html, None);
@@ -1267,9 +1632,15 @@ mod tests {
             result.contains("<f-repeat value=\"{{x in list}}\">"),
             "Shadow f-template should contain <f-repeat>, got: {result}"
         );
+        // shadowrootmode is moved to the outer <f-template>...
         assert!(
-            !result.contains("shadowrootmode"),
-            "Shadow f-template should strip shadowrootmode, got: {result}"
+            result.contains(r#"<f-template name="my-shadow" shadowrootmode="open">"#),
+            "<f-template> should carry shadowrootmode, got: {result}"
+        );
+        // ...not on the inner <template>.
+        assert!(
+            !result.contains("<template shadowrootmode"),
+            "inner <template> should NOT carry shadowrootmode, got: {result}"
         );
         assert!(
             !result.contains("<if "),

--- a/crates/webui-parser/src/plugin/fast_v3.rs
+++ b/crates/webui-parser/src/plugin/fast_v3.rs
@@ -131,6 +131,17 @@ impl ParserPlugin for FastV3ParserPlugin {
 ///
 /// Used by the server to generate templates on demand for route components
 /// that weren't encountered during initial parsing.
+///
+/// Any `shadowroot`-prefixed attributes on the user-supplied wrapping
+/// `<template>` (e.g. `shadowrootmode`, `shadowrootclonable`,
+/// `shadowrootadoptedstylesheets`) are moved onto the outer
+/// `<f-template>` element rather than the inner `<template>`. The inner
+/// `<template>` always has every `shadowroot*` attribute stripped, to
+/// prevent the browser from auto-activating it as a declarative shadow
+/// root inside the f-template body. When CSS Module strategy generates
+/// a `shadowrootadoptedstylesheets` specifier, it is merged with any
+/// user-supplied value (space-separated, de-duplicated) and emitted on
+/// the `<f-template>`.
 pub fn generate_f_template(
     tag_name: &str,
     html_content: &str,
@@ -138,9 +149,34 @@ pub fn generate_f_template(
     css_strategy: CssStrategy,
 ) -> String {
     let mut output = String::with_capacity(256);
+
+    // Pre-scan the user's outer <template> wrapper (if any) to capture
+    // every shadowroot* attribute — these go on <f-template>, not on the
+    // inner <template>. We also capture any user-supplied
+    // shadowrootadoptedstylesheets value so we can merge it with the
+    // parser-generated specifier under CSS Module strategy.
+    let outer = extract_outer_template_shadowroot_attrs(html_content.trim());
+
+    // Emit the <f-template> opening tag with collected shadowroot* attrs
+    // and (under Module strategy) the merged adopted-stylesheets value.
     output.push_str("<f-template name=\"");
     output.push_str(tag_name);
-    output.push_str("\">\n");
+    output.push('"');
+    for attr in &outer.shadowroot_attrs_other {
+        output.push(' ');
+        output.push_str(attr);
+    }
+    let parser_adopted = if css_strategy == CssStrategy::Module && css_content.is_some() {
+        Some(tag_name)
+    } else {
+        None
+    };
+    if let Some(merged) = merge_adopted_stylesheets(outer.adopted.as_deref(), parser_adopted) {
+        output.push_str(" shadowrootadoptedstylesheets=\"");
+        output.push_str(&merged);
+        output.push('"');
+    }
+    output.push_str(">\n");
 
     let converted = convert_btr_to_fast(html_content);
     let trimmed = minify_inter_tag_whitespace(converted.trim());
@@ -165,13 +201,8 @@ pub fn generate_f_template(
     };
 
     if trimmed.starts_with("<template") {
-        if let Some(close_pos) = trimmed.find('>') {
+        if let Some(close_pos) = find_tag_close(&trimmed) {
             output.push_str(&trimmed[..close_pos]);
-            if css_strategy == CssStrategy::Module && css_content.is_some() {
-                output.push_str(" shadowrootadoptedstylesheets=\"");
-                output.push_str(tag_name);
-                output.push('"');
-            }
             output.push('>');
             if let Some(ref injection) = css_injection {
                 output.push_str(injection);
@@ -181,13 +212,7 @@ pub fn generate_f_template(
             output.push_str(&trimmed);
         }
     } else {
-        output.push_str("<template");
-        if css_strategy == CssStrategy::Module && css_content.is_some() {
-            output.push_str(" shadowrootadoptedstylesheets=\"");
-            output.push_str(tag_name);
-            output.push('"');
-        }
-        output.push('>');
+        output.push_str("<template>");
         if let Some(ref injection) = css_injection {
             output.push_str(injection);
         }
@@ -199,6 +224,153 @@ pub fn generate_f_template(
     output
 }
 
+/// Captured `shadowroot*` attribute state from a user-supplied outer
+/// `<template>` wrapper.
+#[derive(Default, Debug)]
+struct OuterTemplateShadowRootAttrs {
+    /// Raw `shadowroot*` attribute tokens to echo back onto the
+    /// `<f-template>` (e.g. `shadowrootmode="open"`,
+    /// `shadowrootclonable`).
+    ///
+    /// Excludes `shadowrootadoptedstylesheets` because that one is
+    /// always handled separately to merge with parser-generated values.
+    shadowroot_attrs_other: Vec<String>,
+    /// Value of `shadowrootadoptedstylesheets`, when present.
+    adopted: Option<String>,
+}
+
+/// Pre-scan the input's outer `<template>` opening tag and collect every
+/// `shadowroot`-prefixed attribute. Returns an empty result when the
+/// input does not start with a `<template>` wrapper or the tag is
+/// malformed. Uses [`find_tag_close`] so values containing an unquoted
+/// `>` (e.g. `data-note="a > b"`) are handled correctly.
+fn extract_outer_template_shadowroot_attrs(html: &str) -> OuterTemplateShadowRootAttrs {
+    let mut out = OuterTemplateShadowRootAttrs::default();
+    if !html.starts_with("<template") {
+        return out;
+    }
+    let Some(close) = find_tag_close(html) else {
+        return out;
+    };
+    // Inner attribute span is between `<template` and the closing `>` (or `/>`).
+    let attr_start = "<template".len();
+    let mut attr_end = close;
+    if attr_end > 0 && html.as_bytes()[attr_end - 1] == b'/' {
+        attr_end -= 1;
+    }
+    if attr_end <= attr_start {
+        return out;
+    }
+    let inner = &html[attr_start..attr_end];
+    let inner_bytes = inner.as_bytes();
+    let inner_len = inner_bytes.len();
+    let mut j = 0;
+    while j < inner_len {
+        if is_whitespace(inner_bytes[j]) {
+            j += 1;
+            continue;
+        }
+        let name_start = j;
+        while j < inner_len && inner_bytes[j] != b'=' && !is_whitespace(inner_bytes[j]) {
+            j += 1;
+        }
+        let name_end = j;
+        let name = &inner[name_start..name_end];
+
+        let value_end = if j < inner_len && inner_bytes[j] == b'=' {
+            j += 1;
+            if j < inner_len && (inner_bytes[j] == b'"' || inner_bytes[j] == b'\'') {
+                let quote = inner_bytes[j];
+                j += 1;
+                while j < inner_len && inner_bytes[j] != quote {
+                    j += 1;
+                }
+                if j < inner_len {
+                    j += 1;
+                }
+            } else {
+                while j < inner_len && !is_whitespace(inner_bytes[j]) {
+                    j += 1;
+                }
+            }
+            j
+        } else {
+            name_end
+        };
+
+        if !name.starts_with("shadowroot") {
+            continue;
+        }
+
+        if name == "shadowrootadoptedstylesheets" {
+            out.adopted = Some(
+                extract_attr_value_raw(&inner[name_start..value_end])
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            continue;
+        }
+
+        // Preserve the raw `name` or `name="value"` token verbatim so
+        // boolean attrs (e.g. `shadowrootclonable`) round-trip correctly.
+        out.shadowroot_attrs_other
+            .push(inner[name_start..value_end].to_string());
+    }
+
+    out
+}
+
+/// Extract the value portion of a raw `name="value"` (or `name='value'`)
+/// attribute token. Returns `None` when no `=` is present (boolean attr)
+/// or the token is malformed. The returned slice excludes surrounding
+/// quotes.
+fn extract_attr_value_raw(raw: &str) -> Option<&str> {
+    let eq_pos = raw.find('=')?;
+    let after = &raw[eq_pos + 1..];
+    let trimmed = after.trim_start();
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        return stripped.strip_suffix('"');
+    }
+    if let Some(stripped) = trimmed.strip_prefix('\'') {
+        return stripped.strip_suffix('\'');
+    }
+    Some(trimmed)
+}
+
+/// Merge two `shadowrootadoptedstylesheets` value strings into a single
+/// space-separated, de-duplicated list. Returns `None` when both inputs
+/// are absent (or only contain whitespace). Tokens from `user` come
+/// first in their original order, then unique tokens from `parser`.
+fn merge_adopted_stylesheets(user: Option<&str>, parser: Option<&str>) -> Option<String> {
+    let mut tokens: Vec<&str> = Vec::new();
+    if let Some(u) = user {
+        for tok in u.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if let Some(p) = parser {
+        for tok in p.split_whitespace() {
+            if !tokens.contains(&tok) {
+                tokens.push(tok);
+            }
+        }
+    }
+    if tokens.is_empty() {
+        return None;
+    }
+    let total: usize = tokens.iter().map(|t| t.len() + 1).sum();
+    let mut out = String::with_capacity(total);
+    for (i, t) in tokens.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(t);
+    }
+    Some(out)
+}
+
 /// Convert WebUI Framework template syntax to FAST syntax in HTML content.
 ///
 /// Performs the following transformations without regex:
@@ -207,9 +379,12 @@ pub fn generate_f_template(
 /// - `<for each="EXPR">` → `<f-repeat value="{{EXPR}}">`
 /// - `</for>` → `</f-repeat>`
 /// - `{{expr}}` inside `:attr` complex attribute values → `{expr}`
-/// - Strips `shadowrootmode` attributes from `<template>` tags
-///   (in f-template context, shadowrootmode must be removed to prevent
-///   the browser from auto-activating it as a declarative shadow root)
+/// - Strips every `shadowroot`-prefixed attribute from any `<template>`
+///   tag (e.g. `shadowrootmode`, `shadowrootclonable`,
+///   `shadowrootadoptedstylesheets`). In f-template context the inner
+///   `<template>` must not carry these attributes — they belong on the
+///   outer `<f-template>` element so the browser does not auto-activate
+///   the inner template as a declarative shadow root.
 fn convert_btr_to_fast(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let bytes = input.as_bytes();
@@ -285,9 +460,11 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
 
     // Check for tags with :attr="{{expr}}" complex attribute values
     if remaining.starts_with("<") {
-        // Strip shadowrootmode from <template> tags
+        // Strip every shadowroot* attr from <template> tags so the inner
+        // template inside an f-template is never auto-activated as a
+        // declarative shadow root by the browser.
         if starts_with_tag_name(remaining, "template") {
-            if let Some(consumed) = strip_shadowrootmode(remaining, result) {
+            if let Some(consumed) = strip_shadowroot_attrs(remaining, result) {
                 return Some(consumed);
             }
         }
@@ -584,24 +761,25 @@ fn minify_inter_tag_whitespace(input: &str) -> String {
     result
 }
 
-/// Strip `shadowrootmode` attribute from a `<template ...>` opening tag.
-/// Returns `Some(bytes_consumed)` if a `<template` tag was found and processed.
-fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
+/// Strip every `shadowroot`-prefixed attribute from a `<template ...>`
+/// opening tag. Returns `Some(bytes_consumed)` if a `<template` tag was
+/// found and processed.
+fn strip_shadowroot_attrs(tag_str: &str, result: &mut String) -> Option<usize> {
     // Find the closing '>' outside of quoted attribute values
     let close = find_tag_close(tag_str)?;
     let tag_content = &tag_str[..=close];
 
-    // Only process if this tag contains shadowrootmode
-    if !tag_content.contains("shadowrootmode") {
+    // Only process if this tag contains any shadowroot* attribute.
+    if !tag_content.contains("shadowroot") {
         return None;
     }
 
-    // Rebuild the tag without the shadowrootmode attribute
+    // Rebuild the tag without any shadowroot* attribute
     result.push_str("<template");
     let attr_start = "<template".len();
     let inner = &tag_content[attr_start..close];
 
-    // Scan through the attributes, skipping shadowrootmode
+    // Scan through the attributes, skipping shadowroot* attrs.
     let inner_bytes = inner.as_bytes();
     let inner_len = inner_bytes.len();
     let mut j = 0;
@@ -624,9 +802,10 @@ fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
         let mut attr_end = j;
         if j < inner_len && inner_bytes[j] == b'=' {
             j += 1; // skip '='
-            if j < inner_len && inner_bytes[j] == b'"' {
+            if j < inner_len && (inner_bytes[j] == b'"' || inner_bytes[j] == b'\'') {
+                let quote = inner_bytes[j];
                 j += 1; // skip opening quote
-                while j < inner_len && inner_bytes[j] != b'"' {
+                while j < inner_len && inner_bytes[j] != quote {
                     j += 1;
                 }
                 if j < inner_len {
@@ -641,8 +820,8 @@ fn strip_shadowrootmode(tag_str: &str, result: &mut String) -> Option<usize> {
             attr_end = j;
         }
 
-        // Skip the shadowrootmode attribute entirely
-        if attr_name == "shadowrootmode" {
+        // Skip every shadowroot* attribute entirely
+        if attr_name.starts_with("shadowroot") {
             continue;
         }
 
@@ -1116,6 +1295,25 @@ mod tests {
     }
 
     #[test]
+    fn strip_shadowroot_attrs_strips_all_shadowroot_prefixed() {
+        // The renamed strip helper should strip *every* shadowroot* attribute,
+        // not just shadowrootmode. Non-shadowroot attrs are preserved.
+        let input = r#"<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus="true" shadowrootadoptedstylesheets="x" data-keep="y"><div>Hi</div></template>"#;
+        let output = convert_btr_to_fast(input);
+        assert!(!output.contains("shadowrootmode"), "got: {output}");
+        assert!(!output.contains("shadowrootclonable"), "got: {output}");
+        assert!(
+            !output.contains("shadowrootdelegatesfocus"),
+            "got: {output}"
+        );
+        assert!(
+            !output.contains("shadowrootadoptedstylesheets"),
+            "got: {output}"
+        );
+        assert!(output.contains(r#"data-keep="y""#), "got: {output}");
+    }
+
+    #[test]
     fn no_strip_when_no_shadowrootmode() {
         let input = r#"<template foo="bar"><div>Hi</div></template>"#;
         let output = convert_btr_to_fast(input);
@@ -1123,7 +1321,7 @@ mod tests {
     }
 
     #[test]
-    fn component_template_strips_shadowrootmode_from_f_template() {
+    fn component_template_moves_shadowrootmode_to_f_template() {
         let mut plugin = FastV3ParserPlugin::new();
         let comp = make_component(
             "my-comp",
@@ -1137,12 +1335,179 @@ mod tests {
         assert_eq!(templates.len(), 1);
         let (name, html) = &templates[0];
         assert_eq!(name, "my-comp");
-        // f-template content should NOT have shadowrootmode
-        assert!(!html.contains("shadowrootmode"));
-        // But should keep @click (framework attr kept in f-template mode)
+        // shadowrootmode is moved to the OUTER <f-template>...
+        assert!(
+            html.contains("<f-template name=\"my-comp\" shadowrootmode=\"open\">"),
+            "<f-template> should carry shadowrootmode, got: {html}"
+        );
+        // ...and is NOT on the inner <template>.
+        assert!(
+            !html.contains("<template shadowrootmode"),
+            "inner <template> should not carry shadowrootmode, got: {html}"
+        );
+        // And @click is still preserved on the inner template (framework attr).
         assert!(html.contains("@click"));
         // Should have the converted content
         assert!(html.contains("{{title}}"));
+    }
+
+    #[test]
+    fn component_template_carries_user_shadowrootmode_closed() {
+        let mut plugin = FastV3ParserPlugin::new();
+        let comp = make_component(
+            "closed-comp",
+            r#"<template shadowrootmode="closed"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("closed-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"<f-template name="closed-comp" shadowrootmode="closed">"#),
+            "<f-template> should carry user-supplied shadowrootmode value, got: {html}"
+        );
+        assert!(
+            !html.contains("<template shadowrootmode"),
+            "inner <template> should not carry shadowrootmode, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_preserves_other_shadowroot_attrs_on_f_template() {
+        let mut plugin = FastV3ParserPlugin::new();
+        let comp = make_component(
+            "clone-comp",
+            r#"<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus="true"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("clone-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"shadowrootmode="open""#),
+            "<f-template> should carry shadowrootmode, got: {html}"
+        );
+        assert!(
+            html.contains("shadowrootclonable"),
+            "<f-template> should carry shadowrootclonable, got: {html}"
+        );
+        assert!(
+            html.contains(r#"shadowrootdelegatesfocus="true""#),
+            "<f-template> should carry shadowrootdelegatesfocus, got: {html}"
+        );
+        // Inner <template> must not carry any of them.
+        let inner_template_start = html.find("\n<template").expect("inner template");
+        let inner_template_end = html[inner_template_start..]
+            .find('>')
+            .expect("inner template close");
+        let inner_open = &html[inner_template_start..inner_template_start + inner_template_end + 1];
+        assert!(
+            !inner_open.contains("shadowroot"),
+            "inner <template> should not carry any shadowroot* attr, got: {inner_open}"
+        );
+    }
+
+    #[test]
+    fn component_template_default_no_shadowroot_attr_on_f_template_when_not_supplied() {
+        // When the user did NOT supply any shadowroot* attribute, the
+        // <f-template> should not gain one — <f-template> is not itself
+        // declarative shadow DOM and the framework hard-codes
+        // attachShadow({ mode: 'open' }) client-side.
+        let mut plugin = FastV3ParserPlugin::new();
+        let comp = make_component("plain-comp", r#"<div>x</div>"#, None);
+        plugin
+            .register_component_template("plain-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        assert!(
+            html.contains(r#"<f-template name="plain-comp">"#),
+            "<f-template> should not have shadowroot* attrs when user did not supply any, got: {html}"
+        );
+        assert!(
+            !html.contains("shadowroot"),
+            "no shadowroot* attr should be emitted, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_module_css_puts_adopted_stylesheets_on_f_template() {
+        let mut plugin = FastV3ParserPlugin::new();
+        plugin.set_css_strategy(CssStrategy::Module);
+        let comp = make_component(
+            "mod-comp",
+            r#"<template shadowrootmode="open"><div>x</div></template>"#,
+            Some("div { color: blue; }"),
+        );
+        plugin
+            .register_component_template("mod-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // shadowrootadoptedstylesheets is on <f-template>, not on inner <template>.
+        assert!(
+            html.contains(r#"<f-template name="mod-comp" shadowrootmode="open" shadowrootadoptedstylesheets="mod-comp">"#),
+            "<f-template> should carry shadowrootadoptedstylesheets for module CSS strategy, got: {html}"
+        );
+        let inner_template_start = html.find("\n<template").expect("inner template");
+        let inner_close = html[inner_template_start..]
+            .find('>')
+            .expect("inner template close");
+        let inner_open = &html[inner_template_start..inner_template_start + inner_close + 1];
+        assert!(
+            !inner_open.contains("shadowrootadoptedstylesheets"),
+            "inner <template> should not carry shadowrootadoptedstylesheets, got: {inner_open}"
+        );
+    }
+
+    #[test]
+    fn component_template_merges_user_and_module_adopted_stylesheets() {
+        let mut plugin = FastV3ParserPlugin::new();
+        plugin.set_css_strategy(CssStrategy::Module);
+        let comp = make_component(
+            "merge-comp",
+            r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="theme other"><div>x</div></template>"#,
+            Some("div { color: blue; }"),
+        );
+        plugin
+            .register_component_template("merge-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // User specifiers come first (in order), parser-generated `merge-comp` is
+        // appended last, no duplicates.
+        assert!(
+            html.contains(r#"shadowrootadoptedstylesheets="theme other merge-comp""#),
+            "<f-template> should merge user and parser specifiers, got: {html}"
+        );
+    }
+
+    #[test]
+    fn component_template_handles_gt_in_quoted_attr_value() {
+        let mut plugin = FastV3ParserPlugin::new();
+        let comp = make_component(
+            "gt-comp",
+            r#"<template shadowrootmode="open" data-note="a > b"><div>x</div></template>"#,
+            None,
+        );
+        plugin
+            .register_component_template("gt-comp", &comp, &comp.html_content)
+            .unwrap();
+        let templates = plugin.take_component_templates();
+        let (_, html) = &templates[0];
+        // Outer <f-template> gets shadowrootmode; inner <template> retains data-note.
+        assert!(
+            html.contains(r#"<f-template name="gt-comp" shadowrootmode="open">"#),
+            "<f-template> should carry shadowrootmode even when an attr value contains '>', got: {html}"
+        );
+        assert!(
+            html.contains(r#"data-note="a > b""#),
+            "data-note should be preserved on the inner <template>, got: {html}"
+        );
     }
 
     #[test]
@@ -1248,7 +1613,7 @@ mod tests {
     }
 
     #[test]
-    fn ftemplate_shadow_dom_strips_shadowroot_and_converts_directives() {
+    fn ftemplate_shadow_dom_moves_shadowroot_and_converts_directives() {
         let mut plugin = FastV3ParserPlugin::new();
         let html = r#"<template shadowrootmode="open"><div><if condition="visible">Shown</if><for each="x in list"><span>{{x}}</span></for></div></template>"#;
         let comp = make_component("my-shadow", html, None);
@@ -1267,9 +1632,15 @@ mod tests {
             result.contains("<f-repeat value=\"{{x in list}}\">"),
             "Shadow f-template should contain <f-repeat>, got: {result}"
         );
+        // shadowrootmode is moved to the outer <f-template>...
         assert!(
-            !result.contains("shadowrootmode"),
-            "Shadow f-template should strip shadowrootmode, got: {result}"
+            result.contains(r#"<f-template name="my-shadow" shadowrootmode="open">"#),
+            "<f-template> should carry shadowrootmode, got: {result}"
+        );
+        // ...not on the inner <template>.
+        assert!(
+            !result.contains("<template shadowrootmode"),
+            "inner <template> should NOT carry shadowrootmode, got: {result}"
         );
         assert!(
             !result.contains("<if "),

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -106,6 +106,17 @@ HTML files. The build tool auto-injects it when absent.
 Root host events catch custom events bubbling up from child components.
 This is the delegated event pattern for parent-child communication.
 
+Any `shadowroot`-prefixed attributes you write on the outer `<template>` —
+`shadowrootmode`, `shadowrootclonable`, `shadowrootdelegatesfocus`,
+`shadowrootserializable`, or `shadowrootadoptedstylesheets` — are preserved
+on the rendered wrapper. The legacy `shadowroot` attribute is also emitted
+alongside `shadowrootmode` with the same value for older user agents.
+When the user-supplied `shadowrootadoptedstylesheets` overlaps with one
+the parser's CSS Module strategy generates, the values are merged (user
+specifiers first, parser specifiers appended only if not already listed).
+Under the FAST plugins (`fast-v2`/`fast-v3`) those attributes are placed
+on the outer `<f-template>` element rather than the inner `<template>`.
+
 ## Template Syntax
 
 ### Text binding

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -52,7 +52,7 @@ Path inputs for `APP`, `--state`, and `--servedir` support absolute paths, relat
 
 | Strategy | Behavior |
 |----------|----------|
-| `shadow` | Components render inside `<template shadowrootmode="open">`. Style encapsulation via Shadow DOM. Default. |
+| `shadow` | Components render inside `<template shadowrootmode="open" shadowroot="open">`. Style encapsulation via Shadow DOM. Default. The mode and any other `shadowroot*` attribute on a user-supplied wrapping `<template>` are preserved (e.g. `shadowrootmode="closed"`, `shadowrootclonable`, `shadowrootdelegatesfocus`). The legacy `shadowroot` attribute is always emitted alongside `shadowrootmode` for older user agents. Under the FAST plugins (`fast-v2`/`fast-v3`) the `shadowroot*` attributes are placed on the outer `<f-template>` element instead of the inner `<template>`. |
 | `light` | Components render as direct children. No shadow boundary. 26% faster FCP on high-component-count pages. |
 
 See [Performance - Light DOM vs Shadow DOM](/guide/concepts/performance#light-dom-vs-shadow-dom) for benchmarks and guidance.

--- a/docs/guide/concepts/components/index.md
+++ b/docs/guide/concepts/components/index.md
@@ -51,7 +51,7 @@ Include it explicitly when you need **root host events** - event listeners on th
 </template>
 ```
 
-When you include the `<template>` tag, the framework uses yours instead of auto-injecting one.
+When you include the `<template>` tag, the framework uses yours instead of auto-injecting one. Any `shadowroot`-prefixed attributes you add (`shadowrootmode`, `shadowrootclonable`, `shadowrootdelegatesfocus`, `shadowrootserializable`, `shadowrootadoptedstylesheets`) are preserved on the rendered wrapper, so you can opt into closed-mode shadow DOM, clone-on-attach, or extra adopted-stylesheet specifiers without losing them at build time. Both `shadowrootmode` and the legacy `shadowroot` attribute are emitted as a paired alias on the wrapper for older user agents and tooling. When the FAST plugins (`fast-v2` / `fast-v3`) are active, those `shadowroot*` attributes are placed on the outer `<f-template>` element rather than the inner `<template>`.
 
 ## How Components Work
 

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -101,7 +101,7 @@ The `--dom` flag controls how the server renders component content:
 
 | Flag | Behavior |
 |------|----------|
-| `--dom=shadow` (default) | Wraps component HTML in `<template shadowrootmode="open">` |
+| `--dom=shadow` (default) | Wraps component HTML in `<template shadowrootmode="open" shadowroot="open">`. Any `shadowroot*` attribute on a user-supplied wrapping `<template>` is preserved. The legacy `shadowroot` attribute is always emitted alongside `shadowrootmode` for older user agents. |
 | `--dom=light` | Renders component content as direct children of the host element |
 
 The runtime auto-detects which mode was used at hydration time:

--- a/packages/webui-framework/RENDERING.md
+++ b/packages/webui-framework/RENDERING.md
@@ -87,7 +87,7 @@ Template:
 Server output:
 
 ```html
-<template shadowrootmode="open">
+<template shadowrootmode="open" shadowroot="open">
   <h1>My List</h1>
   <button>Toggle</button>
   <!--wc--><p>Now you see me</p><!--/wc-->


### PR DESCRIPTION
## Summary

When `DomStrategy::Shadow` is active, the WebUI parser now preserves any `shadowroot`-prefixed attributes the user wrote on their wrapping `<template>` and applies these rules:

- **Mode** — `shadowrootmode` value (or, if absent, a bare legacy `shadowroot=` attribute) is captured. Both attributes are then **always** emitted on the wrapper as `shadowrootmode="<mode>" shadowroot="<mode>"` (the legacy `shadowroot` attribute is emitted as a paired alias for older user agents / tooling that look for either form). Defaults to `"open"` when neither is supplied.
- **Other shadow-root attrs** — `shadowrootclonable`, `shadowrootdelegatesfocus`, `shadowrootserializable`, etc. are preserved verbatim on the emitted `<template>`.
- **`shadowrootadoptedstylesheets`** — when the user supplies a value AND the CSS Module strategy would also generate one, the values are **merged** into a single space-separated list (user-supplied specifiers first in their original order; parser-generated specifiers appended only if not already present, deduplicated).
- **Runtime / non-shadowroot user attrs on `<template>`** — `@event`, `:prop`, `?bool`, and any other non-`shadowroot*` attribute on the user's `<template>` is stripped from the emitted wrapper (existing behaviour).

Under the **FAST v2 / v3 parser plugins** those `shadowroot*` attributes are placed on the outer **`<f-template>`** element rather than the inner `<template>`. `<f-template>` is the framework-owned transport element that the FAST runtime consumes; the inner `<template>` always has all `shadowroot*` attributes stripped so the browser does not auto-activate it as a declarative shadow root inside `<f-template>`. The same `shadowrootadoptedstylesheets` merge rule applies on `<f-template>`.

## Bug fix included

Also fixes a pre-existing bug in `generate_f_template` (fast-v2 / fast-v3) that used `find('>')` to locate the end of the outer `<template>` opening tag — this broke on attribute values containing `>` (e.g. `data-note="a > b"`). The new implementation uses the existing `find_tag_close` helper which respects quoted attribute values, with a regression test in both plugins.

## Backward compatibility

Light-DOM mode is unaffected: the `<template>` wrapper continues to be stripped entirely. The default shadow-DOM behaviour (no user `shadowroot*` attrs supplied) emits `<template shadowrootmode="open" shadowroot="open">`, which is backward-compatible with existing apps that rely on `shadowrootmode="open"`.

## Tests

- 8 new tests in the parser core (`crates/webui-parser/src/lib.rs`) covering: default paired emission, user-supplied `shadowrootmode="closed"`, bare legacy `shadowroot=` promoted to mode, `shadowrootclonable`/`shadowrootdelegatesfocus` preservation, adopted-stylesheets merge with user value, dedup against module specifier, runtime attrs stripped from wrapper, and the light-DOM regression.
- 7 new tests in each of `fast_v2.rs` and `fast_v3.rs` (14 total) covering: `shadowrootmode` moved to `<f-template>`, user closed mode preserved, other shadow-root attrs on `<f-template>`, no `shadowroot*` on `<f-template>` when user did not supply any, module CSS strategy puts `shadowrootadoptedstylesheets` on `<f-template>`, merged with user value, and the `>` in quoted attr regression test. Plus updated existing tests to assert the new placement and a coverage test for the renamed `strip_shadowroot_attrs` helper.
- All 386 parser tests pass.
- Full `cargo xtask check` passes (license-headers, fmt, clippy, deny, test, build, build (wasm), build (examples), bench, docs).

## Documentation

- `DESIGN.md` — new "Shadow DOM `<template>` wrapper" subsection documenting the preservation, paired-alias, merge, and FAST-plugin placement rules.
- `docs/guide/concepts/components/index.md` — updated component-author guidance.
- `docs/guide/cli/index.md` — updated DOM strategy table.
- `docs/ai.md` — updated AI-targeted guidance.
- `packages/webui-framework/README.md` and `RENDERING.md` — example output reflects paired `shadowrootmode`/`shadowroot`.
- Doc-comments on `process_component_template`, `generate_f_template`, `convert_btr_to_fast`, and `strip_shadowroot_attrs` describe the new behaviour.