### PR TITLE
chore(release): bump to 0.0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.12", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.12" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.12" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" }
+microsoft-webui = { path = "../webui", version = "0.0.13", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.13" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.13" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.13" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -37,7 +37,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.13" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.13" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.13", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.12" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.13" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.13" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.13" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.12" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui = { path = "../webui", version = "0.0.13" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.13", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,7 +26,7 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 thiserror = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-html = { workspace = true }
@@ -36,7 +36,7 @@ walkdir = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.13" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,8 +19,8 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.12", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
+microsoft-webui = { path = "../webui", version = "0.0.13", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -43,6 +43,6 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.12" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.13" }
 actix-web = { workspace = true }
 tokio = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.12" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.13" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui_wasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12", default-features = false }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.13", default-features = false }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.12" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.13" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.13" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
@@ -41,8 +41,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.12" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.12" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.13" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.13" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:
- streaming SSR pipeline
- expose @microsoft/webui/platform.js subpath
- expose dom option on Node binding build()
- add nonce to <style type=module>

Fixes:
- preserve developer-authored <template> wrapper verbatim
- @attr property reflection
- trust SSR conditional content during hydration

Docs:
- correct rust integration docs to match published crate
- correct node integration docs to match published render() signature
- cleanup plugin wordings

Chore:
- stop xtask from bloating target/ and slowing the gate
- remove unused dependencies via cargo shear