### PR TITLE
fix: prevent discovery cache corruption under concurrent writers

### DIFF
--- a/crates/webui-discovery/src/cache.rs
+++ b/crates/webui-discovery/src/cache.rs
@@ -13,8 +13,14 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::DiscoveredComponent;
+
+/// Process-local counter used to disambiguate concurrent temp files within
+/// a single process (e.g. two threads calling `put` for different keys).
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Serialized cache entry stored as JSON on disk.
 #[derive(Serialize, Deserialize)]
@@ -145,12 +151,34 @@ impl DiscoveryCache {
         let json = serde_json::to_string(&entry).context("Failed to serialize cache entry")?;
 
         // Write to temp file then rename for atomic operation
-        // (prevents corruption from concurrent builds)
-        let temp_file = self.cache_dir.join(format!("{key}.tmp"));
+        // (prevents corruption from concurrent builds).
+        //
+        // The temp file name must be unique per writer — otherwise two
+        // concurrent processes (or two threads in the same process)
+        // racing the same {key}.tmp would overwrite each other's bytes
+        // and at least one of the renames would observe a partially
+        // written or already-renamed source.
+        //
+        // PID alone is insufficient because (a) the OS recycles PIDs and
+        // (b) two threads in the same process share one PID; we therefore
+        // append a process-local atomic counter as well.
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp_file = self
+            .cache_dir
+            .join(format!("{key}.{}.{}.tmp", process::id(), counter));
         fs::write(&temp_file, &json)
             .with_context(|| format!("Failed to write temp cache file: {}", temp_file.display()))?;
-        fs::rename(&temp_file, &cache_file)
-            .with_context(|| format!("Failed to finalize cache file: {}", cache_file.display()))?;
+        // On Windows, std::fs::rename uses MoveFileExW with
+        // MOVEFILE_REPLACE_EXISTING, which is atomic with respect to
+        // concurrent open-for-read of the destination as of Rust 1.62+.
+        // If the rename fails (e.g., another writer raced ahead) we
+        // remove our orphaned temp file to avoid leaking files on disk.
+        if let Err(e) = fs::rename(&temp_file, &cache_file) {
+            let _ = fs::remove_file(&temp_file);
+            return Err(e).with_context(|| {
+                format!("Failed to finalize cache file: {}", cache_file.display())
+            });
+        }
 
         Ok(())
     }
@@ -245,5 +273,70 @@ mod tests {
         // Should gracefully return None, not error
         let cached = cache.get("test-pkg", &pkg_json).unwrap();
         assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_concurrent_put_does_not_corrupt_cache() {
+        // Regression test for: two writers racing on the same temp file
+        // path overwrote each other and produced a partial/empty
+        // cache.json. With PID+counter suffixes each writer has its own
+        // temp file; the rename loser cleans up after itself.
+        use std::thread;
+
+        let cache = DiscoveryCache::open().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pkg_json = tmp.path().join("package.json");
+        fs::write(&pkg_json, r#"{"name":"test","version":"1.0.0"}"#).unwrap();
+
+        // Build a payload large enough that the temp-file write window
+        // overlaps with sibling threads.
+        let big_html = "x".repeat(64 * 1024);
+        let components = vec![DiscoveredComponent {
+            tag_name: "test-comp".to_string(),
+            html_content: big_html.clone(),
+            css_content: None,
+            source: "test-pkg".to_string(),
+        }];
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let c = DiscoveryCache::open().unwrap();
+            let p = pkg_json.clone();
+            let comp = components.clone();
+            handles.push(thread::spawn(move || {
+                c.put("test-pkg", &p, &comp).unwrap();
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // After all writers exit the cache must be readable and
+        // structurally intact.
+        let cached = cache.get("test-pkg", &pkg_json).unwrap();
+        let cached = cached.expect("cache should contain a valid entry");
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].html_content, big_html);
+
+        // No `.tmp` leftovers should remain for OUR key. We scope to our
+        // own cache_key prefix because `cache_dir` is shared across the
+        // whole `cargo test` process; a sibling test (e.g.
+        // `test_cache_round_trip`) racing the directory at the moment of
+        // our scan must not flake this assertion.
+        let our_key = DiscoveryCache::cache_key("test-pkg", &pkg_json);
+        let stragglers: Vec<_> = fs::read_dir(&cache.cache_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name();
+                let s = name.to_string_lossy();
+                s.starts_with(&our_key) && s.ends_with(".tmp")
+            })
+            .collect();
+        assert!(
+            stragglers.is_empty(),
+            "leftover temp files: {:?}",
+            stragglers.iter().map(|e| e.path()).collect::<Vec<_>>()
+        );
     }
 }

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -122,28 +122,52 @@ interface NativeAddon {
 }
 
 let addon: NativeAddon | null = null;
+let addonLoadError: unknown = null;
+let addonLoadAttempted = false;
 let fallbackWarned = false;
+let cliFallbackWarned = false;
 
 function loadAddon(): NativeAddon | null {
   if (addon) return addon;
+  if (addonLoadAttempted) return null;
+  addonLoadAttempted = true;
 
   const addonPath = resolve("addon");
-  if (addonPath) {
-    try {
-      // .node files load via require(), native libs (.dylib/.so/.dll) via dlopen
-      if (addonPath.endsWith(".node")) {
-        addon = require(addonPath) as NativeAddon;
-      } else {
-        const m: { exports: NativeAddon } = { exports: {} as NativeAddon };
-        process.dlopen(m, addonPath);
-        addon = m.exports;
-      }
-      return addon;
-    } catch {
-      // Fall through to WASM.
-    }
+  if (!addonPath) {
+    addonLoadError = new Error(
+      `No native addon binary found for ${platformKey()}. ` +
+        `Install the platform-specific @microsoft/webui-${platformKey()} package.`,
+    );
+    return null;
   }
-  return null;
+
+  try {
+    // .node files load via require(), native libs (.dylib/.so/.dll) via dlopen
+    if (addonPath.endsWith(".node")) {
+      addon = require(addonPath) as NativeAddon;
+    } else {
+      const m: { exports: NativeAddon } = { exports: {} as NativeAddon };
+      process.dlopen(m, addonPath);
+      addon = m.exports;
+    }
+    return addon;
+  } catch (e) {
+    // Record the failure so we can surface it in error paths and the
+    // WASM/CLI fallback warning. Previously this was a silent `catch {}`
+    // which hid serious problems like missing VC++ runtimes, ABI
+    // mismatches, or corrupted addon binaries.
+    addonLoadError = e;
+    return null;
+  }
+}
+
+function describeAddonError(): string {
+  if (!addonLoadError) return "";
+  const msg =
+    addonLoadError instanceof Error
+      ? addonLoadError.message
+      : String(addonLoadError);
+  return ` Native addon load failed: ${msg}`;
 }
 
 function warnFallback(): void {
@@ -152,7 +176,8 @@ function warnFallback(): void {
   console.warn(
     `[webui] Native addon not available for ${platformKey()}. ` +
       `Using WASM fallback — performance may be degraded.\n` +
-      `Install the platform-specific package for optimal performance.`,
+      `Install the platform-specific package for optimal performance.` +
+      describeAddonError(),
   );
 }
 
@@ -169,7 +194,19 @@ export function build(options: BuildOptions): BuildResult {
   const binPath = resolve("bin");
   if (!binPath) {
     throw new Error(
-      "[webui] Cannot build: no native addon or CLI binary available.",
+      "[webui] Cannot build: no native addon or CLI binary available." +
+        describeAddonError(),
+    );
+  }
+
+  if (addonLoadError && !cliFallbackWarned) {
+    // Warn once per process. A long-running dev server may call `build()`
+    // many times per second; spamming a multi-line warning on every call
+    // is noisy and (for some terminals) actually expensive.
+    cliFallbackWarned = true;
+    console.warn(
+      `[webui] Native addon failed to load; falling back to CLI binary at ${binPath}.` +
+        describeAddonError(),
     );
   }
 


### PR DESCRIPTION
## Summary

Two fixes that surfaced while debugging intermittent build failures observed by an Edge consumer running many parallel WebUI builds against a shared environment.

### 1. `fix(discovery): prevent cache corruption under concurrent writers`

`DiscoveryCache::put` staged every write under `{key}.tmp` in the shared `~/.webui/cache/components/` directory. When multiple processes resolved the same package concurrently, each writer reused the same temp path, so a late writer's `rename` could clobber the cache entry while another writer was still mid-write — producing zero-length or truncated cache entries that subsequent reads then consumed as cache hits.

**Fix:** stage writes under `{key}.{pid}.{counter}.tmp` so concurrent writers no longer collide, and clean up the temp file when the final `rename` fails.

**Test:** new `test_concurrent_put_does_not_corrupt_cache` — 8 threads × 64 KB payload, asserts that the post-storm cache is intact and that no orphan `.tmp` files are left for the key under test. The straggler check is scoped to our key's prefix so sibling tests writing into the same shared cache cannot make it flake.

### 2. `chore(node): surface native addon load failures in build fallback`

When the platform-specific native addon failed to load (corrupted binary, missing symbol, version skew), `packages/webui` silently fell back to the CLI path with no indication of *why*, and the warning fired on every build invocation.

**Fix:** capture the loader error, include it in the WASM fallback warning, the CLI fallback warning, and the "cannot build" error. Gate the CLI fallback warning behind `cliFallbackWarned` so it fires once per process.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test -p microsoft-webui-discovery --lib` — **32 passed**, including the new race-regression test
- Edge-side per-process tmpdir fix (separate change) plus this PR validated over 1540 sequential + parallel Edge builds with 0 failures (vs 26.25% pre-fix)

## Test coverage notes

- **`cache.rs`**: covered end-to-end by the new concurrency stress test plus the existing round-trip / invalidation / cache-miss tests.
- **`index.ts`**: not covered by a new automated test. The existing `integration.test.ts` only exercises the happy path. Fault-injecting an addon load failure would require mocking module-private functions or running with a deliberately broken native addon, which is disproportionate effort for ~50 lines of bookkeeping and string formatting. The change is small, obviously correct on inspection, and ships behind a fallback that is itself already exercised in production.
