### PR TITLE
chore: add GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Report a reproducible problem in WebUI.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve WebUI. Before opening a bug, please read the [bug reporting guidance](https://github.com/microsoft/webui/blob/main/CONTRIBUTING.md#bugs).
+
+        Do not report security vulnerabilities here. Follow the [security policy](https://github.com/microsoft/webui/security/policy) instead.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of WebUI does this affect?
+      options:
+        - CLI
+        - Parser
+        - Handler
+        - Protocol
+        - FFI
+        - WebUI Framework package
+        - WebUI Router package
+        - Documentation
+        - Examples
+        - Integrations
+        - Performance
+        - Not sure / other
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+      placeholder: WebUI fails to render nested route content when...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: If available, provide a sample repository, small code snippet, or minimal template that reproduces the issue.
+      placeholder: Paste the smallest example that reproduces the problem.
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the exact commands or actions needed to reproduce the problem.
+      placeholder: |
+        1. Run `...`
+        2. Open `...`
+        3. Observe `...`
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include relevant versions and the command you ran.
+      value: |
+        - OS:
+        - Rust version:
+        - Node.js version:
+        - WebUI package or CLI version:
+        - Command:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or terminal output
+      description: Paste relevant logs, stack traces, or terminal output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support guidance
+    url: https://github.com/microsoft/webui/blob/main/SUPPORT.md
+    about: Read the support policy before opening a support request.
+  - name: Security vulnerability
+    url: https://github.com/microsoft/webui/security/policy
+    about: Report suspected vulnerabilities privately through the security policy.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -1,0 +1,62 @@
+name: Documentation need
+description: Report missing, confusing, or incorrect WebUI documentation.
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve WebUI documentation. Before opening an issue, please read the [documentation issue guidance](https://github.com/microsoft/webui/blob/main/CONTRIBUTING.md#documentation-issues).
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which documentation area needs attention?
+      options:
+        - Getting started
+        - CLI
+        - Template syntax
+        - Components and interactivity
+        - Routing
+        - State management
+        - Handlers and integrations
+        - Plugins
+        - Performance
+        - Examples
+        - API reference
+        - Not sure / other
+  - type: input
+    id: location
+    attributes:
+      label: Page, section, or workflow
+      description: Link to the page or name the workflow, if you know it.
+      placeholder: https://microsoft.github.io/webui/guide/...
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is the documentation issue?
+      description: Describe what was confusing, missing, incorrect, or hard to find.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to find?
+      description: Describe the information or example you expected.
+  - type: textarea
+    id: helpful-information
+    attributes:
+      label: What information would help?
+      description: Include any details that would make the documentation clearer.
+  - type: textarea
+    id: suggested-wording
+    attributes:
+      label: Suggested wording or examples
+      description: If you have a suggested fix, paste it here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Request a WebUI capability, API, CLI behavior, or workflow improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping shape WebUI. Before opening a feature request, please read the [feature request guidance](https://github.com/microsoft/webui/blob/main/CONTRIBUTING.md#feature-requests).
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before filing
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of WebUI would this improve?
+      options:
+        - CLI
+        - Parser
+        - Handler
+        - Protocol
+        - FFI
+        - WebUI Framework package
+        - WebUI Router package
+        - Documentation
+        - Examples
+        - Integrations
+        - Performance
+        - Not sure / other
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or need
+      description: What are you trying to solve, and why does it matter?
+      placeholder: I want to...
+    validations:
+      required: true
+  - type: textarea
+    id: audience
+    attributes:
+      label: Who would benefit?
+      description: Describe the users, projects, or workflows this would help.
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the API, CLI behavior, runtime behavior, or workflow you would like.
+  - type: textarea
+    id: example
+    attributes:
+      label: Concrete example
+      description: Show the desired API, CLI command, template, or workflow.
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Note any performance, security, compatibility, migration, or ecosystem constraints.
+      placeholder: Performance, security, compatibility, migration, or other constraints.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: What alternatives or workarounds have you considered?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,13 @@ If a maintainer invites a pull request for a focused change, most contributions 
 - Feature requests that explain the need and expected outcome.
 - Documentation issues that identify confusing, missing, or incorrect guidance.
 
-Before opening an issue, search the [existing issues](https://github.com/microsoft/webui/issues) to avoid duplicates. Use one issue per bug, feature, or documentation need.
+Before opening an issue, search the [existing issues](https://github.com/microsoft/webui/issues) to avoid duplicates. Use one issue per bug, feature, or documentation need. Provide as much detail as you can, but do not let a missing version number or code sample stop you from reporting a useful issue.
+
+Start from the [GitHub issue template chooser](https://github.com/microsoft/webui/issues/new/choose), or use a matching form directly:
+
+- [Report a bug](https://github.com/microsoft/webui/issues/new?template=bug_report.yml)
+- [Request a feature](https://github.com/microsoft/webui/issues/new?template=feature_request.yml)
+- [Report a documentation need](https://github.com/microsoft/webui/issues/new?template=documentation_issue.yml)
 
 ## Bugs
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ WebUI is still in active development. We are not accepting unsolicited pull requ
 
 | Need | Where to go |
 |------|-------------|
-| Report a bug | [`CONTRIBUTING.md#bugs`](CONTRIBUTING.md#bugs) |
-| Request a feature | [`CONTRIBUTING.md#feature-requests`](CONTRIBUTING.md#feature-requests) |
-| Report a documentation need | [`CONTRIBUTING.md#documentation-issues`](CONTRIBUTING.md#documentation-issues) |
+| Report a bug | [Choose an issue template](https://github.com/microsoft/webui/issues/new/choose) |
+| Request a feature | [Choose an issue template](https://github.com/microsoft/webui/issues/new/choose) |
+| Report a documentation need | [Choose an issue template](https://github.com/microsoft/webui/issues/new/choose) |
 | Get support guidance | [`SUPPORT.md`](SUPPORT.md) |
 | Report a security issue | [`SECURITY.md`](SECURITY.md) |
 


### PR DESCRIPTION
## Summary

- Add GitHub Issue Forms for bug reports, feature requests, and documentation needs
- Add an issue chooser config that disables blank issues and routes support/security reports to the right places
- Update README and CONTRIBUTING links so reporters can use the chooser or direct forms with fewer required fields

## Validation

- cargo xtask check