### PR TITLE
chore: remove unused dependencies via cargo shear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,12 +992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,15 +1152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fragile"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -1768,7 +1753,6 @@ dependencies = [
  "anyhow",
  "clap",
  "hmac",
- "html-escape",
  "microsoft-webui",
  "microsoft-webui-handler",
  "mime_guess",
@@ -1817,10 +1801,8 @@ dependencies = [
  "microsoft-webui-protocol",
  "microsoft-webui-tokens",
  "mime_guess",
- "serde",
  "serde_json",
  "tempfile",
- "walkdir",
 ]
 
 [[package]]
@@ -1861,7 +1843,6 @@ dependencies = [
  "microsoft-webui-protocol",
  "microsoft-webui-state",
  "microsoft-webui-test-utils",
- "serde",
  "serde_json",
  "thiserror",
 ]
@@ -1871,11 +1852,9 @@ name = "microsoft-webui-ffi"
 version = "0.0.12"
 dependencies = [
  "cbindgen",
- "libc",
  "microsoft-webui-handler",
  "microsoft-webui-parser",
  "microsoft-webui-protocol",
- "serde",
  "serde_json",
 ]
 
@@ -1891,7 +1870,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -1902,7 +1880,6 @@ dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",
  "microsoft-webui-protocol",
- "microsoft-webui-test-utils",
  "napi",
  "napi-build",
  "napi-derive",
@@ -1917,18 +1894,12 @@ dependencies = [
  "clap",
  "criterion",
  "html-escape",
- "microsoft-webui-expressions",
  "microsoft-webui-protocol",
  "microsoft-webui-test-utils",
- "mockall",
- "serde",
- "serde_json",
- "tempfile",
  "thiserror",
  "tree-sitter",
  "tree-sitter-css",
  "tree-sitter-html",
- "tree-sitter-language",
  "walkdir",
 ]
 
@@ -1941,12 +1912,9 @@ dependencies = [
  "clap",
  "comrak",
  "console",
- "libc",
  "microsoft-webui",
  "microsoft-webui-dev-server",
  "microsoft-webui-handler",
- "microsoft-webui-protocol",
- "mime_guess",
  "rayon",
  "serde",
  "serde_json",
@@ -1954,14 +1922,12 @@ dependencies = [
  "syntect",
  "thiserror",
  "tokio",
- "walkdir",
 ]
 
 [[package]]
 name = "microsoft-webui-protocol"
 version = "0.0.12"
 dependencies = [
- "anyhow",
  "criterion",
  "prost",
  "prost-build",
@@ -1976,7 +1942,6 @@ version = "0.0.12"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
- "serde",
  "serde_json",
 ]
 
@@ -1985,17 +1950,14 @@ name = "microsoft-webui-test-utils"
 version = "0.0.12"
 dependencies = [
  "microsoft-webui-protocol",
- "mockall",
  "serde_json",
  "tempfile",
- "tokio-test",
 ]
 
 [[package]]
 name = "microsoft-webui-tokens"
 version = "0.0.12"
 dependencies = [
- "serde",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -2008,8 +1970,6 @@ dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",
  "microsoft-webui-protocol",
- "microsoft-webui-test-utils",
- "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
@@ -2058,32 +2018,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mockall"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2512,32 +2446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -3148,12 +3056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,28 +3179,6 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ thiserror = "2.0.18"
 anyhow = "1.0.101"
 log = "0.4.29"
 env_logger = "0.11.9"
-async-trait = "0.1.89"
 tokio = { version = "1.52.1", features = ["full"] }
 clap = { version = "4.6.1", features = ["derive", "color"] }
 console = "0.16.3"
@@ -51,7 +50,6 @@ notify = "8.2.0"
 notify-debouncer-mini = "0.7.0"
 percent-encoding = "2.3.2"
 tree-sitter = "0.26.8"
-tree-sitter-language = "0.1.7"
 tree-sitter-html = "0.23.2"
 tree-sitter-css = "0.25.0"
 walkdir = "2.5.0"
@@ -62,17 +60,10 @@ serde_yaml = "0.9"
 libc = "0.2.186"
 time = { version = "0.3", features = ["local-offset", "formatting", "macros"] }
 which = "8.0.2"
-windows = { version = "0.62.2", features = [
-    "Win32_Foundation",
-    "Win32_System_LibraryLoader",
-    "Win32_System_Console",
-] }
 
 # Test dependencies
 criterion = "0.8.2"
-mockall = "0.14.0"
 tempfile = "3.27.0"
-tokio-test = "0.4.5"
 
 # Build dependencies
 prost-build = "0.14.3"

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -25,13 +25,11 @@ microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" 
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 actix-web = { workspace = true }
 awc = { workspace = true }
 expand-tilde = { workspace = true }
 mime_guess = { workspace = true }
-walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -17,7 +17,6 @@ name = "webui_expressions"
 [dependencies]
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 microsoft-webui-state = { path = "../webui-state", version = "0.0.12" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -27,9 +27,7 @@ regenerate-header = ["dep:cbindgen"]
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", optional = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-serde = { workspace = true }
 serde_json = { workspace = true }
-libc = { workspace = true }
 
 [build-dependencies]
 cbindgen = { workspace = true, optional = true }

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
-tokio = { workspace = true }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -28,7 +28,6 @@ napi-build = { workspace = true }
 
 [dev-dependencies]
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -20,13 +20,9 @@ fs = ["walkdir"]
 cli = ["clap"]
 
 [dependencies]
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.12" }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tree-sitter = { workspace = true }
-tree-sitter-language = { workspace = true }
 tree-sitter-html = { workspace = true }
 tree-sitter-css = { workspace = true }
 html-escape = { workspace = true }
@@ -34,8 +30,6 @@ walkdir = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-mockall = { workspace = true }
-tempfile = { workspace = true }
 microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 criterion = { workspace = true }
 

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/main.rs"
 [dependencies]
 microsoft-webui = { path = "../webui", version = "0.0.12", features = ["cli"] }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -47,8 +46,3 @@ thiserror = { workspace = true }
 microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
-mime_guess = { workspace = true }
-walkdir = { workspace = true }
-
-[target.'cfg(unix)'.dependencies]
-libc = { workspace = true }

--- a/crates/webui-protocol/Cargo.toml
+++ b/crates/webui-protocol/Cargo.toml
@@ -24,7 +24,6 @@ regenerate-proto = ["dep:prost-build"]
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-anyhow = { workspace = true }
 prost = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["web-programming"]
 name = "webui_state"
 
 [dependencies]
-serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -16,8 +16,6 @@ name = "webui_test_utils"
 
 [dependencies]
 serde_json = { workspace = true }
-mockall = { workspace = true }
-tokio-test = { workspace = true }
 tempfile = { workspace = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
 

--- a/crates/webui-tokens/Cargo.toml
+++ b/crates/webui-tokens/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["web-programming"]
 name = "webui_tokens"
 
 [dependencies]
-serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -22,14 +22,10 @@ crate-type = ["cdylib", "rlib"]
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 thiserror = { workspace = true }
-
-[dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
 
 [lints]
 workspace = true

--- a/examples/app/commerce/server/Cargo.toml
+++ b/examples/app/commerce/server/Cargo.toml
@@ -18,7 +18,6 @@ mime_guess = { workspace = true }
 thiserror = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
-html-escape = { workspace = true }
 rustls = { workspace = true }
 rcgen = { workspace = true }
 microsoft-webui = { path = "../../../../crates/webui" }


### PR DESCRIPTION
Ran `cargo shear --fix` and removed unused Cargo dependencies across the workspace.