### PR TITLE
Add entry_point build option for script tag injection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -857,6 +857,7 @@ pub struct HtmlParser {
     condition_parser: ConditionParser,
     handlebars_parser: HandlebarsParser,
     css_strategy: CssStrategy,
+    entry_point: Option<String>,
     // Other fields...
 }
 ```

--- a/crates/webui-cli/src/commands/common.rs
+++ b/crates/webui-cli/src/commands/common.rs
@@ -45,6 +45,7 @@ impl AppArgs {
             dom: self.dom,
             plugin: self.plugin,
             components: self.components.clone(),
+            entry_point: None,
         }
     }
 }

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -79,6 +79,8 @@ pub struct JsBuildOptions {
     pub plugin: Option<String>,
     /// Additional component sources (npm packages or local paths).
     pub components: Option<Vec<String>>,
+    /// JS entry-point name (without `.js`); injects script tag into protocol.
+    pub entry_point: Option<String>,
 }
 
 /// Build a WebUI application from an app directory.
@@ -107,6 +109,7 @@ pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
         dom: webui::DomStrategy::Shadow,
         plugin,
         components: options.components.unwrap_or_default(),
+        entry_point: options.entry_point,
     };
 
     let result = webui::build(build_options)
@@ -460,6 +463,7 @@ mod tests {
             css: None,
             plugin: None,
             components: None,
+            entry_point: None,
         };
 
         let result = build(options).unwrap();
@@ -480,6 +484,7 @@ mod tests {
             css: None,
             plugin: None,
             components: None,
+            entry_point: None,
         };
 
         let result = build(options).unwrap();
@@ -494,6 +499,7 @@ mod tests {
             css: None,
             plugin: None,
             components: None,
+            entry_point: None,
         };
 
         let result = build(options);
@@ -511,6 +517,7 @@ mod tests {
             css: Some("bogus".to_string()),
             plugin: None,
             components: None,
+            entry_point: None,
         };
 
         let result = build(options);
@@ -530,6 +537,7 @@ mod tests {
             css: Some("link".to_string()),
             plugin: None,
             components: None,
+            entry_point: None,
         };
 
         let result = build(options).unwrap();

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -216,6 +216,9 @@ pub struct HtmlParser {
     /// (e.g., `:root { --color-primary: #0078d4; }`). These are excluded
     /// from the final token set since the app already provides their values.
     token_definitions: HashSet<String>,
+
+    /// JS entry-point name (without `.js`); injects script tag before `</body>`.
+    entry_point: Option<String>,
 }
 
 impl HtmlParser {
@@ -241,6 +244,7 @@ impl HtmlParser {
             plugin: None,
             token_store: HashSet::new(),
             token_definitions: HashSet::new(),
+            entry_point: None,
             parser,
         }
     }
@@ -261,6 +265,12 @@ impl HtmlParser {
     /// Set the DOM strategy for component rendering (shadow or light).
     pub fn set_dom_strategy(&mut self, strategy: DomStrategy) -> &mut Self {
         self.dom_strategy = strategy;
+        self
+    }
+
+    /// Set the JS entry-point name (without `.js` extension).
+    pub fn set_entry_point(&mut self, name: impl Into<String>) -> &mut Self {
+        self.entry_point = Some(name.into());
         self
     }
 
@@ -1225,6 +1235,18 @@ impl HtmlParser {
         fragments.push(WebUIFragment::signal("body_start", true));
         self.process_content_children(node, source, fragments)?;
         self.flush_raw_buffer(fragments);
+
+        // Inject entry-point script tag
+        if let Some(ref ep) = self.entry_point {
+            use std::fmt::Write;
+            write!(
+                self.raw_buffer,
+                r#"<script type="module" src="./{ep}.js"></script>"#
+            )
+            .ok();
+            self.flush_raw_buffer(fragments);
+        }
+
         fragments.push(WebUIFragment::signal("body_end", true));
         self.add_raw_fragment("</body>");
         Ok(())
@@ -4658,6 +4680,70 @@ mod tests {
                 raw("<button>Click</button><br>Part B: "),
                 signal("value2"),
                 raw("<button>Click2</button>"),
+            ]
+        );
+    }
+
+    // ── Entry-point injection tests ───────────────────────────────────
+
+    #[test]
+    fn test_entry_point_injects_script_before_body_end() {
+        let mut parser = HtmlParser::new();
+        parser.set_entry_point("main");
+        let result = parser.parse("index.html", "<body><p>Hello</p></body>");
+        assert!(result.is_ok(), "Parse error: {:?}", result.err());
+        let records = parser.into_fragment_records();
+        let fragments = &records
+            .get("index.html")
+            .expect("missing index.html")
+            .fragments;
+        assert_fragments!(
+            fragments,
+            [
+                raw("<body>"),
+                signal_raw("body_start"),
+                raw("<p>Hello</p>"),
+                raw(r#"<script type="module" src="./main.js"></script>"#),
+                signal_raw("body_end"),
+                raw("</body>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_entry_point_none_no_injection() {
+        let (fragments, _) = parse_and_get_fragments("<body><p>Hi</p></body>");
+        assert_fragments!(
+            fragments,
+            [
+                raw("<body>"),
+                signal_raw("body_start"),
+                raw("<p>Hi</p>"),
+                signal_raw("body_end"),
+                raw("</body>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_entry_point_with_hyphenated_name() {
+        let mut parser = HtmlParser::new();
+        parser.set_entry_point("my-app-entry");
+        let result = parser.parse("index.html", "<body></body>");
+        assert!(result.is_ok(), "Parse error: {:?}", result.err());
+        let records = parser.into_fragment_records();
+        let fragments = &records
+            .get("index.html")
+            .expect("missing index.html")
+            .fragments;
+        assert_fragments!(
+            fragments,
+            [
+                raw("<body>"),
+                signal_raw("body_start"),
+                raw(r#"<script type="module" src="./my-app-entry.js"></script>"#),
+                signal_raw("body_end"),
+                raw("</body>"),
             ]
         );
     }

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -366,6 +366,7 @@ pub fn build_docs_with_cache(
             dom: webui::DomStrategy::Shadow,
             plugin: Some(webui::Plugin::WebUI),
             components: component_sources.clone(),
+            entry_point: None,
         })
         .map_err(|e| Error::Build(format!("{}: {e}", page.path)))?;
 
@@ -507,6 +508,7 @@ pub fn build_docs_with_cache(
         dom: webui::DomStrategy::Shadow,
         plugin: Some(webui::Plugin::WebUI),
         components: component_sources.clone(),
+        entry_point: None,
     })
     .map_err(|e| Error::Build(format!("404 build failed: {e}")))?;
 

--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -255,6 +255,7 @@ fn build_contact_book_protocol() -> (WebUIProtocol, Vec<u8>) {
         dom: DomStrategy::Shadow,
         plugin: None,
         components: Vec::new(),
+        entry_point: None,
     })
     .expect("failed to build contact-book-manager protocol");
 

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -19,6 +19,7 @@
 //!     dom: DomStrategy::Shadow,
 //!     plugin: None,
 //!     components: Vec::new(),
+//!     entry_point: None,
 //! }).unwrap();
 //!
 //! println!("Built {} fragments in {:?}", result.stats.fragment_count, result.stats.duration);
@@ -65,6 +66,8 @@ pub struct BuildOptions {
     pub plugin: Option<Plugin>,
     /// Additional component sources (npm packages or local paths).
     pub components: Vec<String>,
+    /// JS entry-point name (without `.js`); injects script tag before `</body>`.
+    pub entry_point: Option<String>,
 }
 
 /// Statistics about a completed build.
@@ -220,6 +223,10 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
     parser.set_css_strategy(options.css);
     parser.set_dom_strategy(options.dom);
 
+    if let Some(ref ep) = options.entry_point {
+        parser.set_entry_point(ep);
+    }
+
     // Register app directory components
     parser
         .component_registry_mut()
@@ -371,6 +378,7 @@ mod tests {
             dom: DomStrategy::Shadow,
             plugin: None,
             components: Vec::new(),
+            entry_point: None,
         }
     }
 
@@ -709,6 +717,7 @@ mod tests {
             dom: DomStrategy::Shadow,
             plugin: None,
             components: Vec::new(),
+            entry_point: None,
         })
         .unwrap();
 
@@ -879,6 +888,7 @@ mod tests {
             dom: DomStrategy::Shadow,
             plugin: None,
             components: Vec::new(),
+            entry_point: None,
         };
         let result = build(options);
         assert!(result.is_err());
@@ -900,5 +910,42 @@ mod tests {
         assert!(stats.component_count > 0);
         assert!(stats.protocol_size_bytes > 0);
         assert!(!stats.duration.is_zero());
+    }
+
+    #[test]
+    fn test_build_with_entry_point_injects_script_tag() {
+        let app = create_app_dir(&[("index.html", "<body><p>Hello</p></body>")]);
+        let options = BuildOptions {
+            app_dir: app.path().to_path_buf(),
+            entry: "index.html".to_string(),
+            css: CssStrategy::Link,
+            dom: DomStrategy::Shadow,
+            plugin: None,
+            components: Vec::new(),
+            entry_point: Some("my-app".to_string()),
+        };
+        let result = build(options).unwrap();
+        let fragments = &result.protocol.fragments["index.html"].fragments;
+        let has_script = fragments.iter().any(|f| {
+            matches!(
+                f.fragment.as_ref(),
+                Some(Fragment::Raw(r)) if r.value.contains(r#"<script type="module" src="./my-app.js"></script>"#)
+            )
+        });
+        assert!(has_script, "Expected script tag fragment not found");
+    }
+
+    #[test]
+    fn test_build_without_entry_point_no_script_tag() {
+        let app = create_app_dir(&[("index.html", "<body><p>Hello</p></body>")]);
+        let result = build(default_options(app.path())).unwrap();
+        let fragments = &result.protocol.fragments["index.html"].fragments;
+        let has_script = fragments.iter().any(|f| {
+            matches!(
+                f.fragment.as_ref(),
+                Some(Fragment::Raw(r)) if r.value.contains("<script")
+            )
+        });
+        assert!(!has_script, "Unexpected script tag found in fragments");
     }
 }

--- a/docs/guide/integrations/node.md
+++ b/docs/guide/integrations/node.md
@@ -96,6 +96,7 @@ Deno.serve({ port: 3000 }, (req) => {
 | `css` | `"link" \| "style" \| "module"` | `"link"` | CSS delivery strategy |
 | `plugin` | `string` | - | Parser plugin (e.g. `"fast-v3"`; deprecated `"fast"`/`"fast-v2"` keep @microsoft/fast-element 2.x compatibility) |
 | `components` | `string[]` | - | External component sources |
+| `entryPoint` | `string` | - | JS entry-point name (without `.js`); injects `<script type="module">` tag |
 
 ### BuildStats
 

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -171,6 +171,7 @@ async fn main() {
 | `css` | `CssStrategy` | `Link` | CSS delivery: `Link`, `Style`, or `Module` |
 | `plugin` | `Option<String>` | `None` | Parser plugin (e.g. `"fast-v3"`; deprecated `"fast"`/`"fast-v2"` keep @microsoft/fast-element 2.x compatibility) |
 | `components` | `Vec<String>` | `[]` | External component sources |
+| `entry_point` | `Option<String>` | `None` | JS entry-point name (without `.js`); injects `<script type="module">` tag |
 
 ### BuildStats
 

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -41,6 +41,7 @@ impl FrontendRuntime {
             dom: DomStrategy::Shadow,
             plugin: Some(Plugin::WebUI),
             components: Vec::new(),
+            entry_point: None,
         })
         .with_context(|| "Failed to build the commerce WebUI protocol")?;
 

--- a/examples/demo/server/src/shell.rs
+++ b/examples/demo/server/src/shell.rs
@@ -49,6 +49,7 @@ impl ShellState {
             dom: DomStrategy::Shadow,
             plugin: Some(Plugin::WebUI),
             components: Vec::new(),
+            entry_point: None,
         })
         .map_err(|e| anyhow::anyhow!("Failed to build shell protocol: {e}"))?;
 


### PR DESCRIPTION
## Summary

Add an optional \ntry_point\ field to \BuildOptions\ that injects a \<script type=\"module\" src=\"./NAME.js\">\</script>\ raw fragment into the protocol immediately before the \ody_end\ signal. This eliminates the need for consumers to post-process rendered HTML to inject entry scripts.

Closes #289

## Changes

| Layer | Change |
|-------|--------|
| \webui-parser\ | Add \ntry_point\ field + \set_entry_point()\ setter + inject raw fragment before \ody_end\ |
| \webui\ (build API) | Add \ntry_point: Option<String>\ to \BuildOptions\, wire to parser |
| \webui-node\ | Expose \ntryPoint\ in \JsBuildOptions\ |
| DESIGN.md | Add \ntry_point\ to \HtmlParser\ struct listing |
| docs/ | Add \ntry_point\/\ntryPoint\ to Rust and Node integration docs |

## Testing

- 3 unit tests in \webui-parser\ (injection, no-injection, hyphenated name)
- 2 integration tests in \webui\ crate (BuildOptions with/without entry_point)
- All existing tests pass (pre-existing \webui-discovery\ failure is unrelated)

## Backward Compatibility

\ntry_point: None\ (default) = no script tag injected = current behavior.