### PR TITLE
feat: improve docs playground with inline edit and sharing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,8 +48,8 @@ body:
     id: reproduction
     attributes:
       label: Minimal reproduction
-      description: If available, provide a sample repository, small code snippet, or minimal template that reproduces the issue.
-      placeholder: Paste the smallest example that reproduces the problem.
+      description: If possible, reproduce the issue in the WebUI Playground and paste the share link from https://microsoft.github.io/webui/playground/. Otherwise, provide a sample repository, small code snippet, or minimal template.
+      placeholder: Paste a WebUI Playground share link or the smallest example that reproduces the problem.
   - type: textarea
     id: steps
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Start from the [GitHub issue template chooser](https://github.com/microsoft/webu
 When reporting a bug, include:
 
 - A short summary of the problem.
-- A minimal reproduction, sample repository, or small code snippet.
+- A minimal reproduction. Prefer a WebUI Playground share link from <https://microsoft.github.io/webui/playground/> when the issue can be reproduced there. Otherwise, include a sample repository or small code snippet.
 - Exact steps to reproduce the problem.
 - Expected behavior and actual behavior.
 - Environment details such as OS, Rust version, Node.js version, package version, and command used.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,7 +20,7 @@ WebUI is in active development. Support is provided through GitHub Issues for ac
 
 ## What to include
 
-For bugs, include a minimal reproduction, exact steps, expected behavior, actual behavior, environment details, and relevant logs. For feature or documentation requests, describe the need, who is affected, and what outcome would solve it.
+For bugs, include a minimal reproduction, exact steps, expected behavior, actual behavior, environment details, and relevant logs. Prefer a WebUI Playground share link from <https://microsoft.github.io/webui/playground/> when the issue can be reproduced there. For feature or documentation requests, describe the need, who is affected, and what outcome would solve it.
 
 ## Microsoft Support Policy
 

--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -265,9 +265,21 @@
   font-weight: 600;
   letter-spacing: 0.02em;
 }
+.preview-badge.loading {
+  background: var(--docs-color-bg-alt);
+  color: var(--docs-color-text-2);
+}
+.preview-badge.compiling {
+  background: rgba(234, 179, 8, 0.14);
+  color: #b77900;
+}
 .preview-badge.live {
   background: var(--docs-color-brand-bg);
   color: var(--docs-color-brand);
+}
+.preview-badge.failed {
+  background: rgba(208, 72, 72, 0.1);
+  color: #d04848;
 }
 
 .preview-stats {

--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -51,6 +51,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  box-sizing: border-box;
+  position: relative;
   padding: 0 16px;
   font-size: 12px;
   color: var(--docs-color-text-2);
@@ -62,25 +64,101 @@
   white-space: nowrap;
   font-family: var(--docs-font-mono);
   transition: color 0.12s, background 0.12s, border-color 0.12s;
+  user-select: none;
 }
 .tab:hover {
   color: var(--docs-color-text);
   background: var(--docs-color-bg-alt);
+}
+.tab:focus-visible {
+  outline: 1px solid var(--docs-color-brand);
+  outline-offset: -2px;
 }
 .tab[active] {
   color: var(--docs-color-text);
   background: var(--docs-color-bg);
   border-bottom-color: var(--docs-color-brand);
 }
+.tab[data-editing] {
+  padding: 0 8px;
+}
 
 .tab-icon {
   display: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+}
+.tab[data-name$=".html" i] .tab-icon-html,
+.tab[data-name$=".css" i] .tab-icon-css,
+.tab[data-name$=".json" i] .tab-icon-json {
+  display: flex;
+}
+.tab-icon svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  overflow: visible;
+}
+.tab-icon-bg {
+  stroke-width: 1;
+}
+.tab-icon-mark {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.4;
+}
+.tab-icon-html .tab-icon-bg {
+  fill: rgba(249, 115, 22, 0.13);
+  stroke: rgba(249, 115, 22, 0.7);
+}
+.tab-icon-html .tab-icon-mark {
+  stroke: #f97316;
+}
+.tab-icon-css .tab-icon-bg {
+  fill: rgba(59, 130, 246, 0.13);
+  stroke: rgba(59, 130, 246, 0.72);
+}
+.tab-icon-css .tab-icon-mark {
+  stroke: #3b82f6;
+}
+.tab-icon-json .tab-icon-bg {
+  fill: rgba(234, 179, 8, 0.14);
+  stroke: rgba(234, 179, 8, 0.72);
+}
+.tab-icon-json .tab-icon-mark {
+  stroke: #d97706;
 }
 .tab-name {
   font-family: inherit;
 }
+.tab-rename-sizer {
+  visibility: hidden;
+  font-family: inherit;
+}
+.tab-rename-input {
+  position: absolute;
+  left: 30px;
+  right: 8px;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 3px 6px;
+  border: 1px solid var(--docs-color-brand);
+  border-radius: 4px;
+  background: var(--docs-color-bg);
+  color: var(--docs-color-text);
+  outline: none;
+  font: inherit;
+}
+.tab-rename-input::placeholder {
+  color: var(--docs-color-text-3);
+}
 
-/* Protected files cannot be removed: hide their close button entirely. */
+/* Default locked files are hidden before hydration computes dynamic locks. */
 .tab[data-name="index.html"] .tab-close-btn,
 .tab[data-name="state.json"] .tab-close-btn {
   display: none;
@@ -126,23 +204,6 @@
 .tab-add-btn:hover {
   color: var(--docs-color-text);
   background: var(--docs-color-bg-alt);
-}
-
-.new-file-row {
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--docs-color-border);
-  background: var(--docs-color-bg-alt);
-}
-.new-file-row input {
-  width: 220px;
-  padding: 4px 8px;
-  font-size: 12px;
-  border: 1px solid var(--docs-color-brand);
-  border-radius: 4px;
-  background: var(--docs-color-bg);
-  color: var(--docs-color-text);
-  outline: none;
-  font-family: var(--docs-font-mono);
 }
 
 .editor-wrap {
@@ -215,6 +276,12 @@
   gap: 6px;
 }
 
+.preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .stat-badge {
   font-size: 10px;
   padding: 2px 8px;
@@ -230,6 +297,22 @@
 .stat-badge.render {
   background: var(--docs-color-bg-alt);
   color: var(--docs-color-text-2);
+}
+
+.share-btn {
+  height: 24px;
+  padding: 0 10px;
+  border: 1px solid var(--docs-color-border);
+  border-radius: 999px;
+  background: var(--docs-color-bg);
+  color: var(--docs-color-text-2);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+}
+.share-btn:hover {
+  color: var(--docs-color-text);
+  border-color: var(--docs-color-brand);
 }
 
 .error-bar {
@@ -251,6 +334,23 @@
   border: none;
   background: var(--docs-color-bg);
   width: 100%;
+}
+
+.clipboard-toast {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 1000;
+  transform: translate(-50%, -50%);
+  padding: 10px 16px;
+  border: 1px solid var(--docs-color-border);
+  border-radius: 999px;
+  background: var(--docs-color-bg);
+  color: var(--docs-color-text);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  font-size: 13px;
+  font-weight: 600;
+  pointer-events: none;
 }
 
 @media (max-width: 1024px) {

--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -178,6 +178,8 @@
   padding: 0;
   margin-left: 2px;
   opacity: 0;
+  font: inherit;
+  line-height: 1;
   transition: opacity 0.12s;
 }
 .tab:hover .tab-close-btn { opacity: 1; }

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -67,7 +67,7 @@
     <div class="preview-header">
       <div class="preview-header-left">
         <span class="preview-title">Preview</span>
-        <span class="preview-badge live">WASM Live</span>
+        <span class="preview-badge {{previewBadgeState}}">{{previewBadge}}</span>
       </div>
       <div class="preview-actions">
         <div class="preview-stats">

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -67,7 +67,7 @@
     <div class="preview-header">
       <div class="preview-header-left">
         <span class="preview-title">Preview</span>
-        <span class="preview-badge live">Live</span>
+        <span class="preview-badge live">WASM Live</span>
       </div>
       <div class="preview-actions">
         <div class="preview-stats">

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -3,31 +3,63 @@
     <div class="tab-bar">
       <div class="tab-strip">
         <for each="file in files">
-          <button
+          <div
             class="tab"
             ?active="{{file.active}}"
+            ?data-editing="{{file.editing}}"
             title="{{file.name}}"
             data-name="{{file.name}}"
+            role="button"
+            tabindex="0"
             @click="{selectTab(e)}"
+            @dblclick="{startFileRename(e)}"
+            @keydown="{onTabKeydown(e)}"
           >
-            <span class="tab-name">{{file.name}}</span>
-            <span class="tab-close-btn" role="button" title="Close file" data-name="{{file.name}}" @click="{closeFile(e)}">×</span>
-          </button>
+            <span class="tab-icon tab-icon-html" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <rect class="tab-icon-bg" x="1.5" y="1.5" width="13" height="13" rx="4"></rect>
+                <path class="tab-icon-mark" d="M6.3 5.2 3.8 8l2.5 2.8M9.7 5.2 12.2 8l-2.5 2.8"></path>
+              </svg>
+            </span>
+            <span class="tab-icon tab-icon-css" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <rect class="tab-icon-bg" x="1.5" y="1.5" width="13" height="13" rx="4"></rect>
+                <path class="tab-icon-mark" d="M4.2 5.2h7.6M4.2 8h6.5M4.2 10.8h5"></path>
+              </svg>
+            </span>
+            <span class="tab-icon tab-icon-json" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false">
+                <rect class="tab-icon-bg" x="1.5" y="1.5" width="13" height="13" rx="4"></rect>
+                <path class="tab-icon-mark" d="M6.1 4.2c-1.1 0-1.6.5-1.6 1.6v.8c0 .8-.4 1.2-1.1 1.4.7.2 1.1.6 1.1 1.4v.8c0 1.1.5 1.6 1.6 1.6M9.9 4.2c1.1 0 1.6.5 1.6 1.6v.8c0 .8.4 1.2 1.1 1.4-.7.2-1.1.6-1.1 1.4v.8c0 1.1-.5 1.6-1.6 1.6"></path>
+              </svg>
+            </span>
+            <if condition="file.editing">
+              <span class="tab-rename-sizer">{{file.editValue}}</span>
+              <input
+                class="tab-rename-input"
+                type="text"
+                value="{{file.editValue}}"
+                placeholder="{{file.placeholder}}"
+                spellcheck="false"
+                aria-label="File name"
+                @click="{stopTabEvent(e)}"
+                @dblclick="{stopTabEvent(e)}"
+                @input="{onFileEditInput(e)}"
+                @keydown="{onFileEditKey(e)}"
+                @blur="{saveFileEdit(e)}"
+              />
+            </if>
+            <if condition="!file.editing">
+              <span class="tab-name">{{file.name}}</span>
+              <if condition="!file.locked">
+                <span class="tab-close-btn" role="button" title="Close file" data-name="{{file.name}}" @click="{closeFile(e)}" @dblclick="{stopTabEvent(e)}">×</span>
+              </if>
+            </if>
+          </div>
         </for>
       </div>
       <button class="tab-add-btn" type="button" title="New file" @click="{openNewFileInput()}">+</button>
     </div>
-    <if condition="newFileVisible">
-      <div class="new-file-row">
-        <input
-          class="new-file-input"
-          type="text"
-          placeholder="filename.html"
-          @keydown="{onNewFileKey(e)}"
-          @blur="{cancelNewFile()}"
-        />
-      </div>
-    </if>
     <div class="editor-wrap" w-ref="{editorWrap}"></div>
   </div>
   <div class="panel-divider"></div>
@@ -37,11 +69,14 @@
         <span class="preview-title">Preview</span>
         <span class="preview-badge live">Live</span>
       </div>
-      <div class="preview-stats">
-        <if condition="hasStats">
-          <span class="stat-badge build">Build {{buildMs}}ms</span>
-          <span class="stat-badge render">Render {{renderMs}}ms</span>
-        </if>
+      <div class="preview-actions">
+        <div class="preview-stats">
+          <if condition="hasStats">
+            <span class="stat-badge build">Build {{buildMs}}ms</span>
+            <span class="stat-badge render">Render {{renderMs}}ms</span>
+          </if>
+        </div>
+        <button class="share-btn" type="button" @click="{sharePlayground()}">Share</button>
       </div>
     </div>
     <if condition="errorMessage">
@@ -49,4 +84,7 @@
     </if>
     <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
   </div>
+  <if condition="toastMessage">
+    <div class="clipboard-toast">{{toastMessage}}</div>
+  </if>
 </div>

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -52,7 +52,16 @@
             <if condition="!file.editing">
               <span class="tab-name">{{file.name}}</span>
               <if condition="!file.locked">
-                <span class="tab-close-btn" role="button" title="Close file" data-name="{{file.name}}" @click="{closeFile(e)}" @dblclick="{stopTabEvent(e)}">×</span>
+                <button
+                  class="tab-close-btn"
+                  type="button"
+                  title="Close file"
+                  data-name="{{file.name}}"
+                  @click="{closeFile(e)}"
+                  @dblclick="{stopTabEvent(e)}"
+                >
+                  ×
+                </button>
               </if>
             </if>
           </div>
@@ -85,6 +94,13 @@
     <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
   </div>
   <if condition="toastMessage">
-    <div class="clipboard-toast">{{toastMessage}}</div>
+    <div
+      class="clipboard-toast"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {{toastMessage}}
+    </div>
   </if>
 </div>

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -31,15 +31,181 @@ interface FileEntry {
   name: string;
   active: boolean;
   content: string;
+  editing: boolean;
+  locked: boolean;
+  pending: boolean;
+  editValue: string;
+  placeholder: string;
+}
+
+interface SerializedFileEntry {
+  name: string;
+  content: string;
+}
+
+interface LoadedPlayground {
+  files: FileEntry[];
+  entry: string;
+  active: string;
+  stateFile: string;
 }
 
 const STATE_FILE = "state.json";
 const ENTRY_FILE = "index.html";
-const PROTECTED_FILES = new Set([ENTRY_FILE, STATE_FILE]);
+const SHARE_PARAM = "playground";
+const SHARE_VERSION = 1;
+const DEFAULT_NEW_FILE_STEM = "new-component";
+const DEFAULT_NEW_FILE = `${DEFAULT_NEW_FILE_STEM}-1.html`;
+const COMPANION_EXTENSIONS = ["html", "css"];
+const EDITABLE_EXTENSIONS = new Set(COMPANION_EXTENSIONS);
 
 interface PlaygroundData {
   entry?: string;
-  files: FileEntry[];
+  files: SerializedFileEntry[];
+}
+
+interface SharedPlaygroundPayload {
+  v: number;
+  entry: string;
+  active: string;
+  stateFile: string;
+  files: SerializedFileEntry[];
+}
+
+function createFileEntry(
+  name: string,
+  content: string,
+  active: boolean,
+  locked = false,
+): FileEntry {
+  return {
+    name,
+    active,
+    content,
+    editing: false,
+    locked,
+    pending: false,
+    editValue: "",
+    placeholder: "",
+  };
+}
+
+function orderFiles(
+  files: FileEntry[],
+  entry: string,
+  stateFile: string,
+): FileEntry[] {
+  const ordered: FileEntry[] = [];
+  const pinned = new Set<string>();
+  for (const name of [entry, stateFile]) {
+    if (!name || pinned.has(name)) continue;
+    const file = files.find((f) => f.name === name);
+    if (file) {
+      ordered.push(file);
+      pinned.add(name);
+    }
+  }
+  for (const file of files) {
+    if (!pinned.has(file.name)) ordered.push(file);
+  }
+  return ordered;
+}
+
+function fileNameParts(name: string): { stem: string; extension: string } {
+  const slash = Math.max(name.lastIndexOf("/"), name.lastIndexOf("\\"));
+  const dot = name.lastIndexOf(".");
+  if (dot > slash) {
+    return { stem: name.slice(0, dot), extension: name.slice(dot) };
+  }
+  return { stem: name, extension: "" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function encodeBase64Url(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): unknown {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(base64 + padding);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+}
+
+function normalizeSharedFiles(value: unknown): LoadedPlayground | null {
+  if (!isRecord(value)) {
+    throw new Error("Shared playground payload must be an object.");
+  }
+  if (value.v !== SHARE_VERSION) {
+    throw new Error("Shared playground payload version is not supported.");
+  }
+  if (!Array.isArray(value.files) || value.files.length === 0) {
+    throw new Error("Shared playground payload does not contain files.");
+  }
+
+  const seen = new Set<string>();
+  const files: FileEntry[] = [];
+  for (const item of value.files) {
+    if (!isRecord(item)) {
+      throw new Error("Shared playground file entry must be an object.");
+    }
+    if (typeof item.name !== "string" || typeof item.content !== "string") {
+      throw new Error("Shared playground file entries need name and content.");
+    }
+    const name = item.name.trim();
+    if (!name) {
+      throw new Error("Shared playground file names cannot be empty.");
+    }
+    if (seen.has(name)) {
+      throw new Error(`Shared playground contains duplicate file "${name}".`);
+    }
+    seen.add(name);
+    files.push(createFileEntry(name, item.content, false));
+  }
+
+  const entry =
+    typeof value.entry === "string" && seen.has(value.entry)
+      ? value.entry
+      : seen.has(ENTRY_FILE)
+        ? ENTRY_FILE
+        : files[0].name;
+  let stateFile = STATE_FILE;
+  if (typeof value.stateFile === "string") {
+    stateFile =
+      value.stateFile === "" || seen.has(value.stateFile)
+        ? value.stateFile
+        : STATE_FILE;
+  }
+  const active =
+    typeof value.active === "string" && seen.has(value.active)
+      ? value.active
+      : entry;
+  for (const file of files) {
+    file.active = file.name === active;
+    file.locked = file.name === entry || file.name === stateFile;
+  }
+  return { files: orderFiles(files, entry, stateFile), entry, active, stateFile };
+}
+
+function loadSharedPlayground(): LoadedPlayground | null {
+  const encoded = new URLSearchParams(window.location.search).get(SHARE_PARAM);
+  if (!encoded) return null;
+  return normalizeSharedFiles(decodeBase64Url(encoded));
 }
 
 /**
@@ -50,9 +216,12 @@ interface PlaygroundData {
  * `crates/webui-press/src/content.rs`. Falls back to a single empty entry file
  * if the page was published without a state file.
  */
-function loadInitialFiles(): { files: FileEntry[]; entry: string } {
+function loadInitialFiles(): LoadedPlayground {
+  const shared = loadSharedPlayground();
+  if (shared) return shared;
+
   const w = window as unknown as {
-    __webui?: { state?: { files?: FileEntry[]; entry?: string } };
+    __webui?: { state?: PlaygroundData };
   };
   const top = w.__webui?.state;
   if (top && Array.isArray(top.files) && top.files.length > 0) {
@@ -60,48 +229,76 @@ function loadInitialFiles(): { files: FileEntry[]; entry: string } {
       top.entry && top.files.some((f) => f.name === top.entry)
         ? top.entry
         : top.files[0].name;
+    const stateFile = top.files.some((f) => f.name === STATE_FILE)
+      ? STATE_FILE
+      : "";
+    const files = top.files.map((f) =>
+      createFileEntry(
+        f.name,
+        typeof f.content === "string" ? f.content : "",
+        f.name === entry,
+        f.name === entry || f.name === stateFile,
+      ),
+    );
     return {
-      files: top.files.map((f) => ({
-        name: f.name,
-        active: f.name === entry,
-        content: typeof f.content === "string" ? f.content : "",
-      })),
+      files: orderFiles(files, entry, stateFile),
       entry,
+      active: entry,
+      stateFile,
     };
   }
   return {
-    files: [{ name: ENTRY_FILE, active: true, content: "" }],
+    files: [createFileEntry(ENTRY_FILE, "", true, true)],
     entry: ENTRY_FILE,
+    active: ENTRY_FILE,
+    stateFile: STATE_FILE,
   };
 }
 
 function extOf(name: string): string {
   const i = name.lastIndexOf(".");
-  return i >= 0 ? name.slice(i + 1) : "";
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : "";
 }
 
 export class DocsPlayground extends WebUIElement {
   editorWrap!: HTMLDivElement;
 
   @observable files: FileEntry[] = [];
-  @observable newFileVisible = false;
   @observable hasStats = false;
   @observable buildMs = "";
   @observable renderMs = "";
   @observable errorMessage = "";
   @observable previewSrcdoc = "";
+  @observable toastMessage = "";
 
   private active: string = ENTRY_FILE;
+  private entry: string = ENTRY_FILE;
+  private stateFile: string = STATE_FILE;
   private wasm: WasmModule | null = null;
   private editorView: EditorView | null = null;
   private renderTimer: ReturnType<typeof setTimeout> | null = null;
+  private toastTimer: ReturnType<typeof setTimeout> | null = null;
   private themeObserver: MutationObserver | null = null;
+  private suppressNextEditBlur = false;
 
   connectedCallback(): void {
     super.connectedCallback();
-    const initial = loadInitialFiles();
+    let initial: LoadedPlayground;
+    try {
+      initial = loadInitialFiles();
+    } catch (e) {
+      initial = {
+        files: [createFileEntry(ENTRY_FILE, "", true, true)],
+        entry: ENTRY_FILE,
+        active: ENTRY_FILE,
+        stateFile: STATE_FILE,
+      };
+      this.errorMessage = `Unable to load shared playground: ${String(e)}`;
+    }
     this.files = initial.files;
-    this.active = initial.entry;
+    this.entry = initial.entry;
+    this.active = initial.active;
+    this.stateFile = initial.stateFile;
     this.setupEditor();
     void this.loadWasm();
 
@@ -119,6 +316,14 @@ export class DocsPlayground extends WebUIElement {
     super.disconnectedCallback?.();
     this.themeObserver?.disconnect();
     this.themeObserver = null;
+    if (this.renderTimer) {
+      clearTimeout(this.renderTimer);
+      this.renderTimer = null;
+    }
+    if (this.toastTimer) {
+      clearTimeout(this.toastTimer);
+      this.toastTimer = null;
+    }
     this.editorView?.destroy();
     this.editorView = null;
   }
@@ -129,9 +334,52 @@ export class DocsPlayground extends WebUIElement {
     return this.files.find((f) => f.name === name);
   }
 
+  private editingFile(): FileEntry | undefined {
+    return this.files.find((f) => f.editing);
+  }
+
+  private isLockedFile(name: string): boolean {
+    return name === this.entry || (!!this.stateFile && name === this.stateFile);
+  }
+
+  private isStateFile(name: string): boolean {
+    return !!this.stateFile && name === this.stateFile;
+  }
+
+  private clearFileEdit(file: FileEntry, activeName: string): FileEntry {
+    return {
+      ...file,
+      active: file.name === activeName,
+      editing: false,
+      locked: this.isLockedFile(file.name),
+      pending: false,
+      editValue: "",
+      placeholder: "",
+    };
+  }
+
   private setActive(name: string): void {
     this.active = name;
     this.files = this.files.map((f) => ({ ...f, active: f.name === name }));
+  }
+
+  private tabByName(name: string): HTMLElement | null {
+    const tabs = this.shadowRoot?.querySelectorAll<HTMLElement>(".tab");
+    if (!tabs) return null;
+    for (const tab of tabs) {
+      if (tab.dataset.name === name) return tab;
+    }
+    return null;
+  }
+
+  private scrollTabIntoView(name: string): void {
+    setTimeout(() => {
+      this.$flushUpdates();
+      this.tabByName(name)?.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+      });
+    }, 0);
   }
 
   private flushEditorToFile(): void {
@@ -141,59 +389,258 @@ export class DocsPlayground extends WebUIElement {
     if (f) f.content = content;
   }
 
+  private uniqueFileName(candidate: string, ignoreName?: string): string {
+    const requested = candidate.trim() || DEFAULT_NEW_FILE;
+    const existing = new Set(
+      this.files.filter((f) => f.name !== ignoreName).map((f) => f.name),
+    );
+    if (!existing.has(requested)) return requested;
+
+    const { stem, extension } = fileNameParts(requested);
+    for (let i = 1; ; i += 1) {
+      const next = `${stem}-${i}${extension}`;
+      if (!existing.has(next)) return next;
+    }
+  }
+
+  private nextDefaultFileStem(): string {
+    for (let index = 1; ; index += 1) {
+      const stem = `${DEFAULT_NEW_FILE_STEM}-${index}`;
+      const htmlName = `${stem}.html`;
+      const cssName = `${stem}.css`;
+      if (this.fileByName(htmlName) && !this.fileByName(cssName)) {
+        return stem;
+      }
+      if (!this.fileByName(htmlName) && !this.fileByName(cssName)) {
+        return stem;
+      }
+    }
+  }
+
+  private suggestedNewFileName(): string {
+    const stem = this.nextDefaultFileStem();
+    const htmlName = `${stem}.html`;
+    if (this.fileByName(htmlName)) return `${stem}.css`;
+    return htmlName;
+  }
+
+  private focusInlineFileInput(selectValue: boolean): void {
+    setTimeout(() => {
+      this.$flushUpdates();
+      const input = this.shadowRoot?.querySelector<HTMLInputElement>(
+        ".tab-rename-input",
+      );
+      input?.focus();
+      if (selectValue) input?.select();
+    }, 0);
+  }
+
+  private commitCurrentFileEditFromDom(): boolean {
+    const input = this.shadowRoot?.querySelector<HTMLInputElement>(
+      ".tab-rename-input",
+    );
+    return input ? this.finishFileEdit(input.value) : true;
+  }
+
   // ── File operations (called from template event handlers) ─────
 
   selectTab(e: Event): void {
+    const target = e.target;
+    if (target instanceof Element && target.closest(".tab-rename-input")) {
+      return;
+    }
     const name = (e.currentTarget as HTMLElement).dataset.name;
     if (!name || name === this.active) return;
+    if (!this.commitCurrentFileEditFromDom()) return;
     this.flushEditorToFile();
     this.setActive(name);
     this.setupEditor();
+    this.scrollTabIntoView(name);
+  }
+
+  onTabKeydown(ev: KeyboardEvent): void {
+    if (ev.key !== "Enter" && ev.key !== " ") return;
+    ev.preventDefault();
+    this.selectTab(ev);
   }
 
   closeFile(e: Event): void {
     e.stopPropagation();
     const name = (e.currentTarget as HTMLElement).dataset.name;
-    if (!name || PROTECTED_FILES.has(name)) return;
-    this.files = this.files.filter((f) => f.name !== name);
+    const file = name ? this.fileByName(name) : undefined;
+    if (!file || file.locked) return;
+    const closedIndex = this.files.findIndex((f) => f.name === name);
+    const remaining = this.files.filter((f) => f.name !== name);
+    this.files = remaining;
     if (this.active === name) {
-      this.setActive(ENTRY_FILE);
+      const nextActive =
+        remaining[closedIndex - 1]?.name ??
+        remaining[closedIndex]?.name ??
+        ENTRY_FILE;
+      this.setActive(nextActive);
       this.setupEditor();
+      this.scrollTabIntoView(nextActive);
     }
     this.scheduleRender();
   }
 
+  startFileRename(e: Event): void {
+    const name = (e.currentTarget as HTMLElement).dataset.name;
+    const file = name ? this.fileByName(name) : undefined;
+    if (!file || name !== this.active || file.locked) return;
+    this.flushEditorToFile();
+    this.files = this.files.map((f) =>
+      f.name === name
+        ? {
+            ...f,
+            editing: true,
+            pending: false,
+            editValue: f.name,
+            placeholder: f.name,
+          }
+        : this.clearFileEdit(f, name),
+    );
+    this.focusInlineFileInput(true);
+  }
+
   openNewFileInput(): void {
-    this.newFileVisible = true;
-    setTimeout(() => {
-      const input = this.shadowRoot?.querySelector<HTMLInputElement>(
-        ".new-file-input",
-      );
-      input?.focus();
-    }, 0);
+    if (!this.commitCurrentFileEditFromDom()) return;
+    this.flushEditorToFile();
+    const name = this.uniqueFileName(this.suggestedNewFileName());
+    const file = createFileEntry(name, "", true);
+    file.editing = true;
+    file.pending = true;
+    file.editValue = name;
+    file.placeholder = name;
+    this.active = name;
+    this.files = [
+      ...this.files.map((f) => this.clearFileEdit(f, name)),
+      file,
+    ];
+    this.setupEditor();
+    this.scheduleRender();
+    this.scrollTabIntoView(name);
+    this.focusInlineFileInput(true);
   }
 
-  cancelNewFile(): void {
-    this.newFileVisible = false;
+  stopTabEvent(e: Event): void {
+    e.stopPropagation();
   }
 
-  onNewFileKey(ev: KeyboardEvent): void {
+  onFileEditInput(ev: Event): void {
+    const file = this.editingFile();
+    if (file) file.editValue = (ev.currentTarget as HTMLInputElement).value;
+  }
+
+  onFileEditKey(ev: KeyboardEvent): void {
+    ev.stopPropagation();
     if (ev.key === "Enter") {
       ev.preventDefault();
-      const name = (ev.currentTarget as HTMLInputElement).value.trim();
-      if (name && !this.fileByName(name)) {
-        this.files = [
-          ...this.files.map((f) => ({ ...f, active: false })),
-          { name, active: true, content: "" },
-        ];
-        this.active = name;
-        this.setupEditor();
-        this.scheduleRender();
-      }
-      this.cancelNewFile();
+      this.finishFileEdit((ev.currentTarget as HTMLInputElement).value);
     } else if (ev.key === "Escape") {
-      this.cancelNewFile();
+      ev.preventDefault();
+      this.suppressNextEditBlur = true;
+      this.cancelFileEdit();
+      setTimeout(() => {
+        this.suppressNextEditBlur = false;
+      }, 0);
     }
+  }
+
+  saveFileEdit(ev: Event): void {
+    if (this.suppressNextEditBlur) {
+      this.suppressNextEditBlur = false;
+      return;
+    }
+    this.finishFileEdit((ev.currentTarget as HTMLInputElement).value);
+  }
+
+  private validateEditableFileName(
+    name: string,
+    editing: FileEntry,
+  ): string | null {
+    const extension = extOf(name);
+    if (!EDITABLE_EXTENSIONS.has(extension)) {
+      return "Use a .html or .css file name.";
+    }
+    if (editing.name === this.entry && extension !== "html") {
+      return "The entry file must stay an .html file.";
+    }
+    return null;
+  }
+
+  private rejectFileEdit(message: string): boolean {
+    this.showToast(message);
+    this.focusInlineFileInput(false);
+    return false;
+  }
+
+  private finishFileEdit(rawName: string): boolean {
+    const editing = this.editingFile();
+    if (!editing) return true;
+    if (!editing.pending && this.isStateFile(editing.name)) {
+      this.cancelFileEdit();
+      return true;
+    }
+
+    const requested = rawName.trim();
+    if (!requested && !editing.pending) {
+      this.cancelFileEdit();
+      return true;
+    }
+
+    const candidate = requested || editing.placeholder || DEFAULT_NEW_FILE;
+    const validationError = this.validateEditableFileName(candidate, editing);
+    if (validationError) return this.rejectFileEdit(validationError);
+
+    const name = this.uniqueFileName(candidate, editing.name);
+    const renamedValidationError = this.validateEditableFileName(
+      name,
+      editing,
+    );
+    if (renamedValidationError) {
+      return this.rejectFileEdit(renamedValidationError);
+    }
+
+    this.flushEditorToFile();
+    if (editing.name === this.entry) this.entry = name;
+    this.active = name;
+    this.files = this.files.map((f) =>
+      f.name === editing.name
+        ? this.clearFileEdit({ ...f, name }, name)
+        : this.clearFileEdit(f, name),
+    );
+    this.setupEditor();
+    this.scheduleRender();
+    this.scrollTabIntoView(name);
+    return true;
+  }
+
+  private cancelFileEdit(): void {
+    const editing = this.editingFile();
+    if (!editing) return;
+
+    if (editing.pending) {
+      const remaining = this.files.filter((f) => f.name !== editing.name);
+      const nextActive =
+        remaining.find((f) => f.name === this.entry)?.name ??
+        remaining[0]?.name ??
+        ENTRY_FILE;
+      this.active = nextActive;
+      if (remaining.length > 0) {
+        this.files = remaining.map((f) => this.clearFileEdit(f, nextActive));
+      } else {
+        this.entry = ENTRY_FILE;
+        this.stateFile = STATE_FILE;
+        this.files = [createFileEntry(ENTRY_FILE, "", true, true)];
+      }
+      this.setupEditor();
+      this.scheduleRender();
+      return;
+    }
+
+    this.active = editing.name;
+    this.files = this.files.map((f) => this.clearFileEdit(f, editing.name));
   }
 
   // ── Editor ──────────────────────────────────────────────────────
@@ -246,6 +693,68 @@ export class DocsPlayground extends WebUIElement {
     });
   }
 
+  // ── Sharing ─────────────────────────────────────────────────────
+
+  async sharePlayground(): Promise<void> {
+    if (!this.commitCurrentFileEditFromDom()) return;
+    this.flushEditorToFile();
+
+    const payload: SharedPlaygroundPayload = {
+      v: SHARE_VERSION,
+      entry: this.entry,
+      active: this.active,
+      stateFile: this.stateFile,
+      files: this.files.map((f) => ({
+        name: f.name,
+        content: f.content,
+      })),
+    };
+    const url = new URL(window.location.href);
+    url.searchParams.set(SHARE_PARAM, encodeBase64Url(payload));
+
+    try {
+      await this.copyToClipboard(url.toString());
+      this.showToast("URL copied to clipboard");
+    } catch (e) {
+      this.errorMessage = `Unable to copy share URL: ${String(e)}`;
+      this.showToast("Unable to copy URL");
+    }
+  }
+
+  private async copyToClipboard(text: string): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch {
+        // Fall back to the hidden textarea path for non-secure contexts.
+      }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "true");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-1000px";
+    textarea.style.left = "-1000px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    textarea.remove();
+    if (!copied) {
+      throw new Error("Clipboard copy command failed.");
+    }
+  }
+
+  private showToast(message: string): void {
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastMessage = message;
+    this.toastTimer = setTimeout(() => {
+      this.toastMessage = "";
+      this.toastTimer = null;
+    }, 1800);
+  }
+
   // ── WASM render ─────────────────────────────────────────────────
 
   private scheduleRender(): void {
@@ -259,14 +768,14 @@ export class DocsPlayground extends WebUIElement {
       this.errorMessage = "";
       const filesObj: Record<string, string> = {};
       for (const f of this.files) {
-        if (f.name !== STATE_FILE) filesObj[f.name] = f.content;
+        if (f.name !== this.stateFile) filesObj[f.name] = f.content;
       }
 
       const t0 = performance.now();
-      const proto = this.wasm.build_protocol(filesObj, ENTRY_FILE);
+      const proto = this.wasm.build_protocol(filesObj, this.entry);
       const t1 = performance.now();
-      const stateJson = this.fileByName(STATE_FILE)?.content || "{}";
-      const html = this.wasm.render(proto, stateJson, ENTRY_FILE, "/");
+      const stateJson = this.fileByName(this.stateFile)?.content || "{}";
+      const html = this.wasm.render(proto, stateJson, this.entry, "/");
       const t2 = performance.now();
 
       this.buildMs = (t1 - t0).toFixed(1);

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -58,6 +58,7 @@ const DEFAULT_NEW_FILE_STEM = "new-component";
 const DEFAULT_NEW_FILE = `${DEFAULT_NEW_FILE_STEM}-1.html`;
 const COMPANION_EXTENSIONS = ["html", "css"];
 const EDITABLE_EXTENSIONS = new Set(COMPANION_EXTENSIONS);
+const BASE64_CHUNK_SIZE = 0x8000;
 
 interface PlaygroundData {
   entry?: string;
@@ -126,11 +127,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function encodeBase64Url(value: unknown): string {
   const bytes = new TextEncoder().encode(JSON.stringify(value));
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += 1) {
-    binary += String.fromCharCode(bytes[i]);
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += BASE64_CHUNK_SIZE) {
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(i, i + BASE64_CHUNK_SIZE)),
+    );
   }
-  return btoa(binary)
+  return btoa(chunks.join(""))
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/g, "");
@@ -178,18 +181,16 @@ function normalizeSharedFiles(value: unknown): LoadedPlayground | null {
     files.push(createFileEntry(name, item.content, false));
   }
 
-  const entry =
-    typeof value.entry === "string" && seen.has(value.entry)
+  const hasEntryFile = seen.has(ENTRY_FILE);
+  const hasStateFile = seen.has(STATE_FILE);
+  const entry = hasEntryFile
+    ? ENTRY_FILE
+    : typeof value.entry === "string" && seen.has(value.entry)
       ? value.entry
-      : seen.has(ENTRY_FILE)
-        ? ENTRY_FILE
-        : files[0].name;
-  let stateFile = STATE_FILE;
-  if (typeof value.stateFile === "string") {
-    stateFile =
-      value.stateFile === "" || seen.has(value.stateFile)
-        ? value.stateFile
-        : STATE_FILE;
+      : files[0].name;
+  let stateFile = hasStateFile ? STATE_FILE : "";
+  if (!hasStateFile && typeof value.stateFile === "string") {
+    stateFile = seen.has(value.stateFile) ? value.stateFile : "";
   }
   const active =
     typeof value.active === "string" && seen.has(value.active)
@@ -199,7 +200,12 @@ function normalizeSharedFiles(value: unknown): LoadedPlayground | null {
     file.active = file.name === active;
     file.locked = file.name === entry || file.name === stateFile;
   }
-  return { files: orderFiles(files, entry, stateFile), entry, active, stateFile };
+  return {
+    files: orderFiles(files, entry, stateFile),
+    entry,
+    active,
+    stateFile,
+  };
 }
 
 function loadSharedPlayground(): LoadedPlayground | null {

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -270,6 +270,8 @@ export class DocsPlayground extends WebUIElement {
   @observable errorMessage = "";
   @observable previewSrcdoc = "";
   @observable toastMessage = "";
+  @observable previewBadge = "Loading WASM";
+  @observable previewBadgeState = "loading";
 
   private active: string = ENTRY_FILE;
   private entry: string = ENTRY_FILE;
@@ -293,6 +295,7 @@ export class DocsPlayground extends WebUIElement {
         active: ENTRY_FILE,
         stateFile: STATE_FILE,
       };
+      this.setPreviewStatus("Failed", "failed");
       this.errorMessage = `Unable to load shared playground: ${String(e)}`;
     }
     this.files = initial.files;
@@ -757,14 +760,25 @@ export class DocsPlayground extends WebUIElement {
 
   // ── WASM render ─────────────────────────────────────────────────
 
+  private setPreviewStatus(label: string, state: string): void {
+    this.previewBadge = label;
+    this.previewBadgeState = state;
+  }
+
   private scheduleRender(): void {
     if (this.renderTimer) clearTimeout(this.renderTimer);
+    if (!this.wasm) {
+      this.setPreviewStatus("Loading WASM", "loading");
+      return;
+    }
+    this.setPreviewStatus("Compiling", "compiling");
     this.renderTimer = setTimeout(() => this.doRender(), 150);
   }
 
   private doRender(): void {
     if (!this.wasm) return;
     try {
+      this.setPreviewStatus("Compiling", "compiling");
       this.errorMessage = "";
       const filesObj: Record<string, string> = {};
       for (const f of this.files) {
@@ -797,7 +811,9 @@ export class DocsPlayground extends WebUIElement {
         "</style></head><body>" +
         html +
         "</body></html>";
+      this.setPreviewStatus("WASM Live", "live");
     } catch (e) {
+      this.setPreviewStatus("Failed", "failed");
       this.errorMessage = String(e);
     }
   }
@@ -828,6 +844,7 @@ export class DocsPlayground extends WebUIElement {
 
   private async loadWasm(): Promise<void> {
     try {
+      this.setPreviewStatus("Loading WASM", "loading");
       const baseMeta = document.querySelector('meta[name="base"]');
       const base = baseMeta?.getAttribute("content") || "/";
       const mod = await import(/* @vite-ignore */ base + "wasm/webui_wasm.js");
@@ -835,6 +852,7 @@ export class DocsPlayground extends WebUIElement {
       this.wasm = mod;
       this.doRender();
     } catch (e) {
+      this.setPreviewStatus("Failed", "failed");
       this.errorMessage =
         'WASM not available. Run "cargo xtask build-wasm" to enable the playground.\n\n' +
         String(e);


### PR DESCRIPTION
## Summary

- Add inline tab rename for playground files with Enter/blur save and Escape cancel.
- Add immediate inline new-file creation with selected `new-component-N.html` / paired `.css` suggestions.
- Add file-type SVG icons for HTML, CSS, and JSON tabs.
- Restrict editable playground files to `.html` and `.css`, while keeping `index.html` and `state.json` pinned and non-renameable.
- Add shareable playground URLs that encode all files and restore them on load.
- Improve tab UX with active-tab scroll visibility and left-neighbor selection after closing a tab.
- Show playground preview lifecycle states: `Loading WASM`, `Compiling`, `WASM Live`, and `Failed`.
- Ask bug reporters to include a WebUI Playground share link when possible.

## Validation

- `cd docs && pnpm build`
- `cargo xtask check`
