### PR TITLE
docs(integrations): clarify entry accepts any fragment key + FAST-v3 wrapper requirement

### DIFF
--- a/docs/guide/integrations/node.md
+++ b/docs/guide/integrations/node.md
@@ -104,6 +104,16 @@ Deno.serve({ port: 3000 }, (req) => {
 
 `state` accepts either an object (auto-serialized) or a pre-stringified JSON string.
 
+#### Selecting a fragment with `entry`
+
+`entry` accepts any fragment key in the built protocol, not just `"index.html"`. Each HTML file inside `appDir` is registered under its relative path: `appDir/index.html` becomes `"index.html"`, `appDir/widgets/citation.html` becomes `"widgets/citation.html"`. List the keys in a built protocol with `npx webui inspect dist/protocol.bin`.
+
+This lets a non-WebUI host pick which fragment to splice into its response. The host stays in charge of the surrounding HTML; WebUI renders the named fragment and the rest of the protocol is ignored. Passing an `entry` that does not match a key throws an error.
+
+FAST-v3 components are an exception: an `<f-template name="my-component">` block is stored in the protocol's component map, not the fragment map, so it cannot be passed as `entry` directly. To render a single component for embedding, add a thin wrapper HTML file (e.g., `<my-component></my-component>` saved as `src/my-component-entry.html`) and pass that wrapper's key as `entry`.
+
+> `renderPartial` (see [Routing](/guide/concepts/routing)) is a different API: it returns a JSON object consumed by the WebUI client-side router during in-app navigation. Use `render` / `renderStream` with `entry` when you want raw HTML for a non-WebUI host.
+
 ### BuildOptions
 
 | Field | Type | Default | Description |

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -247,6 +247,16 @@ HttpResponse::Ok()
 | `with_head_inject(&str)` | builder | Raw HTML emitted immediately before `</head>` at the parser's structural boundary (see [Streaming SSR](#streaming-ssr)). |
 | `with_body_inject(&str)` | builder | Raw HTML emitted immediately before `</body>`. Same structural-boundary contract. |
 
+#### Selecting a fragment with `entry_id`
+
+`entry_id` accepts any fragment key in the built protocol, not just `"index.html"`. Each HTML file inside `appDir` is registered under its relative path: `appDir/index.html` becomes `"index.html"`, `appDir/widgets/citation.html` becomes `"widgets/citation.html"`. List the keys in a built protocol with `webui inspect dist/protocol.bin`.
+
+This lets a non-WebUI host pick which fragment to splice into its response. Implement `ResponseWriter` (see the Examples above) to push chunks onto whatever the host expects (a `Vec<u8>`, an `axum::body::Bytes` channel, a websocket frame), and call `handler.handle(&protocol, &state, &options, &mut writer)` with the matching `RenderOptions::new(entry_id, request_path)`. Passing an `entry_id` that does not match a key returns `HandlerError::MissingFragment(name)`.
+
+FAST-v3 components are an exception: an `<f-template name="my-component">` block is stored in the protocol's component map, not the fragment map, so it cannot be passed as `entry_id` directly. To render a single component for embedding, add a thin wrapper HTML file (e.g., `<my-component></my-component>` saved as `src/my-component-entry.html`) and pass that wrapper's key as `entry_id`.
+
+> `render_partial` (see [Routing](/guide/concepts/routing)) is a different API: it returns a JSON object consumed by the WebUI client-side router during in-app navigation. Use `WebUIHandler::handle` with `entry_id` when you want raw HTML for a non-WebUI host.
+
 ### HandlerError variants
 
 | Variant | When |


### PR DESCRIPTION
## What

Two small clarifications carried forward from the discussion on #299 (which was closed in favour of inline updates rather than a separate recipe page, per maintainer preference):

1. Both `docs/guide/integrations/node.md` and `docs/guide/integrations/rust.md` now explicitly state that `entry` / `entry_id` accepts **any** fragment key in the built protocol, not just `"index.html"`. Adds a `webui inspect` pointer for listing the valid keys.

2. Calls out the FAST-v3 wrapper-file requirement: an `<f-template name="my-component">` block lives in the protocol's component map (not the fragment map), so it cannot be passed as `entry` directly. Adopters trying to render a single FAST-v3 component into an embedded host were hitting `MissingFragment` and had to read source to figure out why.

Also adds a one-line distinction between `render_partial` (returns JSON for the WebUI client-side router during in-app navigation) and `render` / `WebUIHandler::handle` with `entry` (returns raw HTML for any host), since these two APIs were being conflated in the discussion on #299 and the existing docs don't make the distinction explicit.

## Why

The existing integration pages say `entry` is "Fragment ID to start rendering from" but only ever show `entry: 'index.html'` in examples. An adopter has to read the source to figure out (a) that they can pass any fragment, (b) how to list valid keys, and (c) why their FAST-v3 `<f-template>` block doesn't work as an entry. These three points together are ~20 lines of doc that pay back the source-reading exercise.

## How I tested

- `cargo xtask license-headers` ✔
- `cargo fmt --all --check` ✔ (docs-only change; ran for sanity)
- No new markdown directives, no new code samples; all internal links resolve against existing files.

## Notes

- Follows the docs-sync style (no emdashes, no smart quotes).
- Branch is `users/janechu/clarify-embedded-entry-in-integration-docs` per my host repo's agent-driven branch convention.
- Replaces #299. Independent of #295 / #296 / #297 / #298.