### PR TITLE
feat: re-export hydration plugins from microsoft-webui facade

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -90,11 +90,16 @@ Reports per (path × scale):
 - **bytes/run** — exact bytes requested from the allocator
 - **wall µs/run** — `Instant::elapsed()` per iteration
 - **user µs/run** — `getrusage(RUSAGE_SELF).ru_utime` delta
+- **sys µs/run** — `getrusage(RUSAGE_SELF).ru_stime` delta
 - **process RSS** — `ru_maxrss` high-water mark
 
 This is the **only** bench in the suite that gives you exact
 allocation numbers. Use it to verify "zero per-write allocation"
 claims and to detect allocation-pressure regressions.
+
+On non-Unix targets, `getrusage` is unavailable; the benchmark still runs and
+reports allocation and wall-clock data, while user/sys CPU and RSS counters are
+reported as zero.
 
 ### `streaming-e2e-ttfb` (HTTP-level)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -489,7 +489,7 @@ pub enum ExpressionError {
 ### Core API
 ```rust
 pub struct WebUIHandler {
-    plugin: Option<Box<dyn HandlerPlugin>>,
+    plugin_factory: Option<fn() -> Box<dyn HandlerPlugin>>,
 }
 
 /// Options controlling how the handler renders a protocol.
@@ -519,10 +519,10 @@ impl<'a> RenderOptions<'a> {
 
 impl WebUIHandler {
     pub fn new() -> Self;
-    pub fn with_plugin(plugin: Box<dyn HandlerPlugin>) -> Self;
+    pub fn with_plugin(factory: fn() -> Box<dyn HandlerPlugin>) -> Self;
 
     pub fn handle(
-        &mut self,
+        &self,
         protocol: &WebUIProtocol,
         state: &Value,
         options: &RenderOptions<'_>,
@@ -530,6 +530,14 @@ impl WebUIHandler {
     ) -> Result<()>;
 }
 ```
+
+Programmatic Rust hosts should normally import the handler surface through the
+top-level `microsoft-webui` crate (library name `webui`). It re-exports
+`HandlerResult`, `RenderOptions`, `ResponseWriter`, `WebUIHandler`,
+`HandlerPlugin`, `FastV3HydrationPlugin`, `WebUIHydrationPlugin`, parser
+configuration types, and `WebUIProtocol` so applications do not need direct
+dependencies on the internal handler, parser, or protocol crates for common
+build/render use.
 
 #### ProtocolIndex
 
@@ -761,6 +769,10 @@ pub trait HandlerPlugin {
     fn pop_scope(&mut self);
     fn on_binding_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_binding_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_for_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_for_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_if_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_if_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_start(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
@@ -769,29 +781,50 @@ pub trait HandlerPlugin {
         state: &serde_json::Value,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()>;
+    fn emit_templates(
+        &self,
+        protocol: &WebUIProtocol,
+        components: &HashSet<String>,
+        nonce: Option<&str>,
+        writer: &mut dyn ResponseWriter,
+    ) -> Result<()>;
+    fn collect_template_js(
+        &self,
+        protocol: &WebUIProtocol,
+        components: &HashSet<String>,
+    ) -> Option<Vec<String>>;
 }
 ```
 
 **Hook invocation points:**
 - **Signal**: `on_binding_start` before, `on_binding_end` after (same scope)
-- **For loop**: `on_binding_start/end` around entire loop; `on_repeat_item_start/end` + `push_scope/pop_scope` per item
-- **If condition**: `on_binding_start/end` around condition; `push_scope/pop_scope` if condition is true
+- **For loop**: `on_for_start/end` around entire loop; `on_repeat_item_start/end` + `push_scope/pop_scope` per item
+- **If condition**: `on_if_start/end` around condition; `push_scope/pop_scope` if condition is true
 - **Component**: `push_scope/pop_scope` around component body
 - **Plugin fragment**: `on_element_data` with parser-produced hydration bytes from protocol
 - **Matched route component**: `write_route_component_state` before the opening tag closes
+- **Template emission**: `emit_templates` writes component templates during SSR;
+  `collect_template_js` lets plugins that store executable JS templates merge
+  them into the consolidated `window.__webui` script block.
 
 **Selecting handler plugins**
 
-The CLI and host APIs select handler plugins by name (passed as a string). No plugin
-is loaded by default; output is plain SSR HTML unless a plugin is selected.
+The CLI selects parser/handler plugin pairs by name. Rust hosts pass a
+zero-capture plugin factory to `WebUIHandler::with_plugin`; each render creates
+a fresh plugin instance from the factory so the handler remains shareable. No
+plugin is loaded by default; output is plain SSR HTML unless a plugin is
+selected.
 
-The set of available plugin names is implementation-defined; refer to the CLI and
-crate documentation for the current list. Each plugin emits its own framework-specific
-hydration markers and attributes; WebUI itself does not interpret them.
+The top-level `webui` library re-exports the built-in handler plugin types used
+by Rust hosts, including `FastV3HydrationPlugin` and `WebUIHydrationPlugin`.
+Each plugin emits its own framework-specific hydration markers and attributes;
+WebUI itself does not interpret them.
 
 **Usage:**
 ```rust
-let handler = WebUIHandler::with_plugin(|| Box::new(MyHydrationPlugin::new()));
+use webui::{FastV3HydrationPlugin, WebUIHandler};
+
+let handler = WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()));
 handler.handle(&protocol, &state, &options, &mut writer)?;
 ```
 ### Fragment Processing
@@ -1486,9 +1519,11 @@ webui-ffi ──────► webui-handler ◄────── webui-wasm (
 ```
 
 The `webui` library crate is the primary API surface for programmatic use.
-It re-exports `WebUIHandler`, `ResponseWriter`, and `WebUIProtocol` from their
-respective crates and provides `build()`, `build_to_disk()`, and `inspect()`
-functions with `BuildStats` (duration, fragment/component/CSS counts, protocol size).
+It re-exports `WebUIHandler`, `RenderOptions`, `ResponseWriter`, `HandlerResult`,
+`HandlerPlugin`, `FastV3HydrationPlugin`, `WebUIHydrationPlugin`,
+`WebUIProtocol`, and parser configuration types from their respective crates and
+provides `build()`, `build_to_disk()`, and `inspect()` functions with
+`BuildStats` (duration, fragment/component/CSS counts, protocol size).
 
 ### WASM Distribution
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Or install the Rust CLI:
 cargo install microsoft-webui-cli
 ```
 
+For the Rust library API:
+
+```bash
+cargo add microsoft-webui
+```
+
+Cargo imports the library as `webui`. The crate re-exports the core handler
+API (`WebUIHandler`, `RenderOptions`, `ResponseWriter`) and built-in hydration
+plugins (`FastV3HydrationPlugin`, `WebUIHydrationPlugin`) so Rust hosts can
+build and render through one dependency.
+
 For .NET server-side bindings:
 
 ```bash

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -806,7 +806,7 @@ fn bundle_components(
 
     let out_file = site_dir.join("components.js");
 
-    let status = std::process::Command::new("npx")
+    let status = std::process::Command::new(npx_command())
         .arg("esbuild")
         .arg("--bundle")
         .arg("--format=esm")
@@ -834,6 +834,16 @@ fn bundle_components(
     }
 
     Ok(ts_files.len())
+}
+
+#[cfg(windows)]
+fn npx_command() -> &'static str {
+    "npx.cmd"
+}
+
+#[cfg(not(windows))]
+fn npx_command() -> &'static str {
+    "npx"
 }
 
 const PRE_BLOCK_MARKER_PREFIX: &str = "<span data-webui-press-pre-block=\"";
@@ -1092,5 +1102,11 @@ mod tests {
     fn fxhash_deterministic() {
         assert_eq!(fxhash("abc"), fxhash("abc"));
         assert_ne!(fxhash("abc"), fxhash("abd"));
+    }
+
+    #[test]
+    fn npx_command_uses_platform_shim() {
+        let expected = if cfg!(windows) { "npx.cmd" } else { "npx" };
+        assert_eq!(npx_command(), expected);
     }
 }

--- a/crates/webui/README.md
+++ b/crates/webui/README.md
@@ -5,8 +5,10 @@ Programmatic Rust API for the [WebUI](https://github.com/microsoft/webui) build-
 ## Install
 
 ```bash
-cargo add webui
+cargo add microsoft-webui
 ```
+
+The package is imported as `webui` in Rust code.
 
 ## Quick Start
 
@@ -83,9 +85,9 @@ handler.handle(&protocol, &state, &RenderOptions::new("index.html", "/"), &mut w
 With a hydration plugin enabled (the `webui` plugin shown here; see the WebUI documentation for the available plugin identifiers):
 
 ```rust
-use webui::{WebUIHandler, HandlerPlugin};
-use webui_handler::plugin::webui::WebUIHydrationPlugin;
+use webui::{FastV3HydrationPlugin, WebUIHandler, WebUIHydrationPlugin};
 
+let fast_handler = WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()));
 let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
 ```
 
@@ -125,6 +127,8 @@ let partial = route_handler::render_partial(
 | `WebUIHandler` | Rendering engine (stateless, thread-safe) |
 | `RenderOptions` | Render configuration (entry_id, request_path) |
 | `ResponseWriter` | Trait for streaming rendered output |
+| `HandlerPlugin` | Trait for custom handler-side hydration plugins |
+| `FastV3HydrationPlugin` / `WebUIHydrationPlugin` | Built-in handler plugins re-exported by this crate |
 | `CssStrategy` | CSS delivery mode (Link or Style) |
 | `WebUIError` | Error type for build/inspect operations |
 

--- a/crates/webui/benches/README.md
+++ b/crates/webui/benches/README.md
@@ -16,9 +16,10 @@ Two criterion benches in this directory:
 Two **examples** (in `crates/webui/examples/`) round out the suite:
 
 * **`streaming_resource_bench.rs`** — exact allocation count, bytes
-  allocated, getrusage CPU time, and peak RSS via a custom
+  allocated, getrusage user/system CPU time, and peak RSS via a custom
   `GlobalAlloc`. The only bench in the workspace that gives exact
-  allocation numbers.
+  allocation numbers. On non-Unix targets, getrusage-backed CPU/RSS
+  counters report zero while allocation and wall-clock measurements still run.
 * **`streaming_e2e_ttfb_bench.rs`** — HTTP-level TTFB through a real
   actix-web server.
 

--- a/crates/webui/examples/streaming_resource_bench.rs
+++ b/crates/webui/examples/streaming_resource_bench.rs
@@ -20,13 +20,16 @@
 //!
 //! * **allocations**  — count of `alloc` calls (custom GlobalAlloc)
 //! * **bytes allocated** — total bytes requested
-//! * **CPU user time** — `getrusage(RUSAGE_SELF).ru_utime` delta
-//! * **peak RSS** — `ru_maxrss` high-water mark
+//! * **CPU user time** — `getrusage(RUSAGE_SELF).ru_utime` delta on Unix
+//! * **CPU system time** — `getrusage(RUSAGE_SELF).ru_stime` delta on Unix
+//! * **peak RSS** — `ru_maxrss` high-water mark on Unix
 //!
 //! Unlike criterion (which only reports wall-clock), this gives a
 //! direct allocator-level view useful for verifying that the streaming
 //! writer's "zero per-write allocation" claim actually holds in the
-//! production path.
+//! production path. On non-Unix targets, CPU and RSS counters are reported
+//! as zero because `getrusage` is unavailable; allocation counts and wall-clock
+//! time are still reported.
 //!
 //! Usage:
 //!
@@ -118,6 +121,7 @@ struct Rusage {
 }
 
 impl Rusage {
+    #[cfg(unix)]
     fn now() -> Self {
         let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
         // SAFETY: `usage` is a valid mutable pointer to a fully-initialised
@@ -131,15 +135,27 @@ impl Rusage {
         }
     }
 
+    #[cfg(not(unix))]
+    fn now() -> Self {
+        Self {
+            user_cpu: Duration::ZERO,
+            sys_cpu: Duration::ZERO,
+            max_rss_raw: 0,
+        }
+    }
+
     fn max_rss_bytes(&self) -> i64 {
         if cfg!(target_os = "macos") {
             self.max_rss_raw
-        } else {
+        } else if cfg!(unix) {
             self.max_rss_raw * 1024
+        } else {
+            self.max_rss_raw
         }
     }
 }
 
+#[cfg(unix)]
 fn timeval_to_duration(tv: libc::timeval) -> Duration {
     let secs = tv.tv_sec as u64;
     let usecs = tv.tv_usec as u32;
@@ -791,6 +807,8 @@ fn main() {
     println!("Notes:");
     println!("  * `allocs/run` and `bytes/run` are exact (custom GlobalAlloc).");
     println!("  * `user µs/run` is `getrusage(RUSAGE_SELF).ru_utime` delta / iters.");
+    println!("  * `sys µs/run` is `getrusage(RUSAGE_SELF).ru_stime` delta / iters.");
+    println!("  * On non-Unix targets, getrusage-backed user/sys/RSS values are zero.");
     println!("  * `process RSS` is the high-water mark for the whole process at");
     println!("    phase end. Per-iteration RSS is not directly observable; use");
     println!("    `bytes/run` to compare per-render heap pressure across paths.");

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -5,6 +5,9 @@
 //!
 //! This crate provides the core build, render, and inspection APIs
 //! that power the `webui` CLI, Node.js bindings, and WASM module.
+//! It also re-exports the primary handler, parser, protocol, and built-in
+//! handler plugin types so Rust hosts can depend on `microsoft-webui` alone for
+//! common build/render integration.
 //!
 //! # Example
 //!
@@ -19,6 +22,16 @@
 //!
 //! println!("Built {} fragments in {:?}", result.stats.fragment_count, result.stats.duration);
 //! ```
+//!
+//! # Hydration plugins
+//!
+//! Built-in handler plugins are available from this crate root:
+//!
+//! ```rust,no_run
+//! use webui::{FastV3HydrationPlugin, WebUIHandler};
+//!
+//! let _handler = WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()));
+//! ```
 
 mod error;
 pub mod server;
@@ -26,19 +39,17 @@ pub mod streaming;
 
 pub use error::WebUIError;
 
-// Re-export core types from downstream crates
+// Re-export core types from downstream crates.
+pub use webui_handler::plugin::{
+    fast_v3::FastV3HydrationPlugin, webui::WebUIHydrationPlugin, HandlerPlugin,
+};
 pub use webui_handler::route_handler::{
     encode_inventory, get_needed_components, get_needed_components_for_request, parse_inventory,
     ProtocolIndex,
 };
 pub use webui_handler::route_matcher::CompiledRouteCache;
-pub use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
-pub use webui_handler::plugin::webui::WebUIHydrationPlugin;
 pub use webui_handler::Result as HandlerResult;
-pub use webui_handler::{
-    plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler,
-};
-)
+pub use webui_handler::{HandlerError, RenderOptions, ResponseWriter, WebUIHandler};
 pub use webui_parser::CssStrategy;
 pub use webui_parser::Diagnostic;
 pub use webui_parser::DomStrategy;

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -32,10 +32,13 @@ pub use webui_handler::route_handler::{
     ProtocolIndex,
 };
 pub use webui_handler::route_matcher::CompiledRouteCache;
+pub use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
+pub use webui_handler::plugin::webui::WebUIHydrationPlugin;
 pub use webui_handler::Result as HandlerResult;
 pub use webui_handler::{
     plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler,
 };
+)
 pub use webui_parser::CssStrategy;
 pub use webui_parser::Diagnostic;
 pub use webui_parser::DomStrategy;

--- a/crates/webui/src/streaming.rs
+++ b/crates/webui/src/streaming.rs
@@ -55,8 +55,8 @@
 //! zero scan cost and no risk of mis-firing on `</body>` literals
 //! appearing inside HTML comments, `<iframe srcdoc>`, or inline scripts.
 //!
-//! [`RenderOptions::with_head_inject`]: webui_handler::RenderOptions::with_head_inject
-//! [`RenderOptions::with_body_inject`]: webui_handler::RenderOptions::with_body_inject
+//! [`RenderOptions::with_head_inject`]: crate::RenderOptions::with_head_inject
+//! [`RenderOptions::with_body_inject`]: crate::RenderOptions::with_body_inject
 
 use bytes::Bytes;
 use crossbeam_queue::ArrayQueue;

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -42,7 +42,7 @@ implementations are loaded.
 <webui-press-tab-panel active>
 
 ```rust
-use webui::WebUIHandler;
+use webui::{HandlerPlugin, WebUIHandler};
 
 let handler = WebUIHandler::with_plugin(|| Box::new(MyHydrationPlugin::new()));
 handler.handle(&protocol, &state, &options, &mut writer)?;
@@ -80,9 +80,13 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 ```rust
 // Rust handler
-use webui_handler::plugin::webui::WebUIHydrationPlugin;
+use webui::{WebUIHandler, WebUIHydrationPlugin};
+
 let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
 ```
+
+Rust hosts can also import `FastV3HydrationPlugin` from the same `webui` crate
+root when rendering protocols built with `--plugin=fast-v3`.
 
 ## Writing Custom Plugins
 

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -12,6 +12,10 @@ serde_json = "1"
 
 The crate is published as `microsoft-webui` on crates.io; the bare `webui` name is owned by an unrelated project. Cargo's default rename rules mean items remain importable as `use webui::...` because the crate sets `[lib] name = "webui"` internally.
 
+The top-level crate re-exports the common handler, parser, protocol, and built-in
+handler plugin types needed by Rust hosts, including `FastV3HydrationPlugin` and
+`WebUIHydrationPlugin`.
+
 ## Examples
 
 <webui-press-tabs>
@@ -208,6 +212,22 @@ HttpResponse::Ok()
 
 `StreamingWriter` returns `HandlerError::ClientDisconnected` (receiver dropped) or `HandlerError::StreamTimeout` (flush deadline exceeded) from both `write()` and `end()`, so callers can distinguish "fully delivered" from "client cancelled" for correct telemetry.
 
+## Hydration plugins
+
+Rust hosts can configure built-in handler plugins from the `webui` crate root
+without adding a direct `microsoft-webui-handler` dependency:
+
+```rust
+use webui::{FastV3HydrationPlugin, WebUIHandler, WebUIHydrationPlugin};
+
+let fast_handler = WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()));
+let webui_handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
+```
+
+Use the matching parser plugin at build time (`Plugin::FastV3` or
+`Plugin::WebUI`) so the protocol metadata and handler hydration markers share
+the same contract.
+
 ## API Reference
 
 ### Build
@@ -226,7 +246,7 @@ HttpResponse::Ok()
 | `app_dir` | `PathBuf` | - | Path to app folder |
 | `entry` | `String` | `"index.html"` | Entry file |
 | `css` | `CssStrategy` | `Link` | CSS delivery: `Link`, `Style`, or `Module` |
-| `plugin` | `Option<String>` | `None` | Parser plugin name (see [Plugins](/guide/concepts/plugins/) for the available identifiers) |
+| `plugin` | `Option<Plugin>` | `None` | Parser plugin enum (for example, `Plugin::FastV3` or `Plugin::WebUI`; see [Plugins](/guide/concepts/plugins/)) |
 | `components` | `Vec<String>` | `[]` | External component sources |
 | `css_file_name_template` | `String` | `"[name].[ext]"` | Link-mode CSS filename template. Tokens: `[name]`, `[hash]`, `[ext]` |
 | `css_public_base` | `Option<String>` | `None` | Public URL/path prefix for Link-mode CSS hrefs |
@@ -250,6 +270,14 @@ HttpResponse::Ok()
 | `with_nonce(&str)` | builder | CSP nonce reflected onto inline `<script>` tags (including the `<script type="importmap">` tags that register Module-strategy CSS). Empty string normalises to `None`. |
 | `with_head_inject(&str)` | builder | Raw HTML emitted immediately before `</head>` at the parser's structural boundary (see [Streaming SSR](#streaming-ssr)). |
 | `with_body_inject(&str)` | builder | Raw HTML emitted immediately before `</body>`. Same structural-boundary contract. |
+
+### Handler plugins
+
+| Type | Description |
+|---|---|
+| `HandlerPlugin` | Trait for custom handler-side hydration plugins |
+| `FastV3HydrationPlugin` | Built-in FAST 3 handler hydration plugin |
+| `WebUIHydrationPlugin` | Built-in WebUI Framework handler hydration plugin |
 
 ### HandlerError variants
 


### PR DESCRIPTION
## Summary

Adds `pub use` re-exports for `FastV3HydrationPlugin` and `WebUIHydrationPlugin` from the `microsoft-webui` facade crate.

## Problem

`microsoft-webui` already re-exports `WebUIHandler`, `HandlerError`, `ResponseWriter`, and the `HandlerPlugin` trait from `microsoft-webui-handler`. But the concrete hydration plugin types - `FastV3HydrationPlugin` and `WebUIHydrationPlugin` - are not re-exported. Every embedder that wants client-side hydration must add `microsoft-webui-handler` as a direct dependency just to write one line like:

```rust
use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
```

even when no other handler-only API is used. The facade is otherwise complete, so this is a paper cut that doubles the dependency surface for integrations.

## Change

Two lines in `crates/webui/src/lib.rs`:

```rust
pub use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
pub use webui_handler::plugin::webui::WebUIHydrationPlugin;
```

After this change, a typical embedder needs only `microsoft-webui` as a direct dep:

```rust
use webui::{FastV3HydrationPlugin, RenderOptions, ResponseWriter, WebUIHandler, WebUIProtocol};

let handler = WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()));
```

The deep path `webui_handler::plugin::fast_v3::FastV3HydrationPlugin` remains available for embedders that depend on `microsoft-webui-handler` directly, so this is purely additive.

## Why this pair

These two plugins are the only concrete `HandlerPlugin` impls shipped today. The pair matches the existing facade pattern where `(CssStrategy, DomStrategy, Plugin)` parser-side types are re-exported alongside the parser `Plugin` trait - all the wiring types an embedder needs to construct a render pipeline now live on `webui`.

## Verification

- `cargo check -p microsoft-webui` passes (clean compile)
- No existing import paths break (additive only)
- Tested by an embedded integration that consumes `microsoft-webui` only and constructs both plugins via the facade

## Companion PRs

- #295 (still open): re-exports `RenderOptions` and adds a `HandlerResult` alias on the same facade. Together with this PR, an integration can drop `microsoft-webui-handler` from `Cargo.toml` entirely.
- #299 (still open): documents single-fragment embedded rendering, which is the primary integration shape that benefits from the facade simplification.