### PR TITLE
chore(release): bump to 0.0.15 and summarize release changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "actix-web",
  "awc",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "cbindgen",
  "microsoft-webui-handler",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "clap",
  "criterion",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "criterion",
  "prost",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "microsoft-webui-handler",
  "microsoft-webui-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.14"
+version = "0.0.15"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.14", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.14" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.14" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.14" }
+microsoft-webui = { path = "../webui", version = "0.0.15", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.15" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.15" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.15" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -37,7 +37,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.14" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.15" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.14" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.14", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.14" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.14" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.15" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.15" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.14" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.14" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui = { path = "../webui", version = "0.0.15" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.14", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,7 +26,7 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 thiserror = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-html = { workspace = true }
@@ -37,7 +37,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.14" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,8 +19,8 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.14", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
+microsoft-webui = { path = "../webui", version = "0.0.15", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -43,6 +43,6 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.14" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.15" }
 actix-web = { workspace = true }
 tokio = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.14" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui_wasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.14", default-features = false }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.14" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.14" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.15" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
@@ -41,8 +41,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.14" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.14" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.14</Version>
+    <Version>0.0.15</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.14"
+  "version": "0.0.15"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Features:**
- parser comment policy strips template/style comments while preserving legal comments, with CLI, Node, docs, and benchmark coverage (#326, b513efbc).
- CSS module delivery now emits import-map data URI modules and the commerce demo defaults to module styles (#325, #327, f5cedc39, 88fc3076).

**Fixes:**
- repeat-scope event arguments hydrate correctly for framework bindings, including strict argument handling (#317, #322, 11b6a6dc, c0bd5259).
- client binding lifecycle ordering preserves child updates across conditional and repeated DOM paths (#329, 0f406667).
- compiled templates preserve raw style text instead of altering author-provided CSS content (#330, 4db730ab).

**Docs:**
- issue forms, contribution/support policy, framework rendering docs, CLI docs, and integration guides were refreshed (#321, #328, plus docs in #322/#325/#326/#329; 6853b4ca, f97bdc6a).
