### PR TITLE
fix(parser): preserve devs <template> wrapper

### DIFF
--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -11,6 +11,7 @@ mod error;
 mod handlebars_parser;
 pub mod plugin;
 mod route_parser;
+mod tag_scan;
 
 pub use component_registry::{Component, ComponentRegistry};
 pub use condition_parser::ConditionParser;
@@ -1806,16 +1807,32 @@ impl HtmlParser {
         )
     }
 
-    /// Process component template HTML.
+    /// Process component template HTML for SSR output.
     ///
-    /// - **Shadow DOM** (`DomStrategy::Shadow`): wraps content in
-    ///   `<template shadowrootmode="open">`, preserves `:host` CSS,
-    ///   optionally adds `shadowrootadoptedstylesheets`.
-    /// - **Light DOM** (`DomStrategy::Light`): strips any existing shadow DOM
-    ///   wrapper, outputs plain HTML.
+    /// The developer's authored `<template>` wrapper is the source of truth.
     ///
-    /// In both modes, runtime-only attributes (`@`, `:`, `?`) are stripped
-    /// from the opening `<template>` tag.
+    /// - **Dev supplied `<template ...>`:** preserved verbatim — including
+    ///   signal-fragment attrs (`foo="{{x}}"`), `shadowrootmode`,
+    ///   `shadowrootadoptedstylesheets`, and any other custom attributes.
+    ///   The only modification is stripping runtime-only attributes
+    ///   (`@event`, `:bind`, `?cond`) from the opening tag, since those
+    ///   are protocol metadata and never appear in HTML output. If a CSS
+    ///   snippet is supplied, it is injected immediately inside the opening
+    ///   tag (before the dev's children) so styles still apply. The
+    ///   `adopted_specifier` is ignored — when the dev manages the wrapper,
+    ///   they also manage CSS adoption.
+    ///
+    /// - **Dev omitted `<template>`:**
+    ///   - `DomStrategy::Shadow` wraps the content in a framework-controlled
+    ///     `<template shadowrootmode="open">`, optionally adding
+    ///     `shadowrootadoptedstylesheets="<tag>"` for the CSS-module strategy.
+    ///   - `DomStrategy::Light` emits the content as-is (with the CSS snippet
+    ///     prepended, if any).
+    ///
+    /// Performance: zero recursion, zero regex. The dev-template path runs a
+    /// fast single-pass byte scan to skip tree-sitter entirely when the
+    /// opening tag has no runtime-attribute prefixes. The output buffer is
+    /// pre-sized to avoid reallocation in the hot path.
     fn process_component_template(
         &mut self,
         html: &str,
@@ -1825,63 +1842,83 @@ impl HtmlParser {
         let trimmed = html.trim();
         let snippet = css_snippet.unwrap_or_default();
 
-        // Extract inner content — strip <template shadowrootmode> wrapper if present
-        let has_template = trimmed.starts_with("<template");
-        let inner = if has_template {
+        if trimmed.starts_with("<template") {
+            // Dev owns the wrapper — never modify its attributes.
+            // `adopted_specifier` is intentionally unused: when the developer
+            // manages the wrapper, they manage CSS adoption too.
+            let _ = adopted_specifier;
             let stripped = self.strip_runtime_attrs_from_template(trimmed);
-            if let Some(open_end) = stripped.find('>') {
-                let inner_start = open_end + 1;
-                let inner_end = stripped.rfind("</template>").unwrap_or(stripped.len());
-                if inner_start < inner_end {
-                    stripped[inner_start..inner_end].to_string()
-                } else {
-                    String::new()
+
+            if snippet.is_empty() {
+                return stripped;
+            }
+
+            // Splice the CSS snippet right after the opening `<template …>` tag.
+            // Quote-aware scan avoids matching a `>` inside an attribute value
+            // (e.g., `data-x="a>b"`).
+            match tag_scan::find_tag_close(&stripped) {
+                Some(open_end) => {
+                    let mut result = String::with_capacity(stripped.len() + snippet.len());
+                    result.push_str(&stripped[..=open_end]);
+                    result.push_str(snippet);
+                    result.push_str(&stripped[open_end + 1..]);
+                    result
                 }
-            } else {
-                trimmed.to_string()
+                // Malformed opening tag (no closing `>`): emit as-is rather
+                // than panic. The downstream parser surfaces the error.
+                None => stripped,
             }
         } else {
-            trimmed.to_string()
-        };
-
-        match self.dom_strategy {
-            DomStrategy::Shadow => {
-                // Re-wrap in shadow DOM template
-                let adopted_attr = adopted_specifier.map(|spec| {
-                    let mut s = String::with_capacity(35 + spec.len());
-                    s.push_str(" shadowrootadoptedstylesheets=\"");
-                    s.push_str(spec);
-                    s.push('"');
-                    s
-                });
-                let adopted_ref = adopted_attr.as_deref().unwrap_or_default();
-
-                let mut result =
-                    String::with_capacity(45 + adopted_ref.len() + snippet.len() + inner.len());
-                result.push_str("<template shadowrootmode=\"open\"");
-                result.push_str(adopted_ref);
-                result.push('>');
-                result.push_str(snippet);
-                result.push_str(&inner);
-                result.push_str("</template>");
-                result
-            }
-            DomStrategy::Light => {
-                // Plain light-DOM output
-                if snippet.is_empty() && adopted_specifier.is_none() {
-                    return inner;
+            match self.dom_strategy {
+                DomStrategy::Shadow => {
+                    let adopted = adopted_specifier.unwrap_or_default();
+                    let adopted_extra = if adopted.is_empty() {
+                        0
+                    } else {
+                        33 + adopted.len()
+                    };
+                    let mut result =
+                        String::with_capacity(45 + adopted_extra + snippet.len() + trimmed.len());
+                    result.push_str("<template shadowrootmode=\"open\"");
+                    if !adopted.is_empty() {
+                        result.push_str(" shadowrootadoptedstylesheets=\"");
+                        result.push_str(adopted);
+                        result.push('"');
+                    }
+                    result.push('>');
+                    result.push_str(snippet);
+                    result.push_str(trimmed);
+                    result.push_str("</template>");
+                    result
                 }
-                let mut result = String::with_capacity(snippet.len() + inner.len() + 16);
-                result.push_str(snippet);
-                result.push_str(&inner);
-                result
+                DomStrategy::Light => {
+                    if snippet.is_empty() {
+                        return trimmed.to_string();
+                    }
+                    let mut result = String::with_capacity(snippet.len() + trimmed.len());
+                    result.push_str(snippet);
+                    result.push_str(trimmed);
+                    result
+                }
             }
         }
     }
 
-    /// Strip attributes starting with @, :, or ? from the opening template tag.
-    /// Uses tree-sitter to parse the tag and reconstruct it without runtime attrs.
+    /// Strip attributes starting with `@`, `:`, or `?` from the opening
+    /// `<template>` tag.
+    ///
+    /// Performance: a fast-path quote-aware byte scan checks whether any
+    /// runtime-prefixed attribute exists. If not, we return the original
+    /// HTML unchanged without invoking tree-sitter — the common case for
+    /// most components.
     fn strip_runtime_attrs_from_template(&mut self, html: &str) -> String {
+        // Fast path: skip tree-sitter when the opening tag has no runtime
+        // attribute prefixes. Bounded to the opening tag (stops at the
+        // first unquoted `>`), so cost is O(tag-size) bytes.
+        if !tag_scan::opening_tag_has_runtime_prefix(html) {
+            return html.to_string();
+        }
+
         let tree = match self.parser.parse(html, None) {
             Some(t) => t,
             None => return html.to_string(),
@@ -2245,6 +2282,9 @@ mod tests {
 
     #[test]
     fn test_component_no_double_wrap_template() {
+        // Developer-authored <template foo="bar"> must be preserved verbatim
+        // in --dom=light. The framework only strips runtime-only attrs;
+        // every other attribute is the developer's responsibility.
         let mut parser = HtmlParser::new();
         parser.set_dom_strategy(DomStrategy::Light);
         parser
@@ -2268,11 +2308,19 @@ mod tests {
             ]
         );
 
-        assert_stream!(records, "custom-element", [raw("<slot></slot>"),]);
+        assert_stream!(
+            records,
+            "custom-element",
+            [raw(r#"<template foo="bar"><slot></slot></template>"#),]
+        );
     }
 
     #[test]
     fn test_component_styled_no_double_wrap() {
+        // --dom=light with a developer-supplied <template> wrapper preserves
+        // the wrapper verbatim. CSS is the default `Link` strategy which
+        // injects only in shadow DOM, so in light mode there is no CSS
+        // snippet to splice into the wrapper.
         let mut parser = HtmlParser::new();
         parser.set_dom_strategy(DomStrategy::Light);
         parser
@@ -2287,11 +2335,19 @@ mod tests {
         assert!(result.is_ok());
         let records = parser.into_fragment_records();
 
-        assert_stream!(records, "custom-element", [raw(r#"<slot></slot>"#),]);
+        assert_stream!(
+            records,
+            "custom-element",
+            [raw(r#"<template foo="bar"><slot></slot></template>"#),]
+        );
     }
 
     #[test]
     fn test_component_strip_runtime_attrs() {
+        // Runtime-only attributes (`@event`, `:bind`, `?cond`) are stripped
+        // from the opening <template> tag, but the wrapper itself is
+        // preserved. After stripping in this case the wrapper becomes
+        // `<template>` with no attributes.
         let mut parser = HtmlParser::new();
         parser.set_dom_strategy(DomStrategy::Light);
         parser
@@ -2306,7 +2362,11 @@ mod tests {
         assert!(result.is_ok());
         let records = parser.into_fragment_records();
 
-        assert_stream!(records, "custom-element", [raw("<slot></slot>"),]);
+        assert_stream!(
+            records,
+            "custom-element",
+            [raw("<template><slot></slot></template>"),]
+        );
     }
 
     #[test]
@@ -3594,7 +3654,162 @@ mod tests {
         );
     }
 
-    // ── Ported from NodeJS generator.test.js ─────────────────────────
+    // ── Dev-authored <template> wrapper handling ────────────────────
+    //
+    // These tests verify that when a developer includes a `<template>`
+    // wrapper in their component HTML, the framework respects it instead
+    // of stripping/normalizing it:
+    //
+    //   --dom=light  : dev `<template ...>` preserved verbatim (including
+    //                  signal-fragment attrs like `foo="{{foo}}"`); no
+    //                  wrapper added when dev omits one.
+    //   --dom=shadow : dev `<template ...>` preserved verbatim (framework
+    //                  does NOT inject `shadowrootmode="open"` or overwrite
+    //                  a dev-supplied `shadowrootmode="closed"`); wrapper
+    //                  added only when dev omits one.
+    //
+    // Calls `process_component_template` directly so the assertions observe
+    // the exact HTML string the framework emits for the component template
+    // (this is what gets handed to the inner parse + plugin hooks).
+
+    #[test]
+    fn light_preserves_dev_template_with_static_attrs() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Light);
+        let processed = parser.process_component_template(
+            r#"<template foo="bar"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains(r#"<template foo="bar">"#),
+            "[--dom=light] expected dev <template foo=\"bar\"> preserved verbatim, got: {processed}"
+        );
+        assert!(
+            processed.contains("</template>"),
+            "[--dom=light] expected closing </template> preserved, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn light_preserves_dev_template_with_signal_fragment_attrs() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Light);
+        let processed = parser.process_component_template(
+            r#"<template foo="{{foo}}"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains(r#"<template foo="{{foo}}">"#),
+            "[--dom=light] expected dev <template foo=\"{{{{foo}}}}\"> with signal preserved, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn light_preserves_dev_template_with_multiple_attrs() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Light);
+        let processed = parser.process_component_template(
+            r#"<template autofocus tabindex="0" role="region" data-x="y"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains("autofocus")
+                && processed.contains(r#"tabindex="0""#)
+                && processed.contains(r#"role="region""#)
+                && processed.contains(r#"data-x="y""#),
+            "[--dom=light] expected ALL dev template attrs preserved, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn light_no_template_no_wrapper_added() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Light);
+        let processed = parser.process_component_template("<div>hi</div>", None, None);
+        assert!(
+            !processed.contains("<template"),
+            "[--dom=light] framework must NOT add <template> wrapper when dev omits one, got: {processed}"
+        );
+        assert!(
+            processed.contains("<div>hi</div>"),
+            "[--dom=light] expected inner content emitted as-is, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn shadow_preserves_dev_template_with_static_attrs() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        let processed = parser.process_component_template(
+            r#"<template foo="bar"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains(r#"<template foo="bar">"#),
+            "[--dom=shadow] dev <template foo=\"bar\"> must be preserved verbatim, got: {processed}"
+        );
+        assert!(
+            !processed.contains(r#"shadowrootmode="open""#),
+            "[--dom=shadow] framework must NOT inject shadowrootmode when dev already supplied a <template>, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn shadow_preserves_dev_template_with_shadowrootmode_closed() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        let processed = parser.process_component_template(
+            r#"<template shadowrootmode="closed"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains(r#"shadowrootmode="closed""#),
+            "[--dom=shadow] framework must respect dev's shadowrootmode=\"closed\" (developer is managing), got: {processed}"
+        );
+        assert!(
+            !processed.contains(r#"shadowrootmode="open""#),
+            "[--dom=shadow] framework must not overwrite dev's shadowrootmode with \"open\", got: {processed}"
+        );
+    }
+
+    #[test]
+    fn shadow_preserves_dev_template_with_signal_fragment_attrs() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        let processed = parser.process_component_template(
+            r#"<template foo="{{foo}}"><div>hi</div></template>"#,
+            None,
+            None,
+        );
+        assert!(
+            processed.contains(r#"<template foo="{{foo}}">"#),
+            "[--dom=shadow] dev <template> with signal-fragment attr must be preserved, got: {processed}"
+        );
+    }
+
+    #[test]
+    fn shadow_adds_template_wrapper_when_dev_omits_it() {
+        let mut parser = HtmlParser::new();
+        parser.set_dom_strategy(DomStrategy::Shadow);
+        let processed = parser.process_component_template("<div>hi</div>", None, None);
+        assert!(
+            processed.contains(r#"<template shadowrootmode="open""#),
+            "[--dom=shadow] framework MUST add <template shadowrootmode=\"open\"> when dev omits a wrapper, got: {processed}"
+        );
+        assert!(
+            processed.contains("<div>hi</div>"),
+            "[--dom=shadow] inner content must survive wrapping, got: {processed}"
+        );
+        assert!(
+            processed.contains("</template>"),
+            "[--dom=shadow] framework-added wrapper must be closed, got: {processed}"
+        );
+    }
 
     // test_signal_with_default_value — SKIPPED
     // The NodeJS `<f-signal value="testSignal">Default Text</f-signal>` feature

--- a/crates/webui-parser/src/plugin/fast_v2.rs
+++ b/crates/webui-parser/src/plugin/fast_v2.rs
@@ -9,6 +9,7 @@
 
 use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
+use crate::tag_scan::find_tag_close;
 use crate::{CssStrategy, Result};
 use webui_protocol::FastElementData;
 
@@ -400,21 +401,6 @@ fn convert_route_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     }
 
     Some(close + 1)
-}
-
-/// Find the position of the tag-closing `>` that is NOT inside a quoted
-/// attribute value.  Returns `None` when no unquoted `>` is found.
-fn find_tag_close(tag_str: &str) -> Option<usize> {
-    let bytes = tag_str.as_bytes();
-    let mut in_quote = false;
-    for (i, &b) in bytes.iter().enumerate() {
-        match b {
-            b'"' => in_quote = !in_quote,
-            b'>' if !in_quote => return Some(i),
-            _ => {}
-        }
-    }
-    None
 }
 
 /// Extract the value of a named attribute from a tag string.
@@ -1355,16 +1341,5 @@ mod tests {
             output.contains("⭐"),
             "UTF-8 star should be preserved: {output}"
         );
-    }
-
-    #[test]
-    fn find_tag_close_skips_quoted_gt() {
-        assert_eq!(
-            find_tag_close(r#"<if condition="a > b">"#),
-            Some(21) // the `>` after the closing quote
-        );
-        assert_eq!(find_tag_close(r#"<if condition="a >= b">"#), Some(22));
-        assert_eq!(find_tag_close("<br>"), Some(3));
-        assert_eq!(find_tag_close("<br/>"), Some(4));
     }
 }

--- a/crates/webui-parser/src/plugin/fast_v3.rs
+++ b/crates/webui-parser/src/plugin/fast_v3.rs
@@ -9,6 +9,7 @@
 
 use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
+use crate::tag_scan::find_tag_close;
 use crate::{CssStrategy, Result};
 use webui_protocol::FastElementData;
 
@@ -400,21 +401,6 @@ fn convert_route_tag(tag_str: &str, result: &mut String) -> Option<usize> {
     }
 
     Some(close + 1)
-}
-
-/// Find the position of the tag-closing `>` that is NOT inside a quoted
-/// attribute value.  Returns `None` when no unquoted `>` is found.
-fn find_tag_close(tag_str: &str) -> Option<usize> {
-    let bytes = tag_str.as_bytes();
-    let mut in_quote = false;
-    for (i, &b) in bytes.iter().enumerate() {
-        match b {
-            b'"' => in_quote = !in_quote,
-            b'>' if !in_quote => return Some(i),
-            _ => {}
-        }
-    }
-    None
 }
 
 /// Extract the value of a named attribute from a tag string.
@@ -1355,16 +1341,5 @@ mod tests {
             output.contains("⭐"),
             "UTF-8 star should be preserved: {output}"
         );
-    }
-
-    #[test]
-    fn find_tag_close_skips_quoted_gt() {
-        assert_eq!(
-            find_tag_close(r#"<if condition="a > b">"#),
-            Some(21) // the `>` after the closing quote
-        );
-        assert_eq!(find_tag_close(r#"<if condition="a >= b">"#), Some(22));
-        assert_eq!(find_tag_close("<br>"), Some(3));
-        assert_eq!(find_tag_close("<br/>"), Some(4));
     }
 }

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -62,6 +62,7 @@
 
 use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
+use crate::tag_scan::find_tag_close;
 use crate::{ConditionParser, CssStrategy, DomStrategy, Result};
 use std::cell::Cell;
 use std::fmt::Write;
@@ -897,7 +898,7 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
 
             // <outlet ... /> → keep as <outlet></outlet>
             if remaining.starts_with("<outlet") {
-                if let Some(close) = find_tag_end(remaining) {
+                if let Some(close) = find_tag_close(remaining) {
                     meta.html.push_str("<outlet></outlet>");
                     i += close + 1;
                     continue;
@@ -1342,7 +1343,7 @@ fn parse_fragment_start_tag(input: &str) -> Option<(FragmentElement, usize)> {
         return None;
     }
 
-    let end = find_tag_end(input)?;
+    let end = find_tag_close(input)?;
     let tag_content = &input[1..end];
     let tag_body = tag_content.trim_end();
     let self_closing = tag_body.ends_with('/');
@@ -1492,7 +1493,7 @@ fn strip_template_wrapper(html: &str) -> &str {
     if !html.starts_with("<template") {
         return html;
     }
-    let Some(open_end) = find_tag_end(html) else {
+    let Some(open_end) = find_tag_close(html) else {
         return html;
     };
     let inner_start = open_end + 1;
@@ -1632,7 +1633,7 @@ fn parse_if_block(input: &str) -> Option<(ConditionExpr, String, usize)> {
     let condition = compile_condition_expr(&tag_content[cond_start..cond_end]);
 
     // Extract body (after the closing >)
-    let body_start = find_tag_end(tag_content)? + 1;
+    let body_start = find_tag_close(tag_content)? + 1;
     let body = tag_content[body_start..].trim().to_string();
 
     Some((condition, body, end_pos + close_tag.len()))
@@ -1672,7 +1673,7 @@ fn parse_for_block(input: &str) -> Option<(String, String, String, usize)> {
     let collection = parts[2].to_string();
 
     // Extract body
-    let body_start = find_tag_end(tag_content)? + 1;
+    let body_start = find_tag_close(tag_content)? + 1;
     let body = tag_content[body_start..].trim().to_string();
 
     Some((collection, item_var, body, end_pos + close_tag.len()))
@@ -1751,7 +1752,7 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
         return None;
     }
 
-    let end = find_tag_end(input)?;
+    let end = find_tag_close(input)?;
     let tag_content = &input[1..end];
     let tag_body = tag_content.trim_end();
     let self_closing = tag_body.ends_with('/');
@@ -1957,28 +1958,6 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
     Some((out, end + 1))
 }
 
-fn find_tag_end(input: &str) -> Option<usize> {
-    let bytes = input.as_bytes();
-    let mut quote: Option<u8> = None;
-    let mut i = 1;
-
-    while i < bytes.len() {
-        let ch = bytes[i];
-        if let Some(active) = quote {
-            if ch == active {
-                quote = None;
-            }
-        } else if ch == b'"' || ch == b'\'' {
-            quote = Some(ch);
-        } else if ch == b'>' {
-            return Some(i);
-        }
-        i += 1;
-    }
-
-    None
-}
-
 enum EventHandler {
     Valid(String, bool),
     Invalid(String),
@@ -2075,7 +2054,7 @@ fn extract_root_events(html: &str) -> Vec<(String, String, bool)> {
     if !html.starts_with("<template") {
         return Vec::new();
     }
-    let Some(close) = find_tag_end(html) else {
+    let Some(close) = find_tag_close(html) else {
         return Vec::new();
     };
     let tag = &html[..close];
@@ -2102,7 +2081,7 @@ fn extract_adopted_stylesheet_specifier(html: &str) -> Option<String> {
     if !html.starts_with("<template") {
         return None;
     }
-    let close = find_tag_end(html)?;
+    let close = find_tag_close(html)?;
     let tag = &html[..close];
     let attr = "shadowrootadoptedstylesheets=\"";
     let start = tag.find(attr)? + attr.len();

--- a/crates/webui-parser/src/tag_scan.rs
+++ b/crates/webui-parser/src/tag_scan.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Tiny quote-aware scanners for HTML opening tags.
+//!
+//! These helpers exist to avoid the cost of a tree-sitter parse when we only
+//! need to answer a single localized question about an opening tag (e.g.
+//! "where does it end?" or "does it contain any runtime-prefixed attributes?").
+//!
+//! Each function is a single O(n) byte pass over the opening tag and performs
+//! no allocation. They are quote-aware (both `"` and `'`), so a `>` inside an
+//! attribute value (e.g. `data-x="a>b"` or `x='a>b'`) is never mistaken for
+//! the tag terminator.
+//!
+//! The runtime-prefix scanner is the fast path that lets
+//! [`HtmlParser::strip_runtime_attrs_from_template`] skip tree-sitter entirely
+//! when no runtime attributes are present — the common case for most
+//! components.
+
+/// Return the byte index of the `>` that closes an HTML opening tag, ignoring
+/// any `>` that appears inside a quoted attribute value (single or double
+/// quotes). Returns `None` if the tag is unterminated.
+pub(crate) fn find_tag_close(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut quote: u8 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if quote != 0 {
+            if c == quote {
+                quote = 0;
+            }
+        } else {
+            match c {
+                b'>' => return Some(i),
+                b'"' | b'\'' => quote = c,
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Return `true` iff the opening tag contains any attribute name beginning
+/// with `@`, `:`, or `?` (the WebUI runtime-only prefixes). The scan stops at
+/// the first unquoted `>` so attributes on inner elements never trigger a
+/// false positive.
+pub(crate) fn opening_tag_has_runtime_prefix(input: &str) -> bool {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    let mut quote: u8 = 0;
+    let mut prev_ws = false;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if quote != 0 {
+            if c == quote {
+                quote = 0;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'>' => return false,
+            b' ' | b'\t' | b'\n' | b'\r' => prev_ws = true,
+            b'"' | b'\'' => {
+                quote = c;
+                prev_ws = false;
+            }
+            b'@' | b':' | b'?' if prev_ws => return true,
+            _ => prev_ws = false,
+        }
+        i += 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_tag_close_simple() {
+        assert_eq!(find_tag_close("<br>"), Some(3));
+        assert_eq!(find_tag_close("<br/>"), Some(4));
+        assert_eq!(find_tag_close("<template>"), Some(9));
+    }
+
+    #[test]
+    fn find_tag_close_skips_double_quoted_gt() {
+        assert_eq!(find_tag_close(r#"<if condition="a > b">"#), Some(21));
+        assert_eq!(find_tag_close(r#"<if condition="a >= b">"#), Some(22));
+    }
+
+    #[test]
+    fn find_tag_close_skips_single_quoted_gt() {
+        // Single-quoted attribute values must also be respected, otherwise
+        // a `>` inside the value would be mistaken for the tag terminator.
+        assert_eq!(find_tag_close(r#"<a x='a>b'>"#), Some(10));
+    }
+
+    #[test]
+    fn find_tag_close_unterminated_returns_none() {
+        assert_eq!(find_tag_close("<unterminated"), None);
+        assert_eq!(find_tag_close(r#"<a x="never closed"#), None);
+    }
+
+    #[test]
+    fn runtime_prefix_detects_event() {
+        assert!(opening_tag_has_runtime_prefix("<template @click={fn}>"));
+    }
+
+    #[test]
+    fn runtime_prefix_detects_bind() {
+        assert!(opening_tag_has_runtime_prefix(r#"<template :bar="baz">"#));
+    }
+
+    #[test]
+    fn runtime_prefix_detects_optional() {
+        assert!(opening_tag_has_runtime_prefix(r#"<template ?bool="true">"#));
+    }
+
+    #[test]
+    fn runtime_prefix_ignores_quoted_prefix_char() {
+        // A `:`, `@`, or `?` inside a quoted value is not an attribute prefix.
+        assert!(!opening_tag_has_runtime_prefix(
+            r#"<template href=":colon">"#
+        ));
+        assert!(!opening_tag_has_runtime_prefix(
+            r#"<template href="mailto:x@y">"#
+        ));
+        assert!(!opening_tag_has_runtime_prefix(r#"<template href="?q=1">"#));
+    }
+
+    #[test]
+    fn runtime_prefix_ignores_tag_name() {
+        // The tag name itself is not preceded by whitespace inside the tag,
+        // so even pathological inputs that happen to share a prefix char
+        // would not falsely trigger.
+        assert!(!opening_tag_has_runtime_prefix("<template>"));
+        assert!(!opening_tag_has_runtime_prefix(r#"<template foo="bar">"#));
+    }
+
+    #[test]
+    fn runtime_prefix_stops_at_unquoted_gt() {
+        // Content inside the element must NOT influence the scan; otherwise
+        // a child `<span @click="x">` would force tree-sitter on every
+        // template that contains any inline events anywhere in the body.
+        assert!(!opening_tag_has_runtime_prefix(
+            r#"<template><span @click="x"></span></template>"#
+        ));
+    }
+}


### PR DESCRIPTION
`process_component_template` used to extract only the inner content of a developer-authored `<template>` wrapper and then re-wrap it with framework-controlled attributes (or drop the wrapper entirely in --dom=light). The dev's attributes — `foo="bar"`, `shadowrootmode="closed"`, signal fragments like `foo="{{x}}"`, and any custom data-*/aria-* — were silently discarded. The framework was overriding developer intent.

The new contract treats the dev's wrapper as the source of truth:

* Dev supplied `<template …>`: preserved verbatim in BOTH --dom=light and --dom=shadow. The only modification is stripping runtime-only attrs (`@event`, `:bind`, `?cond`), since those are protocol metadata and never appear in HTML output. If the active CSS strategy emits a snippet, it is spliced immediately inside the dev's opening tag so styles still apply. `adopted_specifier` is intentionally ignored — when the dev manages the wrapper, they manage CSS adoption.
* Dev omitted `<template>`:
  - --dom=shadow wraps with `<template shadowrootmode="open">` (plus the optional `shadowrootadoptedstylesheets="<tag>"` for CSS modules).
  - --dom=light emits the content as-is (with the CSS snippet prepended, if any).

Consolidation:

The codebase had four near-duplicate quote-aware tag scanners (`find_tag_end` in plugin/webui.rs, `find_tag_close` in plugin/fast_v2.rs, `find_tag_close` in plugin/fast_v3.rs, and the two helpers introduced for this fix). They have been unified into `crates/webui-parser/src/tag_scan.rs` with one canonical `find_tag_close` plus the new
`opening_tag_has_runtime_prefix` fast-path helper.

Tests:

* 8 new inline unit tests in webui-parser/src/lib.rs cover all four cells of the {dev-template, dom-strategy} matrix plus signal-fragment attrs, multiple attrs, and dev-supplied `shadowrootmode="closed"`.
* 10 new unit tests in webui-parser/src/tag_scan.rs cover both helpers (single/double quoted `>`, unterminated tags, prefix-in-tag-name ignored, quoted prefix chars ignored, stop-at-unquoted-`>` semantics).
* Three existing tests that asserted the old destructive behaviour (`test_component_no_double_wrap_template`, `test_component_styled_no_double_wrap`, `test_component_strip_runtime_attrs`) have been updated to assert the new correct contract — they previously enforced the bug.
* Duplicate `find_tag_close_skips_quoted_gt` tests in fast_v2 and fast_v3 removed; the canonical tests now live in tag_scan.rs.

`cargo xtask check` passes (license-headers, fmt, clippy, proto-drift, deny, test, build, wasm, examples, bench, docs).