### PR TITLE
fix: scope FAST hydration markers to custom elements

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -757,10 +757,22 @@ completion work such as rendered-component template emission stays in handler co
 
 ```rust
 pub trait HandlerPlugin {
+    /// Enter a structural scope, such as a loop item or active if body.
     fn push_scope(&mut self);
+
+    /// Enter a component scope.
+    /// Defaults to push_scope for plugins that do not distinguish scopes.
+    fn push_component_scope(&mut self) {
+        self.push_scope();
+    }
+
     fn pop_scope(&mut self);
     fn on_binding_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_binding_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_for_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_for_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_if_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn on_if_end(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_start(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
@@ -772,11 +784,17 @@ pub trait HandlerPlugin {
 }
 ```
 
+`push_scope` is reserved for structural scopes and `push_component_scope` is used
+for component bodies and `handle_as_component`. The default implementation keeps
+existing plugins compatible, while FAST v2/v3 override it so normal structural
+scopes do not automatically activate component hydration markers.
+
 **Hook invocation points:**
 - **Signal**: `on_binding_start` before, `on_binding_end` after (same scope)
-- **For loop**: `on_binding_start/end` around entire loop; `on_repeat_item_start/end` + `push_scope/pop_scope` per item
-- **If condition**: `on_binding_start/end` around condition; `push_scope/pop_scope` if condition is true
-- **Component**: `push_scope/pop_scope` around component body
+- **For loop**: `on_for_start/end` around entire loop; `on_repeat_item_start/end` + `push_scope/pop_scope` per item
+- **If condition**: `on_if_start/end` around condition; `push_scope/pop_scope` around the body when the condition is true
+- **Component**: `push_component_scope/pop_scope` around component body
+- **Component-only render**: `handle_as_component` wraps the entry fragment in `push_component_scope/pop_scope`
 - **Plugin fragment**: `on_element_data` with parser-produced hydration bytes from protocol
 - **Matched route component**: `write_route_component_state` before the opening tag closes
 
@@ -1334,6 +1352,15 @@ Nested `<if>` / `<for>` blocks are recursively compiled into the shared `b[]` bl
 The private workspace package `packages/webui-test-support` (`@microsoft/webui-test-support`) exists to build this metadata shape in JS-side tests without duplicating tuple encodings or fixture infrastructure across `webui-framework` and `webui-router`. It centralizes fixture builders such as `buildTemplate`, `registerCompiledTemplate`, and the condition AST helpers, and it also provides shared Node-side fixture bundling/server helpers so browser fixture apps and Playwright servers stay aligned with the runtime/compiler contract as that contract evolves.
 
 ### Plugin data and SSR hydration markers
+
+SSR hydration markers are framework/plugin-specific. The WebUI Framework plugin
+uses the marker format below. FAST v2/v3 use separate FAST marker formats, and
+their handler plugins emit those markers only inside custom element component
+scopes entered through `push_component_scope`. A normal entry page light DOM
+remains marker-free for FAST v2/v3, even when it contains signals, for-loops,
+if-conditions, or plugin element data. Structural scopes nested inside a rendered
+component inherit the component-active state, so nested for/if scopes and element
+data attributes still emit within that component.
 
 The current WebUI parser emits a 12-byte `Plugin` fragment (`WebUIElementData`) for each element that has attribute bindings or `@event` handlers:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebUI
 
-**WebUI** is a high-performance, language-agnostic server-side rendering framework built in Rust. It compiles HTML templates into compact Protocol Buffer binaries at build time so runtime rendering applies state without reparsing templates. Interactive Web Components hydrate as islands on the client.
+**WebUI** is a high-performance, language-agnostic server-side rendering framework built in Rust. It compiles HTML templates into compact Protocol Buffer binaries at build time so runtime rendering applies state without reparsing templates. Interactive custom-element islands hydrate on the client while static entry light DOM remains marker-free.
 
 **Documentation:** [microsoft.github.io/webui](https://microsoft.github.io/webui)
 
@@ -10,7 +10,7 @@
 - **Language agnostic:** Rust, Node/Bun/Deno, C#, Python, Go, and any language that can call C FFI.
 - **Web Components:** Native custom elements with Shadow DOM support.
 - **Server-side logic:** Conditions, loops, and expressions are evaluated on the server.
-- **Plugin-ready:** Parser and handler plugins support framework-specific hydration and directives.
+- **Plugin-ready:** Parser and handler plugins support framework-specific custom-element island hydration and directives.
 
 ## Install
 

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -514,7 +514,7 @@ impl WebUIHandler {
         };
 
         if let Some(p) = &mut context.plugin {
-            p.push_scope();
+            p.push_component_scope();
         }
 
         self.process_fragment_id(entry_id, &mut context)?;
@@ -877,7 +877,7 @@ impl WebUIHandler {
         context.local_vars = saved_component_attrs;
 
         if let Some(p) = &mut context.plugin {
-            p.push_scope();
+            p.push_component_scope();
         }
 
         self.process_fragment_id(&component.fragment_id, context)?;

--- a/crates/webui-handler/src/plugin/fast.rs
+++ b/crates/webui-handler/src/plugin/fast.rs
@@ -52,7 +52,7 @@ mod tests {
     #[allow(deprecated)]
     fn test_fast_alias_uses_v2_markers() {
         let mut plugin = FastHydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         assert!(plugin.on_binding_start("userName", &mut writer).is_ok());
         assert_eq!(writer.output, "<!--fe-b$$start$$0$$userName$$fe-b-->");

--- a/crates/webui-handler/src/plugin/fast_v2.rs
+++ b/crates/webui-handler/src/plugin/fast_v2.rs
@@ -31,6 +31,28 @@ const V2_REPEAT_SUFFIX: &str = "$$fe-repeat-->";
 const V2_ATTR_SINGLE_PREFIX: &str = " data-fe-b-";
 const V2_ATTR_MULTI_PREFIX: &str = " data-fe-c-";
 
+#[derive(Clone, Copy)]
+struct HydrationScope {
+    binding_count: usize,
+    in_component: bool,
+}
+
+impl HydrationScope {
+    const fn root() -> Self {
+        Self {
+            binding_count: 0,
+            in_component: false,
+        }
+    }
+
+    const fn child(in_component: bool) -> Self {
+        Self {
+            binding_count: 0,
+            in_component,
+        }
+    }
+}
+
 /// Deprecated FAST 2 hydration handler plugin.
 ///
 /// Emits the legacy FAST 2 marker format used by the `fast` and `fast-v2`
@@ -39,7 +61,7 @@ const V2_ATTR_MULTI_PREFIX: &str = " data-fe-c-";
 pub struct FastV2HydrationPlugin {
     /// Stack of local binding counters (one per scope).
     /// The bottom of the stack is the root scope (disabled).
-    scopes: Vec<usize>,
+    scopes: Vec<HydrationScope>,
     /// Stack of binding indices for matching start/end pairs.
     binding_stack: Vec<usize>,
     /// Reusable buffer for formatting markers without allocation.
@@ -48,27 +70,27 @@ pub struct FastV2HydrationPlugin {
 
 impl FastV2HydrationPlugin {
     /// Create a new deprecated FAST 2 hydration plugin.
-    /// The initial root scope is disabled — markers only emit in child scopes.
+    /// The initial root scope is disabled — markers only emit inside components.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            // Root scope (index 0) is disabled — only scopes.len() > 1 are active.
-            scopes: vec![0],
+            // Root scope (index 0) is disabled.
+            scopes: vec![HydrationScope::root()],
             binding_stack: Vec::with_capacity(8),
             buffer: String::with_capacity(64),
         }
     }
 
-    /// Whether the current scope is active (not the root scope).
+    /// Whether the current scope is inside a custom element component.
     fn is_active(&self) -> bool {
-        self.scopes.len() > 1
+        matches!(self.scopes.last(), Some(scope) if scope.in_component)
     }
 
     /// Get the next binding index in the current scope, advancing the counter.
     fn next_index(&mut self) -> usize {
-        if let Some(counter) = self.scopes.last_mut() {
-            let index = *counter;
-            *counter += 1;
+        if let Some(scope) = self.scopes.last_mut() {
+            let index = scope.binding_count;
+            scope.binding_count += 1;
             index
         } else {
             0
@@ -77,9 +99,9 @@ impl FastV2HydrationPlugin {
 
     /// Get the next binding index, advancing the counter by `count`.
     fn next_index_n(&mut self, count: u32) -> usize {
-        if let Some(counter) = self.scopes.last_mut() {
-            let index = *counter;
-            *counter += count as usize;
+        if let Some(scope) = self.scopes.last_mut() {
+            let index = scope.binding_count;
+            scope.binding_count += count as usize;
             index
         } else {
             0
@@ -125,11 +147,17 @@ impl Default for FastV2HydrationPlugin {
 
 impl HandlerPlugin for FastV2HydrationPlugin {
     fn push_scope(&mut self) {
-        self.scopes.push(0);
+        self.scopes.push(HydrationScope::child(self.is_active()));
+    }
+
+    fn push_component_scope(&mut self) {
+        self.scopes.push(HydrationScope::child(true));
     }
 
     fn pop_scope(&mut self) {
-        self.scopes.pop();
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
     }
 
     fn on_binding_start(&mut self, name: &str, writer: &mut dyn ResponseWriter) -> Result<()> {
@@ -239,6 +267,10 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use super::*;
+    use crate::{RenderOptions, WebUIHandler};
+    use std::collections::HashMap;
+    use webui_protocol::{ConditionExpr, FragmentList, WebUIFragment, WebUIProtocol};
+    use webui_test_utils::test_json;
 
     struct TestWriter {
         output: String,
@@ -265,7 +297,7 @@ mod tests {
     #[test]
     fn test_fast_v2_binding_marker_format() {
         let mut plugin = FastV2HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("userName", &mut writer).unwrap();
         plugin.on_binding_end("userName", &mut writer).unwrap();
@@ -278,7 +310,7 @@ mod tests {
     #[test]
     fn test_fast_v2_binding_sequence_uses_indexes() {
         let mut plugin = FastV2HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("a", &mut writer).unwrap();
         plugin.on_binding_end("a", &mut writer).unwrap();
@@ -290,7 +322,7 @@ mod tests {
     #[test]
     fn test_fast_v2_repeat_marker_format() {
         let mut plugin = FastV2HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_repeat_item_start(2, &mut writer).unwrap();
         plugin.on_repeat_item_end(2, &mut writer).unwrap();
@@ -303,14 +335,14 @@ mod tests {
     #[test]
     fn test_fast_v2_attribute_marker_formats() {
         let mut single = FastV2HydrationPlugin::new();
-        single.push_scope();
+        single.push_component_scope();
         let mut writer = TestWriter::new();
         let one = 1u32.to_le_bytes();
         single.on_element_data(&one, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-b-0");
 
         let mut multi = FastV2HydrationPlugin::new();
-        multi.push_scope();
+        multi.push_component_scope();
         writer.output.clear();
         let three = 3u32.to_le_bytes();
         multi.on_element_data(&three, &mut writer).unwrap();
@@ -320,7 +352,7 @@ mod tests {
     #[test]
     fn test_fast_v2_attribute_count_advances_binding_index() {
         let mut plugin = FastV2HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let three = 3u32.to_le_bytes();
         plugin.on_element_data(&three, &mut writer).unwrap();
@@ -333,6 +365,20 @@ mod tests {
     #[test]
     fn test_fast_v2_root_scope_disabled() {
         let mut plugin = FastV2HydrationPlugin::new();
+        let mut writer = TestWriter::new();
+        plugin.on_binding_start("x", &mut writer).unwrap();
+        plugin.on_binding_end("x", &mut writer).unwrap();
+        plugin.on_repeat_item_start(0, &mut writer).unwrap();
+        plugin.on_repeat_item_end(0, &mut writer).unwrap();
+        let data = 3u32.to_le_bytes();
+        plugin.on_element_data(&data, &mut writer).unwrap();
+        assert_eq!(writer.output, "");
+    }
+
+    #[test]
+    fn test_fast_v2_structural_scope_disabled_outside_component() {
+        let mut plugin = FastV2HydrationPlugin::new();
+        plugin.push_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("x", &mut writer).unwrap();
         plugin.on_binding_end("x", &mut writer).unwrap();
@@ -366,5 +412,193 @@ mod tests {
             "FAST v2 handler plugin should still emit scalar attrs: {}",
             writer.output
         );
+    }
+
+    fn render_with_fast_v2(protocol: &WebUIProtocol, state: &serde_json::Value) -> String {
+        let mut writer = TestWriter::new();
+        let handler = WebUIHandler::with_plugin(|| Box::new(FastV2HydrationPlugin::new()));
+        handler
+            .handle(
+                protocol,
+                state,
+                &RenderOptions::new("index.html", "/"),
+                &mut writer,
+            )
+            .unwrap();
+        writer.output
+    }
+
+    fn assert_no_fast_v2_markers(output: &str) {
+        assert!(
+            !output.contains("<!--fe-b"),
+            "entry light DOM must not contain FAST v2 binding markers: {output}"
+        );
+        assert!(
+            !output.contains("<!--fe-repeat"),
+            "entry light DOM must not contain FAST v2 repeat markers: {output}"
+        );
+        assert!(
+            !output.contains("data-fe-"),
+            "entry light DOM must not contain FAST v2 attribute markers: {output}"
+        );
+    }
+
+    #[test]
+    fn test_fast_v2_full_render_root_for_skips_hydration_markers() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<main>"),
+                    WebUIFragment::for_loop("item", "items", "row"),
+                    WebUIFragment::raw("</main>"),
+                ],
+            },
+        );
+        fragments.insert(
+            "row".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<p"),
+                    WebUIFragment::attribute("class", "item.name"),
+                    WebUIFragment::plugin(1u32.to_le_bytes().to_vec()),
+                    WebUIFragment::raw(">"),
+                    WebUIFragment::signal("item.name", false),
+                    WebUIFragment::raw("</p>"),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({"items": [{"name": "A"}, {"name": "B"}]});
+        let output = render_with_fast_v2(&protocol, &state);
+
+        assert_eq!(
+            output,
+            r#"<main><p class="A">A</p><p class="B">B</p></main>"#
+        );
+        assert_no_fast_v2_markers(&output);
+    }
+
+    #[test]
+    fn test_fast_v2_full_render_root_if_skips_hydration_markers() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<section>"),
+                    WebUIFragment::if_cond(ConditionExpr::identifier("show"), "visible"),
+                    WebUIFragment::raw("</section>"),
+                ],
+            },
+        );
+        fragments.insert(
+            "visible".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<span"),
+                    WebUIFragment::attribute("title", "title"),
+                    WebUIFragment::plugin(1u32.to_le_bytes().to_vec()),
+                    WebUIFragment::raw(">"),
+                    WebUIFragment::signal("title", false),
+                    WebUIFragment::raw("</span>"),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({"show": true, "title": "Hello"});
+        let output = render_with_fast_v2(&protocol, &state);
+
+        assert_eq!(
+            output,
+            r#"<section><span title="Hello">Hello</span></section>"#
+        );
+        assert_no_fast_v2_markers(&output);
+    }
+
+    #[test]
+    fn test_fast_v2_full_render_component_for_keeps_hydration_markers() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::component("my-comp")],
+            },
+        );
+        fragments.insert(
+            "my-comp".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<ul>"),
+                    WebUIFragment::for_loop("item", "items", "row"),
+                    WebUIFragment::raw("</ul>"),
+                ],
+            },
+        );
+        fragments.insert(
+            "row".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<li"),
+                    WebUIFragment::attribute("data-name", "item"),
+                    WebUIFragment::plugin(1u32.to_le_bytes().to_vec()),
+                    WebUIFragment::raw(">"),
+                    WebUIFragment::signal("item", false),
+                    WebUIFragment::raw("</li>"),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({"items": ["A", "B"]});
+        let output = render_with_fast_v2(&protocol, &state);
+
+        assert!(output.contains("<!--fe-b$$start$$0$$row$$fe-b-->"));
+        assert!(output.contains("<!--fe-repeat$$start$$0$$fe-repeat-->"));
+        assert!(output.contains(r#"<li data-name="A" data-fe-b-0>"#));
+        assert!(output.contains("<!--fe-b$$start$$1$$item$$fe-b-->A"));
+        assert!(output.contains("<!--fe-repeat$$end$$1$$fe-repeat-->"));
+        assert!(output.contains("<!--fe-b$$end$$0$$row$$fe-b-->"));
+    }
+
+    #[test]
+    fn test_fast_v2_full_render_component_if_keeps_hydration_markers() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::component("my-comp")],
+            },
+        );
+        fragments.insert(
+            "my-comp".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::if_cond(
+                    ConditionExpr::identifier("show"),
+                    "if-body",
+                )],
+            },
+        );
+        fragments.insert(
+            "if-body".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<span"),
+                    WebUIFragment::attribute("title", "title"),
+                    WebUIFragment::plugin(1u32.to_le_bytes().to_vec()),
+                    WebUIFragment::raw(">"),
+                    WebUIFragment::signal("title", false),
+                    WebUIFragment::raw("</span>"),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({"show": true, "title": "Hello"});
+        let output = render_with_fast_v2(&protocol, &state);
+
+        assert!(output.contains("<!--fe-b$$start$$0$$if-body$$fe-b-->"));
+        assert!(output.contains(r#"<span title="Hello" data-fe-b-0>"#));
+        assert!(output.contains("<!--fe-b$$start$$1$$title$$fe-b-->Hello"));
+        assert!(output.contains("<!--fe-b$$end$$0$$if-body$$fe-b-->"));
     }
 }

--- a/crates/webui-handler/src/plugin/fast_v3.rs
+++ b/crates/webui-handler/src/plugin/fast_v3.rs
@@ -28,44 +28,67 @@ const REPEAT_END_MARKER: &str = "<!--fe:/r-->";
 const ATTR_PREFIX: &str = " data-fe=\"";
 const ATTR_SUFFIX: &str = "\"";
 
+#[derive(Clone, Copy)]
+struct HydrationScope {
+    binding_count: usize,
+    in_component: bool,
+}
+
+impl HydrationScope {
+    const fn root() -> Self {
+        Self {
+            binding_count: 0,
+            in_component: false,
+        }
+    }
+
+    const fn child(in_component: bool) -> Self {
+        Self {
+            binding_count: 0,
+            in_component,
+        }
+    }
+}
+
 /// FAST 3 hydration handler plugin.
 ///
 /// Emits HTML comment markers around dynamic bindings so that FAST
 /// can re-hydrate server-rendered content on the client side.
 ///
-/// The root scope is disabled (no markers) — hydration only activates in
-/// child scopes (components, for-loop items, if-condition bodies).
-/// This matches the C++ and JS prototype behavior.
+/// The root scope is disabled (no markers) — hydration only activates inside
+/// custom element component scopes. Structural scopes nested under the entry
+/// point remain disabled until a component scope is entered.
 pub struct FastV3HydrationPlugin {
     /// Stack of local binding counters (one per scope).
     /// The bottom of the stack is the root scope (disabled).
-    scopes: Vec<usize>,
+    scopes: Vec<HydrationScope>,
     /// Reusable buffer for formatting markers without allocation.
     buffer: String,
 }
 
 impl FastV3HydrationPlugin {
     /// Create a new FAST 3 hydration plugin.
-    /// The initial root scope is disabled — markers only emitted in child scopes.
+    /// The initial root scope is disabled — markers only emit inside
+    /// component scopes.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            // Root scope (index 0) is disabled — only scopes.len() > 1 are active
-            scopes: vec![0],
+            // Root scope (index 0) is disabled.
+            scopes: vec![HydrationScope::root()],
             buffer: String::with_capacity(64),
         }
     }
 
-    /// Whether the current scope is active (not the root scope).
+    /// Whether the current scope is inside a custom element component.
     fn is_active(&self) -> bool {
-        self.scopes.len() > 1
+        matches!(self.scopes.last(), Some(scope) if scope.in_component)
     }
 
     /// Get the next binding index in the current scope, advancing the counter.
     fn next_index(&mut self) -> usize {
-        if let Some(counter) = self.scopes.last_mut() {
-            let index = *counter;
-            *counter += 1;
+        if let Some(scope) = self.scopes.last_mut() {
+            let index = scope.binding_count;
+            scope.binding_count += 1;
             index
         } else {
             0
@@ -74,9 +97,9 @@ impl FastV3HydrationPlugin {
 
     /// Get the next binding index, advancing the counter by `count`.
     fn next_index_n(&mut self, count: u32) -> usize {
-        if let Some(counter) = self.scopes.last_mut() {
-            let index = *counter;
-            *counter += count as usize;
+        if let Some(scope) = self.scopes.last_mut() {
+            let index = scope.binding_count;
+            scope.binding_count += count as usize;
             index
         } else {
             0
@@ -100,11 +123,18 @@ impl Default for FastV3HydrationPlugin {
 
 impl HandlerPlugin for FastV3HydrationPlugin {
     fn push_scope(&mut self) {
-        self.scopes.push(0);
+        let in_component = self.is_active();
+        self.scopes.push(HydrationScope::child(in_component));
+    }
+
+    fn push_component_scope(&mut self) {
+        self.scopes.push(HydrationScope::child(true));
     }
 
     fn pop_scope(&mut self) {
-        self.scopes.pop();
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
     }
 
     fn on_binding_start(&mut self, _name: &str, writer: &mut dyn ResponseWriter) -> Result<()> {
@@ -248,7 +278,7 @@ mod tests {
     #[test]
     fn test_binding_start_format() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("userName", &mut writer).unwrap();
         assert_eq!(writer.output, "<!--fe:b-->");
@@ -257,7 +287,7 @@ mod tests {
     #[test]
     fn test_binding_end_format() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("userName", &mut writer).unwrap();
         writer.output.clear();
@@ -268,7 +298,7 @@ mod tests {
     #[test]
     fn test_binding_sequence_uses_compact_markers() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_binding_start("a", &mut writer).unwrap();
         plugin.on_binding_end("a", &mut writer).unwrap();
@@ -281,12 +311,11 @@ mod tests {
     fn test_scopes_emit_compact_markers() {
         let mut plugin = FastV3HydrationPlugin::new();
         let mut writer = TestWriter::new();
-        // Push first active scope (root is disabled)
-        plugin.push_scope();
-        // Active scope emits compact markers.
+        // Component scope activates markers.
+        plugin.push_component_scope();
         plugin.on_binding_start("a", &mut writer).unwrap();
         plugin.on_binding_end("a", &mut writer).unwrap();
-        // Push child scope: markers are still emitted.
+        // Push child structural scope: markers are still emitted.
         plugin.push_scope();
         writer.output.clear();
         plugin.on_binding_start("b", &mut writer).unwrap();
@@ -302,7 +331,7 @@ mod tests {
     #[test]
     fn test_repeat_item_markers() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         plugin.on_repeat_item_start(0, &mut writer).unwrap();
         assert_eq!(writer.output, "<!--fe:r-->");
@@ -314,7 +343,7 @@ mod tests {
     #[test]
     fn test_attribute_binding_single() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let data = 1u32.to_le_bytes();
         plugin.on_element_data(&data, &mut writer).unwrap();
@@ -324,7 +353,7 @@ mod tests {
     #[test]
     fn test_attribute_binding_multi() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let data = 3u32.to_le_bytes();
         plugin.on_element_data(&data, &mut writer).unwrap();
@@ -334,7 +363,7 @@ mod tests {
     #[test]
     fn test_attribute_binding_zero_count_no_output() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let data = 0u32.to_le_bytes();
         plugin.on_element_data(&data, &mut writer).unwrap();
@@ -344,7 +373,7 @@ mod tests {
     #[test]
     fn test_attribute_binding_count_allows_following_binding() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let data = 3u32.to_le_bytes();
         plugin.on_element_data(&data, &mut writer).unwrap();
@@ -360,12 +389,11 @@ mod tests {
     fn test_nested_scopes_emit_compact_markers() {
         let mut plugin = FastV3HydrationPlugin::new();
         let mut writer = TestWriter::new();
-        // Push first active scope (root is disabled)
-        plugin.push_scope();
-        // Active scope emits binding markers.
+        // Component scope activates markers.
+        plugin.push_component_scope();
         plugin.on_binding_start("root", &mut writer).unwrap();
         plugin.on_binding_end("root", &mut writer).unwrap();
-        // Component scope
+        // Structural child scope inherits component activation.
         plugin.push_scope();
         // For-loop binding in component emits compact markers.
         writer.output.clear();
@@ -389,7 +417,7 @@ mod tests {
     #[test]
     fn test_empty_element_data_returns_error() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let result = plugin.on_element_data(&[], &mut writer);
         assert!(
@@ -402,7 +430,7 @@ mod tests {
     #[test]
     fn test_short_element_data_returns_error() {
         let mut plugin = FastV3HydrationPlugin::new();
-        plugin.push_scope();
+        plugin.push_component_scope();
         let mut writer = TestWriter::new();
         let result = plugin.on_element_data(&[1, 2], &mut writer);
         assert!(
@@ -540,11 +568,8 @@ mod tests {
         let state = test_json!({"items": ["a", "b"]});
         let output =
             render_with_plugin(&protocol, &state, || Box::new(FastV3HydrationPlugin::new()));
-        // Root scope disabled — no for-loop binding or repeat item markers
-        assert!(!output.contains("<!--fe:r-->"));
-        assert!(!output.contains("<!--fe:/r-->"));
-        // Signal bindings inside each item ARE emitted (for-loop items push scope)
-        assert_eq!(output, "<!--fe:b-->a<!--fe:/b--><!--fe:b-->b<!--fe:/b-->");
+        assert_eq!(output, "ab");
+        assert!(!output.contains("<!--fe:"));
     }
 
     #[test]
@@ -562,16 +587,20 @@ mod tests {
         fragments.insert(
             "if-1".to_string(),
             FragmentList {
-                fragments: vec![WebUIFragment::raw("<p>Visible</p>")],
+                fragments: vec![
+                    WebUIFragment::raw("<p>"),
+                    WebUIFragment::signal("message", false),
+                    WebUIFragment::raw("</p>"),
+                ],
             },
         );
         let protocol = WebUIProtocol::new(fragments);
 
-        // True case — root scope disabled, no markers; content still rendered
-        let state = test_json!({"show": true});
+        // True case — root structural scope disabled, no markers; content still rendered.
+        let state = test_json!({"show": true, "message": "Visible"});
         let output =
             render_with_plugin(&protocol, &state, || Box::new(FastV3HydrationPlugin::new()));
-        assert!(output.contains("<p>Visible</p>"));
+        assert_eq!(output, "<p>Visible</p>");
         assert!(!output.contains("<!--fe:"));
 
         // False case — no content, no markers
@@ -1028,13 +1057,13 @@ mod tests {
         // on_binding_start/on_binding_end because the trait defaults delegate.
         {
             let mut plugin_for = FastV3HydrationPlugin::new();
-            plugin_for.push_scope();
+            plugin_for.push_component_scope();
             let mut writer_for = TestWriter::new();
             plugin_for.on_for_start("items", &mut writer_for).unwrap();
             plugin_for.on_for_end("items", &mut writer_for).unwrap();
 
             let mut plugin_bind = FastV3HydrationPlugin::new();
-            plugin_bind.push_scope();
+            plugin_bind.push_component_scope();
             let mut writer_bind = TestWriter::new();
             plugin_bind
                 .on_binding_start("items", &mut writer_bind)
@@ -1053,13 +1082,13 @@ mod tests {
         // on_binding_start/on_binding_end.
         {
             let mut plugin_if = FastV3HydrationPlugin::new();
-            plugin_if.push_scope();
+            plugin_if.push_component_scope();
             let mut writer_if = TestWriter::new();
             plugin_if.on_if_start("visible", &mut writer_if).unwrap();
             plugin_if.on_if_end("visible", &mut writer_if).unwrap();
 
             let mut plugin_bind = FastV3HydrationPlugin::new();
-            plugin_bind.push_scope();
+            plugin_bind.push_component_scope();
             let mut writer_bind = TestWriter::new();
             plugin_bind
                 .on_binding_start("visible", &mut writer_bind)

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -18,7 +18,8 @@ use webui_protocol::WebUIProtocol;
 /// A handler plugin that can inject additional content during rendering.
 ///
 /// Plugins receive callbacks at key points in the rendering lifecycle:
-/// - **Scope management**: `push_scope` / `pop_scope` for component and loop boundaries
+/// - **Scope management**: `push_component_scope` for components,
+///   `push_scope` / `pop_scope` for nested boundaries
 /// - **Binding lifecycle**: `on_binding_start` / `on_binding_end` around signals
 /// - **For-loop lifecycle**: `on_for_start` / `on_for_end` around for-loop blocks
 /// - **If-condition lifecycle**: `on_if_start` / `on_if_end` around if-condition blocks
@@ -29,9 +30,16 @@ use webui_protocol::WebUIProtocol;
 /// WebUI does not interpret what plugins write — it just calls the hooks.
 /// Each framework defines its own marker format.
 pub trait HandlerPlugin {
-    /// Enter a new scope (component or for-loop item boundary).
+    /// Enter a new non-component scope (for-loop item or if-condition boundary).
     /// Typically resets per-scope counters.
     fn push_scope(&mut self);
+
+    /// Enter a new component scope.
+    /// Defaults to [`push_scope`](HandlerPlugin::push_scope) for plugins that
+    /// do not distinguish custom elements from structural scopes.
+    fn push_component_scope(&mut self) {
+        self.push_scope();
+    }
 
     /// Exit the current scope, restoring the parent scope state.
     fn pop_scope(&mut self);

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -121,8 +121,15 @@ pub trait ParserPlugin {
 
 ```rust
 pub trait HandlerPlugin {
-    /// Enter a new scope (component or loop item).
+    /// Enter a structural scope, such as a loop item or active if body.
     fn push_scope(&mut self);
+
+    /// Enter a component scope.
+    /// Defaults to push_scope for plugins that do not distinguish scopes.
+    fn push_component_scope(&mut self) {
+        self.push_scope();
+    }
+
     /// Leave the current scope.
     fn pop_scope(&mut self);
 
@@ -151,6 +158,14 @@ pub trait HandlerPlugin {
     ) -> Result<()>;
 }
 ```
+
+`push_component_scope` is used for component bodies and `handle_as_component`;
+`push_scope` is used for structural scopes such as loop items and active
+if-condition bodies. Plugins that need island-only markers can activate only
+inside component scopes. FAST v2/v3 use this behavior to keep normal entry page
+light DOM marker-free, including root signals, for-loops, if-conditions, and
+element metadata, while still emitting markers and data attributes inside custom
+element components and their nested structural scopes.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Scope FAST v2 and FAST v3 hydration markers to custom element component scopes.
- Keep entry page light DOM marker-free, including root signals, `for` loops, `if` blocks, and plugin element data.
- Update DESIGN.md, README.md, and plugin docs for the handler scope API and marker behavior.

## Validation
- `cargo test -p microsoft-webui-handler fast_v2 -- --nocapture`
- `cargo test -p microsoft-webui-handler fast_v3 -- --nocapture`
- `git diff --check`
- `cargo xtask check` partially completed on Windows: license headers, fmt, clippy, proto drift check, and deny passed; test phase failed on an unrelated existing Windows compile issue in `crates\webui\examples\streaming_resource_bench.rs` where `libc::rusage`, `libc::getrusage`, and `libc::RUSAGE_SELF` are unavailable.
