### PR TITLE
chore: correct node integration docs to match published render() signature

### DIFF
--- a/docs/guide/integrations/node.md
+++ b/docs/guide/integrations/node.md
@@ -19,14 +19,18 @@ npm install @microsoft/webui
 ```js
 import { createServer } from 'node:http';
 import { readFileSync } from 'node:fs';
-import { render } from '@microsoft/webui';
+import { renderStream } from '@microsoft/webui';
 
 const protocol = readFileSync('./dist/protocol.bin');
 
 const server = createServer((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/html' });
-  render(protocol, JSON.stringify({ title: "Home" }), 'index.html', req.url,
-    (chunk) => res.write(chunk));
+  renderStream(
+    protocol,
+    { title: 'Home' },
+    (chunk) => res.write(chunk),
+    { entry: 'index.html', requestPath: req.url },
+  );
   res.end();
 });
 
@@ -46,10 +50,11 @@ Bun.serve({
   port: 3000,
   fetch(req) {
     const url = new URL(req.url);
-    const chunks: string[] = [];
-    render(protocolData, JSON.stringify({ title: "Home" }), 'index.html', url.pathname,
-      (chunk: string) => chunks.push(chunk));
-    return new Response(chunks.join(''), {
+    const html = render(protocolData, { title: 'Home' }, {
+      entry: 'index.html',
+      requestPath: url.pathname,
+    });
+    return new Response(html, {
       headers: { 'Content-Type': 'text/html' },
     });
   },
@@ -67,10 +72,11 @@ const protocolData = Buffer.from(protocol);
 
 Deno.serve({ port: 3000 }, (req) => {
   const url = new URL(req.url);
-  const chunks: string[] = [];
-  render(protocolData, JSON.stringify({ title: "Home" }), 'index.html', url.pathname,
-    (chunk: string) => chunks.push(chunk));
-  return new Response(chunks.join(''), {
+  const html = render(protocolData, { title: 'Home' }, {
+    entry: 'index.html',
+    requestPath: url.pathname,
+  });
+  return new Response(html, {
     headers: { 'Content-Type': 'text/html' },
   });
 });
@@ -84,8 +90,19 @@ Deno.serve({ port: 3000 }, (req) => {
 | Function | Description |
 |----------|-------------|
 | `build(options)` | Build templates into a protocol. Returns `{ protocol, cssFiles, stats }` |
-| `render(protocol, state, entry, requestPath, onChunk, plugin?)` | Render protocol with route matching, streaming HTML fragments via callback |
+| `render(protocol, state, options?)` | Render protocol with route matching. Returns the rendered HTML as a string |
+| `renderStream(protocol, state, onChunk, options?)` | Render with streaming output. Each HTML fragment is passed to `onChunk` as it is produced |
 | `inspect(protocol)` | Convert protocol to JSON for debugging |
+
+### RenderOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `entry` | `string` | `"index.html"` | Fragment ID to start rendering from |
+| `requestPath` | `string` | `"/"` | URL path to match routes against |
+| `plugin` | `string` | - | Handler plugin name (see [Plugins](/guide/concepts/plugins/)) |
+
+`state` accepts either an object (auto-serialized) or a pre-stringified JSON string.
 
 ### BuildOptions
 


### PR DESCRIPTION
## What

Rewrite the three framework examples and the API Reference table in `docs/guide/integrations/node.md` to match the actual signature of `render()` / `renderStream()` exported from `@microsoft/webui`.

## Why

I'm integrating WebUI into a non-WebUI Node host, and the published Node integration page is the first thing a new adopter reads. The page currently teaches:

```js
render(protocol, JSON.stringify(state), entry, requestPath, onChunk)
```

but `packages/webui/src/index.ts` actually exports:

```ts
render(protocol: Buffer, state: object | string, options?: RenderOptions): string
renderStream(protocol: Buffer, state: object | string, onChunk: (html: string) => void, options?: RenderOptions): void
```

Copying any of the three examples into a fresh project does not work, in three different ways:

1. `entry`, `requestPath`, and `plugin` are properties on a `RenderOptions` object, not positional args.
2. `state` accepts an object directly, so `JSON.stringify` is unnecessary boilerplate that suggests the API requires it.
3. `render` returns the full HTML as a string; only `renderStream` invokes a chunk callback. The Bun and Deno examples collect chunks into an array and `.join('')` them, which is doubly confusing because that's exactly what `render` already does internally.

## How I tested

`packages/webui/src/index.ts` is the source of truth for the exported signatures. The three rewritten examples match the exported types and use the correct entry point (`renderStream` where streaming is desired, `render` for accumulate-then-respond).

## Notes

- Branch is `users/janechu/fix-node-integration-docs` per my host repo's agent-driven branch convention. Happy to rename to `janechu/fix-node-integration-docs` if you prefer.
- Sibling of #295 (Rust integration docs fix). Filing separately because the changes are independent.
