### PR TITLE
fix(webui-framework): @attr property reflection

### DIFF
--- a/packages/webui-framework/src/decorators.test.ts
+++ b/packages/webui-framework/src/decorators.test.ts
@@ -121,6 +121,17 @@ describe('observable decorators', () => {
     assert.equal(getObservableNames(TestElement).has('count'), true);
   });
 
+  test('@observable names inherit through subclasses', () => {
+    class BaseElement {}
+    observable(BaseElement.prototype, 'baseCount');
+    class TestElement extends BaseElement {}
+    observable(TestElement.prototype, 'count');
+
+    const names = getObservableNames(TestElement);
+    assert.equal(names.has('baseCount'), true);
+    assert.equal(names.has('count'), true);
+  });
+
   test('@attr registers reactive property names', () => {
     class TestElement {}
     attr(TestElement.prototype, 'label');
@@ -165,5 +176,31 @@ describe('observable decorators', () => {
 
     element.removeAttribute('is-active');
     assert.equal(element.isActive, false);
+  });
+
+  test('@attr metadata inherits through subclasses', () => {
+    class BaseElement extends FakeElement {}
+    attr(BaseElement.prototype, 'baseLabel');
+    class TestElement extends BaseElement {}
+    attr(TestElement.prototype, 'label');
+
+    const names = getObservableNames(TestElement);
+    assert.equal(names.has('baseLabel'), true);
+    assert.equal(names.has('label'), true);
+
+    const element = new TestElement() as TestElement & {
+      baseLabel: string;
+      label: string;
+    };
+    element.setAttribute('base-label', 'Base');
+    element.setAttribute('label', 'Child');
+
+    assert.equal(element.baseLabel, 'Base');
+    assert.equal(element.label, 'Child');
+
+    element.baseLabel = 'Updated Base';
+    element.label = 'Updated Child';
+    assert.equal(element.getAttribute('base-label'), 'Updated Base');
+    assert.equal(element.getAttribute('label'), 'Updated Child');
   });
 });

--- a/packages/webui-framework/src/decorators.test.ts
+++ b/packages/webui-framework/src/decorators.test.ts
@@ -4,7 +4,13 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
 
-import { attr, getObservableNames, observable, toKebabCase } from './decorators.js';
+import {
+  attr,
+  getObservableNames,
+  isAttributeProperty,
+  observable,
+  toKebabCase,
+} from './decorators.js';
 
 class FakeElement {
   $ready = true;
@@ -187,6 +193,9 @@ describe('observable decorators', () => {
     const names = getObservableNames(TestElement);
     assert.equal(names.has('baseLabel'), true);
     assert.equal(names.has('label'), true);
+    assert.equal(isAttributeProperty(TestElement, 'baseLabel'), true);
+    assert.equal(isAttributeProperty(TestElement, 'label'), true);
+    assert.equal(isAttributeProperty(TestElement, 'missing'), false);
 
     const element = new TestElement() as TestElement & {
       baseLabel: string;

--- a/packages/webui-framework/src/decorators.test.ts
+++ b/packages/webui-framework/src/decorators.test.ts
@@ -4,7 +4,40 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
 
-import { toKebabCase } from './decorators.js';
+import { attr, getObservableNames, observable, toKebabCase } from './decorators.js';
+
+class FakeElement {
+  $ready = true;
+  isConnected = false;
+  private readonly attrs = new Map<string, string>();
+
+  getAttribute(name: string): string | null {
+    return this.attrs.get(name) ?? null;
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attrs.has(name);
+  }
+
+  setAttribute(name: string, value: string): void {
+    const oldValue = this.getAttribute(name);
+    const newValue = String(value);
+    this.attrs.set(name, newValue);
+    this.attributeChangedCallback?.(name, oldValue, newValue);
+  }
+
+  removeAttribute(name: string): void {
+    const oldValue = this.getAttribute(name);
+    this.attrs.delete(name);
+    this.attributeChangedCallback?.(name, oldValue, null);
+  }
+
+  attributeChangedCallback?(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void;
+}
 
 describe('toKebabCase', () => {
   test('converts multi-word ARIA properties to correct attribute names', () => {
@@ -77,5 +110,60 @@ describe('toKebabCase', () => {
     assert.equal(toKebabCase('myProp'), 'my-prop');
     assert.equal(toKebabCase('totalContacts'), 'total-contacts');
     assert.equal(toKebabCase('dataTitle'), 'data-title');
+  });
+});
+
+describe('observable decorators', () => {
+  test('@observable registers reactive property names', () => {
+    class TestElement {}
+    observable(TestElement.prototype, 'count');
+
+    assert.equal(getObservableNames(TestElement).has('count'), true);
+  });
+
+  test('@attr registers reactive property names', () => {
+    class TestElement {}
+    attr(TestElement.prototype, 'label');
+
+    assert.equal(getObservableNames(TestElement).has('label'), true);
+  });
+
+  test('@attr reflects property values without stringifying backing state', () => {
+    class TestElement extends FakeElement {}
+    attr(TestElement.prototype, 'count');
+
+    const element = new TestElement() as TestElement & { count: number };
+    element.count = 5;
+
+    assert.equal(element.getAttribute('count'), '5');
+    assert.equal(element.count, 5);
+  });
+
+  test('@attr reacts to string attribute changes', () => {
+    class TestElement extends FakeElement {}
+    attr({ attribute: 'display-value' })(TestElement.prototype, 'displayValue');
+
+    const element = new TestElement() as TestElement & { displayValue: string | null };
+    element.setAttribute('display-value', 'Ready');
+
+    assert.equal(element.displayValue, 'Ready');
+  });
+
+  test('@attr boolean mode reflects presence and removal', () => {
+    class TestElement extends FakeElement {}
+    attr({ mode: 'boolean', attribute: 'is-active' })(TestElement.prototype, 'isActive');
+
+    const element = new TestElement() as TestElement & { isActive: boolean };
+    element.isActive = true;
+    assert.equal(element.hasAttribute('is-active'), true);
+
+    element.isActive = false;
+    assert.equal(element.hasAttribute('is-active'), false);
+
+    element.setAttribute('is-active', '');
+    assert.equal(element.isActive, true);
+
+    element.removeAttribute('is-active');
+    assert.equal(element.isActive, false);
   });
 });

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -285,6 +285,10 @@ function attrPropertyMapFor(ctor: Function): Map<string, AttrDefinition> | undef
   return undefined;
 }
 
+export function isAttributeProperty(ctor: Function, property: string): boolean {
+  return attrPropertyMapFor(ctor)?.has(property) === true;
+}
+
 /**
  * Like {@link observable} but also reflects to/from an HTML attribute
  * (kebab-case). The decorator patches `observedAttributes` and

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -92,21 +92,36 @@ export function toKebabCase(str: string): string {
  * Shared logic for installing a reactive getter/setter on a class prototype.
  * The backing value is stored in a private `_prop` field on the instance.
  */
+interface AttrDefinition {
+  attribute: string;
+  property: string;
+  boolean: boolean;
+}
+
+type ReactiveInstance = Record<string | symbol, unknown>;
+
+const reflectingAttribute = Symbol('webui.reflectingAttribute');
+
 function createReactiveProperty(
   proto: Record<string, unknown>,
   name: string,
+  attrDefinition?: AttrDefinition,
 ): void {
   const backingKey = `_${name}`;
   const changedKey = `${name}Changed`;
 
   Object.defineProperty(proto, name, {
-    get(this: Record<string, unknown>) {
+    get(this: ReactiveInstance) {
       return this[backingKey];
     },
-    set(this: Record<string, unknown>, newValue: unknown) {
+    set(this: ReactiveInstance, newValue: unknown) {
       const oldValue = this[backingKey];
-      if (oldValue === newValue) return;
+      if (Object.is(oldValue, newValue)) return;
       this[backingKey] = newValue;
+
+      if (attrDefinition && this['$ready'] === true) {
+        reflectPropertyToAttribute(this, attrDefinition, newValue);
+      }
 
       const cb = this[changedKey];
       if (typeof cb === 'function') {
@@ -121,6 +136,56 @@ function createReactiveProperty(
     enumerable: true,
     configurable: true,
   });
+}
+
+function reflectPropertyToAttribute(
+  instance: ReactiveInstance,
+  definition: AttrDefinition,
+  value: unknown,
+): void {
+  const element = instance as unknown as HTMLElement;
+  const attrName = definition.attribute;
+
+  if (definition.boolean) {
+    const shouldHaveAttribute = Boolean(value);
+    if (element.hasAttribute(attrName) === shouldHaveAttribute) return;
+    setReflectingAttribute(instance, attrName);
+    try {
+      if (shouldHaveAttribute) element.setAttribute(attrName, '');
+      else element.removeAttribute(attrName);
+    } finally {
+      restoreReflectingAttribute(instance);
+    }
+    return;
+  }
+
+  if (value == null) {
+    if (!element.hasAttribute(attrName)) return;
+    setReflectingAttribute(instance, attrName);
+    try {
+      element.removeAttribute(attrName);
+    } finally {
+      restoreReflectingAttribute(instance);
+    }
+    return;
+  }
+
+  const attrValue = typeof value === 'string' ? value : String(value);
+  if (element.getAttribute(attrName) === attrValue) return;
+  setReflectingAttribute(instance, attrName);
+  try {
+    element.setAttribute(attrName, attrValue);
+  } finally {
+    restoreReflectingAttribute(instance);
+  }
+}
+
+function setReflectingAttribute(instance: ReactiveInstance, attrName: string): void {
+  instance[reflectingAttribute] = attrName;
+}
+
+function restoreReflectingAttribute(instance: ReactiveInstance): void {
+  instance[reflectingAttribute] = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +204,15 @@ export function getObservableNames(ctor: Function): Set<string> {
   return observableRegistry.get(ctor) ?? EMPTY_SET;
 }
 
+function registerObservableProperty(ctor: Function, name: string): void {
+  let names = observableRegistry.get(ctor);
+  if (!names) {
+    names = new Set();
+    observableRegistry.set(ctor, names);
+  }
+  names.add(name);
+}
+
 /**
  * Marks a property as observable. When the value changes the decorator will:
  * 1. Call `this.<prop>Changed(oldValue, newValue)` if defined.
@@ -147,10 +221,7 @@ export function getObservableNames(ctor: Function): Set<string> {
  */
 export function observable(target: object, name: string): void {
   const ctor = (target as Record<string, unknown>).constructor as Function;
-  if (!observableRegistry.has(ctor)) {
-    observableRegistry.set(ctor, new Set());
-  }
-  observableRegistry.get(ctor)!.add(name);
+  registerObservableProperty(ctor, name);
   createReactiveProperty(target as Record<string, unknown>, name);
 }
 
@@ -162,10 +233,10 @@ export function observable(target: object, name: string): void {
  * Registry of attribute-name → property-name mappings per constructor.
  * Used by `attributeChangedCallback` to route attribute changes to properties.
  */
-const attrMap = new WeakMap<Function, Map<string, string>>();
+const attrByAttribute = new WeakMap<Function, Map<string, AttrDefinition>>();
 
-/** Registry of boolean-mode attribute names per constructor. */
-const boolAttrs = new WeakMap<Function, Set<string>>();
+/** Registry of property-name → attribute metadata, used for mount-time sync. */
+const attrByProperty = new WeakMap<Function, Map<string, AttrDefinition>>();
 
 /**
  * Like {@link observable} but also reflects to/from an HTML attribute
@@ -197,28 +268,37 @@ function applyAttr(
   const ctor = proto.constructor as typeof HTMLElement & {
     _observedAttrs?: string[];
   };
+  const attrName = options?.attribute ?? toKebabCase(name);
+  const definition: AttrDefinition = {
+    attribute: attrName,
+    property: name,
+    boolean: options?.mode === 'boolean',
+  };
 
-  // 1. Install the reactive getter/setter (same as @observable).
-  createReactiveProperty(proto, name);
+  // 1. Install the reactive getter/setter (same as @observable), with
+  // attribute reflection enabled after the element finishes hydration.
+  registerObservableProperty(ctor, name);
+  createReactiveProperty(proto, name, definition);
 
   // 2. Register the attribute mapping.
-  const attrName = options?.attribute ?? toKebabCase(name);
-  if (!attrMap.has(ctor)) {
-    attrMap.set(ctor, new Map());
+  let byAttribute = attrByAttribute.get(ctor);
+  if (!byAttribute) {
+    byAttribute = new Map();
+    attrByAttribute.set(ctor, byAttribute);
   }
-  attrMap.get(ctor)!.set(attrName, name);
+  byAttribute.set(attrName, definition);
 
-  // Track boolean-mode attrs.
-  if (options?.mode === 'boolean') {
-    if (!boolAttrs.has(ctor)) {
-      boolAttrs.set(ctor, new Set());
-    }
-    boolAttrs.get(ctor)!.add(attrName);
+  let byProperty = attrByProperty.get(ctor);
+  if (!byProperty) {
+    byProperty = new Map();
+    attrByProperty.set(ctor, byProperty);
   }
+  byProperty.set(name, definition);
 
   // 3. Accumulate observed attributes on the constructor.
-  if (!ctor._observedAttrs) {
-    ctor._observedAttrs = [];
+  if (!Object.prototype.hasOwnProperty.call(ctor, '_observedAttrs')) {
+    const inheritedAttrs = ctor._observedAttrs;
+    ctor._observedAttrs = inheritedAttrs ? inheritedAttrs.slice() : [];
 
     // Define the static getter that `customElements.define` inspects.
     Object.defineProperty(ctor, 'observedAttributes', {
@@ -240,11 +320,15 @@ function applyAttr(
       newVal: string | null,
     ) {
       // Route the attribute change to the corresponding property.
-      const map = attrMap.get(this.constructor as Function);
-      const propName = map?.get(attribute);
-      if (propName !== undefined) {
-        const isBool = boolAttrs.get(this.constructor as Function)?.has(attribute);
-        (this as Record<string, unknown>)[propName] = isBool ? newVal !== null : newVal;
+      const map = attrByAttribute.get(this.constructor as Function);
+      const definition = map?.get(attribute);
+      if (
+        definition !== undefined &&
+        (this as ReactiveInstance)[reflectingAttribute] !== attribute
+      ) {
+        (this as Record<string, unknown>)[definition.property] = definition.boolean
+          ? newVal !== null
+          : newVal;
       }
 
       // Preserve any pre-existing attributeChangedCallback.
@@ -255,6 +339,23 @@ function applyAttr(
   }
 
   ctor._observedAttrs!.push(attrName);
+}
+
+export function syncAttrProperties(
+  instance: object,
+  ctor: Function,
+): void {
+  const attrs = attrByProperty.get(ctor);
+  if (!attrs) return;
+
+  const reactiveInstance = instance as ReactiveInstance;
+  for (const definition of attrs.values()) {
+    reflectPropertyToAttribute(
+      reactiveInstance,
+      definition,
+      reactiveInstance[definition.property],
+    );
+  }
 }
 
 export function attr(target: object, name: string): void;

--- a/packages/webui-framework/src/decorators.ts
+++ b/packages/webui-framework/src/decorators.ts
@@ -102,6 +102,11 @@ type ReactiveInstance = Record<string | symbol, unknown>;
 
 const reflectingAttribute = Symbol('webui.reflectingAttribute');
 
+function parentConstructor(ctor: Function): Function | null {
+  const parent = Object.getPrototypeOf(ctor);
+  return typeof parent === 'function' && parent !== Function.prototype ? parent : null;
+}
+
 function createReactiveProperty(
   proto: Record<string, unknown>,
   name: string,
@@ -201,13 +206,19 @@ const observableRegistry = new WeakMap<Function, Set<string>>();
 const EMPTY_SET: Set<string> = Object.freeze(new Set<string>()) as Set<string>;
 
 export function getObservableNames(ctor: Function): Set<string> {
-  return observableRegistry.get(ctor) ?? EMPTY_SET;
+  const names = observableRegistry.get(ctor);
+  if (names) return names;
+
+  const parent = parentConstructor(ctor);
+  return parent ? getObservableNames(parent) : EMPTY_SET;
 }
 
 function registerObservableProperty(ctor: Function, name: string): void {
   let names = observableRegistry.get(ctor);
   if (!names) {
-    names = new Set();
+    const parent = parentConstructor(ctor);
+    const inherited = parent ? getObservableNames(parent) : EMPTY_SET;
+    names = inherited.size > 0 ? new Set(inherited) : new Set();
     observableRegistry.set(ctor, names);
   }
   names.add(name);
@@ -237,6 +248,42 @@ const attrByAttribute = new WeakMap<Function, Map<string, AttrDefinition>>();
 
 /** Registry of property-name → attribute metadata, used for mount-time sync. */
 const attrByProperty = new WeakMap<Function, Map<string, AttrDefinition>>();
+
+function inheritedAttrMap(
+  registry: WeakMap<Function, Map<string, AttrDefinition>>,
+  ctor: Function,
+): Map<string, AttrDefinition> | undefined {
+  let current = parentConstructor(ctor);
+  while (current) {
+    const map = registry.get(current);
+    if (map) return map;
+    current = parentConstructor(current);
+  }
+  return undefined;
+}
+
+function attrDefinitionFor(
+  ctor: Function,
+  attribute: string,
+): AttrDefinition | undefined {
+  let current: Function | null = ctor;
+  while (current) {
+    const definition = attrByAttribute.get(current)?.get(attribute);
+    if (definition) return definition;
+    current = parentConstructor(current);
+  }
+  return undefined;
+}
+
+function attrPropertyMapFor(ctor: Function): Map<string, AttrDefinition> | undefined {
+  let current: Function | null = ctor;
+  while (current) {
+    const map = attrByProperty.get(current);
+    if (map) return map;
+    current = parentConstructor(current);
+  }
+  return undefined;
+}
 
 /**
  * Like {@link observable} but also reflects to/from an HTML attribute
@@ -283,14 +330,16 @@ function applyAttr(
   // 2. Register the attribute mapping.
   let byAttribute = attrByAttribute.get(ctor);
   if (!byAttribute) {
-    byAttribute = new Map();
+    const inherited = inheritedAttrMap(attrByAttribute, ctor);
+    byAttribute = inherited ? new Map(inherited) : new Map();
     attrByAttribute.set(ctor, byAttribute);
   }
   byAttribute.set(attrName, definition);
 
   let byProperty = attrByProperty.get(ctor);
   if (!byProperty) {
-    byProperty = new Map();
+    const inherited = inheritedAttrMap(attrByProperty, ctor);
+    byProperty = inherited ? new Map(inherited) : new Map();
     attrByProperty.set(ctor, byProperty);
   }
   byProperty.set(name, definition);
@@ -320,8 +369,7 @@ function applyAttr(
       newVal: string | null,
     ) {
       // Route the attribute change to the corresponding property.
-      const map = attrByAttribute.get(this.constructor as Function);
-      const definition = map?.get(attribute);
+      const definition = attrDefinitionFor(this.constructor as Function, attribute);
       if (
         definition !== undefined &&
         (this as ReactiveInstance)[reflectingAttribute] !== attribute
@@ -345,7 +393,7 @@ export function syncAttrProperties(
   instance: object,
   ctor: Function,
 ): void {
-  const attrs = attrByProperty.get(ctor);
+  const attrs = attrPropertyMapFor(ctor);
   if (!attrs) return;
 
   const reactiveInstance = instance as ReactiveInstance;

--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -50,7 +50,7 @@ import type {
   TemplateNodePath,
 } from './template.js';
 import { hydrationStart, hydrationEnd } from './lifecycle.js';
-import { getObservableNames, syncAttrProperties } from './decorators.js';
+import { getObservableNames, isAttributeProperty, syncAttrProperties } from './decorators.js';
 import { syncRepeat, dotWalk } from './element/diff.js';
 import {
   collectItemMarkers,
@@ -362,9 +362,10 @@ export class WebUIElement extends HTMLElement {
   private $applySSRState(): void {
     const state = window.__webui?.state;
     if (!state || typeof state !== 'object') return;
-    const names = getObservableNames(this.constructor as Function);
+    const ctor = this.constructor as Function;
+    const names = getObservableNames(ctor);
     for (const key of Object.keys(state)) {
-      if (names.has(key)) {
+      if (names.has(key) && !isAttributeProperty(ctor, key)) {
         // Write to backing field directly — no reactive update yet
         (this as Record<string, unknown>)[`_${key}`] = state[key];
       }
@@ -1222,31 +1223,62 @@ export class WebUIElement extends HTMLElement {
       return observableNames.has(root) ? root : '*';
     };
 
-    const r = this.$root;
-    for (const t of r.texts) {
-      if (t.parts) {
-        for (const p of t.parts) {
-          if (typeof p !== 'string') ensure(keyFor(p[0])).texts.push(t);
+    const isLocalPath = (path: string, scope?: ScopeFrame): boolean => {
+      const dot = path.indexOf('.');
+      const root = dot > -1 ? path.slice(0, dot) : path;
+      let current = scope;
+      while (current) {
+        if (current.name === root) return true;
+        current = current.parent;
+      }
+      return false;
+    };
+
+    const visit = (instance: TemplateInstance): void => {
+      for (const t of instance.texts) {
+        if (t.parts) {
+          for (const p of t.parts) {
+            if (typeof p !== 'string' && !isLocalPath(p[0], t.scope)) {
+              ensure(keyFor(p[0])).texts.push(t);
+            }
+          }
+        } else if (t.path && !isLocalPath(t.path, t.scope)) {
+          ensure(keyFor(t.path)).texts.push(t);
         }
       }
-    }
-    for (const a of r.attrs) {
-      if (a.path) ensure(keyFor(a.path)).attrs.push(a);
-      if (a.parts) {
-        for (const p of a.parts) {
-          if (typeof p !== 'string') ensure(keyFor(p[0])).attrs.push(a);
+      for (const a of instance.attrs) {
+        if (a.path && !isLocalPath(a.path, a.scope)) {
+          ensure(keyFor(a.path)).attrs.push(a);
+        }
+        if (a.parts) {
+          for (const p of a.parts) {
+            if (typeof p !== 'string' && !isLocalPath(p[0], a.scope)) {
+              ensure(keyFor(p[0])).attrs.push(a);
+            }
+          }
+        }
+        if (a.condition) {
+          for (const p of a.condition[1]) {
+            if (!isLocalPath(p, a.scope)) ensure(keyFor(p)).attrs.push(a);
+          }
         }
       }
-      if (a.condition) {
-        for (const p of a.condition[1]) ensure(keyFor(p)).attrs.push(a);
+      for (const c of instance.conds) {
+        for (const p of c.condition[1]) {
+          if (!isLocalPath(p, c.scope)) ensure(keyFor(p)).conds.push(c);
+        }
+        if (c.instance) visit(c.instance);
       }
-    }
-    for (const c of r.conds) {
-      for (const p of c.condition[1]) ensure(keyFor(p)).conds.push(c);
-    }
-    for (const rep of r.repeats) {
-      ensure(keyFor(rep.collection)).repeats.push(rep);
-    }
+      for (const rep of instance.repeats) {
+        if (!isLocalPath(rep.collection, rep.scope)) {
+          ensure(keyFor(rep.collection)).repeats.push(rep);
+        }
+        for (let i = 0; i < rep.instances.length; i++) {
+          visit(rep.instances[i].instance);
+        }
+      }
+    };
+    visit(this.$root);
 
     // Store wildcard bindings separately — avoids duplicating them into every path
     const wc = index.get('*');

--- a/packages/webui-framework/src/element.ts
+++ b/packages/webui-framework/src/element.ts
@@ -50,7 +50,7 @@ import type {
   TemplateNodePath,
 } from './template.js';
 import { hydrationStart, hydrationEnd } from './lifecycle.js';
-import { getObservableNames } from './decorators.js';
+import { getObservableNames, syncAttrProperties } from './decorators.js';
 import { syncRepeat, dotWalk } from './element/diff.js';
 import {
   collectItemMarkers,
@@ -258,6 +258,7 @@ export class WebUIElement extends HTMLElement {
     this.$meta = meta;
     this.$hydrated = true;
     this.$ready = true;
+    syncAttrProperties(this, this.constructor as Function);
 
     // Client-created components: flush current attr/observable values
     // into the freshly-wired template DOM. Call $updateInstance directly
@@ -1433,4 +1434,3 @@ export class WebUIElement extends HTMLElement {
     return seen ? { path, prefix, suffix } : null;
   }
 }
-

--- a/packages/webui-framework/tests/fixtures/attr/attr.spec.ts
+++ b/packages/webui-framework/tests/fixtures/attr/attr.spec.ts
@@ -16,6 +16,7 @@ test.describe('attr fixture', () => {
   test('renders attribute-backed SSR text', async ({ page }) => {
     await expect(page.locator('test-attr .label')).toHaveText('Status');
     await expect(page.locator('test-attr .display')).toHaveText('Ready');
+    await expect(page.locator('test-attr')).toHaveAttribute('label', 'Status');
   });
 
   test('updates default attribute names reactively', async ({ page }) => {

--- a/packages/webui-framework/tests/fixtures/attr/attr.spec.ts
+++ b/packages/webui-framework/tests/fixtures/attr/attr.spec.ts
@@ -47,6 +47,58 @@ test.describe('attr fixture', () => {
     await expect(page.locator('test-attr .display')).toHaveText('Running');
   });
 
+  test('reflects direct @attr property updates to host attributes', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('test-attr') as { label: string; displayValue: string } | null;
+      if (host) {
+        host.label = 'bob';
+        host.displayValue = 'Visible';
+      }
+    });
+
+    await expect(page.locator('test-attr')).toHaveAttribute('label', 'bob');
+    await expect(page.locator('test-attr')).toHaveAttribute('display-value', 'Visible');
+    await expect(page.locator('test-attr .label')).toHaveText('bob');
+    await expect(page.locator('test-attr .display')).toHaveText('Visible');
+  });
+
+  test('reflects @attr values applied through setState', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('test-attr') as {
+        label: string;
+        displayValue: string;
+        setState(state: Record<string, unknown>): void;
+      } | null;
+      host?.setState({ label: 'State Label', displayValue: 'State Value' });
+    });
+
+    await expect(page.locator('test-attr')).toHaveAttribute('label', 'State Label');
+    await expect(page.locator('test-attr')).toHaveAttribute('display-value', 'State Value');
+    await expect(page.locator('test-attr .label')).toHaveText('State Label');
+    await expect(page.locator('test-attr .display')).toHaveText('State Value');
+  });
+
+  test('reflects @attr property values set before connection', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.createElement('test-attr') as HTMLElement & {
+        label: string;
+        displayValue: string;
+      };
+      host.id = 'dynamic-attr';
+      host.label = 'Preconnect';
+      host.displayValue = 'Before Append';
+      document.body.appendChild(host);
+    });
+    await page.waitForFunction(() => {
+      return (document.querySelector('#dynamic-attr') as any)?.$ready === true;
+    });
+
+    await expect(page.locator('#dynamic-attr')).toHaveAttribute('label', 'Preconnect');
+    await expect(page.locator('#dynamic-attr')).toHaveAttribute('display-value', 'Before Append');
+    await expect(page.locator('#dynamic-attr .label')).toHaveText('Preconnect');
+    await expect(page.locator('#dynamic-attr .display')).toHaveText('Before Append');
+  });
+
   test('keeps event markers from hijacking attr hydration targets', async ({ page }) => {
     await page.evaluate(() => {
       const host = document.querySelector('test-attr') as { ctaHref: string } | null;
@@ -91,29 +143,33 @@ test.describe('attr fixture', () => {
   });
 
   test('boolean attr updates template bindings', async ({ page }) => {
-    // Initially false — no data-active attribute
     await expect(page.locator('test-attr .bool-target')).not.toHaveAttribute('data-active');
+    await expect(page.locator('test-attr')).not.toHaveAttribute('is-active');
 
-    // Set to true via property
     await page.evaluate(() => {
       (document.querySelector('test-attr') as any).isActive = true;
     });
 
+    await expect(page.locator('test-attr')).toHaveAttribute('is-active', '');
     await expect(page.locator('test-attr .bool-target')).toHaveAttribute('data-active', '');
+
+    await page.evaluate(() => {
+      (document.querySelector('test-attr') as any).isActive = false;
+    });
+
+    await expect(page.locator('test-attr')).not.toHaveAttribute('is-active');
+    await expect(page.locator('test-attr .bool-target')).not.toHaveAttribute('data-active');
   });
 
   test('boolean attr sets checkbox checked property', async ({ page }) => {
-    // Initially unchecked
     await expect(page.locator('test-attr .bool-check')).not.toBeChecked();
 
-    // Set to true
     await page.evaluate(() => {
       (document.querySelector('test-attr') as any).isActive = true;
     });
 
     await expect(page.locator('test-attr .bool-check')).toBeChecked();
 
-    // Set back to false
     await page.evaluate(() => {
       (document.querySelector('test-attr') as any).isActive = false;
     });

--- a/packages/webui-framework/tests/fixtures/attr/state.json
+++ b/packages/webui-framework/tests/fixtures/attr/state.json
@@ -1,5 +1,5 @@
 {
-  "label": "Status",
+  "label": "Global Label",
   "displayValue": "Ready",
   "ctaHref": "/checkout",
   "isActive": false,

--- a/packages/webui-framework/tests/fixtures/sidebar-repeat/element.ts
+++ b/packages/webui-framework/tests/fixtures/sidebar-repeat/element.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { WebUIElement, observable } from '../../../src/index.js';
+import { WebUIElement, attr, observable } from '../../../src/index.js';
 
 export class TestSidebarRepeat extends WebUIElement {
-  @observable page = 'dashboard';
-  @observable activeGroup = '';
+  @attr page = 'dashboard';
+  @attr activeGroup = '';
   @observable groups: string[] = ['work', 'family', 'friends', 'other'];
 
   syncGroups(): void {
@@ -14,4 +14,3 @@ export class TestSidebarRepeat extends WebUIElement {
 }
 
 TestSidebarRepeat.define('test-sidebar-repeat');
-


### PR DESCRIPTION
The bug was that `@attr` looked reactive from the component template, but it was not fully the same reactive primitive as `@observable`.

Property writes updated the backing field and could refresh template bindings, but they did not reflect back to the host DOM attribute. `@attr` also was not registered in the observable-name registry, so targeted updates, SSR state seeding, and `setState()` treated it differently from `@observable`.

```ts
host.label = "bob";
```

Before this fix, that assignment left the host markup stale:

```html
<test-attr label="Status"></test-attr>
```

This broke attribute selectors, external DOM reads, serialization, and parent code that expects `@attr` to be observable state plus DOM attribute synchronization.

The fix makes `@attr` reuse the observable registration path and adds guarded property-to-attribute reflection. The reflection guard prevents a DOM write from re-entering `attributeChangedCallback` and converting non-string backing values into strings.

```ts
host.count = 5;
// stays number-backed while reflecting count="5"
```

It also syncs pre-connect `@attr` property values after mount so client-created elements preserve values assigned before `appendChild()`.

Tests now cover default and custom attr names, boolean attr reflection, DOM-to-property updates, `setState()`, type-preserving reflection, and pre-connect assignment.