### PR TITLE
chore: correct rust integration docs to match published crate

### DIFF
--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -36,7 +36,8 @@ pub use webui_handler::route_handler::{
     ProtocolIndex,
 };
 pub use webui_handler::route_matcher::CompiledRouteCache;
-pub use webui_handler::{plugin::HandlerPlugin, HandlerError, ResponseWriter, WebUIHandler};
+pub use webui_handler::Result as HandlerResult;
+pub use webui_handler::{plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler};
 pub use webui_parser::CssStrategy;
 pub use webui_parser::DomStrategy;
 pub use webui_parser::Plugin;

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -37,7 +37,9 @@ pub use webui_handler::route_handler::{
 };
 pub use webui_handler::route_matcher::CompiledRouteCache;
 pub use webui_handler::Result as HandlerResult;
-pub use webui_handler::{plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler};
+pub use webui_handler::{
+    plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler,
+};
 pub use webui_parser::CssStrategy;
 pub use webui_parser::DomStrategy;
 pub use webui_parser::Plugin;

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -6,9 +6,11 @@ The `webui` crate provides high-performance build and rendering of WebUI protoco
 
 ```toml
 [dependencies]
-webui = "*" # see https://crates.io/crates/webui for latest version
+microsoft-webui = "*" # see https://crates.io/crates/microsoft-webui for latest version
 serde_json = "1"
 ```
+
+The crate is published as `microsoft-webui` on crates.io; the bare `webui` name is owned by an unrelated project. Cargo's default rename rules mean items remain importable as `use webui::...` because the crate sets `[lib] name = "webui"` internally.
 
 ## Examples
 
@@ -27,11 +29,11 @@ use std::fs;
 struct StringWriter(String);
 
 impl ResponseWriter for StringWriter {
-    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+    fn write(&mut self, content: &str) -> webui::HandlerResult<()> {
         self.0.push_str(content);
         Ok(())
     }
-    fn end(&mut self) -> webui_handler::Result<()> { Ok(()) }
+    fn end(&mut self) -> webui::HandlerResult<()> { Ok(()) }
 }
 
 #[actix_web::main]
@@ -70,11 +72,11 @@ use std::{fs, sync::Arc};
 struct StringWriter(String);
 
 impl ResponseWriter for StringWriter {
-    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+    fn write(&mut self, content: &str) -> webui::HandlerResult<()> {
         self.0.push_str(content);
         Ok(())
     }
-    fn end(&mut self) -> webui_handler::Result<()> { Ok(()) }
+    fn end(&mut self) -> webui::HandlerResult<()> { Ok(()) }
 }
 
 #[tokio::main]
@@ -112,11 +114,11 @@ use std::{fs, sync::Arc};
 struct StringWriter(String);
 
 impl ResponseWriter for StringWriter {
-    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+    fn write(&mut self, content: &str) -> webui::HandlerResult<()> {
         self.0.push_str(content);
         Ok(())
     }
-    fn end(&mut self) -> webui_handler::Result<()> { Ok(()) }
+    fn end(&mut self) -> webui::HandlerResult<()> { Ok(()) }
 }
 
 #[tokio::main]


### PR DESCRIPTION
## What

Two small fixes to the public `rust` integration:

1. **`crates/webui/src/lib.rs`** - re-export `RenderOptions` and `Result as HandlerResult` from `webui_handler` through the `webui` facade crate.
2. **`docs/guide/integrations/rust.md`** - use the published crate name (`microsoft-webui`) in the install block, fix trait-impl return types, and note the rename.

`Result` is renamed to `HandlerResult` on re-export so it does not collide with the existing `std::result::Result<T, E>` usage inside `crates/webui/src/lib.rs` (`build` and `build_to_disk`).

## Why

I'm integrating WebUI into an embedded host by following `docs/guide/integrations/rust.md`. Two things were blocking:

- `webui = "*"` in Cargo.toml resolves to an unrelated crate on crates.io. The Microsoft crate is published as `microsoft-webui`; the `[lib] name = "webui"` setting keeps `use webui::...` working unchanged, but the docs don't mention this. This costs a first-time adopter the same hour every time.
- The trait impls in all three framework examples reference `webui_handler::Result<()>` (the `webui_handler` crate is not the dependency the page tells you to add) and `webui::RenderOptions` (not currently re-exported). Copying the example into a fresh project does not compile.

The scope is intentionally narrow: just unblock the first-render-from-a-non-WebUI-host story that the page already promises.

## How I tested

```
cargo check -p microsoft-webui
```

(passes after the re-export)

Happy to also copy one of the framework examples into a scratch crate that depends only on `microsoft-webui` to confirm the rendered text compiles end-to-end - can add that as a doctest if you'd prefer.

## Notes

- Branch is `users/janechu/fix-rust-integration-docs` because that's the convention my host repo uses for agent-driven branches. Happy to rename to `janechu/fix-rust-integration-docs` (matching the local convention in `.github/skills/pr/SKILL.md`) if you prefer.
- Draft PR. There are 4 follow-up PRs queued behind this one addressing related friction in the Node integration docs, handler thread-safety docs, the `@microsoft/webui/platform.js` subpath export, and a fragment-rendering recipe page - opened as siblings rather than stacked.