### PR TITLE
chore: clarify contribution and support policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+Thank you for helping improve WebUI. The project is still in active development, so the best way to contribute right now is by opening high-quality issues that document bugs, feature needs, and documentation gaps.
+
+## Pull requests are paused
+
+We are not accepting unsolicited pull requests at this time. Please do not open a pull request unless a maintainer explicitly asks for one. Unsolicited pull requests may be closed without review so maintainers can focus on stabilizing the project.
+
+If a maintainer invites a pull request for a focused change, most contributions require a Contributor License Agreement (CLA). The CLA bot will guide you through the process. For details, visit <https://cla.opensource.microsoft.com>.
+
+## Issues we welcome
+
+We welcome GitHub Issues for:
+
+- Bugs with clear reproduction steps.
+- Feature requests that explain the need and expected outcome.
+- Documentation issues that identify confusing, missing, or incorrect guidance.
+
+Before opening an issue, search the [existing issues](https://github.com/microsoft/webui/issues) to avoid duplicates. Use one issue per bug, feature, or documentation need.
+
+## Bugs
+
+When reporting a bug, include:
+
+- A short summary of the problem.
+- A minimal reproduction, sample repository, or small code snippet.
+- Exact steps to reproduce the problem.
+- Expected behavior and actual behavior.
+- Environment details such as OS, Rust version, Node.js version, package version, and command used.
+- Relevant logs, stack traces, or terminal output.
+
+## Feature requests
+
+When requesting a feature, include:
+
+- The problem or need you are trying to solve.
+- Who would benefit from the feature.
+- A concrete example of the desired API, CLI behavior, or workflow.
+- Any constraints that matter, especially performance, security, compatibility, or migration concerns.
+- Workarounds or alternatives you considered.
+
+## Documentation issues
+
+When reporting a documentation need, include:
+
+- The page, section, or workflow that was confusing or missing.
+- What you expected to find.
+- What information would have helped.
+- Suggested wording or examples, if you have them.
+
+## Security issues
+
+Do not report security vulnerabilities through public GitHub Issues. Follow the reporting process in [`SECURITY.md`](SECURITY.md).
+
+## Code of Conduct
+
+This project follows the [Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,6 @@ If a maintainer invites a pull request for a focused change, most contributions 
 
 ## Issues we welcome
 
-We welcome GitHub Issues for:
-
 - Bugs with clear reproduction steps.
 - Feature requests that explain the need and expected outcome.
 - Documentation issues that identify confusing, missing, or incorrect guidance.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,16 @@
 # WebUI
 
-**WebUI** is a high-performance, language-agnostic server-side rendering framework built in Rust. It compiles HTML templates into Protocol Buffer binaries at build time — eliminating per-request template parsing entirely. On the client, Web Components hydrate as interactive islands using the [Islands Architecture](https://microsoft.github.io/webui/guide/concepts/how-it-works), where only components that need interactivity ship JavaScript.
+**WebUI** is a high-performance, language-agnostic server-side rendering framework built in Rust. It compiles HTML templates into compact Protocol Buffer binaries at build time so runtime rendering applies state without reparsing templates. Interactive Web Components hydrate as islands on the client.
 
-> 📖 **[Full Documentation →](https://microsoft.github.io/webui)**
+**Documentation:** [microsoft.github.io/webui](https://microsoft.github.io/webui)
 
-### Highlights
+## Highlights
 
-- **Compiled to binary** — Templates are parsed once at build time into a compact protobuf protocol. Runtime just applies state.
-- **Language agnostic** — Native support for Rust, Node/Bun/Deno, C#, Python, Go. Any other language via the C FFI.
-- **Web Components** — Built on native web components with Shadow DOM encapsulation.
-- **Server-side logic** — Conditionals and expressions evaluated on the server, not in the browser.
-- **Plugin system** — Parser and handler plugins for hydration, adding reactivity to interactive islands, custom directives, and framework-specific behavior.
-
-## Documentation
-
-Visit **[microsoft.github.io/webui](https://microsoft.github.io/webui)** for:
-
-- [Getting Started Guide](https://microsoft.github.io/webui/guide/) — What is WebUI and how to install it
-- [How It Works](https://microsoft.github.io/webui/guide/concepts/how-it-works) — Build → Render → Hydrate pipeline
-- [Interactivity Guide](https://microsoft.github.io/webui/guide/concepts/interactivity) — Web Components with `@attr`, `@observable`, events
-- [CLI Reference](https://microsoft.github.io/webui/guide/cli/) — `webui build`, `webui serve`, `webui inspect`
-- [Language Integrations](https://microsoft.github.io/webui/guide/integrations) — Rust, Node, Go, C#, Python
-- [React vs Web Components](https://microsoft.github.io/webui/guide/concepts/react-comparison) — Side-by-side comparison with React
-- [Playground](https://microsoft.github.io/webui/playground/) — Try WebUI in the browser
-- [Tutorials](https://microsoft.github.io/webui/tutorials/hello-world) — Hello World, Todo App
-
-For performance: see **[`BENCHMARKS.md`](BENCHMARKS.md)** for the bench suite, what each layer measures, and the before/after comparison workflow.
+- **Compiled templates:** HTML is parsed once at build time into a compact binary protocol.
+- **Language agnostic:** Rust, Node/Bun/Deno, C#, Python, Go, and any language that can call C FFI.
+- **Web Components:** Native custom elements with Shadow DOM support.
+- **Server-side logic:** Conditions, loops, and expressions are evaluated on the server.
+- **Plugin-ready:** Parser and handler plugins support framework-specific hydration and directives.
 
 ## Install
 
@@ -33,179 +18,69 @@ For performance: see **[`BENCHMARKS.md`](BENCHMARKS.md)** for the bench suite, w
 npm install @microsoft/webui
 ```
 
-Or with Rust: `cargo install microsoft-webui-cli`
+Or install the Rust CLI:
+
+```bash
+cargo install microsoft-webui-cli
+```
+
+## Learn
+
+| Resource | Link |
+|----------|------|
+| Full documentation | <https://microsoft.github.io/webui> |
+| Getting started | <https://microsoft.github.io/webui/guide/> |
+| CLI reference | <https://microsoft.github.io/webui/guide/cli/> |
+| Language integrations | <https://microsoft.github.io/webui/guide/integrations> |
+| Benchmarks | [`BENCHMARKS.md`](BENCHMARKS.md) |
 
 ## Development
 
-### Prerequisites
+Prerequisites:
 
 - Rust 1.93+ with `clippy` and `rustfmt`
 - Node.js 22+ with pnpm
 
-### Commands
-
-All development tasks go through `cargo xtask`:
+Common commands:
 
 | Command | Description |
 |---------|-------------|
-| `cargo xtask check` | **Run before every commit.** Parallel lint → test → build → docs |
-| `cargo xtask e2e` | Run Playwright E2E tests for all example apps |
+| `cargo xtask check` | Run the full repository quality gate before commits |
 | `cargo xtask fmt` | Check formatting |
 | `cargo xtask clippy` | Run clippy lints |
-| `cargo xtask deny` | License & advisory audit |
 | `cargo xtask test` | Run all tests |
-| `cargo xtask build` | Build the workspace + examples |
-| `cargo xtask build-wasm` | Build WASM playground module |
-| `cargo xtask docs` | Build the documentation site |
-| `cargo xtask bench <target>` | Run benchmarks (`parser`, `handler`, `protocol`, `expressions`, `state`, `contact-book`, `streaming`, `streaming-resource`, `streaming-e2e-ttfb`, `streaming-browser`, `streaming-all`/`full`, `all`). Add `--save-baseline NAME` / `--baseline NAME` for before/after comparison. See [`BENCHMARKS.md`](BENCHMARKS.md). |
-| `cargo xtask dev <app>` | Run example app in dev mode |
-| `cargo xtask version <semver>` | Update version across all Cargo.toml and package.json files |
-| `cargo xtask publish-stage` | Stage release artifacts into `publish/` (supports `--native-only` and `--pack-only`) |
+| `cargo xtask build` | Build the workspace and examples |
+| `cargo xtask dev <app>` | Run an example app in development mode |
+| `cargo xtask bench <target>` | Run benchmarks |
 
-### CI Pipelines
+For contribution policy, issue guidelines, and the current pull request policy, see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-#### PR Checks (`pr.yml`)
+## Project layout
 
-The CI workflow parallelizes across jobs with dependency ordering:
-
-```mermaid
-graph LR
-    lint["Lint<br/><small>headers → fmt → clippy → deny</small>"]
-    test["Test<br/><small>cargo test --workspace</small>"]
-    buildL["Build Linux"]
-    buildM["Build macOS"]
-    buildW["Build Windows"]
-    wasm["WASM<br/><small>wasm-pack build</small>"]
-    docs["Docs<br/><small>VitePress</small>"]
-    e2e["E2E<br/><small>Playwright</small>"]
-
-    lint --> test
-    lint --> buildL
-    lint --> buildM
-    lint --> buildW
-    lint --> wasm
-    lint --> docs
-    buildL --> e2e
+```text
+crates/      Rust crates for the CLI, parser, handler, protocol, FFI, and integrations
+packages/    npm packages for the CLI, WebUI Framework, router, and platform binaries
+docs/        VitePress documentation site
+examples/    Example applications and integration samples
 ```
 
-| Phase | Jobs (parallel) | Runner |
-|-------|----------------|--------|
-| 1 | **lint** | Ubuntu |
-| 2 | **test** + **build** (Linux · macOS · Windows) + **wasm** + **docs** | Ubuntu · macOS · Windows |
-| 3 | **e2e** (after Linux build) | Ubuntu (shared Rust cache) |
+## Feedback and support
 
-#### Publish (`publish.yml`)
+WebUI is still in active development. We are not accepting unsolicited pull requests right now, but we do welcome well-documented issues:
 
-Triggered on push to `main` (and `workflow_dispatch`). Skips if the version hasn't changed.
+| Need | Where to go |
+|------|-------------|
+| Report a bug | [`CONTRIBUTING.md#bugs`](CONTRIBUTING.md#bugs) |
+| Request a feature | [`CONTRIBUTING.md#feature-requests`](CONTRIBUTING.md#feature-requests) |
+| Report a documentation need | [`CONTRIBUTING.md#documentation-issues`](CONTRIBUTING.md#documentation-issues) |
+| Get support guidance | [`SUPPORT.md`](SUPPORT.md) |
+| Report a security issue | [`SECURITY.md`](SECURITY.md) |
 
-```mermaid
-graph LR
-    ver["Check Version<br/><small>compare Cargo.toml vs git tag</small>"]
-    buildL["Build Linux<br/><small>x64 + arm64 (cross)</small>"]
-    buildM["Build macOS<br/><small>arm64 + x64 (cross)</small>"]
-    buildW["Build Windows<br/><small>x64 + arm64 (cross)</small>"]
-    release["Release<br/><small>merge staged natives → pack → tag → GitHub Release</small>"]
-
-    ver --> buildL
-    ver --> buildM
-    ver --> buildW
-    buildL --> release
-    buildM --> release
-    buildW --> release
-```
-
-Each build runner uploads only the platform-native inputs it produced:
-
-- `publish/native/` direct-download CLI binaries
-- `packages/webui-*` directories populated with the platform CLI + Node addon
-- `dotnet/runtimes/*` directories populated with the platform FFI library
-
-The release job merges those staged files and then runs `cargo xtask publish-stage --pack-only`
-once on Linux to build the final `publish/` folder:
-
-| Subfolder | Contents | Target registry |
-|-----------|----------|-----------------|
-| `publish/npm/` | `.tgz` tarballs (8 packages) | npmjs |
-| `publish/nuget/` | `.nupkg` files (2 packages) | NuGet |
-| `publish/crates/` | `.crate` files (12 crates) | crates.io |
-| `publish/wasm/` | `.wasm` + `.js` glue | CDN / static hosting |
-| `publish/native/` | CLI binaries per platform | Direct download |
-
-**Release workflow:** `cargo xtask version 0.2.0` → commit → merge to `main` → CI auto-tags `v0.2.0` → creates GitHub Release with all artifacts.
-
-Screenshot baselines are generated on CI (Ubuntu). When e2e fails, CI automatically re-runs with `--update-snapshots` and uploads the corrected baselines as an artifact. Use `cargo xtask e2e-approve` to download and apply them.
-
-### E2E Testing
-
-E2E tests use [Playwright](https://playwright.dev). Screenshot baselines are the CI runner's source of truth — locally, visual regression tests may differ due to platform fonts.
-
-| Command | Description |
-|---------|-------------|
-| `cargo xtask e2e` | Run E2E tests |
-| `cargo xtask e2e --update-snapshots` | Regenerate screenshot baselines locally |
-| `cargo xtask e2e-approve` | Download CI baselines from the latest run on your branch |
-| `cargo xtask e2e-approve <run-id>` | Download CI baselines from a specific run |
-
-**Workflow for visual changes:**
-1. Push your branch → CI runs e2e
-2. If screenshots fail → CI regenerates baselines and uploads `e2e-updated-baselines` artifact
-3. Inspect the `e2e-test-results` artifact to review diffs (actual vs expected)
-4. If the new rendering is correct → run `cargo xtask e2e-approve` → review with `git diff` → commit
-
-Locally, `cargo xtask check` uses the same phased parallelism:
-- Phase 1: `license-headers → fmt → clippy` (sequential, fail-fast)
-- Phase 2: `deny + test` (parallel)
-- Phase 3: `build + build-wasm` (parallel)
-- Phase 4: `build-examples + bench + docs` (parallel, examples built concurrently)
-
-### Project Structure
-
-```
-crates/
-├── webui/              # Library API (build, inspect, re-exports)
-├── webui-cli/          # CLI binary
-├── webui-node/         # Node.js native addon (napi-rs)
-├── webui-ffi/          # C-compatible FFI bindings
-├── webui-wasm/         # WebAssembly bindings
-├── webui-parser/       # HTML/CSS parser
-├── webui-protocol/     # Protocol definition (protobuf)
-├── webui-handler/      # Rendering engine
-├── webui-expressions/  # Expression evaluator
-├── webui-state/        # State management
-├── webui-discovery/    # Component discovery
-└── webui-test-utils/   # Shared test helpers
-packages/
-└── webui/              # @microsoft/webui npm package
-docs/                   # VitePress documentation site
-```
-
-### Key Files
-
-- [`DESIGN.md`](DESIGN.md) — Technical specification (the source of truth)
-- [`clippy.toml`](clippy.toml) — Lint policy (no `unwrap`/`expect`, complexity ≤ 20)
-- [`deny.toml`](deny.toml) — License allowlist & advisory audit
-
-## Contributing
-
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third party policies.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,27 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
-## How to file issues and get help  
+WebUI is in active development. Support is provided through GitHub Issues for actionable bug reports, feature requests, and documentation needs.
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
+## Before opening an issue
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+- Search the [existing issues](https://github.com/microsoft/webui/issues) to avoid duplicates.
+- Check the [documentation](https://microsoft.github.io/webui) for current guidance.
+- Include enough detail for maintainers to understand the need or reproduce the problem.
 
-## Microsoft Support Policy  
+## Where to ask
 
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+| Need | Use |
+|------|-----|
+| Bug report | Open a GitHub Issue using the guidance in [`CONTRIBUTING.md#bugs`](CONTRIBUTING.md#bugs). |
+| Feature request | Open a GitHub Issue using the guidance in [`CONTRIBUTING.md#feature-requests`](CONTRIBUTING.md#feature-requests). |
+| Documentation issue | Open a GitHub Issue using the guidance in [`CONTRIBUTING.md#documentation-issues`](CONTRIBUTING.md#documentation-issues). |
+| Security vulnerability | Do not open a public issue. Follow [`SECURITY.md`](SECURITY.md). |
+| Pull request | Pull requests are not being accepted right now. See [`CONTRIBUTING.md#pull-requests-are-paused`](CONTRIBUTING.md#pull-requests-are-paused). |
+
+## What to include
+
+For bugs, include a minimal reproduction, exact steps, expected behavior, actual behavior, environment details, and relevant logs. For feature or documentation requests, describe the need, who is affected, and what outcome would solve it.
+
+## Microsoft Support Policy
+
+Support for this project is limited to the resources listed above.


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md with the current issue-first contribution policy and paused pull request guidance.
- Replace the SUPPORT.md placeholder with issue-based support guidance for bugs, features, docs, security, and PRs.
- Simplify README.md and link to contribution, support, security, and issue-reporting sections.

## Validation

- cargo xtask check