### PR TITLE
feat: expose @microsoft/webui/platform subpath

### DIFF
--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -31,6 +31,12 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./platform.js": {
+      "import": {
+        "types": "./dist/platform.d.ts",
+        "default": "./dist/platform.js"
+      }
     }
   },
   "optionalDependencies": {


### PR DESCRIPTION
## What

Add a `./platform.js` entry to the `exports` map in `packages/webui/package.json` so adopters can write:

```ts
import { platformKey, packageName, resolve } from '@microsoft/webui/platform.js';
```

The `.js` extension on the subpath stays ESM-compliant and matches the rest of the package's resolved paths.

## Why

I'm integrating WebUI into a non-WebUI Node host. The integration needs to:

1. Surface a clear "you don't have the native addon installed for *your* platform" error to developers running on, say, macOS arm64 without `@microsoft/webui-darwin-arm64`. `platformKey()` and `packageName()` give the exact strings to put in that error.
2. Spawn the WebUI CLI from a tooling script (build step in another package). `resolve('bin')` returns the right binary path; without the subpath export the only options are `npx webui` (slow startup) or reaching into `node_modules/@microsoft/webui/dist/platform.js` directly (fragile).

`packages/webui/src/platform.ts` already exports all three functions, and `dist/platform.js` / `dist/platform.d.ts` are already shipped via `files: ["dist/"]`. The only thing missing is the `exports` map entry, which under Node's strict ESM resolution makes them unreachable.

This PR adds 6 lines to `package.json`. No code change, no behavior change for existing imports.

## How I tested

The new entry mirrors the existing `.` entry exactly:

- `types` points to `./dist/platform.d.ts` (already produced by `tsc` since `src/platform.ts` is a sibling of `src/index.ts`).
- `default` points to `./dist/platform.js`.

Both files exist after `npm run build` because `index.ts` already imports from `./platform.js`.

## Notes

- Branch is `users/janechu/add-platform-exports-to-main-export` per my host repo's agent-driven branch convention.
- Sibling of #295, #296, #297. Independent of those.
- Question for reviewers: is `platform.ts` *intentionally* private (i.e., reserved for internal-only use), or just an oversight in the exports map? If the former, please close this and I'll switch my integration to re-implementing `platformKey()` locally.
