### PR TITLE
feat: surface build errors in the docs playground

### DIFF
--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -338,11 +338,11 @@
   flex-shrink: 0;
   font-size: 12px;
   background: rgba(208, 72, 72, 0.06);
-  border-bottom: 1px solid rgba(208, 72, 72, 0.28);
+  border-top: 1px solid rgba(208, 72, 72, 0.28);
 }
 .error-panel[data-severity="warning"] {
   background: rgba(234, 179, 8, 0.08);
-  border-bottom-color: rgba(234, 179, 8, 0.3);
+  border-top-color: rgba(234, 179, 8, 0.3);
 }
 
 .error-panel-header {
@@ -428,6 +428,9 @@
   display: inline-flex;
   color: var(--docs-color-text-3);
   transition: transform 0.2s ease;
+  /* Bottom drawer: the down-caret SVG points up while collapsed (toward where
+     the body opens), then rotates back to point down when expanded. */
+  transform: rotate(180deg);
 }
 .error-chevron svg {
   width: 16px;
@@ -439,7 +442,7 @@
   stroke-linejoin: round;
 }
 .error-panel[data-expanded] .error-chevron {
-  transform: rotate(180deg);
+  transform: rotate(0deg);
 }
 
 /* Collapsible body: animate the grid row from 0fr to 1fr for a smooth,

--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -283,6 +283,11 @@
   background: rgba(208, 72, 72, 0.1);
   color: #d04848;
 }
+.preview-badge.error {
+  background: #d04848;
+  color: #fff;
+  box-shadow: 0 0 0 3px rgba(208, 72, 72, 0.18);
+}
 
 .preview-stats {
   display: flex;
@@ -329,18 +334,171 @@
   border-color: var(--docs-color-brand);
 }
 
-.error-bar {
+.error-panel {
+  flex-shrink: 0;
+  font-size: 12px;
+  background: rgba(208, 72, 72, 0.06);
+  border-bottom: 1px solid rgba(208, 72, 72, 0.28);
+}
+.error-panel[data-severity="warning"] {
+  background: rgba(234, 179, 8, 0.08);
+  border-bottom-color: rgba(234, 179, 8, 0.3);
+}
+
+.error-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 14px;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  color: #d04848;
+}
+.error-panel[data-severity="warning"] .error-panel-header {
+  color: #b77900;
+}
+.error-panel-header:hover {
+  background: rgba(208, 72, 72, 0.07);
+}
+.error-panel-header:focus-visible {
+  outline: 2px solid var(--docs-color-brand);
+  outline-offset: -2px;
+}
+
+.error-panel-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #d04848;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+.error-panel-icon::before {
+  content: "!";
+}
+.error-panel[data-severity="warning"] .error-panel-icon {
+  background: #b77900;
+}
+
+.error-panel-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+.error-panel-title {
+  font-weight: 600;
+  color: var(--docs-color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.error-code-chip {
+  flex-shrink: 0;
+  font-family: var(--docs-font-mono);
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 6px;
+  background: rgba(208, 72, 72, 0.14);
+  color: #d04848;
+}
+.error-panel[data-severity="warning"] .error-code-chip {
+  background: rgba(234, 179, 8, 0.16);
+  color: #b77900;
+}
+.error-loc {
+  flex-shrink: 0;
+  font-family: var(--docs-font-mono);
+  font-size: 11px;
+  color: var(--docs-color-text-3);
+}
+.error-chevron {
+  flex-shrink: 0;
+  display: inline-flex;
+  color: var(--docs-color-text-3);
+  transition: transform 0.2s ease;
+}
+.error-chevron svg {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.error-panel[data-expanded] .error-chevron {
+  transform: rotate(180deg);
+}
+
+/* Collapsible body: animate the grid row from 0fr to 1fr for a smooth,
+   height-agnostic expand/collapse. */
+.error-panel-body-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.22s ease;
+}
+.error-panel[data-expanded] .error-panel-body-wrap {
+  grid-template-rows: 1fr;
+}
+.error-panel-body {
+  overflow: hidden;
+  min-height: 0;
+  padding-bottom: 12px;
+}
+.error-snippet,
+.error-help,
+.error-raw {
+  margin: 10px 14px 0;
+}
+.error-snippet {
+  font-family: var(--docs-font-mono);
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--docs-color-bg);
+  border: 1px solid rgba(208, 72, 72, 0.2);
+  color: var(--docs-color-text);
+  overflow-x: auto;
+  white-space: pre;
+}
+.error-help {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  padding: 10px 16px;
-  font-size: 12px;
+  line-height: 1.55;
+  color: var(--docs-color-text-2);
+}
+.error-help-label {
+  flex-shrink: 0;
   font-family: var(--docs-font-mono);
-  color: #d04848;
-  background: rgba(208, 72, 72, 0.08);
-  border-bottom: 1px solid rgba(208, 72, 72, 0.28);
+  font-weight: 600;
+  color: var(--docs-color-brand);
+}
+.error-raw {
+  font-family: var(--docs-font-mono);
   line-height: 1.5;
+  color: var(--docs-color-text-2);
   white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-panel-body-wrap,
+  .error-chevron {
+    transition: none;
+  }
 }
 
 .preview-frame {

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -88,8 +88,51 @@
         <button class="share-btn" type="button" @click="{sharePlayground()}">Share</button>
       </div>
     </div>
-    <if condition="errorMessage">
-      <div class="error-bar">{{errorMessage}}</div>
+    <if condition="hasError">
+      <div
+        class="error-panel"
+        data-severity="{{errorSeverity}}"
+        ?data-expanded="{{errorExpanded}}"
+      >
+        <button
+          class="error-panel-header"
+          type="button"
+          aria-expanded="{{errorExpanded}}"
+          @click="{toggleError()}"
+        >
+          <span class="error-panel-icon" aria-hidden="true"></span>
+          <span class="error-panel-summary">
+            <span class="error-panel-title">{{errorTitle}}</span>
+            <if condition="errorCode">
+              <span class="error-code-chip">{{errorCode}}</span>
+            </if>
+          </span>
+          <if condition="errorLocation">
+            <span class="error-loc">{{errorLocation}}</span>
+          </if>
+          <span class="error-chevron" aria-hidden="true">
+            <svg viewBox="0 0 16 16" focusable="false">
+              <path d="M4.5 6.5 8 10l3.5-3.5"></path>
+            </svg>
+          </span>
+        </button>
+        <div class="error-panel-body-wrap">
+          <div class="error-panel-body">
+            <if condition="errorSnippet">
+              <pre class="error-snippet">{{errorSnippet}}</pre>
+            </if>
+            <if condition="errorHelp">
+              <div class="error-help">
+                <span class="error-help-label">help</span>
+                <span class="error-help-text">{{errorHelp}}</span>
+              </div>
+            </if>
+            <if condition="errorRaw">
+              <pre class="error-raw">{{errorRaw}}</pre>
+            </if>
+          </div>
+        </div>
+      </div>
     </if>
     <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
   </div>

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -88,6 +88,7 @@
         <button class="share-btn" type="button" @click="{sharePlayground()}">Share</button>
       </div>
     </div>
+    <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
     <if condition="hasError">
       <div
         class="error-panel"
@@ -134,7 +135,6 @@
         </div>
       </div>
     </if>
-    <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
   </div>
   <if condition="toastMessage">
     <div

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -273,11 +273,22 @@ export class DocsPlayground extends WebUIElement {
   @observable hasStats = false;
   @observable buildMs = "";
   @observable renderMs = "";
-  @observable errorMessage = "";
   @observable previewSrcdoc = "";
   @observable toastMessage = "";
   @observable previewBadge = "Loading WASM";
   @observable previewBadgeState = "loading";
+
+  // Error panel state. `hasError` toggles the collapsible panel; the rest are
+  // the parsed pieces of a build/compile diagnostic (see `setError`).
+  @observable hasError = false;
+  @observable errorExpanded = true;
+  @observable errorSeverity = "error";
+  @observable errorTitle = "";
+  @observable errorCode = "";
+  @observable errorLocation = "";
+  @observable errorSnippet = "";
+  @observable errorHelp = "";
+  @observable errorRaw = "";
 
   private active: string = ENTRY_FILE;
   private entry: string = ENTRY_FILE;
@@ -302,7 +313,7 @@ export class DocsPlayground extends WebUIElement {
         stateFile: STATE_FILE,
       };
       this.setPreviewStatus("Failed", "failed");
-      this.errorMessage = `Unable to load shared playground: ${String(e)}`;
+      this.setError(`Unable to load shared playground: ${String(e)}`);
     }
     this.files = initial.files;
     this.entry = initial.entry;
@@ -724,8 +735,9 @@ export class DocsPlayground extends WebUIElement {
     try {
       await this.copyToClipboard(url.toString());
       this.showToast("URL copied to clipboard");
-    } catch (e) {
-      this.errorMessage = `Unable to copy share URL: ${String(e)}`;
+    } catch {
+      // A clipboard failure is transient UX noise, not a build error - keep it
+      // to a toast rather than the error panel.
       this.showToast("Unable to copy URL");
     }
   }
@@ -771,6 +783,74 @@ export class DocsPlayground extends WebUIElement {
     this.previewBadgeState = state;
   }
 
+  /** Reset the error panel to hidden/empty. */
+  private clearError(): void {
+    this.hasError = false;
+    this.errorSeverity = "error";
+    this.errorTitle = "";
+    this.errorCode = "";
+    this.errorLocation = "";
+    this.errorSnippet = "";
+    this.errorHelp = "";
+    this.errorRaw = "";
+  }
+
+  /**
+   * Parse a build/compile error string into the structured fields the error
+   * panel renders. WebUI surfaces authoring diagnostics in a stable shape:
+   *
+   *   error: <title> [<code>]
+   *     --> <file>:<line>:<col>
+   *       <offending snippet>
+   *     help: <fix>
+   *
+   * Unstructured failures (e.g. WASM unavailable) fall back to a raw message.
+   */
+  private setError(raw: string): void {
+    this.clearError();
+    const text = raw.trim();
+    const lines = text.split("\n");
+    const first = (lines[0] ?? "").trim();
+    const head = /^(error|warning)\b:?\s*(.*)$/i.exec(first);
+
+    if (head) {
+      this.errorSeverity =
+        head[1].toLowerCase() === "warning" ? "warning" : "error";
+      let title = head[2].trim();
+      const code = /\[([a-z0-9][a-z0-9-]*)\]\s*$/i.exec(title);
+      if (code) {
+        this.errorCode = code[1];
+        title = title.slice(0, code.index).trim();
+      }
+      this.errorTitle = title || "Build error";
+      for (let i = 1; i < lines.length; i++) {
+        const t = lines[i].trim();
+        if (!t) continue;
+        if (t.startsWith("-->")) {
+          this.errorLocation = t.replace(/^-->\s*/, "");
+        } else if (/^help:/i.test(t)) {
+          this.errorHelp = t.replace(/^help:\s*/i, "");
+        } else if (!this.errorSnippet) {
+          this.errorSnippet = t;
+        }
+      }
+    } else {
+      // Unstructured (e.g. infra) error: show the first line as the summary
+      // and any remaining detail in the expandable body.
+      this.errorTitle = first || "Error";
+      const rest = lines.slice(1).join("\n").trim();
+      this.errorRaw = rest;
+    }
+
+    this.errorExpanded = true;
+    this.hasError = true;
+  }
+
+  /** Toggle the expand/collapse state of the error panel. */
+  toggleError(): void {
+    this.errorExpanded = !this.errorExpanded;
+  }
+
   private scheduleRender(): void {
     if (this.renderTimer) clearTimeout(this.renderTimer);
     if (!this.wasm) {
@@ -785,7 +865,7 @@ export class DocsPlayground extends WebUIElement {
     if (!this.wasm) return;
     try {
       this.setPreviewStatus("Compiling", "compiling");
-      this.errorMessage = "";
+      this.clearError();
       const filesObj: Record<string, string> = {};
       for (const f of this.files) {
         if (f.name !== this.stateFile) filesObj[f.name] = f.content;
@@ -819,8 +899,8 @@ export class DocsPlayground extends WebUIElement {
         "</body></html>";
       this.setPreviewStatus("WASM Live", "live");
     } catch (e) {
-      this.setPreviewStatus("Failed", "failed");
-      this.errorMessage = String(e);
+      this.setPreviewStatus("Error", "error");
+      this.setError(String(e));
     }
   }
 
@@ -859,9 +939,10 @@ export class DocsPlayground extends WebUIElement {
       this.doRender();
     } catch (e) {
       this.setPreviewStatus("Failed", "failed");
-      this.errorMessage =
+      this.setError(
         'WASM not available. Run "cargo xtask build-wasm" to enable the playground.\n\n' +
-        String(e);
+          String(e),
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Add an explicit **"Error"** status badge and a polished, **expand/collapse error panel** to the docs playground, so developers can see and explore build failures in place — instead of a flat one-line bar that flattened WebUI's structured diagnostics into one unreadable string.

## What changed (docs playground only — no framework code)

- **New `Error` badge state** — solid red with a subtle glow, distinct from the pre-existing dim `Failed` state (which is kept for infra/WASM-load failures).
- **`error-panel` replaces `error-bar`:**
  - Clickable header: severity icon, error **title**, the stable error **`code`** as a chip (e.g. `invalid-for-each`), and the **`file:line:col`** location, with a rotating chevron.
  - Collapsible body (animated via a `0fr`→`1fr` grid-row transition; reduced-motion fallback) showing the offending **snippet** and the **`help:`** fix.
  - Expanded by default on a new error; toggles via `toggleError()`.
- **`setError(raw)`** parses the diagnostic shape WebUI emits into structured fields, with a graceful fallback for unstructured messages (e.g. "WASM not available") that shows the summary plus an expandable raw body.
- Clipboard/share failures now surface only as a **toast**, not the error panel.

## Example

For `error: invalid <for> each expression [invalid-for-each]` / `--> index.html:67:5` / `each="person inpeople"` / `help: …`, the panel header shows the title + `invalid-for-each` chip + `index.html:67:5`, and the expandable body shows the snippet and the help fix.

<img width="1050" height="632" alt="image" src="https://github.com/user-attachments/assets/995f4c6e-59c0-4846-a33d-fdeb5d09af10" />

## Testing

- `cargo xtask check` passes (incl. the docs build, which recompiles the component template).
- Verified the diagnostic parser against real outputs: `for-each` (full), `unknown-component` (no snippet), infra ("WASM not available"), and single-line ("Entry file … not found").
- Confirmed the rebuilt `docs/dist` template contains `error-panel` and no longer references the old `error-bar` / `errorMessage`.

## Notes

Build artifacts (`docs/dist`, `docs/.webui-press/public/wasm`) are gitignored and not committed. Only the three playground source files (`.html` / `.css` / `.ts`) change.
