### PR TITLE
fix: contact book example: Make search great

### DIFF
--- a/examples/app/contact-book-manager/server/api.ts
+++ b/examples/app/contact-book-manager/server/api.ts
@@ -103,6 +103,24 @@ function computeInitials(firstName: string, lastName: string): string {
   return first + last;
 }
 
+/** Case-insensitive substring search across the user-visible text fields. */
+function searchContacts(list: Contact[], query: string): Contact[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter(c =>
+    c.firstName.toLowerCase().indexOf(q) !== -1 ||
+    c.lastName.toLowerCase().indexOf(q) !== -1 ||
+    c.email.toLowerCase().indexOf(q) !== -1 ||
+    c.company.toLowerCase().indexOf(q) !== -1
+  );
+}
+
+/** Contacts in a group, matched case-insensitively (mirrors the SSR route). */
+function contactsInGroup(groupSlug: string): Contact[] {
+  const slug = groupSlug.toLowerCase();
+  return contacts.filter(c => c.group.toLowerCase() === slug);
+}
+
 function pickAvatarColor(): string {
   return AVATAR_COLORS[contacts.length % AVATAR_COLORS.length];
 }
@@ -204,7 +222,7 @@ ssr.get('/favorites', (_req: Request, res: Response) => {
 // Group-filtered contacts
 ssr.get('/groups/:group', (req: Request, res: Response) => {
   const groupSlug = req.params.group;
-  const filtered = contacts.filter(c => c.group.toLowerCase() === groupSlug.toLowerCase());
+  const filtered = contactsInGroup(groupSlug);
   const displayName = filtered[0]?.group ?? groupSlug;
   res.json({
     state: {
@@ -227,20 +245,12 @@ ssr.get('/groups/:group', (req: Request, res: Response) => {
 app.get('/api/contacts', (_req: Request, res: Response) => {
   let result = contacts;
 
-  const query = String(_req.query.q || '');
-  if (query) {
-    const q = query.toLowerCase();
-    result = result.filter(c =>
-      c.firstName.toLowerCase().indexOf(q) !== -1 ||
-      c.lastName.toLowerCase().indexOf(q) !== -1 ||
-      c.email.toLowerCase().indexOf(q) !== -1 ||
-      c.company.toLowerCase().indexOf(q) !== -1
-    );
-  }
+  result = searchContacts(result, String(_req.query.q || ''));
 
   const group = String(_req.query.group || '');
   if (group) {
-    result = result.filter(c => c.group === group);
+    const slug = group.toLowerCase();
+    result = result.filter(c => c.group.toLowerCase() === slug);
   }
 
   if (_req.query.favorites === 'true') {
@@ -248,6 +258,16 @@ app.get('/api/contacts', (_req: Request, res: Response) => {
   }
 
   res.json(result);
+});
+
+// Group resource: canonical name plus (optionally search-filtered) contacts.
+// Mirrors the SSR `/groups/:group` route so client loaders get the same
+// case-insensitive canonicalization, including when a `q` filter is applied.
+app.get('/api/groups/:group', (req: Request, res: Response) => {
+  const members = contactsInGroup(req.params.group);
+  const groupName = members[0]?.group ?? req.params.group;
+  const result = searchContacts(members, String(req.query.q || ''));
+  res.json({ groupName, contacts: result });
 });
 
 // Get single contact

--- a/examples/app/contact-book-manager/src/api.ts
+++ b/examples/app/contact-book-manager/src/api.ts
@@ -44,13 +44,16 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 
 export const api = {
   contacts: {
-    list: (params?: { q?: string; group?: string; favorites?: boolean }) => {
+    list: (
+      params?: { q?: string; group?: string; favorites?: boolean },
+      opts?: { signal?: AbortSignal },
+    ) => {
       const qs = new URLSearchParams();
       if (params?.q) qs.set('q', params.q);
       if (params?.group) qs.set('group', params.group);
       if (params?.favorites) qs.set('favorites', 'true');
       const query = qs.toString();
-      return request<Contact[]>(`/contacts${query ? `?${query}` : ''}`);
+      return request<Contact[]>(`/contacts${query ? `?${query}` : ''}`, { signal: opts?.signal });
     },
     get: (id: string) => request<Contact>(`/contacts/${id}`),
     create: (data: Partial<Contact>) =>

--- a/examples/app/contact-book-manager/src/api.ts
+++ b/examples/app/contact-book-manager/src/api.ts
@@ -30,6 +30,11 @@ export interface Stats {
   recentContacts: Contact[];
 }
 
+export interface GroupResult {
+  groupName: string;
+  contacts: Contact[];
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const resp = await fetch(`${API_BASE}${path}`, {
     headers: { 'Content-Type': 'application/json' },
@@ -68,6 +73,24 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify({ ...contact, favorite: !contact.favorite }),
       });
+    },
+  },
+  groups: {
+    // Resolve a group by its (case-insensitive) slug. The server canonicalizes
+    // the display name and applies the optional `q` search filter, returning
+    // both the canonical name and the filtered contacts in one response.
+    get: (
+      slug: string,
+      params?: { q?: string },
+      opts?: { signal?: AbortSignal },
+    ) => {
+      const qs = new URLSearchParams();
+      if (params?.q) qs.set('q', params.q);
+      const query = qs.toString();
+      return request<GroupResult>(
+        `/groups/${encodeURIComponent(slug)}${query ? `?${query}` : ''}`,
+        { signal: opts?.signal },
+      );
     },
   },
   stats: () => request<Stats>('/stats'),

--- a/examples/app/contact-book-manager/src/cb-app/cb-app.ts
+++ b/examples/app/contact-book-manager/src/cb-app/cb-app.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
-import { Router } from '@microsoft/webui-router';
-import { api } from '#api';
+import { Router, isStateful } from '@microsoft/webui-router';
+import { api, type Contact } from '#api';
 
 // Child components used in cb-app.html
 import '#organisms/cb-header/cb-header.js';
@@ -21,8 +21,63 @@ export class CbApp extends WebUIElement {
   @observable totalFavorites = '0';
   @observable groups: string[] = [];
 
+  private searchGen = 0;
+
+  private readonly onNavigated = (): void => {
+    if (this.searchQuery) void this.applySearch(this.searchQuery);
+  };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('webui:route:navigated', this.onNavigated);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener('webui:route:navigated', this.onNavigated);
+  }
+
   onSearch(e: SearchChangeEvent): void {
     this.searchQuery = e.detail.value;
+    void this.applySearch(e.detail.value);
+  }
+
+  private async applySearch(query: string): Promise<void> {
+    const gen = ++this.searchGen;
+    const root = this.shadowRoot;
+    if (!root) return;
+
+    const activeRoute = root.querySelector('webui-route[active]');
+    if (!activeRoute) return;
+
+    const contactsPage = activeRoute.querySelector('cb-page-contacts');
+    const favoritesPage = activeRoute.querySelector('cb-page-favorites');
+    const groupPage = activeRoute.querySelector('cb-page-group');
+
+    let pageEl: Element | null = null;
+    let favorites = false;
+    let group = '';
+
+    if (contactsPage) {
+      pageEl = contactsPage;
+    } else if (favoritesPage) {
+      pageEl = favoritesPage;
+      favorites = true;
+    } else if (groupPage) {
+      pageEl = groupPage;
+      group = this.activeGroup;
+    }
+
+    if (!pageEl) return;
+
+    const contacts: Contact[] = await api.contacts.list({
+      q: query || undefined,
+      favorites: favorites || undefined,
+      group: group || undefined,
+    });
+
+    if (gen !== this.searchGen) return;
+    if (isStateful(pageEl)) pageEl.setState({ contacts });
   }
 
   onSelectContact(e: ContactEvent): void {

--- a/examples/app/contact-book-manager/src/cb-app/cb-app.ts
+++ b/examples/app/contact-book-manager/src/cb-app/cb-app.ts
@@ -26,6 +26,12 @@ export class CbApp extends WebUIElement {
   // sync on direct loads, back/forward, and when navigating to an unfiltered
   // route. Filtering itself is owned by each list route's loader.
   private readonly onNavigated = (e: Event): void => {
+    // While a search debounce is pending the user is actively typing, so a
+    // navigation settling mid-keystroke (for example the list route's own
+    // navigated event arriving just after the first character) must not
+    // overwrite the in-progress query. The pending debounce will write the
+    // final `q` to the URL, and the resulting navigation mirrors it back.
+    if (this.searchTimer !== null) return;
     const { query } = (e as CustomEvent<NavigationEvent>).detail;
     this.searchQuery = query.q ?? '';
   };

--- a/examples/app/contact-book-manager/src/cb-app/cb-app.ts
+++ b/examples/app/contact-book-manager/src/cb-app/cb-app.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
-import { Router, isStateful } from '@microsoft/webui-router';
-import { api, type Contact } from '#api';
+import { Router } from '@microsoft/webui-router';
+import type { NavigationEvent } from '@microsoft/webui-router';
+import { api } from '#api';
 
 // Child components used in cb-app.html
 import '#organisms/cb-header/cb-header.js';
@@ -21,10 +22,12 @@ export class CbApp extends WebUIElement {
   @observable totalFavorites = '0';
   @observable groups: string[] = [];
 
-  private searchGen = 0;
-
-  private readonly onNavigated = (): void => {
-    if (this.searchQuery) void this.applySearch(this.searchQuery);
+  // Mirror the `q` route query param into the search box so the input stays in
+  // sync on direct loads, back/forward, and when navigating to an unfiltered
+  // route. Filtering itself is owned by each list route's loader.
+  private readonly onNavigated = (e: Event): void => {
+    const { query } = (e as CustomEvent<NavigationEvent>).detail;
+    this.searchQuery = query.q ?? '';
   };
 
   override connectedCallback(): void {
@@ -37,47 +40,21 @@ export class CbApp extends WebUIElement {
     window.removeEventListener('webui:route:navigated', this.onNavigated);
   }
 
+  // Model search as route query state: write `q` to the URL and let the active
+  // list route's loader fetch the filtered contacts. The shell no longer reads
+  // the active page, calls the contacts API, or pushes state into pages.
   onSearch(e: SearchChangeEvent): void {
     this.searchQuery = e.detail.value;
-    void this.applySearch(e.detail.value);
-  }
 
-  private async applySearch(query: string): Promise<void> {
-    const gen = ++this.searchGen;
-    const root = this.shadowRoot;
-    if (!root) return;
-
-    const activeRoute = root.querySelector('webui-route[active]');
-    if (!activeRoute) return;
-
-    const contactsPage = activeRoute.querySelector('cb-page-contacts');
-    const favoritesPage = activeRoute.querySelector('cb-page-favorites');
-    const groupPage = activeRoute.querySelector('cb-page-group');
-
-    let pageEl: Element | null = null;
-    let favorites = false;
-    let group = '';
-
-    if (contactsPage) {
-      pageEl = contactsPage;
-    } else if (favoritesPage) {
-      pageEl = favoritesPage;
-      favorites = true;
-    } else if (groupPage) {
-      pageEl = groupPage;
-      group = this.activeGroup;
+    const next = new URL(window.location.href);
+    const query = e.detail.value.trim();
+    if (query) {
+      next.searchParams.set('q', query);
+    } else {
+      next.searchParams.delete('q');
     }
 
-    if (!pageEl) return;
-
-    const contacts: Contact[] = await api.contacts.list({
-      q: query || undefined,
-      favorites: favorites || undefined,
-      group: group || undefined,
-    });
-
-    if (gen !== this.searchGen) return;
-    if (isStateful(pageEl)) pageEl.setState({ contacts });
+    Router.navigate(`${next.pathname}${next.search}`);
   }
 
   onSelectContact(e: ContactEvent): void {
@@ -113,7 +90,7 @@ export class CbApp extends WebUIElement {
     Router.back();
   }
 
-  async onFormSaveEvent(e: FormSaveEvent): void {
+  async onFormSaveEvent(e: FormSaveEvent): Promise<void> {
     const data = e.detail;
     try {
       let saved;

--- a/examples/app/contact-book-manager/src/cb-app/cb-app.ts
+++ b/examples/app/contact-book-manager/src/cb-app/cb-app.ts
@@ -30,6 +30,11 @@ export class CbApp extends WebUIElement {
     this.searchQuery = query.q ?? '';
   };
 
+  // Trailing-debounce handle for search-as-you-type. Coalesces rapid keystrokes
+  // into a single navigation so the history stack does not gain one entry per
+  // character.
+  private searchTimer: ReturnType<typeof setTimeout> | null = null;
+
   override connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener('webui:route:navigated', this.onNavigated);
@@ -38,23 +43,45 @@ export class CbApp extends WebUIElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener('webui:route:navigated', this.onNavigated);
+    if (this.searchTimer !== null) {
+      clearTimeout(this.searchTimer);
+      this.searchTimer = null;
+    }
   }
 
   // Model search as route query state: write `q` to the URL and let the active
   // list route's loader fetch the filtered contacts. The shell no longer reads
   // the active page, calls the contacts API, or pushes state into pages.
+  //
+  // Navigation is debounced so typing does not fire a route load per keystroke.
+  // Entering or leaving a search (adding/removing `q`) pushes a history entry,
+  // so one Back returns to the pre-search list; refining an existing query
+  // replaces the entry instead, so the intermediate keystrokes do not stack.
   onSearch(e: SearchChangeEvent): void {
     this.searchQuery = e.detail.value;
+    const value = e.detail.value;
 
-    const next = new URL(window.location.href);
-    const query = e.detail.value.trim();
-    if (query) {
-      next.searchParams.set('q', query);
-    } else {
-      next.searchParams.delete('q');
-    }
+    if (this.searchTimer !== null) clearTimeout(this.searchTimer);
+    this.searchTimer = setTimeout(() => {
+      this.searchTimer = null;
 
-    Router.navigate(`${next.pathname}${next.search}`);
+      const current = new URL(window.location.href);
+      const hadQuery = current.searchParams.has('q');
+
+      const next = new URL(current.href);
+      const query = value.trim();
+      if (query) {
+        next.searchParams.set('q', query);
+      } else {
+        next.searchParams.delete('q');
+      }
+
+      // No-op if the URL would not change (e.g. clearing an already-empty box).
+      if (next.search === current.search) return;
+
+      const hasQuery = next.searchParams.has('q');
+      Router.navigate(`${next.pathname}${next.search}`, { replace: hadQuery && hasQuery });
+    }, 200);
   }
 
   onSelectContact(e: ContactEvent): void {

--- a/examples/app/contact-book-manager/src/index.html
+++ b/examples/app/contact-book-manager/src/index.html
@@ -37,12 +37,12 @@
 <body>
   <route path="/" component="cb-app">
     <route path="" component="cb-page-dashboard" exact />
-    <route path="contacts" component="cb-page-contacts" exact keep-alive />
+    <route path="contacts" component="cb-page-contacts" exact keep-alive query="q" />
     <route path="contacts/add" component="cb-contact-form" exact />
     <route path="contacts/:id" component="cb-contact-detail" exact />
     <route path="contacts/:id/edit" component="cb-contact-form" exact />
-    <route path="favorites" component="cb-page-favorites" exact keep-alive />
-    <route path="groups/:group" component="cb-page-group" exact keep-alive />
+    <route path="favorites" component="cb-page-favorites" exact keep-alive query="q" />
+    <route path="groups/:group" component="cb-page-group" exact keep-alive query="q" />
   </route>
 
   <script type="module" src="./index.js"></script>

--- a/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.html
@@ -1,9 +1,14 @@
 <h2 class="page-title">All Contacts</h2>
-<div class="contact-list-container">
-  <for each="contact in contacts">
-    <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-      email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-      favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-      notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-  </for>
-</div>
+<if condition="contacts.length">
+  <div class="contact-list-container">
+    <for each="contact in contacts">
+      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
+        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
+        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
+        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
+    </for>
+  </div>
+</if>
+<if condition="!contacts.length">
+  <cb-empty-state title="No contacts found" message="Try adjusting your search or add a new contact."></cb-empty-state>
+</if>

--- a/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.html
@@ -1,14 +1,2 @@
 <h2 class="page-title">All Contacts</h2>
-<if condition="contacts.length">
-  <div class="contact-list-container">
-    <for each="contact in contacts">
-      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-    </for>
-  </div>
-</if>
-<if condition="!contacts.length">
-  <cb-empty-state title="No contacts found" message="Try adjusting your search or add a new contact."></cb-empty-state>
-</if>
+<cb-contact-list :contacts="{{contacts}}"></cb-contact-list>

--- a/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.ts
@@ -2,12 +2,21 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
-import '#atoms/cb-empty-state/cb-empty-state.js';
-import '#organisms/cb-contact-card/cb-contact-card.js';
-import { Contact } from '#api';
+import type { RouteLoaderContext } from '@microsoft/webui-router';
+import { api, type Contact } from '#api';
+import '#organisms/cb-contact-list/cb-contact-list.js';
 
 export class CbPageContacts extends WebUIElement {
   @observable contacts: Contact[] = [];
+
+  // Run on the initial SSR navigation too, so a direct load of /contacts?q=...
+  // renders the filtered list rather than the full server-rendered one.
+  static ssrLoader = true;
+
+  static async loader({ query, signal }: RouteLoaderContext): Promise<{ contacts: Contact[] }> {
+    const contacts = await api.contacts.list({ q: query.q || undefined }, { signal });
+    return { contacts };
+  }
 }
 
 CbPageContacts.define('cb-page-contacts');

--- a/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-contacts/cb-page-contacts.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
+import '#atoms/cb-empty-state/cb-empty-state.js';
 import '#organisms/cb-contact-card/cb-contact-card.js';
 import { Contact } from '#api';
 

--- a/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.html
@@ -1,9 +1,14 @@
 <h2 class="page-title">Favorites</h2>
-<div class="contact-list-container">
-  <for each="contact in contacts">
-    <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-      email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-      favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-      notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-  </for>
-</div>
+<if condition="contacts.length">
+  <div class="contact-list-container">
+    <for each="contact in contacts">
+      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
+        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
+        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
+        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
+    </for>
+  </div>
+</if>
+<if condition="!contacts.length">
+  <cb-empty-state title="No contacts found" message="Try adjusting your search."></cb-empty-state>
+</if>

--- a/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.html
@@ -1,14 +1,2 @@
 <h2 class="page-title">Favorites</h2>
-<if condition="contacts.length">
-  <div class="contact-list-container">
-    <for each="contact in contacts">
-      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-    </for>
-  </div>
-</if>
-<if condition="!contacts.length">
-  <cb-empty-state title="No contacts found" message="Try adjusting your search."></cb-empty-state>
-</if>
+<cb-contact-list :contacts="{{contacts}}"></cb-contact-list>

--- a/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.ts
@@ -2,12 +2,22 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
-import '#atoms/cb-empty-state/cb-empty-state.js';
-import '#organisms/cb-contact-card/cb-contact-card.js';
-import { Contact } from '#api';
+import type { RouteLoaderContext } from '@microsoft/webui-router';
+import { api, type Contact } from '#api';
+import '#organisms/cb-contact-list/cb-contact-list.js';
 
 export class CbPageFavorites extends WebUIElement {
   @observable contacts: Contact[] = [];
+
+  static ssrLoader = true;
+
+  static async loader({ query, signal }: RouteLoaderContext): Promise<{ contacts: Contact[] }> {
+    const contacts = await api.contacts.list(
+      { q: query.q || undefined, favorites: true },
+      { signal },
+    );
+    return { contacts };
+  }
 }
 
 CbPageFavorites.define('cb-page-favorites');

--- a/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-favorites/cb-page-favorites.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
+import '#atoms/cb-empty-state/cb-empty-state.js';
 import '#organisms/cb-contact-card/cb-contact-card.js';
 import { Contact } from '#api';
 

--- a/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.html
@@ -1,9 +1,14 @@
 <h2 class="page-title">{{groupName}}</h2>
-<div class="contact-list-container">
-  <for each="contact in contacts">
-    <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-      email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-      favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-      notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-  </for>
-</div>
+<if condition="contacts.length">
+  <div class="contact-list-container">
+    <for each="contact in contacts">
+      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
+        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
+        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
+        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
+    </for>
+  </div>
+</if>
+<if condition="!contacts.length">
+  <cb-empty-state title="No contacts found" message="Try adjusting your search."></cb-empty-state>
+</if>

--- a/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.html
+++ b/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.html
@@ -1,14 +1,2 @@
 <h2 class="page-title">{{groupName}}</h2>
-<if condition="contacts.length">
-  <div class="contact-list-container">
-    <for each="contact in contacts">
-      <cb-contact-card id="{{contact.id}}" first-name="{{contact.firstName}}" last-name="{{contact.lastName}}"
-        email="{{contact.email}}" phone="{{contact.phone}}" company="{{contact.company}}" group="{{contact.group}}"
-        favorite="{{contact.favorite}}" initials="{{contact.initials}}" avatar-color="{{contact.avatarColor}}"
-        notes="{{contact.notes}}" address="{{contact.address}}"></cb-contact-card>
-    </for>
-  </div>
-</if>
-<if condition="!contacts.length">
-  <cb-empty-state title="No contacts found" message="Try adjusting your search."></cb-empty-state>
-</if>
+<cb-contact-list :contacts="{{contacts}}"></cb-contact-list>

--- a/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
@@ -2,13 +2,25 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
-import '#atoms/cb-empty-state/cb-empty-state.js';
-import '#organisms/cb-contact-card/cb-contact-card.js';
-import type { Contact } from '#api';
+import type { RouteLoaderContext } from '@microsoft/webui-router';
+import { api, type Contact } from '#api';
+import '#organisms/cb-contact-list/cb-contact-list.js';
 
 export class CbPageGroup extends WebUIElement {
   @observable groupName = '';
   @observable contacts: Contact[] = [];
+
+  static ssrLoader = true;
+
+  static async loader(
+    { params, query, signal }: RouteLoaderContext,
+  ): Promise<{ contacts: Contact[]; groupName: string }> {
+    const contacts = await api.contacts.list(
+      { q: query.q || undefined, group: params.group },
+      { signal },
+    );
+    return { contacts, groupName: params.group };
+  }
 }
 
 CbPageGroup.define('cb-page-group');

--- a/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { WebUIElement, observable } from '@microsoft/webui-framework';
+import '#atoms/cb-empty-state/cb-empty-state.js';
 import '#organisms/cb-contact-card/cb-contact-card.js';
 import type { Contact } from '#api';
 

--- a/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
+++ b/examples/app/contact-book-manager/src/pages/cb-page-group/cb-page-group.ts
@@ -15,11 +15,11 @@ export class CbPageGroup extends WebUIElement {
   static async loader(
     { params, query, signal }: RouteLoaderContext,
   ): Promise<{ contacts: Contact[]; groupName: string }> {
-    const contacts = await api.contacts.list(
-      { q: query.q || undefined, group: params.group },
-      { signal },
-    );
-    return { contacts, groupName: params.group };
+    // Fetch the group as a server resource. The endpoint canonicalizes the
+    // case-insensitive slug (e.g. `/groups/work` -> `Work`) and applies the
+    // `q` search filter, matching the SSR path, so the display name stays
+    // canonical even when the search narrows the list to nothing.
+    return api.groups.get(params.group, { q: query.q || undefined }, { signal });
   }
 }
 

--- a/examples/app/contact-book-manager/tests/contact-book.spec.ts
+++ b/examples/app/contact-book-manager/tests/contact-book.spec.ts
@@ -310,6 +310,48 @@ test.describe('search', () => {
     await expect(page.locator('cb-header .search-input')).toHaveValue('Sarah');
     await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
   });
+
+  test('typing does not stack a history entry per keystroke', async ({ page }) => {
+    // Search updates replace the current history entry, so a single back step
+    // returns to the page that preceded the search rather than walking through
+    // each intermediate query.
+    await page.goto('/');
+    await page.locator('cb-sidebar').getByRole('link', { name: /All Contacts/ }).click();
+    await expect(page).toHaveURL('/contacts');
+
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.pressSequentially('Sarah', { delay: 80 });
+    await expect(page).toHaveURL(/\/contacts\?q=Sarah$/);
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
+
+    // One back step lands on the unfiltered contacts page, not on `?q=Sara`,
+    // `?q=Sar`, etc.
+    await page.goBack();
+    await expect(page).toHaveURL('/contacts');
+    await expect(page.locator('cb-header .search-input')).toHaveValue('');
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(15);
+  });
+});
+
+// ── Group canonicalization (issue #191 review) ───────────────────
+
+test.describe('group route canonicalization', () => {
+  test('lowercase group slug renders the canonical group name', async ({ page }) => {
+    // Direct load of a lowercase slug must hydrate to the canonical "Work"
+    // title and keep the group's contacts (the loader mirrors the SSR path).
+    await page.goto('/groups/work');
+    await expect(page.locator('cb-page-group .page-title')).toHaveText('Work');
+    await expect(page.locator('cb-page-group cb-contact-card').first()).toBeVisible();
+  });
+
+  test('group title stays canonical when a search filters out every contact', async ({ page }) => {
+    // Even when `q` narrows the group to zero matches, the canonical title
+    // must remain and the empty state must show.
+    await page.goto('/groups/work?q=zzz_no_match_zzz');
+    await expect(page.locator('cb-page-group .page-title')).toHaveText('Work');
+    await expect(page.locator('cb-page-group cb-contact-card')).toHaveCount(0);
+    await expect(page.locator('cb-page-group cb-empty-state')).toBeVisible();
+  });
 });
 
 // ── Visual regression tests ──────────────────────────────────────

--- a/examples/app/contact-book-manager/tests/contact-book.spec.ts
+++ b/examples/app/contact-book-manager/tests/contact-book.spec.ts
@@ -246,6 +246,70 @@ test.describe('contact edit does not corrupt sidebar groups', () => {
   });
 });
 
+// ── Search tests ────────────────────────────────────────────────
+
+test.describe('search', () => {
+  test('filters contacts on the contacts page as the user types', async ({ page }) => {
+    await page.goto('/contacts');
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(15);
+
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.fill('Sarah');
+
+    // Only Sarah Chen should remain
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toContainText('Sarah');
+  });
+
+  test('shows empty state when search has no matches', async ({ page }) => {
+    await page.goto('/contacts');
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.fill('zzz_no_match_zzz');
+
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(0);
+    await expect(page.locator('cb-page-contacts cb-empty-state')).toBeVisible();
+  });
+
+  test('restores full list when search is cleared', async ({ page }) => {
+    await page.goto('/contacts');
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.fill('Sarah');
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
+
+    await searchInput.clear();
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(15);
+  });
+
+  test('filters favorites page as the user types', async ({ page }) => {
+    await page.goto('/favorites');
+    const initialCount = await page.locator('cb-page-favorites cb-contact-card').count();
+    expect(initialCount).toBeGreaterThan(0);
+
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.fill('Sarah');
+
+    await expect(page.locator('cb-page-favorites cb-contact-card')).toHaveCount(1);
+    await expect(page.locator('cb-page-favorites cb-contact-card')).toContainText('Sarah');
+  });
+
+  test('search persists when navigating back to contacts page', async ({ page }) => {
+    await page.goto('/contacts');
+    const searchInput = page.locator('cb-header .search-input');
+    await searchInput.fill('Sarah');
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
+
+    // Navigate to a contact detail
+    await page.locator('cb-page-contacts cb-contact-card').click();
+    await expect(page.locator('cb-contact-detail')).toBeVisible();
+
+    // Navigate back — search box still shows query, contacts page should re-filter
+    await page.locator('cb-sidebar').getByRole('link', { name: /All Contacts/ }).click();
+    await expect(page).toHaveURL('/contacts');
+    await expect(page.locator('cb-header .search-input')).toHaveValue('Sarah');
+    await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
+  });
+});
+
 // ── Visual regression tests ──────────────────────────────────────
 
 test.describe('visual regression', () => {

--- a/examples/app/contact-book-manager/tests/contact-book.spec.ts
+++ b/examples/app/contact-book-manager/tests/contact-book.spec.ts
@@ -292,19 +292,21 @@ test.describe('search', () => {
     await expect(page.locator('cb-page-favorites cb-contact-card')).toContainText('Sarah');
   });
 
-  test('search persists when navigating back to contacts page', async ({ page }) => {
+  test('search persists in the URL across back navigation', async ({ page }) => {
     await page.goto('/contacts');
     const searchInput = page.locator('cb-header .search-input');
     await searchInput.fill('Sarah');
+    await expect(page).toHaveURL(/\/contacts\?q=Sarah$/);
     await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
 
-    // Navigate to a contact detail
+    // Open a contact detail, then return via browser back.
     await page.locator('cb-page-contacts cb-contact-card').click();
     await expect(page.locator('cb-contact-detail')).toBeVisible();
 
-    // Navigate back — search box still shows query, contacts page should re-filter
-    await page.locator('cb-sidebar').getByRole('link', { name: /All Contacts/ }).click();
-    await expect(page).toHaveURL('/contacts');
+    // The query lives in the URL, so back restores the filtered list and the
+    // search box stays populated.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/contacts\?q=Sarah$/);
     await expect(page.locator('cb-header .search-input')).toHaveValue('Sarah');
     await expect(page.locator('cb-page-contacts cb-contact-card')).toHaveCount(1);
   });

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -1153,6 +1153,49 @@ describe('WebUIRouter', () => {
   });
 });
 
+// ── navigate() history behavior ──────────────────────────────────
+
+describe('navigate', () => {
+  interface NavCall { url: string; options: unknown }
+  let calls: NavCall[];
+  let original: ((url: string, options?: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    calls = [];
+    const nav = (globalThis as { navigation?: Record<string, unknown> }).navigation!;
+    original = nav.navigate as ((url: string, options?: unknown) => void) | undefined;
+    nav.navigate = (url: string, options?: unknown) => { calls.push({ url, options }); };
+  });
+
+  afterEach(() => {
+    const nav = (globalThis as { navigation?: Record<string, unknown> }).navigation!;
+    nav.navigate = original;
+  });
+
+  test('pushes a new history entry by default (no options)', () => {
+    const router = new WebUIRouter();
+    router.navigate('/contacts?q=Sarah');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/contacts?q=Sarah');
+    assert.equal(calls[0].options, undefined, 'default navigate must not request replace');
+  });
+
+  test('replaces the current history entry when replace is true', () => {
+    const router = new WebUIRouter();
+    router.navigate('/contacts?q=Sarah', { replace: true });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/contacts?q=Sarah');
+    assert.deepEqual(calls[0].options, { history: 'replace' }, 'replace must map to history: replace');
+  });
+
+  test('replace: false behaves like a default push', () => {
+    const router = new WebUIRouter();
+    router.navigate('/contacts', { replace: false });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].options, undefined);
+  });
+});
+
 // ── parseQuery unit tests ────────────────────────────────────────
 
 describe('parseQuery', () => {

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -190,10 +190,17 @@ export class WebUIRouter {
     this.handleNavigation(this.currentTarget());
   }
 
-  /** Navigate to a new path. */
-  navigate(path: string): void {
+  /**
+   * Navigate to a new path.
+   *
+   * Pass `{ replace: true }` to replace the current history entry instead of
+   * pushing a new one. This is useful for high-frequency updates such as
+   * search-as-you-type, where each intermediate query should not become its
+   * own back-button stop.
+   */
+  navigate(path: string, options?: { replace?: boolean }): void {
     const fullPath = prependBasePath(path, this.basePath);
-    window.navigation.navigate(fullPath);
+    window.navigation.navigate(fullPath, options?.replace ? { history: 'replace' } : undefined);
   }
 
   /** Navigate back. */


### PR DESCRIPTION
## Summary

## Root Cause

The search bar in `cb-header` emits `search-change` events that were captured by `cb-app.onSearch`, which stored the query in `this.searchQuery` — but never used it to filter contacts. The `searchQuery` observable was only passed back to `cb-header` (to keep the input in sync) and was not wired to any API call or state update on the active page component.

## Change Made

### `src/cb-app/cb-app.ts`
- Added `isStateful` import from `@microsoft/webui-router` and `Contact` type import.
- Added `searchGen` field (generation counter to prevent stale async updates from racing).
- Added `onNavigated` arrow function and `connectedCallback`/`disconnectedCallback` overrides to listen for `webui:route:navigated` events — this re-applies an active search whenever the user navigates to a list page.
- Modified `onSearch` to call `applySearch` in addition to storing the query.
- Added private `applySearch(query)` method that:
  - Increments a generation counter to cancel stale results.
  - Queries `webui-route[active]` in the shadow DOM to find the currently visible page component.
  - Detects which page type is active (contacts, favorites, or group) and calls `api.contacts.list()` with the appropriate filters.
  - Calls `setState({ contacts })` on the page element to update its rendered list.

### `src/pages/cb-page-contacts/cb-page-contacts.html` + `.ts`
- Added `cb-empty-state` import.
- Wrapped the contact grid in `<if condition="contacts.length">` and added an `<if condition="!contacts.length"><cb-empty-state>` block for zero-result feedback.

### `src/pages/cb-page-favorites/cb-page-favorites.html` + `.ts`
- Same empty state treatment as contacts page.

### `src/pages/cb-page-group/cb-page-group.html` + `.ts`
- Same empty state treatment as contacts page.

### `tests/contact-book.spec.ts`
Added a `search` test suite with five E2E tests:
1. **Filters contacts as user types** — types "Sarah", expects 1 result.
2. **Shows empty state on no matches** — types a nonsense query, expects `cb-empty-state` visible.
3. **Restores full list on clear** — fills then clears search input, expects all 15 contacts back.
4. **Filters favorites page** — same pattern on `/favorites`.
5. **Search persists on navigation** — types "Sarah", navigates to detail, navigates back, asserts search input still shows "Sarah" and list is still filtered.



## Issue

Fixes #191

**Issue URL:** https://github.com/microsoft/webui/issues/191


## Changes

```
.../app/contact-book-manager/src/cb-app/cb-app.ts  | 59 +++++++++++++++++++-
 .../pages/cb-page-contacts/cb-page-contacts.html   | 21 ++++---
 .../src/pages/cb-page-contacts/cb-page-contacts.ts |  1 +
 .../pages/cb-page-favorites/cb-page-favorites.html | 21 ++++---
 .../pages/cb-page-favorites/cb-page-favorites.ts   |  1 +
 .../src/pages/cb-page-group/cb-page-group.html     | 21 ++++---
 .../src/pages/cb-page-group/cb-page-group.ts       |  1 +
 .../tests/contact-book.spec.ts                     | 64 ++++++++++++++++++++++
 8 files changed, 163 insertions(+), 26 deletions(-)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
