### PR TITLE
feat: expose dom option on the Node binding's build() API

### DIFF
--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -75,6 +75,8 @@ pub struct JsBuildOptions {
     pub entry: Option<String>,
     /// CSS mode: "link" (default) or "style".
     pub css: Option<String>,
+    /// DOM strategy for component rendering: "shadow" (default) or "light".
+    pub dom: Option<String>,
     /// Plugin identifier (see crate documentation for available identifiers).
     pub plugin: Option<String>,
     /// Additional component sources (npm packages or local paths).
@@ -94,6 +96,13 @@ pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
         .map_err(NapiError::from_reason)?
         .unwrap_or_default();
 
+    let dom = options
+        .dom
+        .map(|s| s.parse::<webui::DomStrategy>())
+        .transpose()
+        .map_err(NapiError::from_reason)?
+        .unwrap_or_default();
+
     let plugin = options
         .plugin
         .map(|s| s.parse::<webui::Plugin>())
@@ -104,7 +113,7 @@ pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
         app_dir: std::path::PathBuf::from(&options.app_dir),
         entry: options.entry.unwrap_or_else(|| "index.html".to_string()),
         css,
-        dom: webui::DomStrategy::Shadow,
+        dom,
         plugin,
         components: options.components.unwrap_or_default(),
     };
@@ -458,6 +467,7 @@ mod tests {
             app_dir: dir.path().to_string_lossy().to_string(),
             entry: None,
             css: None,
+            dom: None,
             plugin: None,
             components: None,
         };
@@ -478,6 +488,7 @@ mod tests {
             app_dir: dir.path().to_string_lossy().to_string(),
             entry: Some("page.html".to_string()),
             css: None,
+            dom: None,
             plugin: None,
             components: None,
         };
@@ -492,6 +503,7 @@ mod tests {
             app_dir: "/nonexistent/path".to_string(),
             entry: None,
             css: None,
+            dom: None,
             plugin: None,
             components: None,
         };
@@ -509,6 +521,7 @@ mod tests {
             app_dir: dir.path().to_string_lossy().to_string(),
             entry: None,
             css: Some("bogus".to_string()),
+            dom: None,
             plugin: None,
             components: None,
         };
@@ -528,6 +541,7 @@ mod tests {
             app_dir: dir.path().to_string_lossy().to_string(),
             entry: None,
             css: Some("link".to_string()),
+            dom: None,
             plugin: None,
             components: None,
         };
@@ -538,6 +552,70 @@ mod tests {
         assert_eq!(result.css_files[0], "my-card.css");
         assert!(result.css_files[1].contains("color: red"));
         assert_eq!(result.stats.css_file_count, 1);
+    }
+
+    #[test]
+    fn test_build_with_light_dom_omits_shadow_root_template() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<my-card>Hi</my-card>").unwrap();
+        std::fs::write(dir.path().join("my-card.html"), "<div><slot></slot></div>").unwrap();
+
+        let options = JsBuildOptions {
+            app_dir: dir.path().to_string_lossy().to_string(),
+            entry: None,
+            css: None,
+            dom: Some("light".to_string()),
+            plugin: None,
+            components: None,
+        };
+
+        let result = build(options).unwrap();
+        let json = inspect(result.protocol).unwrap();
+        assert!(
+            !json.contains("shadowrootmode"),
+            "light DOM build should not emit shadowrootmode wrappers, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_build_with_shadow_dom_emits_shadow_root_template() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<my-card>Hi</my-card>").unwrap();
+        std::fs::write(dir.path().join("my-card.html"), "<div><slot></slot></div>").unwrap();
+
+        let options = JsBuildOptions {
+            app_dir: dir.path().to_string_lossy().to_string(),
+            entry: None,
+            css: None,
+            dom: Some("shadow".to_string()),
+            plugin: None,
+            components: None,
+        };
+
+        let result = build(options).unwrap();
+        let json = inspect(result.protocol).unwrap();
+        assert!(
+            json.contains("shadowrootmode"),
+            "shadow DOM build should emit shadowrootmode wrappers, got: {json}"
+        );
+    }
+
+    #[test]
+    fn test_build_invalid_dom() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<h1>Hello</h1>").unwrap();
+
+        let options = JsBuildOptions {
+            app_dir: dir.path().to_string_lossy().to_string(),
+            entry: None,
+            css: None,
+            dom: Some("bogus".to_string()),
+            plugin: None,
+            components: None,
+        };
+
+        let result = build(options);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/docs/guide/integrations/node.md
+++ b/docs/guide/integrations/node.md
@@ -111,6 +111,7 @@ Deno.serve({ port: 3000 }, (req) => {
 | `appDir` | `string` | - | Path to app folder |
 | `entry` | `string` | `"index.html"` | Entry file |
 | `css` | `"link" \| "style" \| "module"` | `"link"` | CSS delivery strategy |
+| `dom` | `"shadow" \| "light"` | `"shadow"` | DOM strategy for component rendering |
 | `plugin` | `string` | - | Parser plugin name (see [Plugins](/guide/concepts/plugins/) for the available identifiers) |
 | `components` | `string[]` | - | External component sources |
 


### PR DESCRIPTION
## What

Exposes the `dom` build option on `@microsoft/webui`'s napi-rs Node binding so JavaScript callers can opt into light DOM rendering.

## Why

The CLI already supports `webui build --dom light` and the Rust API already supports `BuildOptions { dom: DomStrategy::Light, .. }`. The Node binding's runtime `build()` function, however, hardcoded `DomStrategy::Shadow` and gave JS callers no way to select light DOM.

Light DOM rendering is the supported path for component output that needs to compose correctly when injected after page load - for example, into a streaming response body whose later HTML lands via `innerHTML` and therefore cannot rely on DSD auto-attachment. The `fast-v3` plugin emits only HTML comment markers (`<!--fe:b-->`, `<!--fe:/b-->`, `<!--fe:r-->`, `<!--fe:/r-->`) and `data-fe="N"` attributes, all of which work identically in light DOM, so `--dom light --plugin fast-v3` is a fully supported combination.

## What changed

- **`crates/webui-node/src/lib.rs`**
  - `JsBuildOptions` gains `pub dom: Option<String>`.
  - `build()` parses the field via the existing `webui::DomStrategy::FromStr` impl (accepts `"shadow"` and `"light"`) and falls back to `webui::DomStrategy::default()` (Shadow) when omitted.
  - Replaces the hardcoded `dom: webui::DomStrategy::Shadow` in `BuildOptions`.
  - Adds three tests:
    - `test_build_with_light_dom_omits_shadow_root_template`
    - `test_build_with_shadow_dom_emits_shadow_root_template`
    - `test_build_invalid_dom`
- **`docs/guide/integrations/node.md`**
  - Adds a `dom` row to the `BuildOptions` reference table, matching the existing CLI documentation.

## Non-breaking

- New field is `Option<String>`. Omitted by every existing caller -> falls back to `DomStrategy::default()` (Shadow) -> byte-for-byte identical output.
- No protocol changes (`DomStrategy` is already in the proto schema).
- No CLI or Rust API changes.

## Validation

- `cargo test -p microsoft-webui-node --lib`: 24 passed.
- `cargo xtask check`: license-headers, fmt, clippy all green. (The proto-drift step requires `protoc` which isn't available in my local env; this PR touches no `.proto` files.)