### PR TITLE
chore: Prepare NuGet packages for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
   #
   # Each runner builds native + cross targets, then stages only the native files
   # for its platforms into package/runtime directories. The release job later
-  # merges those staged files and packs npm/NuGet/crates/WASM once on Linux.
+  # merges those staged files and packs npm/NuGet (.nupkg + .snupkg)/crates/WASM once on Linux.
   #
   #   ubuntu-latest  (x64) → linux-x64    + linux-arm64
   #   macos-latest-large   (arm) → darwin-arm64 + darwin-x64
@@ -234,7 +234,10 @@ jobs:
             git push origin "v${VERSION}"
           fi
 
-      # Create GitHub Release with all artifacts
+      # Create GitHub Release with all artifacts. NuGet artifacts are staged
+      # here for manual nuget.org publishing until ESRP supports automated
+      # NuGet publishing for this project. Manual publish still requires the
+      # approved NuGet owner account and signing/certificate process.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1456,6 +1456,10 @@ webui/
 │   ├── webui-framework/      # WebUI Framework client runtime (@microsoft/webui-framework)
 │   ├── webui-router/         # SPA router for WebUI Framework (@microsoft/webui-router)
 │   └── webui-test-support/   # Private shared JS test metadata helpers (@microsoft/webui-test-support)
+├── dotnet/
+│   ├── src/Microsoft.WebUI/  # Managed .NET bindings for webui-ffi
+│   ├── runtime/              # RID-specific native runtime NuGet packages
+│   └── tool/Microsoft.WebUI.Tool/ # .NET global tool package
 ├── examples/                 # Example applications (todo-fast, todo-webui, routes, …)
 ├── docs/                     # Documentation (VitePress)
 ├── tests/                    # Integration tests
@@ -1488,6 +1492,17 @@ The `@microsoft/webui` npm package follows the esbuild single-package model:
 - `bin: { "webui": "bin/webui" }` — CLI binary via platform-specific `optionalDependencies`
 - `main: "lib/main.js"` — Programmatic API that loads the `.node` native addon directly
 - WASM fallback for render when native addon is unavailable (one-time warning logged)
+
+### .NET / NuGet Distribution
+
+The `Microsoft.WebUI` package is the managed .NET binding for `webui-ffi`. It targets `net8.0` and `net9.0`, packs `dotnet/src/Microsoft.WebUI/README.md`, and publishes XML documentation generated from public API comments.
+
+Native assets are split into `Microsoft.WebUI.Runtime.<rid>` packages for each supported RID. The managed package references every runtime package so NuGet restores them transitively; .NET then resolves `webui_ffi` from the matching `runtimes/<rid>/native` asset. `WEBUI_LIB_PATH` remains the override for custom local native builds.
+
+`dotnet/Directory.Build.props` applies repository metadata, Source Link, and `.snupkg` symbol package generation to packable .NET projects. `cargo xtask publish` runs `dotnet pack` on `dotnet/Microsoft.WebUI.sln` and stages both `.nupkg` and `.snupkg` files under `publish/nuget`.
+
+NuGet publishing is not automated by ESRP today. Release workflows attach staged NuGet artifacts to GitHub Releases for manual/externally tracked nuget.org publishing with the approved owner and signing process.
+
 ### Documentation Guidelines
 - Using `vitepress` in `docs/`
 - API documentation for all public interfaces

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Or install the Rust CLI:
 cargo install microsoft-webui-cli
 ```
 
+For .NET server-side bindings:
+
+```bash
+dotnet add package Microsoft.WebUI
+```
+
+The NuGet package restores platform-specific `Microsoft.WebUI.Runtime.*` native assets transitively. Release builds stage `.nupkg` and `.snupkg` artifacts with repository metadata and Source Link; nuget.org publishing is manual until ESRP automation supports this project.
+
 ## Learn
 
 | Resource | Link |
@@ -60,6 +68,7 @@ For contribution policy, issue guidelines, and the current pull request policy, 
 ```text
 crates/      Rust crates for the CLI, parser, handler, protocol, FFI, and integrations
 packages/    npm packages for the CLI, WebUI Framework, router, and platform binaries
+dotnet/      .NET bindings, runtime packages, and global tool packaging
 docs/        VitePress documentation site
 examples/    Example applications and integration samples
 ```

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -118,7 +118,11 @@ extends:
               downloadPath: '$(System.ArtifactsDirectory)'
 
           # Separate the downloaded files into the directories expected by the
-          # release pipeline template. .tgz → npm, .crate → crates. NuGet skipped.
+          # release pipeline template. .tgz → npm, .crate → crates.
+          # NuGet (.nupkg/.snupkg) is intentionally skipped here: artifacts
+          # stay on the GitHub Release for manual nuget.org publishing until
+          # ESRP supports automated NuGet publishing for this project. Manual
+          # publish still requires the approved owner account and signing/cert.
           - script: |
               mkdir -p publish_artifacts_npm publish_artifacts_crates
               find "$(System.ArtifactsDirectory)" -name "*.tgz"   -exec cp {} publish_artifacts_npm/   \;

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -78,6 +78,16 @@ webui build ./my-app --out ./dist
 
 See the [CLI Reference](/guide/cli/) for full usage details.
 
+## .NET
+
+The managed .NET binding is packaged as `Microsoft.WebUI`:
+
+```bash
+dotnet add package Microsoft.WebUI
+```
+
+It targets .NET 8 and .NET 9. The package restores platform-specific `Microsoft.WebUI.Runtime.*` packages transitively, and .NET selects the matching native asset. Release builds stage `.nupkg` and `.snupkg` artifacts with Source Link and repository metadata; nuget.org publishing is manual until ESRP automation supports this project.
+
 ---
 
 The packages below are client-side runtime libraries. They are installed from npm regardless of whether your build toolchain is npm or Rust, since they ship as JavaScript that runs in the browser.

--- a/docs/guide/integrations/ffi.md
+++ b/docs/guide/integrations/ffi.md
@@ -1,6 +1,6 @@
 # C API
 
-The WebUI FFI (Foreign Function Interface) handler exposes the rendering pipeline as a C-compatible shared library. Any language with C interop, Go, C#, Python, Ruby, PHP, Lua, and more, can load the library and render WebUI templates without a JavaScript runtime.
+The WebUI FFI (Foreign Function Interface) handler exposes the rendering pipeline as a C-compatible shared library. Any language with C interop, Go, Python, Ruby, PHP, Lua, and more, can load the library and render WebUI templates without a JavaScript runtime. .NET applications should prefer the managed `Microsoft.WebUI` NuGet package, which restores native runtime packages transitively.
 
 ## Building the Shared Library
 
@@ -314,6 +314,8 @@ func main() {
 > **Memory note:** `C.GoString(ptr)` copies the string into Go-managed memory, so it's safe to call `webui_free` immediately after.
 
 ## C\#
+
+For most .NET applications, prefer the managed `Microsoft.WebUI` NuGet package. The P/Invoke pattern below documents the underlying ABI for custom bindings or manual native loading.
 
 Use `DllImport` (P/Invoke) to call the C API. Strings going *in* can be marshalled automatically with `LPUTF8Str`; strings coming *out* require manual marshalling via `IntPtr` to control when the native memory is freed.
 

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -6,9 +6,10 @@ Pick the handler that matches your stack:
 
 - [**Rust**](./rust), High-performance native rendering with the Rust programming language
 - [**Node**](./node), Streaming SSR via a native addon built with napi-rs for Node, Bun, and Deno.
+- [**.NET**](/guide/installation#net), Managed `Microsoft.WebUI` NuGet bindings with transitive native runtime packages
 - [**Electron**](./electron), Desktop apps via Electron with custom `webui://` protocol
 - [**WebAssembly**](./wasm), In-browser rendering for playgrounds and client-side use
-- [**C / FFI**](./ffi), Shared library for Go, C#, Python, and any language with C interop
+- [**C / FFI**](./ffi), Shared library for Go, Python, and any language with C interop
 
 ## How Handlers Work
 

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -15,7 +15,7 @@
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>
     <Description>WebUI — high-performance server-side rendering without JavaScript runtimes.</Description>
     <PackageTags>webui</PackageTags>
-    <!-- TODO: set PackageIcon after an approved 128x128 transparent PNG is available. -->
+    <!-- PackageIcon will be set once an approved 128x128 transparent PNG is available. -->
   </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Microsoft.WebUI.Tests'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -7,8 +7,17 @@
     <PackageProjectUrl>https://github.com/microsoft/webui</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/webui</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' or '$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>
     <Description>WebUI — high-performance server-side rendering without JavaScript runtimes.</Description>
     <PackageTags>webui</PackageTags>
+    <!-- TODO: set PackageIcon after an approved 128x128 transparent PNG is available. -->
   </PropertyGroup>
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Microsoft.WebUI.Tests'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup Condition="'$(PackageReadmeFile)' != '' and Exists('$(MSBuildProjectDirectory)\$(PackageReadmeFile)')">
+    <None Include="$(MSBuildProjectDirectory)\$(PackageReadmeFile)" Pack="true" PackagePath="/" />
+  </ItemGroup>
+</Project>

--- a/dotnet/Microsoft.WebUI.sln
+++ b/dotnet/Microsoft.WebUI.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -8,6 +7,20 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Tests", "test\Microsoft.WebUI.Tests\Microsoft.WebUI.Tests.csproj", "{A1B2C3D4-0002-0002-0002-000000000002}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Tool", "tool\Microsoft.WebUI.Tool\Microsoft.WebUI.Tool.csproj", "{A1B2C3D4-0003-0003-0003-000000000003}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime", "runtime", "{B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.linux-arm64", "runtime\Microsoft.WebUI.Runtime.linux-arm64\Microsoft.WebUI.Runtime.linux-arm64.csproj", "{77331337-2269-48D8-98AD-687C7EB96C5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.linux-x64", "runtime\Microsoft.WebUI.Runtime.linux-x64\Microsoft.WebUI.Runtime.linux-x64.csproj", "{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.osx-arm64", "runtime\Microsoft.WebUI.Runtime.osx-arm64\Microsoft.WebUI.Runtime.osx-arm64.csproj", "{176CF5E3-7ADC-43D6-AE32-8840E19204B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.osx-x64", "runtime\Microsoft.WebUI.Runtime.osx-x64\Microsoft.WebUI.Runtime.osx-x64.csproj", "{75413606-ECAE-4159-82F3-CDA3E6DD431A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.win-arm64", "runtime\Microsoft.WebUI.Runtime.win-arm64\Microsoft.WebUI.Runtime.win-arm64.csproj", "{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.WebUI.Runtime.win-x64", "runtime\Microsoft.WebUI.Runtime.win-x64\Microsoft.WebUI.Runtime.win-x64.csproj", "{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,5 +40,37 @@ Global
 		{A1B2C3D4-0003-0003-0003-000000000003}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-0003-0003-0003-000000000003}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-0003-0003-0003-000000000003}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77331337-2269-48D8-98AD-687C7EB96C5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77331337-2269-48D8-98AD-687C7EB96C5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77331337-2269-48D8-98AD-687C7EB96C5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77331337-2269-48D8-98AD-687C7EB96C5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{176CF5E3-7ADC-43D6-AE32-8840E19204B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{176CF5E3-7ADC-43D6-AE32-8840E19204B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{176CF5E3-7ADC-43D6-AE32-8840E19204B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{176CF5E3-7ADC-43D6-AE32-8840E19204B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75413606-ECAE-4159-82F3-CDA3E6DD431A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75413606-ECAE-4159-82F3-CDA3E6DD431A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75413606-ECAE-4159-82F3-CDA3E6DD431A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75413606-ECAE-4159-82F3-CDA3E6DD431A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{77331337-2269-48D8-98AD-687C7EB96C5A} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
+		{7C805D6B-162C-4FB4-A282-EF9B1DBD7D08} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
+		{176CF5E3-7ADC-43D6-AE32-8840E19204B3} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
+		{75413606-ECAE-4159-82F3-CDA3E6DD431A} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
+		{B68F4C51-5D33-4FAE-B989-2CBB33FD3B07} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
+		{C63D0997-0E3B-4C47-A0AE-EFAD2AE596CF} = {B9B45A75-0C0F-0D50-E9F8-ABF69D9594D8}
 	EndGlobalSection
 EndGlobal

--- a/dotnet/src/Microsoft.WebUI/Microsoft.WebUI.csproj
+++ b/dotnet/src/Microsoft.WebUI/Microsoft.WebUI.csproj
@@ -5,7 +5,16 @@
     <RootNamespace>Microsoft.WebUI</RootNamespace>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReadme>README.md</PackageReadme>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- Pack as dependencies so NuGet restores native assets for every supported runtime. -->
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.linux-arm64\Microsoft.WebUI.Runtime.linux-arm64.csproj" />
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.linux-x64\Microsoft.WebUI.Runtime.linux-x64.csproj" />
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.osx-arm64\Microsoft.WebUI.Runtime.osx-arm64.csproj" />
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.osx-x64\Microsoft.WebUI.Runtime.osx-x64.csproj" />
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.win-arm64\Microsoft.WebUI.Runtime.win-arm64.csproj" />
+    <ProjectReference Include="..\..\runtime\Microsoft.WebUI.Runtime.win-x64\Microsoft.WebUI.Runtime.win-x64.csproj" />
+  </ItemGroup>
 </Project>

--- a/dotnet/src/Microsoft.WebUI/README.md
+++ b/dotnet/src/Microsoft.WebUI/README.md
@@ -67,7 +67,7 @@ The response is a JSON string — pipe it directly to the HTTP response. No dese
 dotnet add package Microsoft.WebUI
 ```
 
-The correct native runtime package for your platform is automatically resolved by NuGet.
+The managed package depends on all supported `Microsoft.WebUI.Runtime.<rid>` packages. NuGet restores those native runtime packages transitively, and .NET selects the matching `runtimes/<rid>/native` asset for your platform.
 
 ### Supported Platforms
 
@@ -79,6 +79,10 @@ The correct native runtime package for your platform is automatically resolved b
 | Linux ARM64 | `Microsoft.WebUI.Runtime.linux-arm64` |
 | macOS x64 | `Microsoft.WebUI.Runtime.osx-x64` |
 | macOS ARM64 | `Microsoft.WebUI.Runtime.osx-arm64` |
+
+### Package Metadata
+
+Packed NuGet artifacts include this README, repository metadata, Source Link, and `.snupkg` symbol packages. Release workflows stage `.nupkg` and `.snupkg` files; nuget.org publishing remains manual/externally tracked until ESRP supports automated NuGet publishing for this project.
 
 ### Manual Native Library Path
 

--- a/dotnet/tool/Microsoft.WebUI.Tool/Microsoft.WebUI.Tool.csproj
+++ b/dotnet/tool/Microsoft.WebUI.Tool/Microsoft.WebUI.Tool.csproj
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>webui</ToolCommandName>
-    <PackageReadme>README.md</PackageReadme>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>WebUI CLI tool for building and inspecting WebUI templates.</Description>
   </PropertyGroup>
 </Project>

--- a/dotnet/tool/Microsoft.WebUI.Tool/README.md
+++ b/dotnet/tool/Microsoft.WebUI.Tool/README.md
@@ -8,6 +8,8 @@ CLI tool for building and inspecting WebUI templates.
 dotnet tool install -g Microsoft.WebUI.Tool
 ```
 
+NuGet artifacts for this tool include repository metadata, Source Link, and `.snupkg` symbols. Release workflows stage the artifacts for manual nuget.org publishing until ESRP supports automated NuGet publishing for this project.
+
 ## Usage
 
 ```bash

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -622,7 +622,7 @@ fn is_private_package(pkg_dir: &Path) -> bool {
 
 // ── Phase 3: NuGet packaging ────────────────────────────────────────────
 
-/// Run `dotnet pack` and move `.nupkg`/`.snupkg` files to `publish/nuget/`.
+/// Run `dotnet pack` and write `.nupkg`/`.snupkg` files to `publish/nuget/`.
 fn pack_nuget_packages(root: &Path) -> Result<(), String> {
     let dotnet_dir = root.join("dotnet");
     let nuget_out = root.join("publish").join("nuget");

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -7,7 +7,7 @@
 //! then assembles a consolidated `publish/` folder with:
 //! - `publish/native/`  — CLI binaries per platform
 //! - `publish/npm/`     — `.tgz` tarballs from `pnpm pack`
-//! - `publish/nuget/`   — `.nupkg` files from `dotnet pack`
+//! - `publish/nuget/`   — `.nupkg` and `.snupkg` files from `dotnet pack`
 //! - `publish/crates/`  — `.crate` files from `cargo package`
 //! - `publish/wasm/`    — WASM module + JS glue
 
@@ -622,7 +622,7 @@ fn is_private_package(pkg_dir: &Path) -> bool {
 
 // ── Phase 3: NuGet packaging ────────────────────────────────────────────
 
-/// Run `dotnet pack` and move `.nupkg` files to `publish/nuget/`.
+/// Run `dotnet pack` and move `.nupkg`/`.snupkg` files to `publish/nuget/`.
 fn pack_nuget_packages(root: &Path) -> Result<(), String> {
     let dotnet_dir = root.join("dotnet");
     let nuget_out = root.join("publish").join("nuget");
@@ -635,27 +635,37 @@ fn pack_nuget_packages(root: &Path) -> Result<(), String> {
         return Ok(());
     }
 
+    let solution = dotnet_dir.join("Microsoft.WebUI.sln");
+    if !solution.exists() {
+        return Err("dotnet/Microsoft.WebUI.sln not found".to_string());
+    }
+
+    let solution_arg = solution.to_string_lossy();
+    let nuget_out_arg = nuget_out.to_string_lossy();
+
     // Pack all packable projects (Directory.Build.props controls versioning)
     run_command_quiet(
         "dotnet",
         &[
             "pack",
-            &dotnet_dir.to_string_lossy(),
+            solution_arg.as_ref(),
             "--configuration",
             "Release",
             "--output",
-            &nuget_out.to_string_lossy(),
+            nuget_out_arg.as_ref(),
         ],
         None,
     )
     .map_err(|e| format!("dotnet pack failed: {e}"))?;
 
     // Count produced packages
-    let count = count_files_with_extension(&nuget_out, "nupkg");
+    let package_count = count_files_with_extension(&nuget_out, "nupkg");
+    let symbol_count = count_files_with_extension(&nuget_out, "snupkg");
     eprintln!(
-        "  {} Packed {} NuGet package(s)",
+        "  {} Packed {} NuGet package(s) and {} symbol package(s)",
         console::style("✔").green(),
-        console::style(count).bold(),
+        console::style(package_count).bold(),
+        console::style(symbol_count).bold(),
     );
     Ok(())
 }
@@ -1039,8 +1049,10 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join("a.crate"), "").unwrap();
         fs::write(dir.path().join("b.crate"), "").unwrap();
+        fs::write(dir.path().join("a.snupkg"), "").unwrap();
         fs::write(dir.path().join("c.txt"), "").unwrap();
         assert_eq!(count_files_with_extension(dir.path(), "crate"), 2);
+        assert_eq!(count_files_with_extension(dir.path(), "snupkg"), 1);
         assert_eq!(count_files_with_extension(dir.path(), "txt"), 1);
         assert_eq!(count_files_with_extension(dir.path(), "nupkg"), 0);
     }


### PR DESCRIPTION
## Summary
- Add NuGet publish-readiness metadata: Source Link, repository metadata, symbol packages, package README packing, and runtime package dependencies.
- Pack NuGet `.nupkg` and `.snupkg` artifacts through `cargo xtask publish-stage` and document manual nuget.org publishing while ESRP automation is unavailable.
- Update .NET, installation, integration, and design docs for the managed `Microsoft.WebUI` package and RID-specific runtime packages.

## Validation
- `git diff --check` passed.
- Staged diff scanned with no obvious secrets.
- `cargo xtask check` was attempted. With a local `protoc`, license headers, fmt, clippy, proto drift, and deny passed; the test phase is blocked on Windows by an existing `crates\webui\examples\streaming_resource_bench.rs` compile issue (`libc::rusage`, `getrusage`, and `RUSAGE_SELF` are unavailable on Windows).
- `cargo test -p xtask` passed (41 tests).
- `dotnet restore dotnet\Microsoft.WebUI.sln` passed.
- `dotnet build dotnet\Microsoft.WebUI.sln --configuration Release --no-restore` passed.
- `dotnet pack dotnet\src\Microsoft.WebUI\Microsoft.WebUI.csproj --configuration Release --no-build` produced `.nupkg` and `.snupkg` artifacts.
- `dotnet pack dotnet\tool\Microsoft.WebUI.Tool\Microsoft.WebUI.Tool.csproj --configuration Release --no-build` produced `.nupkg` and `.snupkg` artifacts.

## Notes
- Full solution NuGet packing needs release-staged native assets under `dotnet\runtimes`; local validation used targeted packs without those staged assets.
- Manual nuget.org publishing remains outside this PR until ESRP automation is available.