### PR TITLE
feat: actionable build-time diagnostics with codes, JSON output, and suggestions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,11 @@ Every decision - API design, data structure choice, algorithm, error path - must
 - Library crates (`webui-parser`, `webui-handler`, `webui-expressions`, `webui-state`, `webui-protocol`, `webui-ffi`) use **custom error enums** via `thiserror`.
 - Binary crates (`webui-cli`, `xtask`) may use `anyhow`.
 - **No `unwrap()` or `expect()`** in library code - `clippy.toml` enforces this.
-- Errors must be **actionable**: tell the caller what went wrong *and* what they can do about it.
+- **Never `panic!` on recoverable input.** Bad template/CLI/state input must return `Result` - `panic = "abort"` in release would kill any FFI/WASM/Node host. Build-time authoring mistakes are returned as a structured `ParserError::Template(Box<Diagnostic>)`.
+- Errors must be **actionable**: tell the caller what went wrong *and* what they can do about it (a `help:` line, plus a "did you mean …?" suggestion for typos).
+- Diagnostics are **plain, color-free data** carrying a stable machine-readable `code`, source location (`--> owner:line:column`), snippet, and `help:`. **Color belongs only in `webui-cli`** (via `console::style()`); FFI/WASM/Node and the browser get the plain `Display` text. `webui-cli --format json` emits each error as a machine-readable object on stdout for tools/agents.
+- **Error construction is a cold path:** mark error builders `#[cold]`/`#[inline(never)]` and keep hot fast-paths inlinable - cold error code inlined into a hot function perturbs its layout and regresses performance.
+- For the full error-handling and diagnostics workflow, use the skill: `skills/diagnostics/SKILL.md`.
 
 ### Public API surface
 - Expose the minimum necessary. Use `pub(crate)` for internal helpers.
@@ -155,6 +159,7 @@ The `docs/` directory is a VitePress site for external developers consuming WebU
 
 - **Pull request** - `skills/pr/SKILL.md`
 - **Code review** - `skills/code-review/SKILL.md` (includes FFI safety and protobuf hygiene)
+- **Error handling & diagnostics** - `skills/diagnostics/SKILL.md`
 - **Quality gate** - `skills/quality-gate/SKILL.md`
 - **Docs synchronization** - `skills/docs-sync/SKILL.md`
 - **Performance (speed + memory)** - `skills/perf/SKILL.md`

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -204,6 +204,20 @@ Choose the structure that matches the access pattern. A wrong choice is a design
 | Accepting invalid inputs that pass through | If a `<route>` element is missing `path` or references an unknown component, the parser must reject it with an actionable error. |
 | `bytes[i] as char` on UTF-8 strings | This silently corrupts multi-byte characters. Use `str` slicing or `char_indices()` to preserve UTF-8 correctness. |
 
+### Rust - diagnostics & error presentation
+
+See `skills/diagnostics/SKILL.md` for the full workflow. On review, check:
+
+| Pattern | Preference |
+|---------|-----------|
+| `panic!`/`unwrap` on recoverable (template/CLI/state) input | **Banned.** Return `Result` - `panic = "abort"` kills FFI/WASM/Node hosts. Authoring mistakes return `ParserError::Template(Box<Diagnostic>)`. |
+| Authoring error without a stable `code`, location, or `help:` | A `Diagnostic` must carry a `diagnostic::codes` constant, `--> owner:line:column`, snippet, and an actionable `help:`. Codes are a **stable API** - flag renames. |
+| Color/ANSI in a library, host, browser, or JSON channel | Color belongs **only** in `webui-cli` (`console::style()`). Libraries emit plain data; FFI/WASM/Node/browser get plain `Display`. Split terminal-vs-machine renderings (e.g. `RebuildError { display, message }`) rather than leaking ANSI. |
+| A single SGR span wrapping newlines | Style each line independently - a span across `\n` bleeds when lines are re-prefixed (`[server]`). |
+| Error construction inlined into a hot function | Mark error builders `#[cold]`/`#[inline(never)]`; keep the hot fast-path inlinable. Layout perturbation from cold error code is a real regression - confirm with `cargo bench` vs the base branch. |
+| `serde_json::json!` macro in CLI output | Use the `serde_json::Map` API; the macro `unwrap`s internally and trips `disallowed_methods`. |
+| Tests asserting on error prose | Assert on the stable `code` (and that JSON output contains no `\x1b`), not the human message. |
+
 ### TypeScript
 
 | Pattern | Preference |

--- a/.github/skills/diagnostics/SKILL.md
+++ b/.github/skills/diagnostics/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: diagnostics
+description: Error handling and build-time diagnostics conventions - Result-not-panic, structured Diagnostics with stable codes, actionable help, color/JSON presentation layering, exit codes, and cold-path performance.
+---
+
+# Error Handling & Diagnostics
+
+Use this skill whenever you add, change, or review an error path: a build-time
+authoring error, a parser/handler failure, a CLI validation error, or anything
+surfaced to a host (FFI/WASM/Node) or a tool/agent. WebUI errors must be
+**recoverable**, **actionable**, and **machine-consumable** — for humans and AI
+agents alike.
+
+## 1 - Never panic on recoverable input
+
+`panic = "abort"` in the release profile means a panic **kills the process
+instantly** — including any FFI/WASM/Node host embedding the framework. Bad
+template input, bad CLI input, and bad state are *recoverable* and must return
+`Result`, never `panic!`/`unwrap()`/`expect()`.
+
+| Situation | Do |
+|-----------|----|
+| Malformed template / CSS / route authored by a developer | Return `Result` with a structured `Diagnostic` (see §3). |
+| Missing/invalid CLI input (file, port, flag) | Return a typed `CliError` (see §6). |
+| A genuinely impossible internal state | Prefer `?` with a typed error; only use `unreachable!`/`expect` with a justification comment, and never in a hot or host-reachable path. |
+
+`unwrap()`/`expect()` are banned in library code (`clippy.toml`
+`disallowed-methods`). `todo!`, `unimplemented!`, and `dbg!` are banned
+workspace-wide (`clippy.toml` `disallowed-macros`). Tests opt out with
+`#[allow(clippy::disallowed_methods)]`.
+
+> **Enforcement note.** `unwrap`/`expect`/`todo!`/`unimplemented!`/`dbg!` are
+> caught by clippy. `panic!` is *not* lint-banned (too entrenched) — keep it out
+> of recoverable paths by review. The "no regex in core logic" rule is also
+> review-enforced, not `deny`-banned: `actix-web` pulls `regex` transitively, so
+> a crate-level ban would break the build and can't scope to first-party code.
+
+## 2 - Error type conventions
+
+| Crate kind | Error type |
+|-----------|-----------|
+| Library (`webui-parser`, `webui-handler`, `webui-expressions`, `webui-state`, `webui-protocol`, `webui-ffi`) | Custom `enum` via `thiserror`. |
+| Binary (`webui-cli`, `xtask`) | `anyhow` for orchestration; a typed `enum` when callers must branch on the cause (e.g. `webui-cli`'s `CliError` for hints + exit codes). |
+
+- Each error layer's `Display` describes **only its own level**; the `#[source]`
+  chain carries the rest, so `anyhow`'s `{:#}` never double-prints. Provide a
+  flat `chain_message()` helper for hosts that don't walk the chain (Node, FFI).
+- Add **dedicated variants** instead of overloading a generic `Generic(String)` /
+  `Validation(String)` so callers can `match` programmatically.
+
+## 3 - Authoring errors are structured `Diagnostic`s
+
+Every "the developer wrote invalid template syntax" mistake is returned as
+`ParserError::Template(Box<Diagnostic>)` (`crates/webui-parser/src/diagnostic.rs`),
+so all build errors render identically. A `Diagnostic` carries:
+
+- **`code`** — a stable, machine-readable identifier (e.g. `invalid-for-each`).
+  Defined in `diagnostic::codes`. Treat codes as a **stable API**: tools and AI
+  agents branch on them, so rename only with a deliberate migration.
+- **title** — short, lowercase (`invalid <for> each expression`).
+- **location** — set from a byte offset via `.at_offset(source, offset)`;
+  rendered rustc-style `--> owner:line:column` (single forward scan, **no regex,
+  no recursion**), falling back to `in component <c> · element <e>`.
+- **snippet** — the offending source text.
+- **`help:`** — an actionable fix (see §4).
+
+Add a new authoring error with the parser helpers (`authoring_error`,
+`authoring_error_at`, `html_error`) and a new constant in `diagnostic::codes`.
+Validate at **parse/build time and fail fast** — never defer to render time.
+
+## 4 - Make errors actionable (and typo-aware)
+
+Tell the developer **what** is wrong *and* **how** to fix it. Every `Diagnostic`
+should carry a `help:` line. Where a mistake is likely a typo, suggest the
+intended name via `suggest::closest_match` (iterative Levenshtein — **no
+recursion, no regex**, cold path only):
+
+- Misspelled directive attribute: `<for eahc=…>` -> "did you mean `each`?"
+- Unknown component tag: suggest the closest **same-namespace** registered
+  component (`<mp-buton>` -> `<mp-button>`). **Prefix-guard** the match (text
+  before the first `-` must match) so a genuine third-party custom element
+  (`<md-button>`) is never falsely flagged.
+
+## 5 - Presentation layering: color belongs ONLY in the entry point
+
+Libraries produce **plain, color-free data**. The entry point decides how to
+present it. Never embed ANSI in library output or in any machine/host channel.
+
+| Consumer | Gets |
+|----------|------|
+| `webui-cli` (terminal) | Reads `Diagnostic` fields and colorizes with `console::style()` — the **only** approved styling method (see copilot-instructions "Terminal output styling"). |
+| FFI / WASM / Node | The plain `Display` text through their native error channel (`webui_last_error`, `JsValue`, `napi::Error`). |
+| Browser / tools (dev-server live-reload, SSE, `console.error`) | **Plain** text. ANSI renders as garbage and breaks single-line SSE frames. |
+
+When one value feeds both a terminal and a non-terminal channel, split it:
+`webui-dev-server`'s `RebuildError { display, message }` carries a colorized
+`display` for the reporter and a plain `message` for the browser.
+
+Per-line color: when colorizing multi-line output, style **each line
+independently** (open + close the SGR span within the line). A single span that
+straddles newlines bleeds when the line is later re-prefixed (e.g. `[server]`
+under `xtask dev`).
+
+## 6 - Machine-readable output and exit codes (`webui-cli`)
+
+For editors, CI, and AI/agent tooling:
+
+- `--format json` (global flag) emits each error as one JSON object on
+  **stdout** (no ANSI; decorative output suppressed):
+  `{severity, code, message, file, line, column, snippet, help, chain}`.
+  Branch on the stable `code`, not the human `message`. Build the object with
+  the `serde_json::Map` API, **not** the `json!` macro (it `unwrap`s internally
+  and trips `disallowed_methods`).
+- Exit codes follow BSD `sysexits.h` (`webui-cli`'s `error::exit_code`):
+  `65` data/authoring error, `66` missing input, `69` port in use, `74` I/O,
+  `2` usage (clap), `1` otherwise.
+- Replace fragile `err_msg.contains("...")` dispatch with typed errors that own
+  their `hint()` and `exit_code()`.
+
+## 7 - Error construction is COLD - keep it off the hot path
+
+Building a `Diagnostic` (format strings, suggestions, location scans) is rare,
+but if it inlines into a hot function it bloats that function and perturbs its
+code layout — a real, measurable regression (observed ~4-5% on parse benches
+with **no** added hot-path work).
+
+- Mark error builders `#[cold]` + `#[inline(never)]` (e.g. `authoring_error*`,
+  `html_error`, `css_diagnostic`, `*_error` constructors, `suggest::closest_match`).
+- Keep hot fast-paths inlinable: a per-element check (e.g. `split_once('-')`)
+  must stay inlined; only its cold fallback (the registry scan) goes out-of-line.
+- Validate layout-sensitive changes with `cargo bench -p <crate>` against the
+  base branch (see `skills/perf/SKILL.md`). A "regression" with no added compute
+  is usually layout — fix it with `#[cold]`, don't shrug it off.
+
+## 8 - Checklist for a new error
+
+- [ ] Returned as `Result`, never panicked (host-safe under `panic = "abort"`).
+- [ ] Authoring mistake -> `ParserError::Template(Box<Diagnostic>)` with a new
+      `diagnostic::codes` constant, location, snippet, and `help:`.
+- [ ] `help:` is actionable; add a "did you mean …?" suggestion if it's a typo.
+- [ ] No color/ANSI in library, host, browser, or JSON output.
+- [ ] Surfaced in `--format json` with the stable `code`; exit code classified.
+- [ ] Error construction is `#[cold]`/`#[inline(never)]`; hot path unchanged
+      (confirm with a benchmark if it sits near a hot loop).
+- [ ] Tests: a regression test that fails without the error, asserting on the
+      `code` (not the prose); JSON stays plain (no `\x1b`).
+- [ ] `DESIGN.md` and `docs/` (incl. `docs/ai.md`) updated if the contract or
+      a user-visible code/flag changed.

--- a/.github/skills/perf/SKILL.md
+++ b/.github/skills/perf/SKILL.md
@@ -23,6 +23,7 @@ These apply to `webui-handler`, `webui-state`, `webui-expressions`, `webui-parse
 6. **No `format!` in hex parsing.** Use direct arithmetic (`(hi_nibble << 4) | lo_nibble`) instead of `u8::from_str_radix(&format!(...))`.
 7. **No per-request template re-parsing.** Pre-parse at protocol load time and reuse.
 8. **No silent `unwrap_or` defaults.** If `binding_stack.pop()` returns `None`, that's a protocol error - propagate it, don't mask it.
+9. **Keep cold error/diagnostic construction off the hot path.** Mark error builders `#[cold]`/`#[inline(never)]` so they don't inline into hot functions and perturb their code layout. Adding cold error code with **no** hot-path work has regressed parse benches ~4-5% purely via layout - keep per-element fast-paths inlinable and push the cold fallback out-of-line. See `skills/diagnostics/SKILL.md` §7.
 
 ## Rust - memory rules
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1003,7 +1003,7 @@ pub trait ParserPlugin {
     ) -> Result<()>;
     fn classify_attribute(&mut self, attr_name: &str) -> AttributeAction;
     fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts;
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts>;
 }
 ```
 
@@ -1012,7 +1012,7 @@ pub trait ParserPlugin {
 - **Attribute loop**: `classify_attribute` decides whether framework-owned attrs are kept, skipped, or skipped-and-counted as bindings
 - **Element completion**: `finish_element` runs with the final binding count after all attrs are processed; returned bytes are emitted as a `Plugin` fragment
 - **Component registration**: `register_component_template` receives the final processed component template HTML after HTML/CSS comment stripping
-- **Artifact extraction**: `into_artifacts` returns post-parse outputs such as client component templates without `Any` downcasts
+- **Artifact extraction**: `into_artifacts` returns post-parse outputs such as client component templates without `Any` downcasts. It is **fallible**: template-authoring mistakes found while compiling component templates (an invalid `@event` handler or a non-braced `w-ref`) surface as `ParserError::Template` instead of panicking, so every host (CLI, Node, FFI, WASM) can handle them.
 
 **Selecting parser plugins**
 
@@ -1361,8 +1361,12 @@ The Rust compiler (`generate_compiled_template` in `webui-parser/src/plugin/webu
 | `<for each="v in coll">body</for>`   | `r[]` + `rl[]` + `b[]` | block removed; anchor slot stored |
 | `@event="{handler(item.id, e)}"`     | `e[]`                  | element kept marker-free          |
 | `@event` on `<template>` wrapper     | `re[N]`                | *(stripped)*                      |
-| `w-ref="name"`                       | *(stays)*              | *(unchanged)*                     |
+| `w-ref="{name}"`                     | *(stays)*              | *(unchanged)*                     |
 | `<outlet />`                         | *(stays)*              | `<outlet></outlet>`               |
+
+**Authoring validation.** Build-time authoring mistakes are returned as a structured `ParserError::Template(Box<Diagnostic>)`, never panicked. This covers invalid `@event` handlers (e.g. `@click="e.preventDefault()"`, or a bare `@click="{closeMenu}"`), non-braced `w-ref` (`w-ref="name"` instead of `w-ref="{name}"`), core-parser mistakes — an invalid `<for each>` expression, a missing/invalid `<if condition>`, an unknown component tag, a recursive template reference — malformed CSS in a `<style>` block, and structural HTML well-formedness errors (unclosed/malformed tags, unterminated comments/declarations, unexpected closing tags, excessive nesting), so every build error renders identically. The `Diagnostic` is plain, actionable data — a **stable machine-readable `code`** (e.g. `invalid-for-each`; see `diagnostic::codes`), title, source location (rendered rustc-style as `--> owner:line:column` when the offending byte offset is known, otherwise `in component <c> · element <e>`), offending snippet, and a `help:` fix — and carries **no color**: `webui-cli` styles it with `console`, while Node/FFI/WASM forward the plain `Display` text through their native error channel. Where a fix is likely a typo, the `help:` offers a **"did you mean …?" suggestion** via an iterative Levenshtein match (`suggest::closest_match`): a misspelled directive attribute (`eahc` → `each`), or an unregistered custom-element tag that closely matches a registered component **in the same namespace** (`<mp-buton>` → `<mp-button>`; cross-namespace tags like `<md-button>` still pass through as genuine custom elements). This mirrors `ParserError::MissingAdoptedStylesheets`: authoring errors are returned so consumers can recover instead of aborting (`panic = "abort"` in release would otherwise kill the process).
+
+**Machine-readable diagnostics.** `webui-cli` accepts a global `--format <human|json>` flag. In `json` mode the colorized terminal output is suppressed and each error is emitted as a single JSON object on **stdout** (`{severity, code, message, file, line, column, snippet, help, chain}`), so editors, CI, and AI assistants consume diagnostics without scraping ANSI text. The process exit code follows BSD `sysexits.h` so callers can branch on the cause: `65` (`EX_DATAERR`) for a template/authoring error, `66` (`EX_NOINPUT`) for a missing app folder / state file / serve dir / entry, `69` (`EX_UNAVAILABLE`) for an occupied port, `74` (`EX_IOERR`) for other I/O failures, `2` for argument/usage errors (clap), and `1` otherwise.
 
 `tx[]` stores text runs as `[slot, parts]`, where `parts` reuse the compact attribute-part encoding (`string` for static text, `[path]` for dynamic text). Client-created DOM inserts one runtime `Text` node per run instead of scanning compiled marker comments.
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -7,6 +7,11 @@ disallowed-methods = [
 disallowed-types = [
   { path = "std::collections::LinkedList", reason = "poor cache locality; use Vec or VecDeque" },
 ]
+disallowed-macros = [
+  { path = "std::todo", reason = "unfinished code must not ship; implement it or return a typed error" },
+  { path = "std::unimplemented", reason = "unfinished code must not ship; implement it or return a typed error" },
+  { path = "std::dbg", reason = "debug-only macro; remove before committing" },
+]
 cognitive-complexity-threshold = 20
 too-many-arguments-threshold = 5
 large-error-threshold = 128

--- a/crates/webui-cli/src/commands/build.rs
+++ b/crates/webui-cli/src/commands/build.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use super::common::*;
+use crate::utils::error::CliError;
 use crate::utils::output;
 
 #[derive(Args)]
@@ -48,17 +49,12 @@ fn resolve_out(out: &Path) -> (PathBuf, OsString) {
 }
 
 pub fn execute(args: &BuildArgs) -> Result<()> {
-    run(args).map_err(|err| {
-        output::error(&err);
-
-        let err_msg = format!("{:#}", err);
-        if err_msg.contains("App folder not found") {
-            output::hint("Check that the app folder path exists");
-        } else if err_msg.contains("Failed to read") && args.app_args.entry == "index.html" {
-            output::hint("Try using --entry <file> to specify a different entry file");
+    run(args).inspect_err(|err| {
+        output::error(err);
+        if let Some(cli_err) = err.chain().find_map(|c| c.downcast_ref::<CliError>()) {
+            output::hint(cli_err.hint());
         }
         eprintln!();
-        err
     })
 }
 
@@ -72,7 +68,17 @@ fn run(args: &BuildArgs) -> Result<()> {
 
     let app = app_input
         .canonicalize()
-        .with_context(|| format!("App folder not found: {}", args.app_args.app.display()))?;
+        .map_err(|_| CliError::AppFolderNotFound {
+            path: args.app_args.app.display().to_string(),
+        })?;
+
+    let entry_path = app.join(&args.app_args.entry);
+    if !entry_path.is_file() {
+        return Err(CliError::EntryReadFailed {
+            path: entry_path.display().to_string(),
+        }
+        .into());
+    }
 
     let (out_dir, protocol_name) = resolve_out(&out);
     let protocol_path = out_dir.join(&protocol_name);

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -25,6 +25,7 @@ use webui_handler::{RenderOptions, ResponseWriter};
 use webui_protocol::WebUIProtocol;
 
 use super::common::*;
+use crate::utils::error::CliError;
 use crate::utils::output;
 
 #[derive(Args)]
@@ -81,7 +82,9 @@ impl ServePaths {
 
         let app_dir = app_input
             .canonicalize()
-            .with_context(|| format!("App folder not found: {}", args.app_args.app.display()))?;
+            .map_err(|_| CliError::AppFolderNotFound {
+                path: args.app_args.app.display().to_string(),
+            })?;
 
         let state_file = match &args.state {
             Some(state_path) => {
@@ -91,9 +94,12 @@ impl ServePaths {
                     })?
                     .into_owned();
 
-                let canonical = state_input
-                    .canonicalize()
-                    .with_context(|| format!("State file not found: {}", state_path.display()))?;
+                let canonical =
+                    state_input
+                        .canonicalize()
+                        .map_err(|_| CliError::StateFileNotFound {
+                            path: state_path.display().to_string(),
+                        })?;
 
                 if !canonical.is_file() {
                     return Err(anyhow::anyhow!(
@@ -117,9 +123,12 @@ impl ServePaths {
                     })?
                     .into_owned();
 
-                let canonical = serve_input.canonicalize().with_context(|| {
-                    format!("Serve directory not found: {}", serve_arg.display())
-                })?;
+                let canonical =
+                    serve_input
+                        .canonicalize()
+                        .map_err(|_| CliError::ServeDirNotFound {
+                            path: serve_arg.display().to_string(),
+                        })?;
 
                 if !canonical.is_dir() {
                     return Err(anyhow::anyhow!(
@@ -218,23 +227,12 @@ fn watch_disabled_by_env() -> bool {
 }
 
 pub fn execute(args: &ServeArgs) -> Result<()> {
-    run(args).map_err(|err| {
-        output::error(&err);
-
-        let err_msg = format!("{:#}", err);
-        if err_msg.contains("App folder not found") {
-            output::hint("Check that the app folder path exists");
-        } else if err_msg.contains("State file not found") {
-            output::hint("Pass a valid --state path to a JSON file");
-        } else if err_msg.contains("Serve directory not found") {
-            output::hint("Pass a valid --servedir path for static assets");
-        } else if err_msg.contains("already in use") {
-            output::hint(
-                "Stop the process using that port, or rerun with --port <free-port>. Previous dev sessions may have left a server running.",
-            );
+    run(args).inspect_err(|err| {
+        output::error(err);
+        if let Some(cli_err) = err.chain().find_map(|c| c.downcast_ref::<CliError>()) {
+            output::hint(cli_err.hint());
         }
         eprintln!();
-        err
     })
 }
 
@@ -423,7 +421,7 @@ fn ensure_local_port_available(port: u16) -> Result<()> {
 
 fn map_bind_error(port: u16, bind_addr: &str, error: std::io::Error) -> anyhow::Error {
     if error.kind() == ErrorKind::AddrInUse {
-        return anyhow::anyhow!("Port {port} on 127.0.0.1 is already in use");
+        return CliError::PortInUse { port }.into();
     }
 
     anyhow::anyhow!("Failed to bind to {bind_addr}: {error}")
@@ -1072,8 +1070,10 @@ fn start_file_watcher(config: WatcherConfig) -> Result<webui_dev_server::Watcher
     // The closure here is just the cli-specific render-and-update step.
     let lr_for_inject = livereload.clone();
     let tick_tx = webui_dev_server::spawn_rebuild_worker(livereload, move || {
-        let result = build_and_render(&render_config, Some(&lr_for_inject))
-            .map_err(|err| format!("{err:#}"))?;
+        let result = build_and_render(&render_config, Some(&lr_for_inject)).map_err(|err| {
+            let (display, message) = crate::utils::output::build_error_renderings(&err);
+            webui_dev_server::RebuildError::new(display, message)
+        })?;
         match state.lock() {
             Ok(mut s) => {
                 s.rendered_html = result.html;
@@ -1082,7 +1082,9 @@ fn start_file_watcher(config: WatcherConfig) -> Result<webui_dev_server::Watcher
                 s.state_data = Some(result.state_data);
                 Ok(())
             }
-            Err(_) => Err("shared state mutex poisoned".to_string()),
+            Err(_) => Err(webui_dev_server::RebuildError::plain(
+                "shared state mutex poisoned".to_owned(),
+            )),
         }
     });
 

--- a/crates/webui-cli/src/main.rs
+++ b/crates/webui-cli/src/main.rs
@@ -6,16 +6,23 @@ mod utils;
 
 use clap::{CommandFactory, Parser};
 use commands::Commands;
+use utils::output::OutputFormat;
 
 #[derive(Parser)]
 #[command(name = "webui", about = "WebUI build tool")]
 struct Cli {
+    /// Output format: `human` (colorized terminal, default) or `json`
+    /// (machine-readable diagnostics on stdout for editors, CI, and tools).
+    #[arg(long, value_enum, default_value_t = OutputFormat::Human, global = true)]
+    format: OutputFormat,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
 
 fn main() {
     let cli = Cli::parse();
+    utils::output::set_format(cli.format);
 
     let Some(command) = &cli.command else {
         Cli::command().print_help().ok();
@@ -28,7 +35,7 @@ fn main() {
         Commands::Serve(args) => commands::serve::execute(args),
     };
 
-    if result.is_err() {
-        std::process::exit(1);
+    if let Err(err) = result {
+        std::process::exit(utils::error::exit_code(&err));
     }
 }

--- a/crates/webui-cli/src/utils/error.rs
+++ b/crates/webui-cli/src/utils/error.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Typed CLI-level errors.
+//!
+//! These represent the handful of failures the CLI itself raises before (or
+//! around) a build/serve — missing inputs, an occupied port, an unreadable
+//! entry file. Modelling them as a type (rather than bare `anyhow!` strings)
+//! lets the command layer attach an actionable `hint:` and pick a meaningful
+//! process exit code by matching the variant, instead of fragile substring
+//! checks against the message text.
+
+use std::fmt;
+
+/// A CLI-level failure with an actionable hint and a stable exit code.
+#[derive(Debug)]
+pub enum CliError {
+    /// The positional app folder argument does not exist.
+    AppFolderNotFound {
+        /// The path that was not found.
+        path: String,
+    },
+
+    /// The `--state` JSON file does not exist.
+    StateFileNotFound {
+        /// The path that was not found.
+        path: String,
+    },
+
+    /// The `--servedir` static-assets directory does not exist.
+    ServeDirNotFound {
+        /// The path that was not found.
+        path: String,
+    },
+
+    /// The requested port is already bound by another process.
+    PortInUse {
+        /// The conflicting port.
+        port: u16,
+    },
+
+    /// The entry file could not be read.
+    EntryReadFailed {
+        /// The path that could not be read.
+        path: String,
+    },
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CliError::AppFolderNotFound { path } => write!(f, "App folder not found: {path}"),
+            CliError::StateFileNotFound { path } => write!(f, "State file not found: {path}"),
+            CliError::ServeDirNotFound { path } => write!(f, "Serve directory not found: {path}"),
+            CliError::PortInUse { port } => {
+                write!(f, "Port {port} on 127.0.0.1 is already in use")
+            }
+            CliError::EntryReadFailed { path } => write!(f, "Failed to read entry file: {path}"),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+impl CliError {
+    /// A short, actionable next step shown to the developer as `hint:`.
+    #[must_use]
+    pub fn hint(&self) -> &'static str {
+        match self {
+            CliError::AppFolderNotFound { .. } => "Check that the app folder path exists",
+            CliError::StateFileNotFound { .. } => "Pass a valid --state path to a JSON file",
+            CliError::ServeDirNotFound { .. } => "Pass a valid --servedir path for static assets",
+            CliError::PortInUse { .. } => {
+                "Stop the process using that port, or rerun with --port <free-port>. Previous dev \
+                 sessions may have left a server running."
+            }
+            CliError::EntryReadFailed { .. } => {
+                "Use --entry <file> to specify a different entry file"
+            }
+        }
+    }
+
+    /// The process exit code for this failure, following the BSD `sysexits.h`
+    /// conventions so scripts and CI can branch on the cause.
+    #[must_use]
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            // Missing input file/dir → EX_NOINPUT.
+            CliError::AppFolderNotFound { .. }
+            | CliError::StateFileNotFound { .. }
+            | CliError::ServeDirNotFound { .. }
+            | CliError::EntryReadFailed { .. } => 66,
+            // A required service (the port) is unavailable → EX_UNAVAILABLE.
+            CliError::PortInUse { .. } => 69,
+        }
+    }
+}
+
+/// Map a top-level CLI error to a process exit code, following BSD
+/// `sysexits.h` so scripts, CI, and tooling can branch on the cause:
+///
+/// - `66` (`EX_NOINPUT`) / `69` (`EX_UNAVAILABLE`) — CLI input/port failures
+///   (see [`CliError::exit_code`]).
+/// - `65` (`EX_DATAERR`) — a template authoring or parse error (the source is
+///   malformed).
+/// - `74` (`EX_IOERR`) — an I/O failure reading or writing files.
+/// - `1` — any other failure.
+///
+/// (clap already exits with `2` for argument/usage errors before this runs.)
+#[must_use]
+pub fn exit_code(err: &anyhow::Error) -> i32 {
+    if let Some(cli) = err.chain().find_map(|c| c.downcast_ref::<CliError>()) {
+        return i32::from(cli.exit_code());
+    }
+    if let Some(web) = err
+        .chain()
+        .find_map(|c| c.downcast_ref::<webui::WebUIError>())
+    {
+        return match web {
+            webui::WebUIError::Parse { .. }
+            | webui::WebUIError::Serialization(_)
+            | webui::WebUIError::InvalidBuildOptions(_) => 65,
+            webui::WebUIError::Io { .. } => 74,
+            _ => 1,
+        };
+    }
+    if err.chain().any(|c| c.is::<std::io::Error>()) {
+        return 74;
+    }
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_error_hints_and_codes() {
+        let missing = CliError::AppFolderNotFound { path: "x".into() };
+        assert_eq!(missing.exit_code(), 66);
+        assert!(missing.hint().contains("app folder"));
+
+        let port = CliError::PortInUse { port: 3000 };
+        assert_eq!(port.exit_code(), 69);
+        assert!(port.hint().contains("--port"));
+    }
+
+    #[test]
+    fn exit_code_classifies_cli_error_through_chain() {
+        let err = anyhow::Error::new(CliError::StateFileNotFound {
+            path: "s.json".into(),
+        })
+        .context("while starting the dev server");
+        assert_eq!(exit_code(&err), 66);
+    }
+
+    #[test]
+    fn exit_code_for_parse_error_is_dataerr() {
+        let err: anyhow::Error = webui::WebUIError::InvalidBuildOptions("bad".into()).into();
+        assert_eq!(exit_code(&err), 65);
+    }
+
+    #[test]
+    fn exit_code_for_plain_io_error_is_ioerr() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "nope");
+        let err = anyhow::Error::new(io).context("reading file");
+        assert_eq!(exit_code(&err), 74);
+    }
+
+    #[test]
+    fn exit_code_default_is_one() {
+        let err = anyhow::anyhow!("something generic");
+        assert_eq!(exit_code(&err), 1);
+    }
+}

--- a/crates/webui-cli/src/utils/mod.rs
+++ b/crates/webui-cli/src/utils/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+pub mod error;
 pub mod output;

--- a/crates/webui-cli/src/utils/output.rs
+++ b/crates/webui-cli/src/utils/output.rs
@@ -1,7 +1,48 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use std::sync::OnceLock;
+
+use webui::{Diagnostic, ParserError, WebUIError};
+
+/// CLI output format, selected with the global `--format` flag.
+///
+/// `Human` is the default colorized terminal rendering. `Json` emits a single
+/// machine-readable object per error on **stdout** (and suppresses decorative
+/// human output) so editors, CI, and AI assistants can consume diagnostics
+/// without scraping ANSI text.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// Colorized, human-readable terminal output (default).
+    #[default]
+    Human,
+    /// Machine-readable JSON diagnostics on stdout.
+    Json,
+}
+
+static FORMAT: OnceLock<OutputFormat> = OnceLock::new();
+
+/// Set the process-wide CLI output format. Call once at startup, before any
+/// output is produced; later calls are ignored.
+pub fn set_format(format: OutputFormat) {
+    let _ = FORMAT.set(format);
+}
+
+/// The configured output format (defaults to [`OutputFormat::Human`]).
+#[must_use]
+pub fn format() -> OutputFormat {
+    FORMAT.get().copied().unwrap_or_default()
+}
+
+#[must_use]
+fn is_json() -> bool {
+    matches!(format(), OutputFormat::Json)
+}
+
 pub fn header(title: &str) {
+    if is_json() {
+        return;
+    }
     eprintln!(
         "\n  {} {}\n",
         console::style("⚡").cyan().bold(),
@@ -10,6 +51,9 @@ pub fn header(title: &str) {
 }
 
 pub fn field(label: &str, value: &dyn std::fmt::Display) {
+    if is_json() {
+        return;
+    }
     eprintln!(
         "  {} {}",
         console::style(format!("▸ {label:<10}")).dim(),
@@ -18,14 +62,88 @@ pub fn field(label: &str, value: &dyn std::fmt::Display) {
 }
 
 pub fn success(message: &str) {
+    if is_json() {
+        return;
+    }
     eprintln!("  {} {message}", console::style("✔").green());
 }
 
 pub fn finish(message: &str) {
+    if is_json() {
+        return;
+    }
     eprintln!("\n  {} {message}\n", console::style("✨").green());
 }
 
+/// Find a build-time template [`Diagnostic`] within an error's source chain.
+fn template_diagnostic(err: &anyhow::Error) -> Option<&Diagnostic> {
+    err.chain()
+        .find_map(|cause| match cause.downcast_ref::<WebUIError>() {
+            Some(WebUIError::Parse {
+                source: ParserError::Template(diag),
+                ..
+            }) => Some(&**diag),
+            _ => None,
+        })
+}
+
+/// Serialize an error as a single machine-readable JSON object.
+///
+/// A structured template [`Diagnostic`] contributes its `code`, `severity`,
+/// owning `file`, `line`/`column`, `snippet`, and `help`; any error also
+/// carries the flattened source `chain`. Fields that don't apply are `null`.
+///
+/// Built via the `serde_json::Map` API rather than the `json!` macro, whose
+/// expansion trips the workspace `disallowed_methods` lint (it `unwrap`s on
+/// internally-constructed values).
+#[must_use]
+fn error_json(err: &anyhow::Error) -> serde_json::Value {
+    use serde_json::Value;
+
+    let chain: Vec<Value> = err.chain().map(|c| Value::from(c.to_string())).collect();
+    let str_or_null = |value: Option<&str>| value.map_or(Value::Null, Value::from);
+
+    let mut map = serde_json::Map::new();
+    match template_diagnostic(err) {
+        Some(diag) => {
+            let (line, column) = match diag.position_line_column() {
+                Some((line, column)) => (Value::from(line), Value::from(column)),
+                None => (Value::Null, Value::Null),
+            };
+            map.insert("severity".into(), Value::from(diag.severity().label()));
+            map.insert("code".into(), str_or_null(diag.error_code()));
+            map.insert("message".into(), Value::from(diag.title()));
+            map.insert("file".into(), str_or_null(diag.component_name()));
+            map.insert("line".into(), line);
+            map.insert("column".into(), column);
+            map.insert("snippet".into(), str_or_null(diag.snippet_text()));
+            map.insert("help".into(), str_or_null(diag.help_text()));
+        }
+        None => {
+            map.insert("severity".into(), Value::from("error"));
+            map.insert("code".into(), Value::Null);
+            map.insert("message".into(), Value::from(err.to_string()));
+        }
+    }
+    map.insert("chain".into(), Value::Array(chain));
+    Value::Object(map)
+}
+
 pub fn error(err: &anyhow::Error) {
+    if is_json() {
+        // One machine-readable object on stdout; tools parse this instead of
+        // scraping the colorized stderr rendering.
+        println!("{}", error_json(err));
+        return;
+    }
+
+    // Build-time template-authoring mistakes carry a structured diagnostic;
+    // render it in a friendly, colorized format instead of the generic chain.
+    if let Some(diag) = template_diagnostic(err) {
+        diagnostic(diag);
+        return;
+    }
+
     eprintln!(
         "\n  {} {}",
         console::style("✘").red().bold(),
@@ -36,6 +154,194 @@ pub fn error(err: &anyhow::Error) {
     }
 }
 
+/// Render a build error for the dev-server rebuild loop into a
+/// `(display, message)` pair.
+///
+/// - `display` is per-line colorized for the terminal [`RebuildReporter`].
+/// - `message` is plain, color-free text for the browser overlay /
+///   live-reload console (ANSI must never reach a browser).
+///
+/// A template authoring mistake renders as its self-contained [`Diagnostic`]
+/// (`title` + `--> file:line:col` + snippet + `help:`), so it isn't buried
+/// under redundant `Build failed: Failed to parse …:` context. Any other error
+/// flattens the anyhow chain for both renderings.
+///
+/// [`RebuildReporter`]: webui_dev_server::RebuildReporter
+#[must_use]
+pub fn build_error_renderings(err: &anyhow::Error) -> (String, String) {
+    match template_diagnostic(err) {
+        Some(diag) => (styled_diagnostic_body(diag), diag.body()),
+        None => {
+            let flat = format!("{err:#}");
+            (flat.clone(), flat)
+        }
+    }
+}
+
+/// Build the per-line-colorized body of `diag` for the dev-server reporter.
+///
+/// Mirrors [`diagnostic`], but returns a string because the reporter prepends
+/// its own `✘ build error:` marker. Each line opens and closes its own SGR
+/// span so the output survives being re-prefixed line-by-line (e.g. `[server]`
+/// under `xtask dev`); a single span across newlines would bleed.
+fn styled_diagnostic_body(diag: &Diagnostic) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(128);
+    let _ = write!(out, "{}", console::style(diag.title()).red().bold());
+    if let Some(code) = diag.error_code() {
+        let _ = write!(out, " {}", console::style(format!("[{code}]")).dim());
+    }
+    if let Some(location) = diag.location() {
+        let _ = write!(out, "\n  {}", console::style(location).dim());
+    }
+    if let Some(snippet) = diag.snippet_text() {
+        let _ = write!(out, "\n    {}", console::style(snippet).yellow());
+    }
+    if let Some(help) = diag.help_text() {
+        let _ = write!(out, "\n  {} {help}", console::style("help:").cyan().bold());
+    }
+    out
+}
+
+/// Render a structured build-time [`Diagnostic`] with rustc-style coloring.
+///
+/// Color is the entry point's responsibility: the parser produces the plain
+/// structured data, and the CLI styles it here.
+pub fn diagnostic(diag: &Diagnostic) {
+    let code = diag
+        .error_code()
+        .map(|c| format!(" {}", console::style(format!("[{c}]")).dim()))
+        .unwrap_or_default();
+    eprintln!(
+        "\n  {} {}{}",
+        console::style("✘").red().bold(),
+        console::style(format!("{}: {}", diag.severity().label(), diag.title()))
+            .red()
+            .bold(),
+        code
+    );
+    if let Some(location) = diag.location() {
+        eprintln!("  {}", console::style(location).dim());
+    }
+    if let Some(snippet) = diag.snippet_text() {
+        eprintln!("    {}", console::style(snippet).yellow());
+    }
+    if let Some(help) = diag.help_text() {
+        eprintln!("  {} {help}", console::style("help:").cyan().bold());
+    }
+}
+
 pub fn hint(message: &str) {
+    if is_json() {
+        return;
+    }
     eprintln!("\n  {} {message}", console::style("hint:").dim());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn template_error() -> anyhow::Error {
+        let diag = Diagnostic::error("invalid <for> each expression")
+            .code("invalid-for-each")
+            .component("index.html")
+            .position(67, 5)
+            .snippet(r#"each="person inpeople""#)
+            .help(r#"use the form each="item in collection", e.g. each="todo in todos""#);
+        WebUIError::Parse {
+            context: "Failed to parse index.html".to_owned(),
+            source: ParserError::Template(Box::new(diag)),
+        }
+        .into()
+    }
+
+    #[test]
+    fn build_error_message_is_plain_for_browser() {
+        // The browser receives `message` via live-reload and logs it with
+        // `console.error`; ANSI escape codes would render as literal garbage
+        // and break the single-line SSE frame. It must stay color-free even
+        // when terminal color is forced on.
+        let prev = console::colors_enabled();
+        console::set_colors_enabled(true);
+        let (_display, message) = build_error_renderings(&template_error());
+        console::set_colors_enabled(prev);
+
+        assert!(
+            !message.contains('\u{1b}'),
+            "browser message must not contain ANSI escapes: {message:?}"
+        );
+        assert!(message.contains("invalid <for> each expression"));
+        assert!(message.contains("--> index.html:67:5"));
+        assert!(message.contains(r#"each="person inpeople""#));
+        assert!(message.contains("help:"));
+    }
+
+    #[test]
+    fn build_error_display_is_colorized_for_terminal() {
+        let prev = console::colors_enabled();
+        console::set_colors_enabled(true);
+        let (display, _message) = build_error_renderings(&template_error());
+        console::set_colors_enabled(prev);
+
+        // The terminal rendering carries color...
+        assert!(
+            display.contains('\u{1b}'),
+            "terminal display should be colorized when color is enabled: {display:?}"
+        );
+        // ...applied per line: no SGR span may straddle a newline, or it would
+        // bleed when each line is re-prefixed (e.g. `[server]`). Every line
+        // that opens a color must reset before its end.
+        for line in display.lines() {
+            if line.contains('\u{1b}') {
+                assert!(
+                    line.contains("\u{1b}[0m"),
+                    "colored line must reset within itself: {line:?}"
+                );
+            }
+        }
+        // Same content as the plain body, just styled.
+        assert!(console::strip_ansi_codes(&display).contains("invalid <for> each expression"));
+        assert!(console::strip_ansi_codes(&display).contains("--> index.html:67:5"));
+    }
+
+    #[test]
+    fn build_error_falls_back_to_flat_chain_without_diagnostic() {
+        let err: anyhow::Error = WebUIError::Serialization("bad state json".to_owned()).into();
+        let (display, message) = build_error_renderings(&err);
+        assert_eq!(display, message);
+        assert!(message.contains("bad state json"));
+        assert!(!message.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn error_json_for_diagnostic_has_structured_fields() {
+        let value = error_json(&template_error());
+        assert_eq!(value["severity"], "error");
+        assert_eq!(value["code"], "invalid-for-each");
+        assert_eq!(value["message"], "invalid <for> each expression");
+        assert_eq!(value["file"], "index.html");
+        assert_eq!(value["line"], 67);
+        assert_eq!(value["column"], 5);
+        assert_eq!(value["snippet"], "each=\"person inpeople\"");
+        assert!(value["help"]
+            .as_str()
+            .is_some_and(|h| h.contains("item in collection")));
+        // The flattened source chain is always present.
+        assert!(value["chain"].is_array());
+        // The serialized object never carries ANSI escapes.
+        assert!(!value.to_string().contains('\u{1b}'));
+    }
+
+    #[test]
+    fn error_json_without_diagnostic_is_minimal() {
+        let err: anyhow::Error = WebUIError::Serialization("bad state json".to_owned()).into();
+        let value = error_json(&err);
+        assert_eq!(value["severity"], "error");
+        assert!(value["code"].is_null());
+        assert!(value["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("bad state json")));
+        assert!(value["chain"].is_array());
+    }
 }

--- a/crates/webui-cli/src/utils/output.rs
+++ b/crates/webui-cli/src/utils/output.rs
@@ -120,9 +120,16 @@ fn error_json(err: &anyhow::Error) -> serde_json::Value {
             map.insert("help".into(), str_or_null(diag.help_text()));
         }
         None => {
+            // Keep the same key set as the structured branch so `--format json`
+            // has one stable shape; fields that don't apply are null.
             map.insert("severity".into(), Value::from("error"));
             map.insert("code".into(), Value::Null);
             map.insert("message".into(), Value::from(err.to_string()));
+            map.insert("file".into(), Value::Null);
+            map.insert("line".into(), Value::Null);
+            map.insert("column".into(), Value::Null);
+            map.insert("snippet".into(), Value::Null);
+            map.insert("help".into(), Value::Null);
         }
     }
     map.insert("chain".into(), Value::Array(chain));
@@ -334,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    fn error_json_without_diagnostic_is_minimal() {
+    fn error_json_without_diagnostic_has_consistent_shape() {
         let err: anyhow::Error = WebUIError::Serialization("bad state json".to_owned()).into();
         let value = error_json(&err);
         assert_eq!(value["severity"], "error");
@@ -343,5 +350,13 @@ mod tests {
             .as_str()
             .is_some_and(|m| m.contains("bad state json")));
         assert!(value["chain"].is_array());
+        // Non-applicable fields are present as null, not omitted, so tools see
+        // one stable object shape regardless of error kind.
+        for key in ["file", "line", "column", "snippet", "help"] {
+            assert!(
+                value.get(key).is_some_and(serde_json::Value::is_null),
+                "expected `{key}` to be present and null"
+            );
+        }
     }
 }

--- a/crates/webui-dev-server/src/lib.rs
+++ b/crates/webui-dev-server/src/lib.rs
@@ -31,4 +31,4 @@ pub use livereload::{sse_handler, LiveReload, ReloadEvent};
 pub use reporter::{local_hms, RebuildReporter};
 pub use serve::{serve_file_response, serve_static_file, NotFoundStrategy, StaticServeConfig};
 pub use watch::{default_ignore_paths, spawn_watcher, WatchConfig, WatcherHandle};
-pub use worker::{spawn_rebuild_worker, TickSender};
+pub use worker::{spawn_rebuild_worker, RebuildError, TickSender};

--- a/crates/webui-dev-server/src/reporter.rs
+++ b/crates/webui-dev-server/src/reporter.rs
@@ -107,10 +107,15 @@ impl RebuildReporter {
     /// so it isn't overwritten.
     pub fn error(&mut self, msg: &str) {
         self.commit_pending();
+        // Color only the leading marker here. The body (`msg`) arrives
+        // pre-rendered from the caller — either plain, or per-line colorized
+        // with self-contained SGR spans. We must never wrap it in one span
+        // that straddles newlines: that bleeds when each line is later
+        // re-emitted with a process prefix (e.g. `[server]`).
         eprintln!(
-            "  {} {}",
+            "  {} {} {msg}",
             style("✘").red().bold(),
-            style(format!("build error: {msg}")).red()
+            style("build error:").red().bold(),
         );
     }
 

--- a/crates/webui-dev-server/src/worker.rs
+++ b/crates/webui-dev-server/src/worker.rs
@@ -15,8 +15,8 @@
 //!
 //! The closure is the only thing that varies between consumers
 //! (webui-cli builds and renders an app, webui-press rebuilds a docs
-//! site). It returns `Result<(), String>` so the worker can
-//! uniformly format the error and broadcast it to connected browsers.
+//! site). It returns `Result<(), RebuildError>` so the worker can
+//! print a terminal rendering and broadcast a plain one to browsers.
 
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::thread;
@@ -33,22 +33,73 @@ const TICK_CHANNEL_CAPACITY: usize = 8;
 /// Tick sender given to the watcher closure. Cheap to clone.
 pub type TickSender = SyncSender<()>;
 
+/// Failure returned by a rebuild closure.
+///
+/// Carries two renderings of the same error so the worker can route each to
+/// the surface that needs it:
+///
+/// - `display` — text for the terminal [`RebuildReporter`]. May embed ANSI
+///   color, but each line must keep its **own** self-contained SGR span:
+///   a single span that straddles newlines bleeds when the line is later
+///   re-prefixed (e.g. `[server]` under `xtask dev`).
+/// - `message` — plain, color-free text broadcast to connected browsers over
+///   live-reload (logged to the dev console / shown in overlays). Never embed
+///   ANSI here — browsers render escape codes as literal garbage.
+///
+/// Use [`RebuildError::plain`] (or the `From<String>` / `From<&str>`
+/// conversions) when one rendering serves both surfaces.
+pub struct RebuildError {
+    display: String,
+    message: String,
+}
+
+impl RebuildError {
+    /// Build an error with distinct terminal `display` and browser `message`
+    /// renderings. The caller owns colorization of `display`.
+    #[must_use]
+    pub fn new(display: String, message: String) -> Self {
+        Self { display, message }
+    }
+
+    /// Build an error whose terminal and browser renderings are identical.
+    /// Use when the failure has no structured form to colorize.
+    #[must_use]
+    pub fn plain(text: String) -> Self {
+        Self {
+            display: text.clone(),
+            message: text,
+        }
+    }
+}
+
+impl From<String> for RebuildError {
+    fn from(text: String) -> Self {
+        Self::plain(text)
+    }
+}
+
+impl From<&str> for RebuildError {
+    fn from(text: &str) -> Self {
+        Self::plain(text.to_owned())
+    }
+}
+
 /// Spawn the rebuild worker on a dedicated OS thread and return the
 /// sender used to enqueue rebuild ticks. The watcher closure should
 /// call `tx.try_send(())` for every filesystem event burst — failed
 /// sends (channel full) are intentional coalescing.
 ///
 /// The closure runs synchronously on the worker thread, so it may use
-/// blocking I/O freely. It returns `Ok(())` on success or `Err(msg)`
-/// with a user-facing message on failure; the worker handles printing
-/// and broadcasting based on the result.
+/// blocking I/O freely. It returns `Ok(())` on success or
+/// `Err(RebuildError)` on failure; the worker prints the error's terminal
+/// rendering and broadcasts its plain message to connected browsers.
 ///
 /// The returned [`TickSender`] does not need to be held to keep the
 /// worker alive — the worker stops only when every clone of the
 /// sender is dropped.
 pub fn spawn_rebuild_worker<F>(livereload: LiveReload, mut rebuild: F) -> TickSender
 where
-    F: FnMut() -> Result<(), String> + Send + 'static,
+    F: FnMut() -> Result<(), RebuildError> + Send + 'static,
 {
     let (tx, rx) = sync_channel::<()>(TICK_CHANNEL_CAPACITY);
     thread::spawn(move || {
@@ -89,9 +140,9 @@ where
                     reporter.success(start.elapsed());
                     livereload.broadcast_reload();
                 }
-                Err(msg) => {
-                    reporter.error(&msg);
-                    livereload.broadcast_error(msg);
+                Err(e) => {
+                    reporter.error(&e.display);
+                    livereload.broadcast_error(e.message);
                 }
             }
         }

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -137,7 +137,7 @@ pub fn build(options: JsBuildOptions) -> napi::Result<JsBuildResult> {
     };
 
     let result = webui::build(build_options)
-        .map_err(|e| NapiError::from_reason(format!("Build error: {e}")))?;
+        .map_err(|e| NapiError::from_reason(format!("Build error: {}", e.chain_message())))?;
 
     // Flatten css_files into alternating [filename, content, ...] for JS interop
     let css_files: Vec<String> = result

--- a/crates/webui-parser/src/component_registry.rs
+++ b/crates/webui-parser/src/component_registry.rs
@@ -245,6 +245,14 @@ impl ComponentRegistry {
         self.components.values()
     }
 
+    /// Iterate the registered component tag names (e.g. `mp-button`).
+    ///
+    /// Used to offer "did you mean …?" suggestions when an unknown component
+    /// tag is encountered during parsing.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.components.keys().map(String::as_str)
+    }
+
     /// Get the number of registered components.
     pub fn len(&self) -> usize {
         self.components.len()

--- a/crates/webui-parser/src/css_parser.rs
+++ b/crates/webui-parser/src/css_parser.rs
@@ -11,6 +11,16 @@ use std::fmt;
 /// Parser for CSS files.
 pub struct CssParser;
 
+/// Format a byte `offset` into CSS `source` as `at line L, column C`.
+///
+/// CSS is parsed as an extracted chunk (a component `.css` file or inline
+/// `<style>` body) with no enclosing-file context, so the position is relative
+/// to that chunk — still far more actionable than a raw byte offset.
+fn css_loc(source: &str, offset: usize) -> String {
+    let (line, column) = crate::diagnostic::line_column(source, offset);
+    format!("at line {line}, column {column}")
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CssComment {
     pub start_byte: usize,
@@ -118,7 +128,8 @@ fn scan_css(
             b'/' if index + 1 < bytes.len() && bytes[index + 1] == b'*' => {
                 let Some(offset) = source[index + 2..].find("*/") else {
                     return Err(ParserError::Css(format!(
-                        "Unterminated CSS block comment near byte {index}. Close the comment with `*/` before building."
+                        "Unterminated CSS block comment {}. Close the comment with `*/` before building.",
+                        css_loc(source, index)
                     )));
                 };
                 let end = index + 2 + offset + 2;
@@ -170,7 +181,8 @@ fn scan_css(
             b'}' => {
                 if brace_depth == 0 {
                     return Err(ParserError::Css(format!(
-                        "Unexpected CSS closing brace near byte {index}. Remove the extra `}}` or add a matching opening `{{`."
+                        "Unexpected CSS closing brace {}. Remove the extra `}}` or add a matching opening `{{`.",
+                        css_loc(source, index)
                     )));
                 }
                 brace_depth -= 1;
@@ -183,7 +195,8 @@ fn scan_css(
             b')' => {
                 if paren_depth == 0 {
                     return Err(ParserError::Css(format!(
-                        "Unexpected CSS closing parenthesis near byte {index}. Remove the extra `)` or add a matching opening `(`."
+                        "Unexpected CSS closing parenthesis {}. Remove the extra `)` or add a matching opening `(`.",
+                        css_loc(source, index)
                     )));
                 }
                 paren_depth -= 1;
@@ -196,7 +209,8 @@ fn scan_css(
             b']' => {
                 if bracket_depth == 0 {
                     return Err(ParserError::Css(format!(
-                        "Unexpected CSS closing bracket near byte {index}. Remove the extra `]` or add a matching opening `[`."
+                        "Unexpected CSS closing bracket {}. Remove the extra `]` or add a matching opening `[`.",
+                        css_loc(source, index)
                     )));
                 }
                 bracket_depth -= 1;
@@ -262,7 +276,8 @@ fn scan_var_call(source: &str, start: usize, tokens: &mut HashSet<String>) -> Re
             b'/' if index + 1 < bytes.len() && bytes[index + 1] == b'*' => {
                 let Some(offset) = source[index + 2..].find("*/") else {
                     return Err(ParserError::Css(format!(
-                        "Unterminated CSS block comment inside var() near byte {index}. Close the comment with `*/` before building."
+                        "Unterminated CSS block comment inside var() {}. Close the comment with `*/` before building.",
+                        css_loc(source, index)
                     )));
                 };
                 index += 2 + offset + 2;
@@ -280,12 +295,14 @@ fn scan_var_call(source: &str, start: usize, tokens: &mut HashSet<String>) -> Re
                 if depth == 0 {
                     if brace_depth != 0 {
                         return Err(ParserError::Css(format!(
-                            "Unterminated CSS brace expression inside var() near byte {start}. Add the missing `}}` before building."
+                            "Unterminated CSS brace expression inside var() {}. Add the missing `}}` before building.",
+                            css_loc(source, start)
                         )));
                     }
                     if bracket_depth != 0 {
                         return Err(ParserError::Css(format!(
-                            "Unterminated CSS bracket expression inside var() near byte {start}. Add the missing `]` before building."
+                            "Unterminated CSS bracket expression inside var() {}. Add the missing `]` before building.",
+                            css_loc(source, start)
                         )));
                     }
                     for token in pending_tokens {
@@ -301,7 +318,8 @@ fn scan_var_call(source: &str, start: usize, tokens: &mut HashSet<String>) -> Re
             b'}' => {
                 if brace_depth == 0 {
                     return Err(ParserError::Css(format!(
-                        "Unterminated CSS var() call near byte {start}. Add the missing `)` before the closing `}}`."
+                        "Unterminated CSS var() call {}. Add the missing `)` before the closing `}}`.",
+                        css_loc(source, start)
                     )));
                 }
                 brace_depth -= 1;
@@ -314,7 +332,8 @@ fn scan_var_call(source: &str, start: usize, tokens: &mut HashSet<String>) -> Re
             b']' => {
                 if bracket_depth == 0 {
                     return Err(ParserError::Css(format!(
-                        "Unexpected CSS closing bracket inside var() near byte {index}. Remove the extra `]` or add a matching opening `[`."
+                        "Unexpected CSS closing bracket inside var() {}. Remove the extra `]` or add a matching opening `[`.",
+                        css_loc(source, index)
                     )));
                 }
                 bracket_depth -= 1;
@@ -334,13 +353,15 @@ fn scan_var_call(source: &str, start: usize, tokens: &mut HashSet<String>) -> Re
 
     if quote != 0 {
         return Err(ParserError::Css(format!(
-            "Unterminated CSS string literal inside var() near byte {start}. Close the `{}` quote before building.",
+            "Unterminated CSS string literal inside var() {}. Close the `{}` quote before building.",
+            css_loc(source, start),
             char::from(quote)
         )));
     }
 
     Err(ParserError::Css(format!(
-        "Unterminated CSS var() call near byte {start}. Add the missing `)` before building."
+        "Unterminated CSS var() call {}. Add the missing `)` before building.",
+        css_loc(source, start)
     )))
 }
 

--- a/crates/webui-parser/src/diagnostic.rs
+++ b/crates/webui-parser/src/diagnostic.rs
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Centralized, structured diagnostics for build-time template-authoring
+//! mistakes.
+//!
+//! Every "the developer wrote invalid template syntax" problem is described by
+//! a [`Diagnostic`] so they share one consistent shape (title + location +
+//! offending snippet + actionable `help`). A [`Diagnostic`] is **plain data**:
+//! it carries no color and never decides whether output is a terminal.
+//!
+//! Presentation is the responsibility of the **entry point**, not the library:
+//! - `webui-cli` reads the structured fields and colorizes them with
+//!   `console::style()` for a friendly terminal report.
+//! - `webui-ffi`, `webui-node`, and `webui-wasm` surface the plain
+//!   [`fmt::Display`] text through their own error channel
+//!   (`webui_last_error`, `napi::Error`, `JsValue`) so the host application can
+//!   handle it however it likes.
+//!
+//! A [`Diagnostic`] reaches those consumers as the payload of
+//! [`crate::ParserError::Template`]; its [`fmt::Display`] renders the plain
+//! report below:
+//!
+//! ```text
+//! error: invalid @pointerdown handler [invalid-event-handler]
+//!   in component <mail-inbox-page> · element <button>
+//!     @pointerdown="e.preventDefault()"
+//!   help: use @pointerdown="{handler()}" or @pointerdown="{handler(e)}" to pass the event
+//! ```
+
+use std::fmt;
+use std::fmt::Write as _;
+
+/// Severity of a [`Diagnostic`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    /// A fatal authoring error — the build cannot continue.
+    Error,
+    /// A non-fatal warning — the build continues. Part of the diagnostics
+    /// surface for future advisories; not constructed while every current
+    /// authoring check is fatal.
+    #[allow(dead_code)]
+    Warning,
+}
+
+impl Severity {
+    /// Human label printed before the title (`error` / `warning`).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        }
+    }
+}
+
+/// Stable, machine-readable diagnostic codes.
+///
+/// Each constant is a permanent identifier for one class of authoring mistake.
+/// The code is rendered alongside every diagnostic and emitted as a structured
+/// field by `webui build --format json`, so editors, CI, and AI assistants can
+/// map an error to a deterministic fix or docs page regardless of the
+/// human-readable wording. Treat these as a stable API surface — rename only
+/// with a deliberate, documented migration.
+pub mod codes {
+    /// `<for>` element is missing its required `each` attribute.
+    pub const MISSING_FOR_EACH: &str = "missing-for-each";
+    /// `<for each>` value is not of the form `item in collection`.
+    pub const INVALID_FOR_EACH: &str = "invalid-for-each";
+    /// `<for each>` item or collection name uses disallowed characters.
+    pub const INVALID_FOR_IDENTIFIER: &str = "invalid-for-identifier";
+    /// `<if>` element is missing its required `condition` attribute.
+    pub const MISSING_IF_CONDITION: &str = "missing-if-condition";
+    /// `<if condition>` value is not a parseable expression.
+    pub const INVALID_IF_CONDITION: &str = "invalid-if-condition";
+    /// A component tag has no matching registered component.
+    pub const UNKNOWN_COMPONENT: &str = "unknown-component";
+    /// An `@event` handler value is not a valid `{handler()}` expression.
+    pub const INVALID_EVENT_HANDLER: &str = "invalid-event-handler";
+    /// A `w-ref` binding is missing its required `{braces}`.
+    pub const INVALID_W_REF: &str = "invalid-w-ref";
+    /// An HTML element is missing its closing tag.
+    pub const UNCLOSED_HTML_TAG: &str = "unclosed-html-tag";
+    /// An HTML tag could not be parsed (missing `>`, stray `<`, …).
+    pub const MALFORMED_HTML_TAG: &str = "malformed-html-tag";
+    /// A closing tag has no matching opening tag.
+    pub const UNEXPECTED_CLOSING_TAG: &str = "unexpected-closing-tag";
+    /// An HTML comment was opened but never closed with `-->`.
+    pub const UNTERMINATED_HTML_COMMENT: &str = "unterminated-html-comment";
+    /// An HTML declaration was opened but never closed with `>`.
+    pub const UNTERMINATED_HTML_DECLARATION: &str = "unterminated-html-declaration";
+    /// Template nesting exceeds the parser's depth limit.
+    pub const EXCESSIVE_NESTING: &str = "excessive-nesting";
+    /// A template references itself (directly or transitively) at build time.
+    pub const RECURSIVE_TEMPLATE: &str = "recursive-template";
+    /// A `<style>` block contains malformed CSS.
+    pub const INVALID_CSS: &str = "invalid-css";
+}
+
+/// A build-time template-authoring diagnostic.
+///
+/// Construct with [`Diagnostic::error`] / [`Diagnostic::warning`], attach
+/// context with the builder methods, then return it inside
+/// [`crate::ParserError::Template`]. The library never colors or prints it; the
+/// CLI reads the fields via the getters and renders them, while other hosts use
+/// the plain [`fmt::Display`] text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    severity: Severity,
+    /// Stable, machine-readable code (e.g. `invalid-for-each`); see [`codes`].
+    code: Option<&'static str>,
+    title: String,
+    component: Option<String>,
+    element: Option<String>,
+    snippet: Option<String>,
+    help: Option<String>,
+    /// 1-based `(line, column)` of the offending source location, if known.
+    position: Option<(usize, usize)>,
+}
+
+impl Diagnostic {
+    /// Start a fatal error diagnostic. Titles are short and lowercase by
+    /// convention (e.g. `invalid @click handler`).
+    #[must_use]
+    pub fn error(title: impl Into<String>) -> Self {
+        Self::new(Severity::Error, title)
+    }
+
+    /// Start a non-fatal warning diagnostic.
+    ///
+    /// Reserved for future advisories; every current authoring check is fatal,
+    /// so this is not yet called outside tests.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn warning(title: impl Into<String>) -> Self {
+        Self::new(Severity::Warning, title)
+    }
+
+    fn new(severity: Severity, title: impl Into<String>) -> Self {
+        Self {
+            severity,
+            code: None,
+            title: title.into(),
+            component: None,
+            element: None,
+            snippet: None,
+            help: None,
+            position: None,
+        }
+    }
+
+    /// Attach a stable, machine-readable error [`code`](codes) (e.g.
+    /// `invalid-for-each`).
+    ///
+    /// The code is a constant identifier that does not change with the wording
+    /// of the message, so tools and AI assistants can recognize the error class
+    /// and apply a deterministic fix. Prefer the constants in [`codes`].
+    #[must_use]
+    pub fn code(mut self, code: &'static str) -> Self {
+        self.code = Some(code);
+        self
+    }
+
+    /// Name the owning component template (e.g. `mail-inbox-page`).
+    #[must_use]
+    pub fn component(mut self, component: impl Into<String>) -> Self {
+        self.component = Some(component.into());
+        self
+    }
+
+    /// Name the offending element tag (e.g. `button`), when known.
+    #[must_use]
+    pub fn element(mut self, element: impl Into<String>) -> Self {
+        self.element = Some(element.into());
+        self
+    }
+
+    /// Attach the offending source snippet (e.g. `@click="bad()"`).
+    #[must_use]
+    pub fn snippet(mut self, snippet: impl Into<String>) -> Self {
+        self.snippet = Some(snippet.into());
+        self
+    }
+
+    /// Attach a `help:` hint describing the fix.
+    #[must_use]
+    pub fn help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    /// Attach the 1-based `(line, column)` of the offending source location.
+    #[must_use]
+    pub fn position(mut self, line: usize, column: usize) -> Self {
+        self.position = Some((line, column));
+        self
+    }
+
+    /// Attach the source location computed from a byte `offset` into `source`.
+    ///
+    /// Convenience over [`Diagnostic::position`] for callers that hold the
+    /// source text and a byte offset (e.g. an element's start). Computes the
+    /// 1-based line and column in a single forward scan.
+    #[must_use]
+    pub fn at_offset(self, source: &str, offset: usize) -> Self {
+        let (line, column) = line_column(source, offset);
+        self.position(line, column)
+    }
+
+    /// Severity of this diagnostic.
+    #[must_use]
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    /// The stable, machine-readable error [`code`](codes), if set.
+    #[must_use]
+    pub fn error_code(&self) -> Option<&'static str> {
+        self.code
+    }
+
+    /// The short error title (e.g. `invalid @click handler`).
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// The owning component tag, if set.
+    #[must_use]
+    pub fn component_name(&self) -> Option<&str> {
+        self.component.as_deref()
+    }
+
+    /// The offending element tag, if set.
+    #[must_use]
+    pub fn element_name(&self) -> Option<&str> {
+        self.element.as_deref()
+    }
+
+    /// The offending source snippet, if set.
+    #[must_use]
+    pub fn snippet_text(&self) -> Option<&str> {
+        self.snippet.as_deref()
+    }
+
+    /// The `help:` hint, if set.
+    #[must_use]
+    pub fn help_text(&self) -> Option<&str> {
+        self.help.as_deref()
+    }
+
+    /// The 1-based `(line, column)` of the offending source location, if known.
+    #[must_use]
+    pub fn position_line_column(&self) -> Option<(usize, usize)> {
+        self.position
+    }
+
+    /// Render the location line content (already including its leading marker),
+    /// if any.
+    ///
+    /// When a source position is known it is reported rustc-style as
+    /// `--> owner:line:column` (the `owner` is the entry file or component
+    /// tag), which is compact and recognizable. Without a position it falls
+    /// back to a descriptive `in component <c> · element <e>` form. Returned so
+    /// callers (e.g. the CLI) can render the location on its own styled line.
+    #[must_use]
+    pub fn location(&self) -> Option<String> {
+        if let Some((line, column)) = self.position {
+            return Some(match &self.component {
+                Some(c) => format!("--> {c}:{line}:{column}"),
+                None => format!("--> {line}:{column}"),
+            });
+        }
+        match (&self.component, &self.element) {
+            (Some(c), Some(e)) => Some(format!("in component <{c}> · element <{e}>")),
+            (Some(c), None) => Some(format!("in component <{c}>")),
+            (None, Some(e)) => Some(format!("in element <{e}>")),
+            (None, None) => None,
+        }
+    }
+
+    /// Render the message body — everything after the severity label: title,
+    /// location, offending snippet, and `help:` hint, each on its own line.
+    ///
+    /// Used by callers that supply their own leading label (e.g. the dev
+    /// server prints `build error: {body}`) so the severity word isn't
+    /// duplicated. [`fmt::Display`] prepends the severity to this body.
+    #[must_use]
+    pub fn body(&self) -> String {
+        let mut out = String::with_capacity(96);
+        out.push_str(&self.title);
+        if let Some(code) = self.code {
+            let _ = write!(out, " [{code}]");
+        }
+        if let Some(location) = self.location() {
+            let _ = write!(out, "\n  {location}");
+        }
+        if let Some(snippet) = &self.snippet {
+            let _ = write!(out, "\n    {snippet}");
+        }
+        if let Some(help) = &self.help {
+            let _ = write!(out, "\n  help: {help}");
+        }
+        out
+    }
+}
+
+/// Compute the 1-based `(line, column)` of a byte `offset` into `source`.
+///
+/// A single forward scan over the bytes preceding `offset` (no regex, no
+/// allocation); the column counts characters within the line so multi-byte
+/// UTF-8 is reported correctly.
+#[must_use]
+pub(crate) fn line_column(source: &str, offset: usize) -> (usize, usize) {
+    let offset = offset.min(source.len());
+    let mut line = 1usize;
+    let mut line_start = 0usize;
+    for (i, &b) in source.as_bytes()[..offset].iter().enumerate() {
+        if b == b'\n' {
+            line += 1;
+            line_start = i + 1;
+        }
+    }
+    let column = source[line_start..offset].chars().count() + 1;
+    (line, column)
+}
+
+impl fmt::Display for Diagnostic {
+    /// Render the plain, color-free report. Hosts that want color (the CLI)
+    /// read the fields via the getters instead.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.severity.label(), self.body())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_full_error_compact() {
+        let diag = Diagnostic::error("invalid @pointerdown handler")
+            .component("mail-inbox-page")
+            .element("button")
+            .snippet(r#"@pointerdown="e.preventDefault()""#)
+            .help(r#"use @pointerdown="{handler()}" to pass the event"#);
+
+        let expected = "error: invalid @pointerdown handler\n  \
+             in component <mail-inbox-page> · element <button>\n    \
+             @pointerdown=\"e.preventDefault()\"\n  \
+             help: use @pointerdown=\"{handler()}\" to pass the event";
+
+        assert_eq!(diag.to_string(), expected);
+    }
+
+    #[test]
+    fn omits_optional_sections_when_absent() {
+        let diag = Diagnostic::warning("something minor").component("my-card");
+        assert_eq!(
+            diag.to_string(),
+            "warning: something minor\n  in component <my-card>"
+        );
+    }
+
+    #[test]
+    fn element_only_location() {
+        let diag = Diagnostic::error("x").element("button");
+        assert_eq!(diag.to_string(), "error: x\n  in element <button>");
+    }
+
+    #[test]
+    fn getters_expose_structured_fields() {
+        let diag = Diagnostic::error("boom")
+            .component("c")
+            .element("e")
+            .snippet("snip")
+            .help("do this");
+        assert_eq!(diag.severity(), Severity::Error);
+        assert_eq!(diag.title(), "boom");
+        assert_eq!(diag.component_name(), Some("c"));
+        assert_eq!(diag.element_name(), Some("e"));
+        assert_eq!(diag.snippet_text(), Some("snip"));
+        assert_eq!(diag.help_text(), Some("do this"));
+        assert_eq!(
+            diag.location().as_deref(),
+            Some("in component <c> · element <e>")
+        );
+    }
+
+    #[test]
+    fn position_renders_rustc_style_location() {
+        let diag = Diagnostic::error("boom")
+            .component("index.html")
+            .element("for")
+            .position(3, 7);
+        assert_eq!(diag.position_line_column(), Some((3, 7)));
+        // A known position overrides the descriptive form with `--> file:l:c`.
+        assert_eq!(diag.location().as_deref(), Some("--> index.html:3:7"));
+        assert!(diag.to_string().contains("--> index.html:3:7"));
+    }
+
+    #[test]
+    fn bare_position_renders_without_component_or_element() {
+        let diag = Diagnostic::error("boom").position(5, 1);
+        assert_eq!(diag.location().as_deref(), Some("--> 5:1"));
+    }
+
+    #[test]
+    fn line_column_counts_lines_and_chars() {
+        let src = "<div>\n  <for each=\"x\">\n</div>";
+        // Offset of the '<' in "<for" — line 2, column 3 (after two spaces).
+        let offset = src.find("<for").unwrap();
+        assert_eq!(line_column(src, offset), (2, 3));
+        // Start of file.
+        assert_eq!(line_column(src, 0), (1, 1));
+    }
+
+    #[test]
+    fn line_column_uses_char_columns_for_multibyte() {
+        // "📚x" — the 'x' is one char in, though the emoji is 4 bytes.
+        let src = "📚x";
+        let offset = src.find('x').unwrap();
+        assert_eq!(line_column(src, offset), (1, 2));
+    }
+}

--- a/crates/webui-parser/src/error.rs
+++ b/crates/webui-parser/src/error.rs
@@ -3,6 +3,7 @@
 
 //! Error handling for the WebUI parser.
 
+use crate::diagnostic::Diagnostic;
 use thiserror::Error;
 
 /// Result type for WebUI parser operations.
@@ -16,7 +17,7 @@ pub enum ParserError {
     Generic(String),
 
     /// I/O error with context.
-    #[error("I/O error: {context}: {source}")]
+    #[error("I/O error: {context}")]
     IO {
         /// What operation failed.
         context: String,
@@ -69,4 +70,21 @@ pub enum ParserError {
     /// TypeScript parse error.
     #[error("TypeScript parse error: {0}")]
     TsParseError(String),
+
+    /// A build-time template-authoring mistake (e.g. an invalid `@event`
+    /// handler or a non-braced `w-ref`). Carries a structured [`Diagnostic`]
+    /// whose [`std::fmt::Display`] is an actionable, color-free report. The CLI
+    /// colorizes it; FFI/Node/WASM forward the plain text to their host error
+    /// channel so the application can handle it.
+    ///
+    /// The diagnostic is boxed so this cold error path does not enlarge
+    /// `Result<_, ParserError>` on the common success path.
+    #[error("{0}")]
+    Template(Box<Diagnostic>),
+}
+
+impl From<Diagnostic> for ParserError {
+    fn from(diagnostic: Diagnostic) -> Self {
+        ParserError::Template(Box::new(diagnostic))
+    }
 }

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -484,9 +484,15 @@ impl HtmlParser {
     /// Parse HTML content to generate WebUI fragments.
     pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<()> {
         let fragment_key = fragment_id.to_string();
-        self.current_fragment_id = fragment_key.clone();
+        // Save the caller's fragment id and restore it before returning. A
+        // component parse recurses through `enter_component_directive`
+        // (`self.parse(child, …)`); without restoring, the parent would keep
+        // parsing with `current_fragment_id` pointing at the child, so a later
+        // diagnostic in the parent would be attributed to the wrong owner.
+        let previous_fragment_id =
+            std::mem::replace(&mut self.current_fragment_id, fragment_key.clone());
         if !self.in_progress_fragments.insert(fragment_key.clone()) {
-            return Err(self
+            let err = self
                 .authoring_error(
                     codes::RECURSIVE_TEMPLATE,
                     format!("recursive template reference while parsing <{fragment_id}>"),
@@ -495,11 +501,14 @@ impl HtmlParser {
                     "move the recursive usage behind runtime data, or split the component graph \
                      so templates do not reference themselves at build time",
                 )
-                .into());
+                .into();
+            self.current_fragment_id = previous_fragment_id;
+            return Err(err);
         }
 
         let result = self.parse_inner(fragment_id, html_content);
         self.in_progress_fragments.remove(&fragment_key);
+        self.current_fragment_id = previous_fragment_id;
         result
     }
 
@@ -2588,6 +2597,34 @@ mod tests {
         assert!(
             help.contains("found `eahc`") && help.contains("did you mean"),
             "expected an attribute-typo suggestion, got: {help}"
+        );
+    }
+
+    #[test]
+    fn parent_diagnostic_owner_survives_nested_component_parse() {
+        // Regression: a component parse recurses through `self.parse(child, …)`,
+        // which used to leave `current_fragment_id` pointing at the child. A
+        // later error in the PARENT template must still be attributed to the
+        // parent (here `index.html`), not the nested component.
+        let mut parser = HtmlParser::with_options(DomStrategy::Light);
+        parser
+            .component_registry
+            .register_component("my-card", "<div>card</div>", None)
+            .expect("register");
+
+        // A registered component first, then a broken <for> in the same template.
+        let html = r#"<my-card></my-card><for each="bad inval"></for>"#;
+        let err = parser
+            .parse("index.html", html)
+            .expect_err("the malformed <for> should error");
+        let ParserError::Template(diag) = err else {
+            panic!("expected ParserError::Template, got {err:?}");
+        };
+        assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_EACH));
+        assert_eq!(
+            diag.component_name(),
+            Some("index.html"),
+            "parent diagnostic must be owned by index.html, not the nested component"
         );
     }
 

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -9,16 +9,20 @@ mod component_registry;
 mod condition_parser;
 mod css_link;
 mod css_parser;
+mod diagnostic;
 mod error;
 mod handlebars_parser;
 mod html_parser;
 pub mod plugin;
 mod route_parser;
+mod suggest;
 
 pub use component_registry::{Component, ComponentRegistry};
 pub use condition_parser::ConditionParser;
 pub use css_link::{CssLinkHref, CssLinkOptions, DEFAULT_CSS_FILE_NAME_TEMPLATE};
 pub use css_parser::CssParser;
+use diagnostic::codes;
+pub use diagnostic::{Diagnostic, Severity};
 pub use error::{ParserError, Result};
 pub use handlebars_parser::HandlebarsParser;
 
@@ -366,6 +370,10 @@ pub struct HtmlParser {
     /// Fragment IDs currently being parsed, used to reject recursive component
     /// references before they can recurse through template parsing.
     in_progress_fragments: HashSet<String>,
+
+    /// The fragment ID (entry file or component tag) currently being parsed.
+    /// Used to name the owning template in authoring [`Diagnostic`]s.
+    current_fragment_id: String,
 }
 
 impl HtmlParser {
@@ -393,6 +401,7 @@ impl HtmlParser {
             token_store: HashSet::new(),
             token_definitions: HashSet::new(),
             in_progress_fragments: HashSet::new(),
+            current_fragment_id: String::new(),
         }
     }
 
@@ -441,11 +450,15 @@ impl HtmlParser {
     }
 
     /// Take any post-parse artifacts captured by the parser plugin.
-    #[must_use]
-    pub fn take_plugin_artifacts(&mut self) -> ParserPluginArtifacts {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParserError::Template`] if a tracked component contains an
+    /// invalid `@event` handler or a non-braced `w-ref` binding.
+    pub fn take_plugin_artifacts(&mut self) -> Result<ParserPluginArtifacts> {
         self.plugin
             .take()
-            .map_or(ParserPluginArtifacts::None, |plugin| {
+            .map_or(Ok(ParserPluginArtifacts::None), |plugin| {
                 plugin.into_artifacts()
             })
     }
@@ -471,10 +484,18 @@ impl HtmlParser {
     /// Parse HTML content to generate WebUI fragments.
     pub fn parse(&mut self, fragment_id: &str, html_content: &str) -> Result<()> {
         let fragment_key = fragment_id.to_string();
+        self.current_fragment_id = fragment_key.clone();
         if !self.in_progress_fragments.insert(fragment_key.clone()) {
-            return Err(ParserError::Directive(format!(
-                "Recursive template reference detected while parsing '{fragment_id}'. Move the recursive usage behind runtime data or split the component graph so templates do not reference themselves at build time."
-            )));
+            return Err(self
+                .authoring_error(
+                    codes::RECURSIVE_TEMPLATE,
+                    format!("recursive template reference while parsing <{fragment_id}>"),
+                )
+                .help(
+                    "move the recursive usage behind runtime data, or split the component graph \
+                     so templates do not reference themselves at build time",
+                )
+                .into());
         }
 
         let result = self.parse_inner(fragment_id, html_content);
@@ -586,10 +607,19 @@ impl HtmlParser {
             match op {
                 ParseOp::Parse { range, depth } => {
                     if depth > MAX_TEMPLATE_DEPTH {
-                        return Err(ParserError::Html(format!(
-                            "Template nesting exceeds the {MAX_TEMPLATE_DEPTH} level parser limit near byte {}. Split deeply nested markup into components or reduce generated nesting before build.",
-                            range.start
-                        )));
+                        return Err(self
+                            .html_error(
+                                codes::EXCESSIVE_NESTING,
+                                format!(
+                                    "template nesting exceeds the {MAX_TEMPLATE_DEPTH}-level limit"
+                                ),
+                                source,
+                                range.start,
+                            )
+                            .help(
+                                "split deeply nested markup into components, or reduce generated nesting",
+                            )
+                            .into());
                     }
 
                     let end = range.end;
@@ -598,9 +628,15 @@ impl HtmlParser {
                         let remaining = &source[index..end];
                         if remaining.starts_with("<!--") {
                             let Some(close) = html::find_comment_close(remaining) else {
-                                return Err(ParserError::Html(format!(
-                                    "Unterminated HTML comment near byte {index}. Close the comment with `-->` before building."
-                                )));
+                                return Err(self
+                                    .html_error(
+                                        codes::UNTERMINATED_HTML_COMMENT,
+                                        "unterminated HTML comment",
+                                        source,
+                                        index,
+                                    )
+                                    .help("close the comment with `-->`")
+                                    .into());
                             };
                             index += close;
                             continue;
@@ -608,9 +644,15 @@ impl HtmlParser {
 
                         if remaining.starts_with("<!") {
                             let Some(close) = html::find_declaration_close(remaining) else {
-                                return Err(ParserError::Html(format!(
-                                    "Unterminated HTML declaration near byte {index}. Close the declaration with `>` before building."
-                                )));
+                                return Err(self
+                                    .html_error(
+                                        codes::UNTERMINATED_HTML_DECLARATION,
+                                        "unterminated HTML declaration",
+                                        source,
+                                        index,
+                                    )
+                                    .help("close the declaration with `>`")
+                                    .into());
                             };
                             self.add_raw_fragment(&remaining[..close]);
                             index += close;
@@ -619,15 +661,28 @@ impl HtmlParser {
 
                         if remaining.starts_with('<') {
                             let Some(tag) = html::parse_tag(remaining) else {
-                                return Err(ParserError::Html(format!(
-                                    "Malformed HTML tag near byte {index}. Close the tag with `>` or escape a literal `<` as `&lt;`."
-                                )));
+                                return Err(self
+                                    .html_error(
+                                        codes::MALFORMED_HTML_TAG,
+                                        "malformed HTML tag",
+                                        source,
+                                        index,
+                                    )
+                                    .help(
+                                        "close the tag with `>`, or escape a literal `<` as `&lt;`",
+                                    )
+                                    .into());
                             };
                             if tag.closing {
-                                return Err(ParserError::Html(format!(
-                                    "Unexpected closing HTML tag </{}> near byte {index}. Remove it or add the matching opening tag before it.",
-                                    tag.name
-                                )));
+                                return Err(self
+                                    .html_error(
+                                        codes::UNEXPECTED_CLOSING_TAG,
+                                        format!("unexpected closing tag </{}>", tag.name),
+                                        source,
+                                        index,
+                                    )
+                                    .help("remove it, or add the matching opening tag before it")
+                                    .into());
                             }
 
                             let content_start = index + tag.close + 1;
@@ -640,10 +695,18 @@ impl HtmlParser {
                             {
                                 (index + close_start, index + close_end)
                             } else {
-                                return Err(ParserError::Html(format!(
-                                        "Unclosed HTML tag <{}> near byte {index}. Add the matching </{}> closing tag or make the element self-closing.",
-                                        tag.name, tag.name
-                                    )));
+                                return Err(self
+                                    .html_error(
+                                        codes::UNCLOSED_HTML_TAG,
+                                        format!("unclosed <{}> tag", tag.name),
+                                        source,
+                                        index,
+                                    )
+                                    .help(format!(
+                                        "add the matching </{}> closing tag, or make the element self-closing",
+                                        tag.name
+                                    ))
+                                    .into());
                             };
 
                             let element = Element {
@@ -691,6 +754,7 @@ impl HtmlParser {
                                     )?;
                                 }
                                 _ => {
+                                    self.check_component_typo(&element)?;
                                     self.enter_regular_element(
                                         &element, fragments, depth, &mut ops,
                                     )?;
@@ -851,6 +915,186 @@ impl HtmlParser {
         Ok(())
     }
 
+    /// Start an authoring [`Diagnostic`] for the template currently being
+    /// parsed, naming the owning fragment (entry file or component tag) when
+    /// known. `code` is the stable machine-readable [`code`](crate::diagnostic::codes).
+    ///
+    /// Marked `#[cold]`/`#[inline(never)]`: this only runs while *building* a
+    /// build error, so keeping it out-of-line preserves hot parse-path layout.
+    #[cold]
+    #[inline(never)]
+    fn authoring_error(&self, code: &'static str, title: impl Into<String>) -> Diagnostic {
+        let diag = Diagnostic::error(title).code(code);
+        if self.current_fragment_id.is_empty() {
+            diag
+        } else {
+            diag.component(self.current_fragment_id.clone())
+        }
+    }
+
+    /// Like [`HtmlParser::authoring_error`], but also records the source
+    /// position (line/column) of `element` so the diagnostic can point at the
+    /// exact spot in the template.
+    #[cold]
+    #[inline(never)]
+    fn authoring_error_at(
+        &self,
+        code: &'static str,
+        title: impl Into<String>,
+        element: &Element<'_>,
+    ) -> Diagnostic {
+        self.authoring_error(code, title)
+            .at_offset(element.source(), element.start)
+    }
+
+    /// Build a positioned [`Diagnostic`] for a structural HTML well-formedness
+    /// error (unclosed/malformed tag, unterminated comment, …), naming the
+    /// owning fragment and the source position from a byte `offset`.
+    #[cold]
+    #[inline(never)]
+    fn html_error(
+        &self,
+        code: &'static str,
+        title: impl Into<String>,
+        source: &str,
+        offset: usize,
+    ) -> Diagnostic {
+        self.authoring_error(code, title).at_offset(source, offset)
+    }
+
+    /// Build the `help:` line for an unknown component `<name>`.
+    ///
+    /// Offers the closest registered component as a "did you mean …?" fix when
+    /// one is a near typo; otherwise falls back to the generic registration
+    /// hint.
+    #[cold]
+    #[inline(never)]
+    fn unknown_component_help(&self, name: &str) -> String {
+        match suggest::closest_match(name, self.component_registry.names()) {
+            Some(suggestion) => format!(
+                "did you mean <{suggestion}>? otherwise register the component by adding a \
+                 matching .html file"
+            ),
+            None => "register the component (add a matching .html file) or check the tag name \
+                     for a typo"
+                .to_string(),
+        }
+    }
+
+    /// Suggest a registered component that an unregistered custom-element `tag`
+    /// likely mistypes.
+    ///
+    /// Only same-namespace candidates are considered — the text before the
+    /// first `-` must match exactly — so a genuine third-party custom element
+    /// (`<md-button>` when `<mp-button>` is registered) is never flagged, while
+    /// an in-namespace slip (`<mp-buton>` → `<mp-button>`) is. Returns `None`
+    /// for non-hyphenated (native) tags and when no near match exists.
+    fn suggest_component(&self, tag: &str) -> Option<&str> {
+        let (prefix, _) = tag.split_once('-')?;
+        let same_namespace = self
+            .component_registry
+            .names()
+            .filter(|name| name.split_once('-').map(|(p, _)| p) == Some(prefix));
+        suggest::closest_match(tag, same_namespace)
+    }
+
+    /// Error with a "did you mean …?" hint when `element` is an unregistered
+    /// custom-element tag that closely matches a registered component in the
+    /// same namespace. Genuine external custom elements pass through as raw
+    /// HTML (returns `Ok`).
+    fn check_component_typo(&self, element: &Element<'_>) -> Result<()> {
+        if let Some(suggestion) = self.suggest_component(element.name()) {
+            return Err(self
+                .authoring_error_at(
+                    codes::UNKNOWN_COMPONENT,
+                    format!("unknown component <{}>", element.name()),
+                    element,
+                )
+                .help(format!(
+                    "did you mean <{suggestion}>? otherwise register <{}> by adding a matching \
+                     .html file",
+                    element.name()
+                ))
+                .into());
+        }
+        Ok(())
+    }
+
+    /// Name of an attribute on `element` that looks like a typo of `expected`
+    /// (close edit distance, not an exact match), if any. Used to suggest the
+    /// intended directive attribute (e.g. `eahc` → `each`).
+    #[cold]
+    #[inline(never)]
+    fn attr_typo_suggestion<'a>(element: &Element<'a>, expected: &str) -> Option<&'a str> {
+        suggest::closest_match(expected, element.attrs().map(|attr| attr.name))
+            .filter(|&name| name != expected)
+    }
+
+    /// Promote a standalone [`ParserError::Css`] into a structured authoring
+    /// [`Diagnostic`] (code [`codes::INVALID_CSS`], owning fragment), so CSS
+    /// mistakes render and serialize like every other authoring error. The
+    /// message already carries the in-`<style>` line/column. Non-CSS errors
+    /// pass through unchanged.
+    #[cold]
+    #[inline(never)]
+    fn css_diagnostic(&self, err: ParserError) -> ParserError {
+        match err {
+            ParserError::Css(message) => self.authoring_error(codes::INVALID_CSS, message).into(),
+            other => other,
+        }
+    }
+
+    /// Build the error for a `<for>` missing its `each` attribute (cold path).
+    #[cold]
+    #[inline(never)]
+    fn for_each_missing_error(&self, element: &Element<'_>) -> ParserError {
+        let diag = self
+            .authoring_error_at(
+                codes::MISSING_FOR_EACH,
+                "missing each attribute on <for>",
+                element,
+            )
+            .element("for");
+        match Self::attr_typo_suggestion(element, "each") {
+            Some(typo) => diag.help(format!(
+                "found `{typo}` \u{2014} did you mean each=\"item in collection\"?"
+            )),
+            None => diag.help("add each=\"item in collection\", e.g. <for each=\"todo in todos\">"),
+        }
+        .into()
+    }
+
+    /// Build the error for a malformed `<for each>` expression (cold path).
+    #[cold]
+    #[inline(never)]
+    fn for_each_invalid_error(&self, element: &Element<'_>, each: &str) -> ParserError {
+        self.authoring_error_at(
+            codes::INVALID_FOR_EACH,
+            "invalid <for> each expression",
+            element,
+        )
+        .element("for")
+        .snippet(format!("each=\"{each}\""))
+        .help("use the form each=\"item in collection\", e.g. each=\"todo in todos\"")
+        .into()
+    }
+
+    /// Build the error for a `<for each>` with disallowed identifier characters
+    /// (cold path).
+    #[cold]
+    #[inline(never)]
+    fn for_identifier_error(&self, element: &Element<'_>, each: &str) -> ParserError {
+        self.authoring_error_at(
+            codes::INVALID_FOR_IDENTIFIER,
+            "invalid identifier in <for> each expression",
+            element,
+        )
+        .element("for")
+        .snippet(format!("each=\"{each}\""))
+        .help("item and collection names may use only letters, digits, '_', '-', and '.'")
+        .into()
+    }
+
     fn enter_for_directive<'a>(
         &mut self,
         element: &Element<'a>,
@@ -861,24 +1105,16 @@ impl HtmlParser {
         let each = element
             .attr("each")
             .map(ToString::to_string)
-            .ok_or_else(|| {
-                ParserError::Directive("Missing 'each' attribute on <for>".to_string())
-            })?;
+            .ok_or_else(|| self.for_each_missing_error(element))?;
 
         let mut parts = each.split_whitespace();
         let (Some(item), Some(in_kw), Some(collection), None) =
             (parts.next(), parts.next(), parts.next(), parts.next())
         else {
-            return Err(ParserError::Directive(format!(
-                "Invalid for each: {}",
-                each
-            )));
+            return Err(self.for_each_invalid_error(element, &each));
         };
         if in_kw != "in" {
-            return Err(ParserError::Directive(format!(
-                "Invalid for each: {}",
-                each
-            )));
+            return Err(self.for_each_invalid_error(element, &each));
         }
 
         let allowed = |s: &str| {
@@ -886,10 +1122,7 @@ impl HtmlParser {
                 .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
         };
         if !allowed(item) || !allowed(collection) {
-            return Err(ParserError::Directive(format!(
-                "Invalid identifier in for each: {}",
-                each
-            )));
+            return Err(self.for_identifier_error(element, &each));
         }
 
         let custom_fragment_id = element.attr("template").map(ToString::to_string);
@@ -914,6 +1147,42 @@ impl HtmlParser {
         Ok(())
     }
 
+    /// Build the error for an `<if>` missing its `condition` attribute (cold
+    /// path).
+    #[cold]
+    #[inline(never)]
+    fn if_condition_missing_error(&self, element: &Element<'_>) -> ParserError {
+        let diag = self
+            .authoring_error_at(
+                codes::MISSING_IF_CONDITION,
+                "missing condition attribute on <if>",
+                element,
+            )
+            .element("if");
+        match Self::attr_typo_suggestion(element, "condition") {
+            Some(typo) => diag.help(format!(
+                "found `{typo}` \u{2014} did you mean condition=\"expression\"?"
+            )),
+            None => diag.help("add condition=\"expression\", e.g. <if condition=\"isActive\">"),
+        }
+        .into()
+    }
+
+    /// Build the error for a malformed `<if condition>` expression (cold path).
+    #[cold]
+    #[inline(never)]
+    fn if_condition_invalid_error(&self, element: &Element<'_>, condition: &str) -> ParserError {
+        self.authoring_error_at(
+            codes::INVALID_IF_CONDITION,
+            "invalid <if> condition expression",
+            element,
+        )
+        .element("if")
+        .snippet(format!("condition=\"{condition}\""))
+        .help("use a simple expression like \"isActive\", \"count > 0\", or \"!hidden\"")
+        .into()
+    }
+
     fn enter_if_directive<'a>(
         &mut self,
         element: &Element<'a>,
@@ -924,13 +1193,12 @@ impl HtmlParser {
         let condition_str = element
             .attr("condition")
             .map(ToString::to_string)
-            .ok_or_else(|| {
-                ParserError::Directive("Missing 'condition' attribute on <if>".to_string())
-            })?;
+            .ok_or_else(|| self.if_condition_missing_error(element))?;
 
-        let condition = self.condition_parser.parse(&condition_str).map_err(|_| {
-            ParserError::Directive(format!("Invalid condition expression: {condition_str}"))
-        })?;
+        let condition = self
+            .condition_parser
+            .parse(&condition_str)
+            .map_err(|_| self.if_condition_invalid_error(element, &condition_str))?;
 
         self.flush_raw_buffer(fragments);
         let parent = ParseContext {
@@ -978,7 +1246,12 @@ impl HtmlParser {
 
         let (html_content, css_content, css_tokens) = {
             let component = self.component_registry.get(element.name()).ok_or_else(|| {
-                ParserError::Directive(format!("Component not found: {}", element.name()))
+                self.authoring_error_at(
+                    codes::UNKNOWN_COMPONENT,
+                    format!("unknown component <{}>", element.name()),
+                    element,
+                )
+                .help(self.unknown_component_help(element.name()))
             })?;
             (
                 component.html_content.clone(),
@@ -994,7 +1267,12 @@ impl HtmlParser {
                 .component_registry
                 .get(element.name())
                 .ok_or_else(|| {
-                    ParserError::Directive(format!("Component not found: {}", element.name()))
+                    self.authoring_error_at(
+                        codes::UNKNOWN_COMPONENT,
+                        format!("unknown component <{}>", element.name()),
+                        element,
+                    )
+                    .help(self.unknown_component_help(element.name()))
                 })?
                 .clone();
             let processed = self.build_component_template(
@@ -1336,7 +1614,8 @@ impl HtmlParser {
         let style_content = &element.source()[inner.start..inner.end];
         let (tokens, defs, comments) = self
             .css_parser
-            .extract_tokens_definitions_and_comments(style_content, self.options.legal_comments)?;
+            .extract_tokens_definitions_and_comments(style_content, self.options.legal_comments)
+            .map_err(|e| self.css_diagnostic(e))?;
         self.token_store.extend(tokens);
         self.token_definitions.extend(defs);
         self.process_style_content(style_content, &comments, fragments);
@@ -1395,7 +1674,7 @@ impl HtmlParser {
 
         let mut all_params = std::collections::HashSet::new();
         all_params.extend(route_params);
-        Self::validate_route_nesting_depth(element.source(), element.inner(), 1)?;
+        self.validate_route_nesting_depth(element.source(), element.inner(), 1)?;
         let children =
             self.parse_child_routes(element.source(), element.inner(), &all_params, 1)?;
 
@@ -1421,16 +1700,22 @@ impl HtmlParser {
         depth: usize,
     ) -> Result<Vec<WebUiFragmentRoute>> {
         if depth > MAX_TEMPLATE_DEPTH {
-            return Err(ParserError::Directive(format!(
-                "Route nesting exceeds the {MAX_TEMPLATE_DEPTH} level parser limit. Flatten deeply nested <route> trees before build."
-            )));
+            return Err(self
+                .html_error(
+                    codes::EXCESSIVE_NESTING,
+                    format!("route nesting exceeds the {MAX_TEMPLATE_DEPTH}-level limit"),
+                    source,
+                    range.start,
+                )
+                .help("flatten deeply nested <route> trees before building")
+                .into());
         }
 
         let mut children = Vec::new();
         for event in Walker::new_range(source, range.start, range.end) {
             match event {
                 Event::Element(element) => {
-                    Self::validate_closed_element(&element)?;
+                    self.validate_closed_element(&element)?;
                     if element.name() == "route" {
                         children.push(self.parse_route_as_fragment(
                             &element,
@@ -1445,20 +1730,23 @@ impl HtmlParser {
                 }
                 Event::Text(text) => {
                     if text.contains('<') {
-                        return Err(ParserError::Html(
-                            "Malformed HTML tag inside <route>. Close the tag with `>` or escape a literal `<` as `&lt;`."
-                                .to_string(),
-                        ));
+                        return Err(self
+                            .authoring_error(
+                                codes::MALFORMED_HTML_TAG,
+                                "malformed HTML tag in <route>",
+                            )
+                            .help("close the tag with `>`, or escape a literal `<` as `&lt;`")
+                            .into());
                     }
                 }
                 Event::Comment(comment_range) => {
-                    Self::validate_comment_range(source, comment_range)?;
+                    self.validate_comment_range(source, comment_range)?;
                 }
                 Event::Declaration(declaration_range) => {
-                    Self::validate_declaration_range(source, declaration_range)?;
+                    self.validate_declaration_range(source, declaration_range)?;
                 }
                 Event::ClosingTag(closing_range) => {
-                    return Err(Self::unexpected_closing_tag_error(source, closing_range));
+                    return Err(self.unexpected_closing_tag_error(source, closing_range));
                 }
             }
         }
@@ -1466,18 +1754,29 @@ impl HtmlParser {
         Ok(children)
     }
 
-    fn validate_route_nesting_depth(source: &str, range: Range<usize>, depth: usize) -> Result<()> {
+    fn validate_route_nesting_depth(
+        &self,
+        source: &str,
+        range: Range<usize>,
+        depth: usize,
+    ) -> Result<()> {
         let mut stack = vec![(range, depth)];
         while let Some((range, depth)) = stack.pop() {
             if depth > MAX_TEMPLATE_DEPTH {
-                return Err(ParserError::Directive(format!(
-                    "Route nesting exceeds the {MAX_TEMPLATE_DEPTH} level parser limit. Flatten deeply nested <route> trees before build."
-                )));
+                return Err(self
+                    .html_error(
+                        codes::EXCESSIVE_NESTING,
+                        format!("route nesting exceeds the {MAX_TEMPLATE_DEPTH}-level limit"),
+                        source,
+                        range.start,
+                    )
+                    .help("flatten deeply nested <route> trees before building")
+                    .into());
             }
 
             for event in Walker::new_range(source, range.start, range.end) {
                 if let Event::Element(element) = event {
-                    Self::validate_closed_element(&element)?;
+                    self.validate_closed_element(&element)?;
                     if element.name() == "route" && !element.self_closing() {
                         stack.push((element.inner(), depth + 1));
                     }
@@ -1496,16 +1795,21 @@ impl HtmlParser {
         let mut stack = vec![(range, depth)];
         while let Some((range, depth)) = stack.pop() {
             if depth > MAX_TEMPLATE_DEPTH {
-                return Err(ParserError::Html(format!(
-                    "Template nesting exceeds the {MAX_TEMPLATE_DEPTH} level parser limit near byte {}. Split deeply nested markup into components or reduce generated nesting before build.",
-                    range.start
-                )));
+                return Err(self
+                    .html_error(
+                        codes::EXCESSIVE_NESTING,
+                        format!("template nesting exceeds the {MAX_TEMPLATE_DEPTH}-level limit"),
+                        source,
+                        range.start,
+                    )
+                    .help("split deeply nested markup into components, or reduce generated nesting")
+                    .into());
             }
 
             for event in Walker::new_range(source, range.start, range.end) {
                 match event {
                     Event::Element(element) => {
-                        Self::validate_closed_element(&element)?;
+                        self.validate_closed_element(&element)?;
                         if element.name().eq_ignore_ascii_case("style") {
                             self.validate_style_element(&element)?;
                         } else if !element.self_closing() && !element.is_void() {
@@ -1514,20 +1818,23 @@ impl HtmlParser {
                     }
                     Event::Text(text) => {
                         if text.contains('<') {
-                            return Err(ParserError::Html(
-                                "Malformed HTML tag inside <route>. Close the tag with `>` or escape a literal `<` as `&lt;`."
-                                    .to_string(),
-                            ));
+                            return Err(self
+                                .authoring_error(
+                                    codes::MALFORMED_HTML_TAG,
+                                    "malformed HTML tag in <route>",
+                                )
+                                .help("close the tag with `>`, or escape a literal `<` as `&lt;`")
+                                .into());
                         }
                     }
                     Event::Comment(comment_range) => {
-                        Self::validate_comment_range(source, comment_range)?;
+                        self.validate_comment_range(source, comment_range)?;
                     }
                     Event::Declaration(declaration_range) => {
-                        Self::validate_declaration_range(source, declaration_range)?;
+                        self.validate_declaration_range(source, declaration_range)?;
                     }
                     Event::ClosingTag(closing_range) => {
-                        return Err(Self::unexpected_closing_tag_error(source, closing_range));
+                        return Err(self.unexpected_closing_tag_error(source, closing_range));
                     }
                 }
             }
@@ -1535,17 +1842,23 @@ impl HtmlParser {
         Ok(())
     }
 
-    fn validate_closed_element(element: &Element<'_>) -> Result<()> {
+    fn validate_closed_element(&self, element: &Element<'_>) -> Result<()> {
         if !element.self_closing()
             && !element.is_void()
             && element.close_end() == element.content_end()
         {
-            return Err(ParserError::Html(format!(
-                "Unclosed HTML tag <{}> near byte {}. Add the matching </{}> closing tag or make the element self-closing.",
-                element.name(),
-                element.inner().start.saturating_sub(element.opening().len()),
-                element.name()
-            )));
+            return Err(self
+                .html_error(
+                    codes::UNCLOSED_HTML_TAG,
+                    format!("unclosed <{}> tag", element.name()),
+                    element.source(),
+                    element.start,
+                )
+                .help(format!(
+                    "add the matching </{}> closing tag, or make the element self-closing",
+                    element.name()
+                ))
+                .into());
         }
         Ok(())
     }
@@ -1554,41 +1867,52 @@ impl HtmlParser {
         let inner = element.inner();
         let style_content = &element.source()[inner.start..inner.end];
         self.css_parser
-            .extract_tokens_definitions_and_comments(style_content, self.options.legal_comments)?;
+            .extract_tokens_definitions_and_comments(style_content, self.options.legal_comments)
+            .map_err(|e| self.css_diagnostic(e))?;
         Ok(())
     }
 
-    fn validate_comment_range(source: &str, range: Range<usize>) -> Result<()> {
+    fn validate_comment_range(&self, source: &str, range: Range<usize>) -> Result<()> {
+        let start = range.start;
         if source[range].ends_with("-->") {
             return Ok(());
         }
-        Err(ParserError::Html(
-            "Unterminated HTML comment inside <route>. Close the comment with `-->` before building."
-                .to_string(),
-        ))
+        Err(self
+            .html_error(
+                codes::UNTERMINATED_HTML_COMMENT,
+                "unterminated HTML comment in <route>",
+                source,
+                start,
+            )
+            .help("close the comment with `-->`")
+            .into())
     }
 
-    fn validate_declaration_range(source: &str, range: Range<usize>) -> Result<()> {
+    fn validate_declaration_range(&self, source: &str, range: Range<usize>) -> Result<()> {
+        let start = range.start;
         if source[range].ends_with('>') {
             return Ok(());
         }
-        Err(ParserError::Html(
-            "Unterminated HTML declaration inside <route>. Close the declaration with `>` before building."
-                .to_string(),
-        ))
+        Err(self
+            .html_error(
+                codes::UNTERMINATED_HTML_DECLARATION,
+                "unterminated HTML declaration in <route>",
+                source,
+                start,
+            )
+            .help("close the declaration with `>`")
+            .into())
     }
 
-    fn unexpected_closing_tag_error(source: &str, range: Range<usize>) -> ParserError {
-        if let Some(tag) = html::parse_tag(&source[range]) {
-            return ParserError::Html(format!(
-                "Unexpected closing HTML tag </{}> inside <route>. Remove it or add the matching opening tag before it.",
-                tag.name
-            ));
-        }
-        ParserError::Html(
-            "Unexpected closing HTML tag inside <route>. Remove it or add the matching opening tag before it."
-                .to_string(),
-        )
+    fn unexpected_closing_tag_error(&self, source: &str, range: Range<usize>) -> ParserError {
+        let start = range.start;
+        let title = match html::parse_tag(&source[range]) {
+            Some(tag) => format!("unexpected closing tag </{}> in <route>", tag.name),
+            None => "unexpected closing tag in <route>".to_string(),
+        };
+        self.html_error(codes::UNEXPECTED_CLOSING_TAG, title, source, start)
+            .help("remove it, or add the matching opening tag before it")
+            .into()
     }
 
     fn route_attrs_from_element(element: &Element<'_>) -> route_parser::RouteAttributes {
@@ -1673,7 +1997,11 @@ impl HtmlParser {
             .component_registry
             .get(component)
             .ok_or_else(|| {
-                crate::error::ParserError::Directive(format!("Component not found: {component}"))
+                self.authoring_error(
+                    codes::UNKNOWN_COMPONENT,
+                    format!("unknown component <{component}>"),
+                )
+                .help(self.unknown_component_help(component))
             })?
             .clone();
 
@@ -1883,7 +2211,8 @@ impl HtmlParser {
             let css = &html[style_start..style_end];
             let (_tokens, _defs, comments) = self
                 .css_parser
-                .extract_tokens_definitions_and_comments(css, self.options.legal_comments)?;
+                .extract_tokens_definitions_and_comments(css, self.options.legal_comments)
+                .map_err(|e| self.css_diagnostic(e))?;
             for comment in comments {
                 let comment_text = &css[comment.start_byte..comment.end_byte];
                 if comment.preserve || self.css_signal_comment_fragment(comment_text).is_some() {
@@ -1914,9 +2243,11 @@ impl HtmlParser {
             let remaining = &html[index..];
             if remaining.starts_with("<!--") {
                 let Some(end) = html::find_comment_close(remaining) else {
-                    return Err(ParserError::Html(format!(
-                        "Unterminated HTML comment near byte {index}. Close the comment with `-->` before building."
-                    )));
+                    return Err(Diagnostic::error("unterminated HTML comment")
+                        .code(codes::UNTERMINATED_HTML_COMMENT)
+                        .at_offset(html, index)
+                        .help("close the comment with `-->`")
+                        .into());
                 };
                 comment_ranges.push((index, index + end));
                 index += end;
@@ -2076,6 +2407,43 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_for_each_is_template_diagnostic() {
+        let mut parser = HtmlParser::new();
+        let err = parser
+            .parse(
+                "index.html",
+                "<div>\n  <for each=\"person inpeople\"><p>x</p></for>\n</div>",
+            )
+            .expect_err("invalid for-each must error");
+        assert!(matches!(err, ParserError::Template(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("invalid <for> each expression"), "{msg}");
+        assert!(msg.contains(r#"each="person inpeople""#), "{msg}");
+        // The <for> sits on line 2, column 3 (after the two-space indent),
+        // reported rustc-style as `--> index.html:2:3`.
+        assert!(
+            msg.contains("--> index.html:2:3"),
+            "missing line:column — {msg}"
+        );
+        assert!(msg.contains("help:"), "{msg}");
+    }
+
+    #[test]
+    fn test_invalid_if_condition_is_template_diagnostic() {
+        let mut parser = HtmlParser::new();
+        let err = parser
+            .parse("index.html", r#"<if condition="a +"><p>x</p></if>"#)
+            .expect_err("invalid condition must error");
+        assert!(matches!(err, ParserError::Template(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("invalid <if> condition expression"), "{msg}");
+        assert!(
+            msg.contains("--> index.html:1:1"),
+            "missing line:column — {msg}"
+        );
+    }
+
+    #[test]
     fn test_parse_for_directive() {
         let mut parser = HtmlParser::new();
         let html = r#"<for each="item in items"><div class="item">{{item.name}}</div></for>"#;
@@ -2157,6 +2525,69 @@ mod tests {
         assert!(
             matches!(comp[0].fragment.as_ref(), Some(Fragment::Raw(raw)) if
                 !raw.value.contains("<template shadowrootmode") && raw.value.contains("<div>My Component</div>"))
+        );
+    }
+
+    #[test]
+    fn unknown_component_typo_in_same_namespace_errors_with_suggestion() {
+        let mut parser = HtmlParser::with_options(DomStrategy::Light);
+        parser
+            .component_registry
+            .register_component("mp-button", "<button>b</button>", None)
+            .expect("Failed to register component");
+
+        // `<mp-buton>` is a same-namespace one-character typo of `mp-button`.
+        let err = parser
+            .parse("test.html", "<mp-buton></mp-buton>")
+            .expect_err("a near-typo component tag should error");
+        let ParserError::Template(diag) = err else {
+            panic!("expected ParserError::Template, got {err:?}");
+        };
+        assert_eq!(diag.error_code(), Some(codes::UNKNOWN_COMPONENT));
+        let help = diag
+            .help_text()
+            .expect("diagnostic should carry a help line");
+        assert!(
+            help.contains("did you mean <mp-button>?"),
+            "expected a suggestion, got: {help}"
+        );
+    }
+
+    #[test]
+    fn external_custom_element_in_other_namespace_passes_through() {
+        let mut parser = HtmlParser::with_options(DomStrategy::Light);
+        parser
+            .component_registry
+            .register_component("mp-button", "<button>b</button>", None)
+            .expect("Failed to register component");
+
+        // `<md-button>` is a different namespace (md- vs mp-): a genuine
+        // third-party custom element must pass through as raw HTML, not error.
+        let result = parser.parse("test.html", "<md-button></md-button>");
+        assert!(
+            result.is_ok(),
+            "external custom element should pass through, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn for_missing_each_suggests_typoed_attribute() {
+        let mut parser = HtmlParser::with_options(DomStrategy::Light);
+        // `eahc` is a transposition of the required `each` attribute.
+        let err = parser
+            .parse("test.html", "<for eahc=\"todo in todos\"></for>")
+            .expect_err("a <for> without `each` should error");
+        let ParserError::Template(diag) = err else {
+            panic!("expected ParserError::Template, got {err:?}");
+        };
+        assert_eq!(diag.error_code(), Some(codes::MISSING_FOR_EACH));
+        let help = diag
+            .help_text()
+            .expect("diagnostic should carry a help line");
+        assert!(
+            help.contains("found `eahc`") && help.contains("did you mean"),
+            "expected an attribute-typo suggestion, got: {help}"
         );
     }
 
@@ -3524,8 +3955,8 @@ mod tests {
         // Port of: 'should fail with invalid markup'
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "<div><span>Unclosed div");
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unclosed HTML tag <div>")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unclosed <div> tag")
         ));
     }
 
@@ -3533,8 +3964,8 @@ mod tests {
     fn test_unterminated_opening_tag_returns_error() {
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "before <div");
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Malformed HTML tag")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("malformed HTML tag")
         ));
     }
 
@@ -3542,9 +3973,9 @@ mod tests {
     fn test_unterminated_html_comment_returns_error() {
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "<div><!-- missing close</div>");
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unclosed HTML tag <div>")
-                || message.contains("Unterminated HTML comment")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unclosed <div> tag")
+                || diag.to_string().contains("unterminated HTML comment")
         ));
     }
 
@@ -3552,8 +3983,8 @@ mod tests {
     fn test_unexpected_closing_tag_returns_error() {
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "</span>");
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unexpected closing HTML tag </span>")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unexpected closing tag </span>")
         ));
     }
 
@@ -3581,8 +4012,8 @@ mod tests {
 
         let result = parser.parse("index.html", &html);
 
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("nesting exceeds") && message.contains("parser limit")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("nesting exceeds")
         ));
     }
 
@@ -3605,8 +4036,9 @@ mod tests {
 
         let result = parser.parse("index.html", &html);
 
-        assert!(matches!(result, Err(ParserError::Directive(message)) if
-            message.contains("Route nesting exceeds") && message.contains("parser limit")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.error_code() == Some(codes::EXCESSIVE_NESTING)
+                && diag.to_string().contains("route nesting exceeds")
         ));
     }
 
@@ -3620,8 +4052,9 @@ mod tests {
 
         let result = parser.parse("index.html", "<self-card></self-card>");
 
-        assert!(matches!(result, Err(ParserError::Directive(message)) if
-            message.contains("Recursive template reference")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.error_code() == Some(codes::RECURSIVE_TEMPLATE)
+                && diag.to_string().contains("recursive template reference")
         ));
     }
 
@@ -4180,8 +4613,8 @@ mod tests {
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "<div><span></div></span>");
 
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unclosed HTML tag <span>")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unclosed <span> tag")
         ));
     }
 
@@ -4520,8 +4953,8 @@ mod tests {
 
         let result = parser.parse("index.html", "<x-bad></x-bad>");
 
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unterminated HTML comment")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unterminated HTML comment")
         ));
     }
 
@@ -4542,7 +4975,7 @@ mod tests {
             .parse("index.html", "<x-bleed></x-bleed>")
             .expect("parse failed");
 
-        let artifacts = parser.take_plugin_artifacts();
+        let artifacts = parser.take_plugin_artifacts().unwrap();
         let ParserPluginArtifacts::ComponentTemplates(templates) = artifacts else {
             panic!("expected component templates");
         };
@@ -4571,7 +5004,7 @@ mod tests {
             .parse("index.html", "<x-style></x-style>")
             .expect("parse failed");
 
-        let artifacts = parser.take_plugin_artifacts();
+        let artifacts = parser.take_plugin_artifacts().unwrap();
         let ParserPluginArtifacts::ComponentTemplates(templates) = artifacts else {
             panic!("expected component templates");
         };
@@ -4604,8 +5037,9 @@ mod tests {
         </style>"#;
         let result = parser.parse("test.html", html);
 
-        assert!(matches!(result, Err(ParserError::Css(message)) if
-            message.contains("Unterminated CSS var() call")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.error_code() == Some(codes::INVALID_CSS)
+                && diag.to_string().contains("Unterminated CSS var() call")
         ));
     }
 
@@ -4912,8 +5346,8 @@ mod tests {
         let html = r#"<route path="/" component="home-page"><div><span></div></route>"#;
         let result = parser.parse("test.html", html);
 
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unclosed HTML tag <span>")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unclosed <span> tag")
         ));
     }
 
@@ -4923,8 +5357,9 @@ mod tests {
         let html = r#"<route path="/" component="home-page"><style>.bad { color: var(--x; }</style></route>"#;
         let result = parser.parse("test.html", html);
 
-        assert!(matches!(result, Err(ParserError::Css(message)) if
-            message.contains("Unterminated CSS var() call")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.error_code() == Some(codes::INVALID_CSS)
+                && diag.to_string().contains("Unterminated CSS var() call")
         ));
     }
 
@@ -5282,8 +5717,8 @@ mod tests {
     fn test_unclosed_style_element_returns_error() {
         let mut parser = HtmlParser::new();
         let result = parser.parse("index.html", "<style>.x { color: red; ");
-        assert!(matches!(result, Err(ParserError::Html(message)) if
-            message.contains("Unclosed HTML tag <style>")
+        assert!(matches!(result, Err(ParserError::Template(diag)) if
+            diag.to_string().contains("unclosed <style> tag")
         ));
     }
 

--- a/crates/webui-parser/src/plugin/fast_v2.rs
+++ b/crates/webui-parser/src/plugin/fast_v2.rs
@@ -109,8 +109,10 @@ impl ParserPlugin for FastV2ParserPlugin {
         }
     }
 
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
-        ParserPluginArtifacts::ComponentTemplates(self.take_component_templates())
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts> {
+        Ok(ParserPluginArtifacts::ComponentTemplates(
+            self.take_component_templates(),
+        ))
     }
 }
 

--- a/crates/webui-parser/src/plugin/fast_v3.rs
+++ b/crates/webui-parser/src/plugin/fast_v3.rs
@@ -109,8 +109,10 @@ impl ParserPlugin for FastV3ParserPlugin {
         }
     }
 
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
-        ParserPluginArtifacts::ComponentTemplates(self.take_component_templates())
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts> {
+        Ok(ParserPluginArtifacts::ComponentTemplates(
+            self.take_component_templates(),
+        ))
     }
 }
 

--- a/crates/webui-parser/src/plugin/mod.rs
+++ b/crates/webui-parser/src/plugin/mod.rs
@@ -72,7 +72,12 @@ pub trait ParserPlugin {
     fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
 
     /// Consume the plugin and return any build artifacts it captured.
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
-        ParserPluginArtifacts::None
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the plugin encountered an invalid template construct
+    /// while producing its artifacts (e.g. an invalid `@event` handler).
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts> {
+        Ok(ParserPluginArtifacts::None)
     }
 }

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -62,6 +62,7 @@
 use super::{AttributeAction, ParserPlugin, ParserPluginArtifacts};
 use crate::comment_policy;
 use crate::component_registry::Component;
+use crate::diagnostic::Diagnostic;
 use crate::html_parser::{find_tag_close, style_element_bounds};
 use crate::{ConditionParser, DomStrategy, ParserOptions, Result};
 use std::cell::Cell;
@@ -115,21 +116,24 @@ impl WebUIParserPlugin {
     /// Each script block is a self-executing IIFE that registers a metadata
     /// object into `window.__webui.templates[tagName]`. Call this after all
     /// HTML parsing is complete.
-    #[must_use]
-    pub fn take_component_templates(&self) -> Vec<(String, String)> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::ParserError::Template`] if any tracked component
+    /// contains an invalid `@event` handler or a non-braced `w-ref` binding.
+    pub fn take_component_templates(&self) -> Result<Vec<(String, String)>> {
         let use_shadow = matches!(self.dom_strategy, DomStrategy::Shadow);
-        self.components
-            .iter()
-            .map(|c| {
-                let script = generate_compiled_template_with_root_source(
-                    &c.tag_name,
-                    &c.template_html,
-                    &c.root_event_source,
-                    use_shadow,
-                );
-                (c.tag_name.clone(), script)
-            })
-            .collect()
+        let mut out = Vec::with_capacity(self.components.len());
+        for c in &self.components {
+            let script = generate_compiled_template_with_root_source(
+                &c.tag_name,
+                &c.template_html,
+                &c.root_event_source,
+                use_shadow,
+            )?;
+            out.push((c.tag_name.clone(), script));
+        }
+        Ok(out)
     }
 
     fn store_component_template(
@@ -212,8 +216,10 @@ impl ParserPlugin for WebUIParserPlugin {
         )
     }
 
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
-        ParserPluginArtifacts::ComponentTemplates(self.take_component_templates())
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts> {
+        Ok(ParserPluginArtifacts::ComponentTemplates(
+            self.take_component_templates()?,
+        ))
     }
 }
 
@@ -286,6 +292,10 @@ struct TemplateMeta {
 
 type EventBinding = (String, String, Vec<EventArg>);
 
+/// Result of parsing one `@event` attribute: the event binding
+/// (`event_name`, `handler_name`, `args`) plus the number of bytes consumed.
+type ParsedEventAttr = (String, String, Vec<EventArg>, usize);
+
 #[derive(Clone, Debug, PartialEq)]
 enum EventArg {
     Event,
@@ -350,7 +360,12 @@ enum CompiledAttrPart {
 /// | `@event="{handler(e)}"`               | `e[]`                      | element kept marker-free          |
 /// | `w-ref="name"` / `w-ref={name}`       | *(stays in HTML)*          | *(unchanged)*                     |
 /// | `<outlet />` / `<outlet>`             | *(stays in HTML)*          | `<outlet></outlet>`               |
-pub fn generate_compiled_template(tag_name: &str, html_content: &str) -> String {
+///
+/// # Errors
+///
+/// Returns [`crate::ParserError::Template`] if the template contains an invalid
+/// `@event` handler or a non-braced `w-ref` binding.
+pub fn generate_compiled_template(tag_name: &str, html_content: &str) -> Result<String> {
     generate_compiled_template_with_root_source(tag_name, html_content, html_content, false)
 }
 
@@ -359,12 +374,12 @@ fn generate_compiled_template_with_root_source(
     html_content: &str,
     root_event_source: &str,
     shadow_dom: bool,
-) -> String {
+) -> Result<String> {
     let trimmed = html_content.trim();
-    let root_events = extract_root_events(root_event_source.trim());
+    let root_events = extract_root_events(tag_name, root_event_source.trim())?;
     let adopted_stylesheet = extract_adopted_stylesheet_specifier(trimmed);
     let body = strip_template_wrapper(trimmed);
-    let meta = compile_to_metadata(body, root_events);
+    let meta = compile_to_metadata(tag_name, body, root_events)?;
 
     let mut out = String::with_capacity(512 + html_content.len());
     out.push_str("(function(){var w=(window.__webui||(window.__webui={})).templates||(window.__webui.templates={});w['");
@@ -416,7 +431,7 @@ fn generate_compiled_template_with_root_source(
     }
 
     out.push_str("};})();\n");
-    out
+    Ok(out)
 }
 
 fn emit_js_string(s: &str, out: &mut String) {
@@ -848,21 +863,29 @@ fn emit_js_template_section(meta: &TemplateSectionMeta, out: &mut String) {
 ///   SSR `data-ev="COUNT"` markers that are later replaced by client locators.
 /// - **Everything else** — copied verbatim to the intermediate static HTML.
 ///
-fn compile_to_metadata(input: &str, root_events: Vec<EventBinding>) -> TemplateMeta {
+fn compile_to_metadata(
+    component: &str,
+    input: &str,
+    root_events: Vec<EventBinding>,
+) -> Result<TemplateMeta> {
     let mut blocks = Vec::new();
-    let mut root = compile_section(input, &mut blocks);
+    let mut root = compile_section(component, input, &mut blocks)?;
     finalize_template_section(&mut root);
     for block in &mut blocks {
         finalize_template_section(block);
     }
-    TemplateMeta {
+    Ok(TemplateMeta {
         root,
         blocks,
         root_events,
-    }
+    })
 }
 
-fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> TemplateSectionMeta {
+fn compile_section(
+    component: &str,
+    input: &str,
+    blocks: &mut Vec<TemplateSectionMeta>,
+) -> Result<TemplateSectionMeta> {
     let mut meta = TemplateSectionMeta {
         html: String::with_capacity(input.len()),
         text_bindings: Vec::new(),
@@ -908,7 +931,7 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
                 if let Some((cond, body, consumed)) = parse_if_block(remaining) {
                     let block_index = blocks.len();
                     blocks.push(TemplateSectionMeta::default());
-                    let block = compile_section(&body, blocks);
+                    let block = compile_section(component, &body, blocks)?;
                     blocks[block_index] = block;
                     let idx = meta.conditionals.len();
                     meta.conditionals.push((cond, block_index));
@@ -923,7 +946,7 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
                 if let Some((collection, item_var, body, consumed)) = parse_for_block(remaining) {
                     let block_index = blocks.len();
                     blocks.push(TemplateSectionMeta::default());
-                    let block = compile_section(&body, blocks);
+                    let block = compile_section(component, &body, blocks)?;
                     blocks[block_index] = block;
                     let idx = meta.repeats.len();
                     meta.repeats.push((collection, item_var, block_index));
@@ -950,7 +973,8 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
                 }
             }
 
-            if let Some((tag_html, consumed)) = parse_regular_tag(remaining, &mut meta) {
+            if let Some((tag_html, consumed)) = parse_regular_tag(component, remaining, &mut meta)?
+            {
                 meta.html.push_str(&tag_html);
                 i += consumed;
                 continue;
@@ -959,7 +983,9 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
 
         // @event attributes → replace with a per-element event-count marker
         if bytes[i] == b'@' && is_inside_tag(input, i) {
-            if let Some((event_name, handler, args, consumed)) = parse_event_attr(input, i) {
+            if let Some((event_name, handler, args, consumed)) =
+                parse_event_attr(component, input, i)?
+            {
                 meta.events.push((event_name, handler, args));
                 meta.html.push_str("data-ev=\"1\"");
                 i += consumed;
@@ -980,7 +1006,7 @@ fn compile_section(input: &str, blocks: &mut Vec<TemplateSectionMeta>) -> Templa
         }
     }
 
-    meta
+    Ok(meta)
 }
 
 fn compile_text_binding_at(
@@ -1938,6 +1964,30 @@ fn parse_for_block(input: &str) -> Option<(String, String, String, usize)> {
     Some((collection, item_var, body, end_pos + close_tag.len()))
 }
 
+/// Build a [`Diagnostic`] for an invalid `@event` handler.
+///
+/// Names the owning component (and element, when known) so the build error
+/// points at the exact template to fix instead of only echoing the expression.
+fn invalid_event_handler(
+    component: &str,
+    element: Option<&str>,
+    event_name: &str,
+    raw: &str,
+) -> Diagnostic {
+    let mut diag = Diagnostic::error(format!("invalid @{event_name} handler"))
+        .code(crate::diagnostic::codes::INVALID_EVENT_HANDLER)
+        .component(component)
+        .snippet(format!("@{event_name}=\"{raw}\""))
+        .help(format!(
+            "use @{event_name}=\"{{handler()}}\" or @{event_name}=\"{{handler(e)}}\" \
+             to pass the event"
+        ));
+    if let Some(tag) = element {
+        diag = diag.element(tag);
+    }
+    diag
+}
+
 /// Parse `@event="{handler()}"` or `@event={handler()}` into event metadata.
 ///
 /// Supports three value quoting styles:
@@ -1946,33 +1996,40 @@ fn parse_for_block(input: &str) -> Option<(String, String, String, usize)> {
 /// - `@click='onClick()'` — single-quoted
 ///
 /// The handler name and full argument list are extracted from the function call syntax.
-fn parse_event_attr(input: &str, pos: usize) -> Option<(String, String, Vec<EventArg>, usize)> {
+/// `component` is the owning component tag, used only for error messages.
+fn parse_event_attr(component: &str, input: &str, pos: usize) -> Result<Option<ParsedEventAttr>> {
     let remaining = &input[pos..];
-    let eq_pos = remaining.find('=')?;
+    let Some(eq_pos) = remaining.find('=') else {
+        return Ok(None);
+    };
     let event_name = remaining[1..eq_pos].to_string(); // skip @
 
     let after_eq = &remaining[eq_pos + 1..];
     if after_eq.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let first = after_eq.as_bytes()[0];
     let (raw_value, total_consumed) = if first == b'"' || first == b'\'' {
         let value_start = eq_pos + 2;
-        let close = remaining[value_start..].find(first as char)?;
+        let Some(close) = remaining[value_start..].find(first as char) else {
+            return Ok(None);
+        };
         (
             &remaining[value_start..value_start + close],
             value_start + close + 1,
         )
     } else if first == b'{' {
         let value_start = eq_pos + 2;
-        let close = remaining[value_start..].find('}')?;
+        let Some(close) = remaining[value_start..].find('}') else {
+            return Ok(None);
+        };
         (
             &remaining[value_start..value_start + close],
             value_start + close + 1,
         )
     } else {
-        return None;
+        return Ok(None);
     };
 
     let inner = raw_value
@@ -1984,32 +2041,36 @@ fn parse_event_attr(input: &str, pos: usize) -> Option<(String, String, Vec<Even
 
     // Extract method name and argument specs from "handler(...)".
     if inner.is_empty() {
-        return None;
+        return Ok(None);
     }
     match parse_event_handler(inner) {
         EventHandler::Valid(handler_name, args) => {
-            Some((event_name, handler_name, args, total_consumed))
+            Ok(Some((event_name, handler_name, args, total_consumed)))
         }
-        EventHandler::Empty => None,
-        EventHandler::Invalid(_raw) => panic!(
-            "Invalid @{event_name} handler: \"{inner}\". \
-             Use @{event_name}=\"{{handler()}}\" or \
-             @{event_name}=\"{{handler(e)}}\" to pass the event.",
-        ),
+        EventHandler::Empty => Ok(None),
+        EventHandler::Invalid(_raw) => {
+            Err(invalid_event_handler(component, None, &event_name, inner).into())
+        }
     }
 }
 
-fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(String, usize)> {
+fn parse_regular_tag(
+    component: &str,
+    input: &str,
+    meta: &mut TemplateSectionMeta,
+) -> Result<Option<(String, usize)>> {
     if !input.starts_with('<') || input.starts_with("</") || input.starts_with("<!") {
-        return None;
+        return Ok(None);
     }
 
     let bytes = input.as_bytes();
     if bytes.len() < 2 || !bytes[1].is_ascii_alphabetic() {
-        return None;
+        return Ok(None);
     }
 
-    let end = find_tag_close(input)?;
+    let Some(end) = find_tag_close(input) else {
+        return Ok(None);
+    };
     let tag_content = &input[1..end];
     let tag_body = tag_content.trim_end();
     let self_closing = tag_body.ends_with('/');
@@ -2027,7 +2088,7 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
 
     let tag_name = &tag_body[..cursor];
     if tag_name.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     let mut out = String::with_capacity(tag_body.len() + 24);
@@ -2108,10 +2169,8 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
                         .push((event_name.to_string(), handler_name, args));
                 }
                 EventHandler::Invalid(raw) => {
-                    panic!(
-                        "Invalid @{event_name} handler: \"{raw}\". \
-                         Use @{event_name}=\"{{handler()}}\" or \
-                         @{event_name}=\"{{handler(e)}}\" to pass the event.",
+                    return Err(
+                        invalid_event_handler(component, Some(tag_name), event_name, &raw).into(),
                     );
                 }
                 EventHandler::Empty => {}
@@ -2121,14 +2180,18 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
 
         if name == "w-ref" {
             // Validate: w-ref must use {braces} to bind to a component property.
-            // This is a build-time check — the runtime also validates.
+            // This is a fatal build-time check — the runtime also validates.
             if let Some(val) = value {
                 if !val.starts_with('{') || !val.ends_with('}') {
-                    eprintln!(
-                        "\x1b[1;31merror\x1b[0m: invalid w-ref=\"{}\" in <{}> — \
-                         use w-ref={{{}}} with braces to bind to a component property",
-                        val, tag_name, val
-                    );
+                    return Err(Diagnostic::error("invalid w-ref binding")
+                        .code(crate::diagnostic::codes::INVALID_W_REF)
+                        .component(component)
+                        .element(tag_name)
+                        .snippet(format!("w-ref=\"{val}\""))
+                        .help(format!(
+                            "use w-ref={{{val}}} with braces to bind to a component property"
+                        ))
+                        .into());
                 }
             }
             out.push(' ');
@@ -2212,7 +2275,7 @@ fn parse_regular_tag(input: &str, meta: &mut TemplateSectionMeta) -> Option<(Str
         out.push('>');
     }
 
-    Some((out, end + 1))
+    Ok(Some((out, end + 1)))
 }
 
 enum EventHandler {
@@ -2468,12 +2531,12 @@ fn parse_attr_parts(value: &str) -> Option<Vec<CompiledAttrPart>> {
 ///
 /// These become "root events" (`re` array) attached to the host element
 /// rather than to an element inside the shadow DOM.
-fn extract_root_events(html: &str) -> Vec<EventBinding> {
+fn extract_root_events(component: &str, html: &str) -> Result<Vec<EventBinding>> {
     if !html.starts_with("<template") {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let Some(close) = find_tag_close(html) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let tag = &html[..close];
     let mut events = Vec::new();
@@ -2483,7 +2546,7 @@ fn extract_root_events(html: &str) -> Vec<EventBinding> {
 
     while i < len {
         if bytes[i] == b'@' {
-            if let Some((name, handler, args, consumed)) = parse_event_attr(tag, i) {
+            if let Some((name, handler, args, consumed)) = parse_event_attr(component, tag, i)? {
                 events.push((name, handler, args));
                 i += consumed;
                 continue;
@@ -2492,7 +2555,7 @@ fn extract_root_events(html: &str) -> Vec<EventBinding> {
         i += 1;
     }
 
-    events
+    Ok(events)
 }
 
 fn extract_adopted_stylesheet_specifier(html: &str) -> Option<String> {
@@ -2512,6 +2575,14 @@ fn extract_adopted_stylesheet_specifier(html: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Test helper: compile a template and unwrap. The vast majority of tests
+    /// exercise valid templates; tests that assert on authoring errors call
+    /// [`super::generate_compiled_template`] directly and inspect the `Result`.
+    #[allow(clippy::disallowed_methods)]
+    fn generate_compiled_template(tag_name: &str, html_content: &str) -> String {
+        super::generate_compiled_template(tag_name, html_content).expect("valid template compiles")
+    }
 
     fn assert_no_client_markers(result: &str) {
         assert!(!result.contains("<!--t:"), "text markers should be removed");
@@ -2833,6 +2904,24 @@ mod tests {
     }
 
     #[test]
+    fn test_w_ref_without_braces_is_fatal() {
+        let err =
+            super::generate_compiled_template("mail-inbox-page", r#"<input w-ref="myInput" />"#)
+                .expect_err("non-braced w-ref must fail the build");
+        assert!(err.to_string().contains("invalid w-ref binding"));
+    }
+
+    #[test]
+    fn test_w_ref_error_names_component_and_element() {
+        let err =
+            super::generate_compiled_template("mail-inbox-page", r#"<input w-ref="myInput" />"#)
+                .expect_err("non-braced w-ref must fail the build");
+        assert!(err
+            .to_string()
+            .contains("component <mail-inbox-page> · element <input>"));
+    }
+
+    #[test]
     fn test_metadata_has_root_events() {
         let result = generate_compiled_template(
             "my-comp",
@@ -2907,7 +2996,7 @@ mod tests {
         plugin
             .register_component_template("test-el", &comp, &comp.html_content)
             .unwrap();
-        assert_eq!(plugin.take_component_templates().len(), 1);
+        assert_eq!(plugin.take_component_templates().unwrap().len(), 1);
     }
 
     #[test]
@@ -2960,7 +3049,7 @@ mod tests {
                 r#"<template shadowrootmode="open"><link rel="stylesheet" href="test-el.css"><p>hi</p></template>"#,
             )
             .unwrap();
-        let templates = plugin.take_component_templates();
+        let templates = plugin.take_component_templates().unwrap();
         assert_eq!(templates.len(), 1);
         assert!(templates[0].1.contains(r#"rel=\"stylesheet\""#));
         assert!(templates[0].1.contains(r#"href=\"test-el.css\""#));
@@ -2989,7 +3078,7 @@ mod tests {
                 r#"<template shadowrootmode="open"><link rel="stylesheet" href="test-el.css"><p>hi</p></template>"#,
             )
             .unwrap();
-        let templates = plugin.take_component_templates();
+        let templates = plugin.take_component_templates().unwrap();
         assert_eq!(templates.len(), 1);
         assert!(templates[0]
             .1
@@ -3016,7 +3105,7 @@ mod tests {
                 r#"<template shadowrootmode="open" shadowrootadoptedstylesheets="test-el"><p>hi</p></template>"#,
             )
             .unwrap();
-        let templates = plugin.take_component_templates();
+        let templates = plugin.take_component_templates().unwrap();
         assert_eq!(templates.len(), 1);
         assert!(templates[0].1.contains(r#",sa:"test-el""#));
     }
@@ -3107,10 +3196,12 @@ mod tests {
     fn test_regular_tag_uses_single_event_marker_per_element() {
         let mut meta = TemplateSectionMeta::default();
         let (tag_html, _) = parse_regular_tag(
+            "test-input",
             r#"<input @keydown="{onKey(e)}" @focus="{onFocus()}" />"#,
             &mut meta,
         )
-        .expect("regular tag should parse");
+        .expect("regular tag parse should succeed")
+        .expect("regular tag should produce output");
 
         assert_eq!(tag_html, r#"<input data-ev="2" />"#);
     }
@@ -3413,6 +3504,28 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_event_handler_error_names_component_and_element() {
+        let err = super::generate_compiled_template(
+            "mail-inbox-page",
+            r#"<button @pointerdown="e.preventDefault()">x</button>"#,
+        )
+        .expect_err("invalid @event handler must fail the build");
+        assert!(err
+            .to_string()
+            .contains("component <mail-inbox-page> · element <button>"));
+    }
+
+    #[test]
+    fn test_invalid_root_event_handler_error_names_component() {
+        let err = super::generate_compiled_template(
+            "my-card",
+            r#"<template shadowrootmode="open" @click="e.stopPropagation()"><slot></slot></template>"#,
+        )
+        .expect_err("invalid root @event handler must fail the build");
+        assert!(err.to_string().contains("in component <my-card>"));
+    }
+
+    #[test]
     fn test_parse_event_handler_bare_name_is_invalid() {
         assert!(matches!(
             parse_event_handler("{closeMenu}"),
@@ -3421,10 +3534,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid @click handler")]
-    fn test_parse_event_attr_bare_name_panics() {
+    fn test_parse_event_attr_bare_name_errors() {
         let input = r#"<button @click="{closeMenu}">Click</button>"#;
-        parse_event_attr(input, 8);
+        let err = parse_event_attr("test-button", input, 8)
+            .expect_err("bare handler name must be rejected");
+        assert!(err.to_string().contains("invalid @click handler"));
     }
 
     #[test]

--- a/crates/webui-parser/src/suggest.rs
+++ b/crates/webui-parser/src/suggest.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! "Did you mean …?" suggestions for authoring typos.
+//!
+//! When the parser encounters an unknown name (e.g. a component tag that is not
+//! registered), it offers the closest registered name as a fix hint. The
+//! matcher is a deterministic, iterative Levenshtein edit distance — no
+//! recursion and no regular expressions — run only on the cold error path.
+
+/// Return the candidate closest to `target` by Levenshtein edit distance, if
+/// one is within a small typo tolerance.
+///
+/// The tolerance scales with the longer of the two names (`max_len / 3`, at
+/// least 2 so a single transposition on a short word like `each`→`eahc` still
+/// matches), so a one- or two-character slip matches while grossly different
+/// names are rejected. On ties the first-seen candidate wins; callers that need
+/// determinism across runs should pass a sorted iterator.
+///
+/// Marked `#[cold]`/`#[inline(never)]`: only invoked while building a build
+/// error (or for the rare hyphenated-but-unregistered tag), so keeping it
+/// out-of-line preserves hot parse-path code layout.
+#[cold]
+#[inline(never)]
+#[must_use]
+pub(crate) fn closest_match<'a>(
+    target: &str,
+    candidates: impl Iterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let target_len = target.chars().count();
+    let mut best: Option<(&str, usize)> = None;
+    for candidate in candidates {
+        let tolerance = (target_len.max(candidate.chars().count()) / 3).max(2);
+        let distance = levenshtein(target, candidate);
+        if distance <= tolerance && best.is_none_or(|(_, best_distance)| distance < best_distance) {
+            best = Some((candidate, distance));
+        }
+    }
+    best.map(|(name, _)| name)
+}
+
+/// Compute the Levenshtein edit distance between `a` and `b`.
+///
+/// Iterative two-row dynamic programming: O(len(a) × len(b)) time and
+/// O(len(b)) space, counting characters (not bytes) so multi-byte UTF-8 is
+/// handled correctly. No recursion.
+#[must_use]
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b_chars: Vec<char> = b.chars().collect();
+    if b_chars.is_empty() {
+        return a.chars().count();
+    }
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b_chars.len() + 1];
+    for (i, a_char) in a.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, &b_char) in b_chars.iter().enumerate() {
+            let substitution_cost = usize::from(a_char != b_char);
+            curr[j + 1] = (prev[j + 1] + 1)
+                .min(curr[j] + 1)
+                .min(prev[j] + substitution_cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b_chars.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn levenshtein_basic_distances() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("mp-buton", "mp-button"), 1);
+    }
+
+    #[test]
+    fn levenshtein_counts_chars_not_bytes() {
+        // Multi-byte characters count as one edit each.
+        assert_eq!(levenshtein("café", "cafe"), 1);
+        assert_eq!(levenshtein("naïve", "naive"), 1);
+    }
+
+    #[test]
+    fn closest_match_finds_near_typo() {
+        let names = ["mp-button", "mp-card", "mp-list"];
+        assert_eq!(
+            closest_match("mp-buton", names.into_iter()),
+            Some("mp-button")
+        );
+    }
+
+    #[test]
+    fn closest_match_rejects_distant_names() {
+        let names = ["mp-button", "mp-card"];
+        assert_eq!(closest_match("sidebar-nav", names.into_iter()), None);
+    }
+
+    #[test]
+    fn closest_match_picks_nearest_on_multiple_candidates() {
+        let names = ["mp-button", "mp-buttonx", "mp-bton"];
+        // Exact-ish "mp-button" (distance 1) beats the others.
+        assert_eq!(
+            closest_match("mp-buttn", names.into_iter()),
+            Some("mp-button")
+        );
+    }
+
+    #[test]
+    fn closest_match_empty_candidates_is_none() {
+        assert_eq!(closest_match("anything", std::iter::empty()), None);
+    }
+
+    #[test]
+    fn closest_match_tolerates_short_word_transposition() {
+        // `eahc` is a transposition of `each` (Levenshtein distance 2); the
+        // minimum tolerance of 2 lets short directive attributes still match.
+        let attrs = ["eahc", "template"];
+        assert_eq!(closest_match("each", attrs.into_iter()), Some("eahc"));
+    }
+}

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -18,6 +18,7 @@ use webui_handler::plugin::fast_v2::FastV2HydrationPlugin;
 use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
+use webui_parser::plugin::webui::WebUIParserPlugin;
 use webui_parser::{CssStrategy, HtmlParser, Plugin};
 use webui_protocol::WebUIProtocol;
 
@@ -264,18 +265,14 @@ pub(crate) fn build_and_render_inner(
     Ok(writer.content)
 }
 
-/// Parse virtual files into a `WebUIProtocol` using the real `webui-parser`.
-fn parse_to_protocol(
+/// Register all component `.html` files (and their optional `.css`) from the
+/// virtual file map, skipping the entry. Shared by protocol generation and
+/// authoring validation.
+fn register_components(
+    parser: &mut HtmlParser,
     files: &HashMap<String, String>,
     entry: &str,
-) -> Result<WebUIProtocol, BuildError> {
-    let entry_html = files
-        .get(entry)
-        .ok_or_else(|| BuildError::MissingEntry(entry.to_string()))?;
-
-    let mut parser = HtmlParser::with_options(CssStrategy::Style);
-
-    // Register components from virtual files (no filesystem needed)
+) -> Result<(), BuildError> {
     for (filename, content) in files {
         if filename != entry && filename.ends_with(".html") {
             let tag_name = filename.trim_end_matches(".html");
@@ -288,8 +285,29 @@ fn parse_to_protocol(
             }
         }
     }
+    Ok(())
+}
 
+/// Parse virtual files into a `WebUIProtocol` using the real `webui-parser`
+/// with the WebUI plugin. Compiling the tracked component templates also
+/// validates them, so authoring mistakes — an invalid `@event` handler or a
+/// non-braced `w-ref` — surface as a `ParserError::Template` error (and thus a
+/// catchable JS error) instead of passing silently.
+fn parse_to_protocol(
+    files: &HashMap<String, String>,
+    entry: &str,
+) -> Result<WebUIProtocol, BuildError> {
+    let entry_html = files
+        .get(entry)
+        .ok_or_else(|| BuildError::MissingEntry(entry.to_string()))?;
+
+    let mut parser =
+        HtmlParser::with_plugin_options(Box::new(WebUIParserPlugin::new()), CssStrategy::Style);
+    register_components(&mut parser, files, entry)?;
     parser.parse(entry, entry_html)?;
+    // Compile tracked component templates; this is where @event / w-ref
+    // authoring mistakes are reported.
+    parser.take_plugin_artifacts()?;
 
     Ok(WebUIProtocol::new(parser.into_fragment_records()))
 }
@@ -336,6 +354,53 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not found"), "Unexpected error: {}", err);
+    }
+
+    #[test]
+    fn test_build_protocol_surfaces_invalid_w_ref() {
+        let mut files = HashMap::new();
+        files.insert(
+            "index.html".to_string(),
+            "<my-card>Hi</my-card>".to_string(),
+        );
+        files.insert(
+            "my-card.html".to_string(),
+            r#"<div><input w-ref="myInput" /></div>"#.to_string(),
+        );
+
+        let result = build_protocol_inner(&files, "index.html");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid w-ref binding"),
+            "Unexpected error: {err}"
+        );
+        assert!(
+            err.contains("component <my-card> · element <input>"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_and_render_surfaces_invalid_event_handler() {
+        let mut files = HashMap::new();
+        files.insert("index.html".to_string(), "<my-btn>x</my-btn>".to_string());
+        files.insert(
+            "my-btn.html".to_string(),
+            r#"<div><button @click="e.preventDefault()">x</button></div>"#.to_string(),
+        );
+
+        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid @click handler"),
+            "Unexpected error: {err}"
+        );
+        assert!(
+            err.contains("component <my-btn> · element <button>"),
+            "Unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/webui/src/error.rs
+++ b/crates/webui/src/error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum WebUIError {
     /// I/O error (file read/write failures).
-    #[error("I/O error: {context}: {source}")]
+    #[error("I/O error: {context}")]
     Io {
         /// What operation failed.
         context: String,
@@ -27,7 +27,7 @@ pub enum WebUIError {
     ComponentDiscovery(String),
 
     /// HTML/CSS parsing failure with context about which file failed.
-    #[error("{context}: {source}")]
+    #[error("{context}")]
     Parse {
         /// What was being parsed.
         context: String,
@@ -37,7 +37,7 @@ pub enum WebUIError {
     },
 
     /// Protocol serialization or deserialization failure.
-    #[error("{0}")]
+    #[error("protocol error")]
     Protocol(#[from] webui_protocol::ProtocolError),
 
     /// JSON serialization failure.
@@ -45,10 +45,32 @@ pub enum WebUIError {
     Serialization(String),
 
     /// Handler rendering error.
-    #[error("{0}")]
+    #[error("rendering error")]
     Rendering(#[from] webui_handler::HandlerError),
 
     /// Invalid build-option configuration.
     #[error("Invalid build options: {0}")]
     InvalidBuildOptions(String),
+}
+
+impl WebUIError {
+    /// The full, single-line message including the source chain, e.g.
+    /// `Failed to parse index.html: Directive error: Invalid for each: x`.
+    ///
+    /// Each error layer's [`std::fmt::Display`] describes only its own level
+    /// (the `#[source]` chain carries the rest), so the CLI and dev server can
+    /// use anyhow's `{:#}` formatting without repetition. Hosts that surface a
+    /// flat string instead of walking the chain — Node, FFI — use this helper
+    /// to get the same complete message.
+    #[must_use]
+    pub fn chain_message(&self) -> String {
+        let mut message = self.to_string();
+        let mut source = std::error::Error::source(self);
+        while let Some(err) = source {
+            message.push_str(": ");
+            message.push_str(&err.to_string());
+            source = err.source();
+        }
+        message
+    }
 }

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -37,8 +37,10 @@ pub use webui_handler::{
     plugin::HandlerPlugin, HandlerError, RenderOptions, ResponseWriter, WebUIHandler,
 };
 pub use webui_parser::CssStrategy;
+pub use webui_parser::Diagnostic;
 pub use webui_parser::DomStrategy;
 pub use webui_parser::LegalComments;
+pub use webui_parser::ParserError;
 pub use webui_parser::ParserOptions;
 pub use webui_parser::Plugin;
 pub use webui_parser::DEFAULT_CSS_FILE_NAME_TEMPLATE;
@@ -315,10 +317,19 @@ fn build_protocol_inner(options: &BuildOptions) -> Result<RawBuildOutput, WebUIE
     let tokens = parser.take_tokens();
     let token_count = tokens.len();
 
-    let component_templates = match parser.take_plugin_artifacts() {
-        ParserPluginArtifacts::None => Vec::new(),
-        ParserPluginArtifacts::ComponentTemplates(templates) => templates,
-    };
+    let component_templates =
+        match parser
+            .take_plugin_artifacts()
+            .map_err(|source| WebUIError::Parse {
+                context: format!(
+                    "Failed to compile component templates for {}",
+                    options.entry
+                ),
+                source,
+            })? {
+            ParserPluginArtifacts::None => Vec::new(),
+            ParserPluginArtifacts::ComponentTemplates(templates) => templates,
+        };
 
     // Build protocol (consumes parser)
     let fragment_records = parser.into_fragment_records();
@@ -430,6 +441,68 @@ mod tests {
         assert!(result.stats.fragment_count > 0);
         assert!(result.stats.protocol_size_bytes > 0);
         assert!(!result.stats.duration.is_zero());
+    }
+
+    #[test]
+    fn test_build_returns_actionable_error_for_invalid_w_ref() {
+        let app = create_app_dir(&[
+            ("index.html", "<my-card>Hello</my-card>"),
+            ("my-card.html", r#"<div><input w-ref="myInput" /></div>"#),
+        ]);
+        let mut options = default_options(app.path());
+        options.plugin = Some(Plugin::WebUI);
+
+        // Authoring mistakes are returned (not panicked) so every consumer —
+        // CLI, Node, FFI, WASM — can surface the message its own way.
+        let Err(err) = build(options) else {
+            panic!("non-braced w-ref must fail the build");
+        };
+        let msg = err.chain_message();
+        assert!(msg.contains("invalid w-ref binding"), "msg: {msg}");
+        assert!(
+            msg.contains("component <my-card> · element <input>"),
+            "msg: {msg}"
+        );
+        assert!(msg.contains("help:"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_build_returns_actionable_error_for_invalid_event_handler() {
+        let app = create_app_dir(&[
+            ("index.html", "<my-btn>x</my-btn>"),
+            (
+                "my-btn.html",
+                r#"<div><button @click="e.preventDefault()">x</button></div>"#,
+            ),
+        ]);
+        let mut options = default_options(app.path());
+        options.plugin = Some(Plugin::WebUI);
+
+        let Err(err) = build(options) else {
+            panic!("invalid @event handler must fail the build");
+        };
+        let msg = err.chain_message();
+        assert!(msg.contains("invalid @click handler"), "msg: {msg}");
+        assert!(
+            msg.contains("component <my-btn> · element <button>"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_error_chain_message_has_no_duplicate_source() {
+        let err = WebUIError::Parse {
+            context: "Failed to parse index.html".to_string(),
+            source: webui_parser::ParserError::Directive("Invalid for each: x".to_string()),
+        };
+        // Each layer's Display describes only its own level — the source is not
+        // embedded — so anyhow's `{:#}` / chain walks never repeat it.
+        assert_eq!(err.to_string(), "Failed to parse index.html");
+        // The flat message includes the source exactly once (no repetition).
+        assert_eq!(
+            err.chain_message(),
+            "Failed to parse index.html: Directive error: Invalid for each: x"
+        );
     }
 
     #[test]

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -524,6 +524,7 @@ webui build ./src --out ./dist --plugin=webui
 | `--css-file-name-template <TEMPLATE>` | `[name].[ext]` | Link-mode CSS filename template. Tokens: `[name]`, `[hash]`, `[ext]` |
 | `--css-public-base <BASE>` | none | Public URL/path prefix for Link-mode CSS hrefs |
 | `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
+| `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
 
 For CDN/browser caching in `link` mode, prefer:
 
@@ -568,6 +569,7 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 | `--css-file-name-template <TEMPLATE>` | `[name].[ext]` | Link-mode CSS filename template |
 | `--css-public-base <BASE>` | none | Public URL/path prefix for Link-mode CSS hrefs |
 | `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
+| `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
 
 ### Inspect
 
@@ -575,6 +577,68 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 webui inspect ./dist/protocol.bin
 webui inspect ./dist/protocol.bin | jq '.fragments | keys'
 ```
+
+## Build Diagnostics & Error Output
+
+Authoring mistakes fail `webui build` with a structured, actionable diagnostic
+(never a stack trace). Each one has a **stable error code**, the source
+location, the offending snippet, and a `help:` fix:
+
+```
+✘ error: invalid <for> each expression [invalid-for-each]
+  --> index.html:67:5
+    each="person inpeople"
+  help: use the form each="item in collection", e.g. each="todo in todos"
+```
+
+When a mistake looks like a typo, `help:` suggests the intended name — a
+misspelled directive attribute (`eahc` → `each`) or an unregistered
+custom-element tag that closely matches a registered component **in the same
+namespace** (`<mp-buton>` → `<mp-button>`). A different-namespace tag (e.g. a
+third-party `<md-button>`) passes through as a genuine custom element.
+
+### Machine-readable output (`--format json`)
+
+For editors, CI, and AI tooling, pass the global `--format json` flag. Each
+error is emitted as a single JSON object on **stdout** (no ANSI), so it can be
+parsed directly instead of scraping terminal text:
+
+```bash
+webui build ./src --out ./dist --format json
+```
+
+```json
+{
+  "severity": "error",
+  "code": "invalid-for-each",
+  "message": "invalid <for> each expression",
+  "file": "index.html",
+  "line": 67,
+  "column": 5,
+  "snippet": "each=\"person inpeople\"",
+  "help": "use the form each=\"item in collection\", e.g. each=\"todo in todos\"",
+  "chain": ["Build failed", "Failed to parse index.html", "..."]
+}
+```
+
+Branch on the stable `code`, not the human-readable `message`. Fields that don't
+apply to a given error are `null`.
+
+### Error codes
+
+`invalid-for-each`, `invalid-for-identifier`, `missing-for-each`,
+`invalid-if-condition`, `missing-if-condition`, `unknown-component`,
+`invalid-event-handler`, `invalid-w-ref`, `unclosed-html-tag`,
+`malformed-html-tag`, `unexpected-closing-tag`, `unterminated-html-comment`,
+`unterminated-html-declaration`, `excessive-nesting`, `recursive-template`,
+`invalid-css`.
+
+### Exit codes
+
+Following `sysexits.h`: `0` success, `2` argument/usage error, `65`
+template/authoring error, `66` missing input (app folder, `--state`,
+`--servedir`, or entry file), `69` port already in use, `74` I/O error, `1`
+otherwise.
 
 ## `--components` - External Component Sources
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -18,6 +18,16 @@ cargo install microsoft-webui-cli
 
 ## Commands
 
+### Global options
+
+These flags work with any command:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--format <FORMAT>` | Output format: `human` (colorized terminal) or `json` (machine-readable diagnostics on stdout) | `human` |
+
+Use `--format json` in editors, CI, or AI/agent tooling that needs to parse build errors programmatically instead of scraping colorized terminal text. See [Error output and exit codes](#error-output-and-exit-codes).
+
 ### `webui build`
 
 Build a WebUI application from an app folder.
@@ -217,6 +227,57 @@ webui serve ./my-app --state ./state.json --theme ./themes/dark.json --watch
 | `/` or `/index.html` | Rendered HTML with live-reload script |
 | `/*` | Static files from `--servedir` (when provided) |
 | `/hmr` | HMR version endpoint (polling backend, only when `--watch`) |
+
+## Error output and exit codes
+
+When a template has an authoring mistake, the CLI prints a structured diagnostic with a stable error code, the source location, the offending snippet, and an actionable `help:` line:
+
+```
+✘ error: invalid <for> each expression [invalid-for-each]
+  --> index.html:67:5
+    each="person inpeople"
+  help: use the form each="item in collection", e.g. each="todo in todos"
+```
+
+Where the mistake is likely a typo, the `help:` line suggests the intended name — a misspelled directive attribute (`eahc` → `each`) or an unregistered custom-element tag that closely matches a registered component **in the same namespace** (`<mp-buton>` → `<mp-button>`). A custom element in a different namespace (e.g. a third-party `<md-button>`) is left untouched and passes through to the browser.
+
+### JSON diagnostics
+
+With `--format json`, each error is emitted as a single JSON object on **stdout** (the colorized terminal output is suppressed), so editors, CI, and AI assistants can consume it directly:
+
+```bash
+webui build ./my-app --out ./dist --format json
+```
+
+```json
+{
+  "severity": "error",
+  "code": "invalid-for-each",
+  "message": "invalid <for> each expression",
+  "file": "index.html",
+  "line": 67,
+  "column": 5,
+  "snippet": "each=\"person inpeople\"",
+  "help": "use the form each=\"item in collection\", e.g. each=\"todo in todos\"",
+  "chain": ["Build failed", "Failed to parse index.html", "..."]
+}
+```
+
+Fields that don't apply to a given error are `null`. The `code` is stable across releases — branch on it rather than on the human-readable `message`.
+
+### Exit codes
+
+The process exit code follows the BSD `sysexits.h` conventions so scripts and CI can branch on the cause:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Generic failure |
+| `2` | Invalid arguments / usage |
+| `65` | Template or authoring error (`EX_DATAERR`) |
+| `66` | Missing input: app folder, `--state` file, `--servedir`, or entry file (`EX_NOINPUT`) |
+| `69` | Requested `--port` is already in use (`EX_UNAVAILABLE`) |
+| `74` | I/O error reading or writing files (`EX_IOERR`) |
 
 ## App Folder Structure
 

--- a/docs/guide/concepts/interactivity.md
+++ b/docs/guide/concepts/interactivity.md
@@ -189,12 +189,16 @@ Event handlers use method-call syntax only. Arguments can be:
 General JavaScript expressions and nested function calls are not parsed in
 templates. Compute those values in the component class or pass a supported path.
 
+Invalid handler syntax — a general expression such as `@click="e.preventDefault()"`,
+or a bare name like `@click="{closeMenu}"` — fails the build with an actionable
+error that names the offending component and element.
+
 ### DOM References
 
 Use `w-ref` to get a direct reference to a DOM element:
 
 ```html
-<input w-ref="inputEl" type="text" />
+<input w-ref="{inputEl}" type="text" />
 <button @click="{focusInput()}">Focus</button>
 ```
 
@@ -205,6 +209,10 @@ focusInput(): void {
   this.inputEl.focus();
 }
 ```
+
+`w-ref` must use braces to bind to a component property — `w-ref="{inputEl}"`
+(or the unquoted `w-ref={inputEl}`), never `w-ref="inputEl"`. The build fails
+with an actionable error otherwise.
 
 ### Conditional Rendering
 

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -111,8 +111,11 @@ pub trait ParserPlugin {
     fn finish_element(&mut self, binding_attribute_count: u32) -> Option<Vec<u8>>;
 
     /// Consume the plugin and return captured build artifacts.
-    fn into_artifacts(self: Box<Self>) -> ParserPluginArtifacts {
-        ParserPluginArtifacts::None
+    ///
+    /// Returns an error if the plugin captured an invalid template construct
+    /// (e.g. a malformed `@event` handler) while producing its artifacts.
+    fn into_artifacts(self: Box<Self>) -> Result<ParserPluginArtifacts> {
+        Ok(ParserPluginArtifacts::None)
     }
 }
 ```

--- a/xtask/src/dev.rs
+++ b/xtask/src/dev.rs
@@ -116,11 +116,26 @@ pub fn run(app: Option<&str>) -> ExitCode {
         }
     }
 
-    // Start client bundler (watch mode)
+    // Start client bundler (watch mode).
+    //
+    // esbuild only emits color when its stderr is a TTY and ignores the
+    // `FORCE_COLOR`/`CLICOLOR_FORCE` env vars; under our output pipe it would
+    // print plain text. Forward esbuild's `--color=true` flag (via pnpm) when
+    // we are attached to a terminal so its build errors stay colored, matching
+    // the server's behavior. All example `start:client` scripts use esbuild.
+    //
+    // The flag is appended WITHOUT a `--` separator: pnpm forwards extra args
+    // verbatim (it does not consume `--`), so a `--` would reach esbuild and be
+    // rejected as an invalid build flag.
+    let client_args: &[&str] = if console::colors_enabled_stderr() {
+        &["start:client", "--color=true"]
+    } else {
+        &["start:client"]
+    };
     match process::spawn_child_prefixed(
         "client",
         "pnpm",
-        &["start:client"],
+        client_args,
         &app_dir,
         console::Color::Green,
     ) {

--- a/xtask/src/process.rs
+++ b/xtask/src/process.rs
@@ -163,6 +163,18 @@ pub fn spawn_child_prefixed(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    // Children write through our pipes, not a TTY, so their own `console`
+    // color auto-detection disables ANSI and their output arrives plain.
+    // Propagate the parent's terminal color decision: force color when we are
+    // attached to an interactive terminal (so prefixed child output stays
+    // colored), and leave it off when redirected / in CI (so logs stay clean).
+    // `CLICOLOR_FORCE` covers the Rust/`console` server; `FORCE_COLOR` covers
+    // pnpm and other Node/chalk-based tooling.
+    if console::colors_enabled_stderr() {
+        command.env("CLICOLOR_FORCE", "1");
+        command.env("FORCE_COLOR", "1");
+    }
+
     match spawn_managed(&mut command) {
         Ok(mut managed) => {
             fn pipe_reader<R: std::io::Read + Send + 'static>(


### PR DESCRIPTION
## Summary

Make WebUI build-time errors **actionable** and **machine-consumable** — for human developers and AI/LLM agents alike. Authoring mistakes are now returned as structured, recoverable diagnostics (never panics) and rendered with a consistent shape: a **stable error code**, a rustc-style **source location**, the offending **snippet**, and an actionable **`help:`** fix. The CLI can emit them as **JSON** for tools, and exits with **differentiated codes**.

## Motivation

- **DX:** authoring errors were terse, sometimes pointed at a raw byte offset (`near byte 1526`), and were emitted inconsistently (some panicked, some were bare strings).
- **Agents/tools:** had to scrape colorized terminal text to understand a failure; no stable identifier to map an error → a fix.
- **Safety:** `panic = "abort"` in release would kill any FFI/WASM/Node host on a bad template, so authoring errors must be `Result`, not `panic!`.

## Layering (contract enforced everywhere)

- `webui-parser` produces plain, **color-free** `Diagnostic` data.
- `webui-cli` is the **only** layer that colorizes (via `console`).
- FFI / WASM / Node forward the plain `Display` text through their native error channels.

## What's included

**Diagnostics core (`webui-parser`)**
- New `Diagnostic` type: severity, stable `code`, title, owning component/element, snippet, `help:`, 1-based line/column.
- Location rendered rustc-style `--> owner:line:column` (single forward byte scan — no regex, no recursion), falling back to `in component <c> · element <e>`.
- All authoring errors return `ParserError::Template(Box<Diagnostic>)`: `<for each>` / `<if condition>`, `@event` handlers, `w-ref`, unknown components, recursive templates, malformed CSS, and structural HTML errors.
- CSS scanner errors now report `at line L, column C` instead of `near byte N`.

**Stable error codes** — independent of message wording, so tools/agents map errors to deterministic fixes:
`invalid-for-each`, `invalid-for-identifier`, `missing-for-each`, `invalid-if-condition`, `missing-if-condition`, `unknown-component`, `invalid-event-handler`, `invalid-w-ref`, `unclosed-html-tag`, `malformed-html-tag`, `unexpected-closing-tag`, `unterminated-html-comment`, `unterminated-html-declaration`, `excessive-nesting`, `recursive-template`, `invalid-css`.

**"Did you mean …?" suggestions** (iterative Levenshtein; no recursion/regex)
- Misspelled directive attributes: `<for eahc=…>` → suggests `each`.
- **Prefix-guarded** component typos: `<mp-buton>` → `<mp-button>` errors with a suggestion, while a different-namespace tag (e.g. a third-party `<md-button>`) still passes through as a genuine custom element — **no false positives**.

**Machine-readable output (`webui-cli`)** — new global `--format <human|json>` flag. In `json` mode, each error is one object on **stdout** (no ANSI), decorative output suppressed.

**Typed CLI errors + hints** — replaced fragile `err_msg.contains(...)` dispatch with a typed `CliError` enum whose variants own their `hint()` and exit code.

**Differentiated exit codes** (`sysexits.h`) — `65` authoring/parse, `66` missing input, `69` port in use, `74` I/O, `2` usage (clap), `1` otherwise.

**CLI color consistency** — startup and incremental (watch) rebuild errors render identically (per-line ANSI that survives `[server]` re-prefixing in `xtask dev`). Dev-server rebuild errors split into `RebuildError { display, message }`: `display` is colorized for the terminal; `message` stays **plain** for the browser (live-reload logs it via `console.error` / single-line SSE).

## Examples

Human:
```
✘ error: invalid <for> each expression [invalid-for-each]
  --> index.html:67:5
    each="person inpeople"
  help: use the form each="item in collection", e.g. each="todo in todos"
```

`--format json` (stdout, no ANSI):
```json
{
  "severity": "error",
  "code": "unknown-component",
  "message": "unknown component <mp-buton>",
  "file": "index.html",
  "line": 1,
  "column": 7,
  "snippet": null,
  "help": "did you mean <mp-button>? otherwise register <mp-buton> by adding a matching .html file",
  "chain": ["Build failed", "Failed to parse index.html", "..."]
}
```

## Performance

Validated with `cargo bench -p microsoft-webui-parser` against `origin/main` (Criterion baselines). The only hot-path addition is a per-element `check_component_typo` (a `split_once('-')` fast-path for native tags); the element-heavy `many_siblings_1000` (1000 elements) bench shows **no change**.

An initial pass regressed two benches by ~4-5% (`directives_l4_n16`, `external_css`) due to **code-layout/inlining perturbation** — cold error-construction closures bloating hot functions. Fixed by moving error construction out-of-line behind `#[cold]` / `#[inline(never)]`:

| Benchmark | Before fix | After fix |
|---|---|---|
| `parser_parse_reuse/reuse/directives_l4_n16` | +5.4% | -0.6% (no change) |
| `parser_css_strategy/external_css` | +4.5% | -0.3% (no change) |
| `parser_adversarial/parse/many_siblings_1000` | +0.2% | -0.7% (no change) |

Final full-suite comparison: **zero regressions** (all benches within measurement noise).

## Conventions & enforcement

Codified these error-handling conventions so future contributors and AI agents apply them consistently:

- **New skill `.github/skills/diagnostics/SKILL.md`** — Result-not-panic, structured `Diagnostic`s with stable codes, actionable help + did-you-mean, color/JSON presentation layering, exit codes, and the cold-path performance rule.
- **`.github/copilot-instructions.md`** — expanded Error handling section + linked the skill.
- **`code-review` skill** — added a "diagnostics & error presentation" review subsection; **`perf` skill** — added the cold-error-path rule.
- **`clippy.toml`** — bans `todo!` / `unimplemented!` / `dbg!` via `disallowed-macros` (zero current usage). `panic!` and the no-regex rule stay review-enforced (panic is entrenched; `actix-web` pulls `regex` transitively, so a `deny` ban would break the build and can't scope to first-party code).

## Testing

- `cargo xtask check` passes: license-headers, fmt, clippy, proto drift, deny, tests, build, build (wasm), build (examples), bench (validate), docs.
- Added unit/integration tests: Levenshtein matcher; did-you-mean reachability + external-element passthrough; `--format json` schema + browser-plain (no-ANSI) invariant; `CliError` hints + exit-code classification; CSS line:col; dev-server `RebuildError` routing.
- Verified end-to-end: build/serve human + JSON rendering, dev-server incremental rebuild coloring, and exit codes (`65`/`66`/`69`/`2`).

## Docs

- `DESIGN.md` — authoring-validation + machine-readable diagnostics sections.
- `docs/guide/cli/index.md` — global options, error output, JSON diagnostics, exit codes.
- `docs/ai.md` — LLM reference: diagnostics, codes, JSON, exit codes.

## Notes

No backwards-compatibility concerns (pre-1.0). Touches core framework code (parser, CLI runtime, dev-server) — reviewed against the code-review checklist. No new recursion/regex in core paths; no new `unwrap`/`expect` in library code; no new dependencies. Squashed to a single commit.
