### PR TITLE
feat: split WASM parser and handler bundles

### DIFF
--- a/.github/actions/setup-wasm/action.yml
+++ b/.github/actions/setup-wasm/action.yml
@@ -26,6 +26,8 @@ runs:
     - name: Verify WASM output
       shell: bash
       run: |
-        test -f docs/.webui-press/public/wasm/webui_wasm_bg.wasm
-        test -f docs/.webui-press/public/wasm/webui_wasm.js
-        ! grep -q "from 'env'" docs/.webui-press/public/wasm/webui_wasm.js
+        for variant in all handler parser; do
+          test -f "docs/.webui-press/public/wasm/${variant}/webui_wasm_${variant}_bg.wasm"
+          test -f "docs/.webui-press/public/wasm/${variant}/webui_wasm_${variant}.js"
+          ! grep -q "from 'env'" "docs/.webui-press/public/wasm/${variant}/webui_wasm_${variant}.js"
+        done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,6 +246,6 @@ jobs:
             publish/npm/*
             publish/nuget/*
             publish/crates/*
-            publish/wasm/*
+            publish/wasm/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
 name = "microsoft-webui-wasm"
 version = "0.0.15"
 dependencies = [
+ "js-sys",
  "microsoft-webui-handler",
  "microsoft-webui-parser",
  "microsoft-webui-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ prost = "0.14.3"
 napi = { version = "3.8.5", features = ["napi4"] }
 napi-derive = "3.5.4"
 wasm-bindgen = "=0.2.100"
+js-sys = "0.3.77"
 serde-wasm-bindgen = "0.6"
 actix-web = "4.11.0"
 rustls = "0.23.39"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1476,15 +1476,38 @@ webui-cli ──────► webui (library) ◄────── webui-node
                     ├── webui-protocol        └── serde_json
                     └── webui-discovery
 
-webui-ffi ──────► webui-handler ◄────── webui-wasm
-                  webui-parser              webui-parser
-                  webui-protocol            webui-protocol
+webui-ffi ──────► webui-handler ◄────── webui-wasm (handler feature)
+                  webui-parser       ┌──── webui-wasm (parser feature)
+                  webui-protocol     └──── webui-wasm (all/default feature)
 ```
 
 The `webui` library crate is the primary API surface for programmatic use.
 It re-exports `WebUIHandler`, `ResponseWriter`, and `WebUIProtocol` from their
 respective crates and provides `build()`, `build_to_disk()`, and `inspect()`
 functions with `BuildStats` (duration, fragment/component/CSS counts, protocol size).
+
+### WASM Distribution
+
+The `microsoft-webui-wasm` crate exposes feature-gated browser bindings so
+consumers only ship the parser and/or handler code they need:
+
+- `handler` builds `webui_wasm_handler.js` and exports `render`,
+  `render_partial`, `protocol_tokens`, and `render_component_templates`. It
+  accepts protobuf protocol bytes and depends on `webui-handler` and
+  `webui-protocol`, not `webui-parser`. `render(protocolBytes, stateJson,
+  onChunk, options)` uses the same `ResponseWriter` callback shape as the
+  Node binding: each handler write calls `onChunk(html)`, while callers that
+  need a full string concatenate chunks in JavaScript.
+- `parser` builds `webui_wasm_parser.js` and exports `build_protocol`. It
+  returns protobuf protocol bytes and depends on `webui-parser` and
+  `webui-protocol`, not `webui-handler`.
+- `all` is the default feature, builds `webui_wasm_all.js`, and exports the
+  parser plus handler surfaces for playground-style live preview. Callers
+  compose `build_protocol()` and callback-based `render()` explicitly.
+
+`cargo xtask build-wasm` builds all three variants into
+`docs/.webui-press/public/wasm/{all,handler,parser}/` with stable `wasm-pack`
+output names.
 
 ### npm Distribution
 

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -18,12 +18,19 @@ wasm-opt = false
 name = "webui_wasm"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["all"]
+all = ["handler", "parser"]
+handler = ["dep:microsoft-webui-handler"]
+parser = ["dep:microsoft-webui-parser"]
+
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15", optional = true }
 microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/webui-wasm/README.md
+++ b/crates/webui-wasm/README.md
@@ -1,10 +1,26 @@
 # microsoft-webui-wasm
 
-WebAssembly bindings for the [WebUI](https://github.com/microsoft/webui) framework, built with `wasm-bindgen`. Powers the online WebUI playground.
+WebAssembly bindings for the [WebUI](https://github.com/microsoft/webui) framework, built with `wasm-bindgen`.
 
 ## Overview
 
-`microsoft-webui-wasm` exposes WebUI's parser and handler to the browser via a WASM module, enabling live template preview without a server.
+`microsoft-webui-wasm` can be built as three browser bundles:
+
+| Feature | Bundle | Exports |
+|---------|--------|---------|
+| `handler` | `webui_wasm_handler.js` | `render`, `render_partial`, `protocol_tokens`, `render_component_templates` |
+| `parser` | `webui_wasm_parser.js` | `build_protocol` |
+| `all` | `webui_wasm_all.js` | Parser and handler exports |
+
+The default feature is `all`, which powers the online playground. Consumers that only need to render prebuilt protobuf protocol bytes should use the handler bundle to avoid shipping parser code.
+
+## Building
+
+```bash
+cargo xtask build-wasm
+```
+
+This writes the three generated bundles under `docs/.webui-press/public/wasm/`.
 
 ## Documentation
 
@@ -12,4 +28,4 @@ See the [WebUI repository](https://github.com/microsoft/webui) for full usage gu
 
 ## License
 
-MIT — Copyright (c) Microsoft Corporation.
+MIT - Copyright (c) Microsoft Corporation.

--- a/crates/webui-wasm/src/error.rs
+++ b/crates/webui-wasm/src/error.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Shared WASM binding errors.
+
+/// Error type used by the WASM binding layer.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WasmError {
+    /// Requested entry file was not present in the virtual file map.
+    #[cfg(feature = "parser")]
+    #[error("Entry file '{0}' not found")]
+    MissingEntry(String),
+
+    /// Template parsing or authoring validation failed.
+    #[cfg(feature = "parser")]
+    #[error("{0}")]
+    Parse(#[from] webui_parser::ParserError),
+
+    /// Protocol protobuf bytes could not be decoded or encoded.
+    #[error("Protocol error: {0}")]
+    Protocol(#[from] webui_protocol::ProtocolError),
+
+    /// State JSON could not be decoded.
+    #[cfg(feature = "handler")]
+    #[error("State JSON error: {0}")]
+    State(serde_json::Error),
+
+    /// Rendering failed.
+    #[cfg(feature = "handler")]
+    #[error("{0}")]
+    Render(#[from] webui_handler::HandlerError),
+
+    /// A requested handler plugin name is not supported.
+    #[cfg(feature = "handler")]
+    #[error("Unknown plugin: {0}. Use \"webui\", \"fast-v3\", \"fast-v2\", or \"fast\".")]
+    UnknownPlugin(String),
+
+    /// The JavaScript render options object was invalid.
+    #[cfg(feature = "handler")]
+    #[error("Invalid render options: {0}")]
+    InvalidOptions(String),
+}

--- a/crates/webui-wasm/src/handler.rs
+++ b/crates/webui-wasm/src/handler.rs
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Handler-only WASM exports.
+
+use crate::error::WasmError;
+use js_sys::{Function, Object, Reflect};
+use serde_json::Value;
+use wasm_bindgen::prelude::*;
+use webui_handler::plugin::fast_v2::FastV2HydrationPlugin;
+use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
+use webui_handler::{HandlerError, RenderOptions, ResponseWriter, WebUIHandler};
+use webui_protocol::WebUIProtocol;
+
+/// A simple string buffer for collecting rendered output.
+#[cfg(test)]
+struct StringWriter {
+    content: String,
+}
+
+#[cfg(test)]
+impl StringWriter {
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            content: String::with_capacity(cap),
+        }
+    }
+}
+
+#[cfg(test)]
+impl ResponseWriter for StringWriter {
+    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+        self.content.push_str(content);
+        Ok(())
+    }
+
+    fn end(&mut self) -> webui_handler::Result<()> {
+        Ok(())
+    }
+}
+
+/// A writer that streams rendered fragments to a JavaScript callback.
+struct CallbackWriter<'a> {
+    on_chunk: &'a Function,
+}
+
+impl<'a> CallbackWriter<'a> {
+    fn new(on_chunk: &'a Function) -> Self {
+        Self { on_chunk }
+    }
+}
+
+impl ResponseWriter for CallbackWriter<'_> {
+    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+        self.on_chunk
+            .call1(&JsValue::UNDEFINED, &JsValue::from_str(content))
+            .map(|_| ())
+            .map_err(|e| HandlerError::Writer(format!("{e:?}")))
+    }
+
+    fn end(&mut self) -> webui_handler::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandlerPluginKind {
+    FastV2,
+    FastV3,
+    WebUI,
+}
+
+impl HandlerPluginKind {
+    fn parse(name: &str) -> Result<Self, WasmError> {
+        match name {
+            "fast" | "fast-v2" => Ok(Self::FastV2),
+            "fast-v3" => Ok(Self::FastV3),
+            "webui" => Ok(Self::WebUI),
+            other => Err(WasmError::UnknownPlugin(other.to_string())),
+        }
+    }
+}
+
+struct WasmRenderOptions {
+    entry: String,
+    request_path: String,
+    plugin: Option<HandlerPluginKind>,
+}
+
+impl Default for WasmRenderOptions {
+    fn default() -> Self {
+        Self {
+            entry: "index.html".to_string(),
+            request_path: "/".to_string(),
+            plugin: None,
+        }
+    }
+}
+
+/// Render a pre-built WebUI protocol with state data, streaming chunks to a callback.
+///
+/// # Arguments
+///
+/// * `protocol_bytes` - Protobuf bytes of the serialized `WebUIProtocol`.
+/// * `state_json` - JSON string of the state data.
+/// * `on_chunk` - Callback invoked with each rendered HTML fragment.
+/// * `options` - Optional object with `entry`, `requestPath`, and `plugin` fields.
+///
+/// # Returns
+///
+/// Nothing on success, or throws a JS error on failure.
+#[wasm_bindgen]
+pub fn render(
+    protocol_bytes: &[u8],
+    state_json: &str,
+    on_chunk: &Function,
+    options: Option<Object>,
+) -> Result<(), JsValue> {
+    let options = parse_render_options(options).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    render_stream_inner(protocol_bytes, state_json, on_chunk, &options)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Produce a complete JSON partial response for client-side navigation.
+///
+/// Combines application state, route templates, inventory, request path, and
+/// matched route chain into a single JSON string:
+/// `{"state":{...},"templates":[...],"inventory":"...","path":"...","chain":[...]}`.
+///
+/// Host servers return this directly - no assembly required.
+#[wasm_bindgen]
+pub fn render_partial(
+    protocol_bytes: &[u8],
+    state_json: &str,
+    entry_id: &str,
+    request_path: &str,
+    inventory_hex: &str,
+) -> Result<String, JsValue> {
+    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)
+        .map_err(|e| JsValue::from_str(&format!("Protocol error: {e}")))?;
+
+    let state: serde_json::Value = serde_json::from_str(state_json)
+        .map_err(|e| JsValue::from_str(&format!("invalid state JSON: {e}")))?;
+
+    let mut index = webui_handler::route_handler::ProtocolIndex::new(&protocol);
+
+    let mut result = webui_handler::route_handler::render_partial(
+        &protocol,
+        entry_id,
+        request_path,
+        inventory_hex,
+        &mut index,
+    )
+    .map_err(|e| JsValue::from_str(&format!("render_partial failed: {e}")))?;
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("state".into(), state);
+    }
+
+    serde_json::to_string(&result)
+        .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))
+}
+
+/// Extract the CSS token name list from protocol protobuf bytes.
+///
+/// Returns a JavaScript array of token name strings, preserving the original
+/// order from the build step.
+#[wasm_bindgen]
+pub fn protocol_tokens(protocol_bytes: &[u8]) -> Result<JsValue, JsValue> {
+    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)
+        .map_err(|e| JsValue::from_str(&format!("Protocol error: {e}")))?;
+
+    serde_wasm_bindgen::to_value(&protocol.tokens)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
+}
+
+/// Return component template payloads for requested component tags.
+#[wasm_bindgen]
+pub fn render_component_templates(
+    protocol_bytes: &[u8],
+    component_tags_json: &str,
+    inventory_hex: &str,
+) -> Result<String, JsValue> {
+    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)
+        .map_err(|e| JsValue::from_str(&format!("Protocol error: {e}")))?;
+
+    let tags: Vec<String> = serde_json::from_str(component_tags_json)
+        .map_err(|e| JsValue::from_str(&format!("invalid tags JSON: {e}")))?;
+    let tag_refs: Vec<&str> = tags.iter().map(String::as_str).collect();
+
+    let index = webui_handler::route_handler::ProtocolIndex::new(&protocol);
+
+    let result = webui_handler::route_handler::render_component_templates(
+        &protocol,
+        &tag_refs,
+        inventory_hex,
+        &index,
+    )
+    .map_err(|e| JsValue::from_str(&format!("render_component_templates failed: {e}")))?;
+
+    serde_json::to_string(&result)
+        .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))
+}
+
+fn render_stream_inner(
+    protocol_bytes: &[u8],
+    state_json: &str,
+    on_chunk: &Function,
+    options: &WasmRenderOptions,
+) -> Result<(), WasmError> {
+    let protocol = WebUIProtocol::from_protobuf(protocol_bytes)?;
+    render_protocol_to_callback(&protocol, state_json, options, on_chunk)
+}
+
+#[cfg(test)]
+pub(crate) fn render_protocol_to_string(
+    protocol: &WebUIProtocol,
+    state_json: &str,
+    entry: &str,
+    request_path: &str,
+    plugin: Option<HandlerPluginKind>,
+) -> Result<String, WasmError> {
+    let state: Value = serde_json::from_str(state_json).map_err(WasmError::State)?;
+
+    let mut writer = StringWriter::with_capacity(1024);
+    let handler = create_handler(plugin);
+    handler.render(
+        protocol,
+        &state,
+        &RenderOptions::new(entry, request_path),
+        &mut writer,
+    )?;
+
+    Ok(writer.content)
+}
+
+fn render_protocol_to_callback(
+    protocol: &WebUIProtocol,
+    state_json: &str,
+    options: &WasmRenderOptions,
+    on_chunk: &Function,
+) -> Result<(), WasmError> {
+    let state: Value = serde_json::from_str(state_json).map_err(WasmError::State)?;
+
+    let mut writer = CallbackWriter::new(on_chunk);
+    let handler = create_handler(options.plugin);
+    handler.render(
+        protocol,
+        &state,
+        &RenderOptions::new(&options.entry, &options.request_path),
+        &mut writer,
+    )?;
+
+    Ok(())
+}
+
+pub(crate) fn parse_optional_plugin(
+    plugin: Option<&str>,
+) -> Result<Option<HandlerPluginKind>, WasmError> {
+    plugin.map(HandlerPluginKind::parse).transpose()
+}
+
+fn parse_render_options(options: Option<Object>) -> Result<WasmRenderOptions, WasmError> {
+    let mut parsed = WasmRenderOptions::default();
+    let Some(options) = options else {
+        return Ok(parsed);
+    };
+
+    if let Some(entry) = optional_string_field(options.as_ref(), "entry")? {
+        parsed.entry = entry;
+    }
+    if let Some(request_path) = optional_string_field(options.as_ref(), "requestPath")? {
+        parsed.request_path = request_path;
+    }
+    let plugin = optional_string_field(options.as_ref(), "plugin")?;
+    parsed.plugin = parse_optional_plugin(plugin.as_deref())?;
+
+    Ok(parsed)
+}
+
+fn optional_string_field(options: &JsValue, field: &str) -> Result<Option<String>, WasmError> {
+    let value = Reflect::get(options, &JsValue::from_str(field)).map_err(|_| {
+        WasmError::InvalidOptions(format!("failed to read `{field}` from options object"))
+    })?;
+    if value.is_null() || value.is_undefined() {
+        return Ok(None);
+    }
+    value.as_string().map(Some).ok_or_else(|| {
+        WasmError::InvalidOptions(format!("`{field}` must be a string when provided"))
+    })
+}
+
+fn create_handler(plugin: Option<HandlerPluginKind>) -> WebUIHandler {
+    match plugin {
+        Some(HandlerPluginKind::FastV2) => {
+            WebUIHandler::with_plugin(|| Box::new(FastV2HydrationPlugin::new()))
+        }
+        Some(HandlerPluginKind::FastV3) => {
+            WebUIHandler::with_plugin(|| Box::new(FastV3HydrationPlugin::new()))
+        }
+        Some(HandlerPluginKind::WebUI) => {
+            WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()))
+        }
+        None => WebUIHandler::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_plugin_keeps_fast_aliases_parser_free() {
+        assert_eq!(
+            parse_optional_plugin(Some("fast")).unwrap(),
+            Some(HandlerPluginKind::FastV2)
+        );
+        assert_eq!(
+            parse_optional_plugin(Some("fast-v2")).unwrap(),
+            Some(HandlerPluginKind::FastV2)
+        );
+        assert_eq!(
+            parse_optional_plugin(Some("fast-v3")).unwrap(),
+            Some(HandlerPluginKind::FastV3)
+        );
+        assert_eq!(
+            parse_optional_plugin(Some("webui")).unwrap(),
+            Some(HandlerPluginKind::WebUI)
+        );
+    }
+
+    #[test]
+    fn parse_plugin_rejects_unknown_names() {
+        let err = parse_optional_plugin(Some("unknown")).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Unknown plugin: unknown. Use \"webui\", \"fast-v3\", \"fast-v2\", or \"fast\"."
+        );
+    }
+}

--- a/crates/webui-wasm/src/lib.rs
+++ b/crates/webui-wasm/src/lib.rs
@@ -3,337 +3,42 @@
 
 //! WebAssembly bindings for the WebUI framework.
 //!
-//! This crate exposes the WebUI rendering pipeline to JavaScript via `wasm-bindgen`,
-//! powering the interactive playground in the documentation site.
-//!
-//! Two modes of operation:
-//! - **`render`** — Takes a pre-built protocol (JSON) + state and renders HTML.
-//! - **`build_and_render`** — Takes virtual files + state, parses and renders HTML
-//!   using the real `webui-parser` (same parser used by the CLI).
+//! This crate can be built as three WASM variants:
+//! - **handler** - render pre-built protocol bytes with state.
+//! - **parser** - build protocol bytes from virtual files.
+//! - **all** - parser plus handler exports for playground-style live preview.
 
-use serde_json::Value;
-use std::collections::HashMap;
-use wasm_bindgen::prelude::*;
-use webui_handler::plugin::fast_v2::FastV2HydrationPlugin;
-use webui_handler::plugin::fast_v3::FastV3HydrationPlugin;
-use webui_handler::plugin::webui::WebUIHydrationPlugin;
-use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
-use webui_parser::plugin::webui::WebUIParserPlugin;
-use webui_parser::{CssStrategy, HtmlParser, Plugin};
-use webui_protocol::WebUIProtocol;
+mod error;
 
-/// A simple string buffer for collecting rendered output.
-struct StringWriter {
-    content: String,
-}
+#[cfg(all(not(feature = "handler"), not(feature = "parser")))]
+compile_error!("microsoft-webui-wasm requires at least one of the `handler` or `parser` features");
 
-impl StringWriter {
-    fn with_capacity(cap: usize) -> Self {
-        Self {
-            content: String::with_capacity(cap),
-        }
-    }
-}
+#[cfg(feature = "handler")]
+mod handler;
+#[cfg(feature = "parser")]
+mod parser;
 
-impl ResponseWriter for StringWriter {
-    fn write(&mut self, content: &str) -> webui_handler::Result<()> {
-        self.content.push_str(content);
-        Ok(())
-    }
+#[cfg(feature = "handler")]
+pub use handler::{protocol_tokens, render, render_component_templates, render_partial};
+#[cfg(feature = "parser")]
+pub use parser::build_protocol;
 
-    fn end(&mut self) -> webui_handler::Result<()> {
-        Ok(())
-    }
-}
-
-/// Render a pre-built WebUI protocol with state data.
-///
-/// # Arguments
-///
-/// * `protocol_json` — JSON string of the serialized `WebUIProtocol`.
-/// * `state_json` — JSON string of the state data.
-/// * `plugin` — Optional plugin identifier (see crate documentation for available identifiers).
-///
-/// # Returns
-///
-/// The rendered HTML string, or throws a JS error on failure.
-#[wasm_bindgen]
-pub fn render(
-    protocol_json: &str,
-    state_json: &str,
-    entry: &str,
-    request_path: &str,
-    plugin: Option<String>,
-) -> Result<String, JsValue> {
-    let plugin = plugin
-        .map(|s| s.parse::<Plugin>())
-        .transpose()
-        .map_err(|e| JsValue::from_str(&e))?;
-    render_inner(protocol_json, state_json, entry, request_path, plugin)
-        .map_err(|e| JsValue::from_str(&e.to_string()))
-}
-
-/// Build and render a WebUI application from virtual files.
-///
-/// Uses a lightweight pure-Rust parser suitable for the playground.
-/// Handles signals, for-loops, if-conditions, components, and dynamic attributes.
-///
-/// # Arguments
-///
-/// * `files` — A JS object mapping filenames to their string content.
-///   Example: `{ "index.html": "<h1>{{title}}</h1>", "my-card.html": "<p><slot></slot></p>" }`
-/// * `state_json` — A JSON string of the state data to render with.
-/// * `entry` — The entry HTML filename (e.g. `"index.html"`).
-///
-/// # Returns
-///
-/// The rendered HTML string, or throws a JS error on failure.
-#[wasm_bindgen]
-pub fn build_and_render(
-    files: JsValue,
-    state_json: &str,
-    entry: &str,
-    request_path: &str,
-) -> Result<String, JsValue> {
-    let files_map: HashMap<String, String> =
-        serde_wasm_bindgen::from_value(files).map_err(|e| JsValue::from_str(&e.to_string()))?;
-
-    build_and_render_inner(&files_map, state_json, entry, request_path)
-        .map_err(|e| JsValue::from_str(&e.to_string()))
-}
-
-/// Build the protocol JSON from virtual files without rendering.
-///
-/// Returns the serialized `WebUIProtocol` as a JSON string.
-#[wasm_bindgen]
-pub fn build_protocol(files: JsValue, entry: &str) -> Result<String, JsValue> {
-    let files_map: HashMap<String, String> =
-        serde_wasm_bindgen::from_value(files).map_err(|e| JsValue::from_str(&e.to_string()))?;
-
-    build_protocol_inner(&files_map, entry).map_err(|e| JsValue::from_str(&e.to_string()))
-}
-
-/// Produce a complete JSON partial response for client-side navigation.
-///
-/// Combines application state, route templates, inventory, request path, and
-/// matched route chain into a single JSON string:
-/// `{"state":{...},"templates":[...],"inventory":"...","path":"...","chain":[...]}`.
-///
-/// Host servers return this directly — no assembly required.
-#[wasm_bindgen]
-pub fn render_partial(
-    protocol_json: &str,
-    state_json: &str,
-    entry_id: &str,
-    request_path: &str,
-    inventory_hex: &str,
-) -> Result<String, JsValue> {
-    let protocol: WebUIProtocol = serde_json::from_str(protocol_json)
-        .map_err(|e| JsValue::from_str(&format!("Protocol JSON error: {e}")))?;
-
-    let state: serde_json::Value = serde_json::from_str(state_json)
-        .map_err(|e| JsValue::from_str(&format!("invalid state JSON: {e}")))?;
-
-    // TODO: ProtocolIndex is created per-request here. Ideally the host should
-    // cache it alongside the protocol — it's deterministic per protocol.
-    let mut index = webui_handler::route_handler::ProtocolIndex::new(&protocol);
-
-    let mut result = webui_handler::route_handler::render_partial(
-        &protocol,
-        entry_id,
-        request_path,
-        inventory_hex,
-        &mut index,
-    )
-    .map_err(|e| JsValue::from_str(&format!("render_partial failed: {e}")))?;
-    if let Some(obj) = result.as_object_mut() {
-        obj.insert("state".into(), state);
-    }
-
-    serde_json::to_string(&result)
-        .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))
-}
-
-/// Extract the CSS token name list from a protocol JSON string.
-///
-/// Returns a JavaScript array of token name strings, preserving the original
-/// order from the build step.
-#[wasm_bindgen]
-pub fn protocol_tokens(protocol_json: &str) -> Result<JsValue, JsValue> {
-    let protocol: WebUIProtocol = serde_json::from_str(protocol_json)
-        .map_err(|e| JsValue::from_str(&format!("Protocol JSON error: {e}")))?;
-
-    serde_wasm_bindgen::to_value(&protocol.tokens)
-        .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
-}
-
-#[wasm_bindgen]
-pub fn render_component_templates(
-    protocol_json: &str,
-    component_tags_json: &str,
-    inventory_hex: &str,
-) -> Result<String, JsValue> {
-    let protocol: WebUIProtocol = serde_json::from_str(protocol_json)
-        .map_err(|e| JsValue::from_str(&format!("Protocol JSON error: {e}")))?;
-
-    let tags: Vec<String> = serde_json::from_str(component_tags_json)
-        .map_err(|e| JsValue::from_str(&format!("invalid tags JSON: {e}")))?;
-    let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
-
-    // Per-request index — see ProtocolIndex doc for caching guidance.
-    let index = webui_handler::route_handler::ProtocolIndex::new(&protocol);
-
-    let result = webui_handler::route_handler::render_component_templates(
-        &protocol,
-        &tag_refs,
-        inventory_hex,
-        &index,
-    )
-    .map_err(|e| JsValue::from_str(&format!("render_component_templates failed: {e}")))?;
-
-    serde_json::to_string(&result)
-        .map_err(|e| JsValue::from_str(&format!("JSON serialize error: {e}")))
-}
-
-fn build_protocol_inner(
-    files: &HashMap<String, String>,
-    entry: &str,
-) -> Result<String, BuildError> {
-    let protocol = parse_to_protocol(files, entry)?;
-    serde_json::to_string(&protocol).map_err(BuildError::Protocol)
-}
-
-/// Create a handler with an optional plugin.
-fn create_handler(plugin: Option<Plugin>) -> Result<WebUIHandler, BuildError> {
-    match plugin {
-        Some(Plugin::Fast | Plugin::FastV2) => Ok(WebUIHandler::with_plugin(|| {
-            Box::new(FastV2HydrationPlugin::new())
-        })),
-        Some(Plugin::FastV3) => Ok(WebUIHandler::with_plugin(|| {
-            Box::new(FastV3HydrationPlugin::new())
-        })),
-        Some(Plugin::WebUI) => Ok(WebUIHandler::with_plugin(|| {
-            Box::new(WebUIHydrationPlugin::new())
-        })),
-        None => Ok(WebUIHandler::new()),
-    }
-}
-
-fn render_inner(
-    protocol_json: &str,
-    state_json: &str,
-    entry: &str,
-    request_path: &str,
-    plugin: Option<Plugin>,
-) -> Result<String, BuildError> {
-    let protocol: WebUIProtocol =
-        serde_json::from_str(protocol_json).map_err(BuildError::Protocol)?;
-    let state: Value = serde_json::from_str(state_json).map_err(BuildError::State)?;
-
-    let mut writer = StringWriter::with_capacity(1024);
-    let handler = create_handler(plugin)?;
-    handler.render(
-        &protocol,
-        &state,
-        &RenderOptions::new(entry, request_path),
-        &mut writer,
-    )?;
-
-    Ok(writer.content)
-}
-
-/// Core build-and-render implementation (testable without WASM).
-pub(crate) fn build_and_render_inner(
-    files: &HashMap<String, String>,
-    state_json: &str,
-    entry: &str,
-    request_path: &str,
-) -> Result<String, BuildError> {
-    let protocol = parse_to_protocol(files, entry)?;
-
-    let state: Value = serde_json::from_str(state_json).map_err(BuildError::State)?;
-
-    let mut writer = StringWriter::with_capacity(1024);
-    let handler = create_handler(None)?;
-    handler.render(
-        &protocol,
-        &state,
-        &RenderOptions::new(entry, request_path),
-        &mut writer,
-    )?;
-
-    Ok(writer.content)
-}
-
-/// Register all component `.html` files (and their optional `.css`) from the
-/// virtual file map, skipping the entry. Shared by protocol generation and
-/// authoring validation.
-fn register_components(
-    parser: &mut HtmlParser,
-    files: &HashMap<String, String>,
-    entry: &str,
-) -> Result<(), BuildError> {
-    for (filename, content) in files {
-        if filename != entry && filename.ends_with(".html") {
-            let tag_name = filename.trim_end_matches(".html");
-            if tag_name.contains('-') {
-                let css_key = format!("{tag_name}.css");
-                let css = files.get(&css_key).map(|s| s.as_str());
-                parser
-                    .component_registry_mut()
-                    .register_component(tag_name, content, css)?;
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Parse virtual files into a `WebUIProtocol` using the real `webui-parser`
-/// with the WebUI plugin. Compiling the tracked component templates also
-/// validates them, so authoring mistakes — an invalid `@event` handler or a
-/// non-braced `w-ref` — surface as a `ParserError::Template` error (and thus a
-/// catchable JS error) instead of passing silently.
-fn parse_to_protocol(
-    files: &HashMap<String, String>,
-    entry: &str,
-) -> Result<WebUIProtocol, BuildError> {
-    let entry_html = files
-        .get(entry)
-        .ok_or_else(|| BuildError::MissingEntry(entry.to_string()))?;
-
-    let mut parser =
-        HtmlParser::with_plugin_options(Box::new(WebUIParserPlugin::new()), CssStrategy::Style);
-    register_components(&mut parser, files, entry)?;
-    parser.parse(entry, entry_html)?;
-    // Compile tracked component templates; this is where @event / w-ref
-    // authoring mistakes are reported.
-    parser.take_plugin_artifacts()?;
-
-    Ok(WebUIProtocol::new(parser.into_fragment_records()))
-}
-
-/// Errors from the build-and-render pipeline.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum BuildError {
-    #[error("Entry file '{0}' not found")]
-    MissingEntry(String),
-
-    #[error("{0}")]
-    Parse(#[from] webui_parser::ParserError),
-
-    #[error("Protocol JSON error: {0}")]
-    Protocol(serde_json::Error),
-
-    #[error("State JSON error: {0}")]
-    State(serde_json::Error),
-
-    #[error("{0}")]
-    Render(#[from] webui_handler::HandlerError),
-}
-
-#[cfg(test)]
+#[cfg(all(test, feature = "handler", feature = "parser"))]
 mod tests {
     use super::*;
+    use crate::error::WasmError;
+    use std::collections::HashMap;
+    use webui_protocol::WebUIProtocol;
+
+    fn render_files_for_test(
+        files: &HashMap<String, String>,
+        state_json: &str,
+        entry: &str,
+        request_path: &str,
+    ) -> Result<String, WasmError> {
+        let protocol = parser::parse_to_protocol(files, entry)?;
+        handler::render_protocol_to_string(&protocol, state_json, entry, request_path, None)
+    }
 
     #[test]
     fn test_simple_render() {
@@ -343,14 +48,14 @@ mod tests {
             "<h1>Hello, {{name}}!</h1>".to_string(),
         );
 
-        let result = build_and_render_inner(&files, r#"{"name": "WebUI"}"#, "index.html", "/");
+        let result = render_files_for_test(&files, r#"{"name": "WebUI"}"#, "index.html", "/");
         assert_eq!(result.unwrap(), "<h1>Hello, WebUI!</h1>");
     }
 
     #[test]
     fn test_missing_entry_file() {
         let files = HashMap::new();
-        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        let result = render_files_for_test(&files, "{}", "index.html", "/");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("not found"), "Unexpected error: {}", err);
@@ -368,7 +73,7 @@ mod tests {
             r#"<div><input w-ref="myInput" /></div>"#.to_string(),
         );
 
-        let result = build_protocol_inner(&files, "index.html");
+        let result = parser::build_protocol_inner(&files, "index.html");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -382,7 +87,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_and_render_surfaces_invalid_event_handler() {
+    fn test_render_files_surfaces_invalid_event_handler() {
         let mut files = HashMap::new();
         files.insert("index.html".to_string(), "<my-btn>x</my-btn>".to_string());
         files.insert(
@@ -390,7 +95,7 @@ mod tests {
             r#"<div><button @click="e.preventDefault()">x</button></div>"#.to_string(),
         );
 
-        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        let result = render_files_for_test(&files, "{}", "index.html", "/");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -415,7 +120,7 @@ mod tests {
             "<div class=\"card\"><slot></slot></div>".to_string(),
         );
 
-        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        let result = render_files_for_test(&files, "{}", "index.html", "/");
         assert!(result.is_ok(), "Render failed: {:?}", result);
         let html = result.as_deref().unwrap_or("");
         assert!(html.contains("card"), "Expected card class in: {}", html);
@@ -430,7 +135,7 @@ mod tests {
         );
 
         let state = r#"{"items": [{"name": "A"}, {"name": "B"}]}"#;
-        let result = build_and_render_inner(&files, state, "index.html", "/");
+        let result = render_files_for_test(&files, state, "index.html", "/");
         assert!(result.is_ok(), "Render failed: {:?}", result);
         let html = result.as_deref().unwrap_or("");
         assert!(html.contains("A"), "Expected 'A' in: {}", html);
@@ -445,10 +150,10 @@ mod tests {
             "<if condition=\"show\">Visible</if>".to_string(),
         );
 
-        let result_true = build_and_render_inner(&files, r#"{"show": true}"#, "index.html", "/");
+        let result_true = render_files_for_test(&files, r#"{"show": true}"#, "index.html", "/");
         assert_eq!(result_true.unwrap(), "Visible");
 
-        let result_false = build_and_render_inner(&files, r#"{"show": false}"#, "index.html", "/");
+        let result_false = render_files_for_test(&files, r#"{"show": false}"#, "index.html", "/");
         assert_eq!(result_false.unwrap(), "");
     }
 
@@ -457,7 +162,7 @@ mod tests {
         let mut files = HashMap::new();
         files.insert("index.html".to_string(), "<p>Hi</p>".to_string());
 
-        let result = build_and_render_inner(&files, "not json", "index.html", "/");
+        let result = render_files_for_test(&files, "not json", "index.html", "/");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -480,10 +185,9 @@ mod tests {
         );
         files.insert("my-card.css".to_string(), "p { color: red; }".to_string());
 
-        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        let result = render_files_for_test(&files, "{}", "index.html", "/");
         assert!(result.is_ok(), "Render failed: {:?}", result);
         let html = result.as_deref().unwrap_or("");
-        // WASM uses CssStrategy::Style, so CSS should be in <style> tags, not <link>
         assert!(
             html.contains("<style>p { color: red; }</style>"),
             "Expected inline <style> tag in: {}",
@@ -505,7 +209,7 @@ mod tests {
         );
 
         let result =
-            build_and_render_inner(&files, r#"{"raw_html": "<b>bold</b>"}"#, "index.html", "/");
+            render_files_for_test(&files, r#"{"raw_html": "<b>bold</b>"}"#, "index.html", "/");
         assert!(result.is_ok(), "Render failed: {:?}", result);
         let html = result.as_deref().unwrap_or("");
         assert!(
@@ -523,15 +227,15 @@ mod tests {
             "<h1>Static</h1><p>Content</p>".to_string(),
         );
 
-        let result = build_and_render_inner(&files, "{}", "index.html", "/");
+        let result = render_files_for_test(&files, "{}", "index.html", "/");
         assert_eq!(result.unwrap(), "<h1>Static</h1><p>Content</p>");
     }
 
     #[test]
     fn test_protocol_tokens_empty() {
         let protocol = WebUIProtocol::new(HashMap::new());
-        let json = serde_json::to_string(&protocol).unwrap();
-        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        let bytes = protocol.to_protobuf().unwrap();
+        let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert!(decoded.tokens.is_empty());
     }
 
@@ -542,8 +246,8 @@ mod tests {
             "fontSizeBase300".to_string(),
         ];
         let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
-        let json = serde_json::to_string(&protocol).unwrap();
-        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        let bytes = protocol.to_protobuf().unwrap();
+        let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert_eq!(decoded.tokens, tokens);
     }
 
@@ -551,8 +255,8 @@ mod tests {
     fn test_protocol_tokens_preserves_order() {
         let tokens = vec!["zeta".to_string(), "alpha".to_string(), "zeta".to_string()];
         let protocol = WebUIProtocol::with_tokens(HashMap::new(), tokens.clone());
-        let json = serde_json::to_string(&protocol).unwrap();
-        let decoded: WebUIProtocol = serde_json::from_str(&json).unwrap();
+        let bytes = protocol.to_protobuf().unwrap();
+        let decoded = WebUIProtocol::from_protobuf(&bytes).unwrap();
         assert_eq!(decoded.tokens, tokens);
     }
 }

--- a/crates/webui-wasm/src/parser.rs
+++ b/crates/webui-wasm/src/parser.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Parser-only WASM exports.
+
+use crate::error::WasmError;
+use std::collections::HashMap;
+use wasm_bindgen::prelude::*;
+use webui_parser::plugin::webui::WebUIParserPlugin;
+use webui_parser::{CssStrategy, HtmlParser};
+use webui_protocol::WebUIProtocol;
+
+/// Build protocol protobuf bytes from virtual files without rendering.
+///
+/// Returns the serialized `WebUIProtocol` as protobuf bytes.
+#[wasm_bindgen]
+pub fn build_protocol(files: JsValue, entry: &str) -> Result<Vec<u8>, JsValue> {
+    let files_map: HashMap<String, String> =
+        serde_wasm_bindgen::from_value(files).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    build_protocol_inner(&files_map, entry).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+pub(crate) fn build_protocol_inner(
+    files: &HashMap<String, String>,
+    entry: &str,
+) -> Result<Vec<u8>, WasmError> {
+    let protocol = parse_to_protocol(files, entry)?;
+    protocol.to_protobuf().map_err(WasmError::Protocol)
+}
+
+/// Register all component `.html` files and optional companion `.css` files
+/// from the virtual file map, skipping the entry.
+fn register_components(
+    parser: &mut HtmlParser,
+    files: &HashMap<String, String>,
+    entry: &str,
+) -> Result<(), WasmError> {
+    for (filename, content) in files {
+        if filename != entry && filename.ends_with(".html") {
+            let tag_name = filename.trim_end_matches(".html");
+            if tag_name.contains('-') {
+                let css_key = format!("{tag_name}.css");
+                let css = files.get(&css_key).map(String::as_str);
+                parser
+                    .component_registry_mut()
+                    .register_component(tag_name, content, css)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse virtual files into a `WebUIProtocol` using the real `webui-parser`
+/// with the WebUI plugin.
+pub(crate) fn parse_to_protocol(
+    files: &HashMap<String, String>,
+    entry: &str,
+) -> Result<WebUIProtocol, WasmError> {
+    let entry_html = files
+        .get(entry)
+        .ok_or_else(|| WasmError::MissingEntry(entry.to_string()))?;
+
+    let mut parser =
+        HtmlParser::with_plugin_options(Box::new(WebUIParserPlugin::new()), CssStrategy::Style);
+    register_components(&mut parser, files, entry)?;
+    parser.parse(entry, entry_html)?;
+    parser.take_plugin_artifacts()?;
+
+    Ok(WebUIProtocol::new(parser.into_fragment_records()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_protocol_reports_missing_entry() {
+        let files = HashMap::new();
+        let err = build_protocol_inner(&files, "index.html").unwrap_err();
+        assert_eq!(err.to_string(), "Entry file 'index.html' not found");
+    }
+}

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -23,8 +23,13 @@ import { json as jsonLang } from "@codemirror/lang-json";
 import { css as cssLang } from "@codemirror/lang-css";
 
 interface WasmModule {
-  build_protocol(files: Record<string, string>, entry: string): string;
-  render(protocol: string, state: string, entry: string, path: string): string;
+  build_protocol(files: Record<string, string>, entry: string): Uint8Array;
+  render(
+    protocol: Uint8Array,
+    state: string,
+    onChunk: (chunk: string) => void,
+    options?: { entry?: string; requestPath?: string; plugin?: string },
+  ): void;
 }
 
 interface FileEntry {
@@ -862,7 +867,9 @@ export class DocsPlayground extends WebUIElement {
   }
 
   private doRender(): void {
-    if (!this.wasm) return;
+    if (!this.wasm) {
+      return;
+    }
     try {
       this.setPreviewStatus("Compiling", "compiling");
       this.clearError();
@@ -875,7 +882,12 @@ export class DocsPlayground extends WebUIElement {
       const proto = this.wasm.build_protocol(filesObj, this.entry);
       const t1 = performance.now();
       const stateJson = this.fileByName(this.stateFile)?.content || "{}";
-      const html = this.wasm.render(proto, stateJson, this.entry, "/");
+      let html = "";
+      let chunks = 0;
+      this.wasm.render(proto, stateJson, (chunk) => {
+        chunks += 1;
+        html += chunk;
+      }, { entry: this.entry, requestPath: "/" });
       const t2 = performance.now();
 
       this.buildMs = (t1 - t0).toFixed(1);
@@ -933,14 +945,15 @@ export class DocsPlayground extends WebUIElement {
       this.setPreviewStatus("Loading WASM", "loading");
       const baseMeta = document.querySelector('meta[name="base"]');
       const base = baseMeta?.getAttribute("content") || "/";
-      const mod = await import(/* @vite-ignore */ base + "wasm/webui_wasm.js");
+      const wasmUrl = base + "wasm/all/webui_wasm_all.js";
+      const mod = await import(/* @vite-ignore */ wasmUrl);
       await mod.default();
       this.wasm = mod;
       this.doRender();
     } catch (e) {
       this.setPreviewStatus("Failed", "failed");
       this.setError(
-        'WASM not available. Run "cargo xtask build-wasm" to enable the playground.\n\n' +
+        'WASM not available at "wasm/all/webui_wasm_all.js". Run "cargo xtask build-wasm" to enable the playground.\n\n' +
           String(e),
       );
     }

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -991,6 +991,28 @@ const protocol = readFileSync('./dist/protocol.bin');
 const html = render(protocol, JSON.stringify(state), 'index.html', req.url);
 ```
 
+### WebAssembly
+
+Use the split WASM bundles when rendering or parsing in the browser:
+
+```javascript
+import initHandler, { render } from './wasm/handler/webui_wasm_handler.js';
+await initHandler();
+const protocolBytes = new Uint8Array(await (await fetch('/protocol.bin')).arrayBuffer());
+let html = '';
+render(protocolBytes, JSON.stringify(state), (chunk) => {
+  html += chunk;
+}, { entry: 'index.html', requestPath: '/', plugin: 'webui' });
+```
+
+```javascript
+import initParser, { build_protocol } from './wasm/parser/webui_wasm_parser.js';
+await initParser();
+const protocolBytes = build_protocol({ 'index.html': '<h1>{{title}}</h1>' }, 'index.html');
+```
+
+Use `wasm/all/webui_wasm_all.js` when both parser and handler exports are needed in one module, such as a playground.
+
 ### Python (FFI)
 
 ```python

--- a/docs/guide/integrations/index.md
+++ b/docs/guide/integrations/index.md
@@ -7,7 +7,7 @@ Pick the handler that matches your stack:
 - [**Rust**](./rust), High-performance native rendering with the Rust programming language
 - [**Node**](./node), Streaming SSR via a native addon built with napi-rs for Node, Bun, and Deno.
 - [**Electron**](./electron), Desktop apps via Electron with custom `webui://` protocol
-- [**WebAssembly**](./wasm), In-browser rendering for playgrounds and client-side use
+- [**WebAssembly**](./wasm), Split parser, handler, and combined browser bundles
 - [**C / FFI**](./ffi), Shared library for Go, C#, Python, and any language with C interop
 
 ## How Handlers Work

--- a/docs/guide/integrations/wasm.md
+++ b/docs/guide/integrations/wasm.md
@@ -1,135 +1,121 @@
-# WebUI WebAssembly Handler
+# WebUI WebAssembly
 
-The WebUI WASM handler compiles the full rendering pipeline to WebAssembly via `wasm-bindgen`, enabling client-side rendering directly in the browser. It powers the interactive [Playground](/playground/) in the documentation site.
+WebUI provides browser-ready WebAssembly bindings through `wasm-bindgen`. The bindings are built as three variants so you can choose only the parser, only the handler, or the combined playground bundle.
 
-## How It Works
+## Variants
 
-The WASM module includes the real `webui-parser` and `webui-handler` - the same code used by the CLI and the Rust handler. This means templates parsed in the browser produce identical output to server-side rendering.
+| Variant | Import path | Exports | Use when |
+|---------|-------------|---------|----------|
+| Handler | `wasm/handler/webui_wasm_handler.js` | `render`, `render_partial`, `protocol_tokens`, `render_component_templates` | You already have protocol bytes and only need rendering |
+| Parser | `wasm/parser/webui_wasm_parser.js` | `build_protocol` | You need to compile virtual browser files into protocol bytes |
+| All | `wasm/all/webui_wasm_all.js` | Parser and handler exports | You need both sides in one module, such as the docs playground |
 
-Two modes of operation are available:
+The handler-only bundle excludes `webui-parser`, and the parser-only bundle excludes `webui-handler`. The combined bundle keeps the previous playground behavior.
 
-1. **`render`** - Takes a pre-built protocol (JSON) + state and renders HTML
-2. **`build_and_render`** - Takes virtual files + state, parses and renders in one call
-
-## Building the WASM Module
+## Building the WASM bundles
 
 ```bash
 cargo xtask build-wasm
 ```
 
-The output is committed to the repository under `docs/` for use by the playground. Most developers don't need to rebuild it - only rebuild when you change Rust code in the core crates.
+The output is generated under `docs/.webui-press/public/wasm/` for the documentation playground and release staging. Rebuild it when Rust code in `webui-wasm`, `webui-parser`, `webui-handler`, or `webui-protocol` changes.
 
-## API Reference
+## Handler-only API
 
-### `render(protocolJson, stateJson, plugin?)`
+Use the handler bundle when the protocol was built elsewhere and loaded as protobuf bytes in the browser.
+
+```js
+import init, { render } from './wasm/handler/webui_wasm_handler.js';
+
+await init();
+
+const protocolBytes = new Uint8Array(await (await fetch('/protocol.bin')).arrayBuffer());
+const stateJson = '{"title": "Hello"}';
+let html = '';
+
+render(protocolBytes, stateJson, (chunk) => {
+  html += chunk;
+}, { entry: 'index.html', requestPath: '/', plugin: 'webui' });
+```
+
+### `render(protocolBytes, stateJson, onChunk, options?)`
 
 Render a pre-built WebUI protocol with state data.
 
-```js
-import init, { render } from './webui_wasm.js';
-
-await init();
-
-const protocolJson = '{"fragments": {...}}';
-const stateJson = '{"title": "Hello"}';
-
-const html = render(protocolJson, stateJson);
-```
-
-**Parameters:**
-
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `protocolJson` | `string` | JSON-serialized `WebUIProtocol` |
-| `stateJson` | `string` | JSON string with the render state |
-| `plugin` | `string \| undefined` | Parser plugin name (see [Plugins](/guide/concepts/plugins/) for the available identifiers) |
+| `protocolBytes` | `Uint8Array` | Protobuf-serialized `WebUIProtocol`, such as `protocol.bin` |
+| `stateJson` | `string` | JSON string with render state |
+| `onChunk` | `(html: string) => void` | Callback invoked with each rendered HTML fragment |
+| `options.entry` | `string \| undefined` | Entry fragment ID, defaults to `index.html` |
+| `options.requestPath` | `string \| undefined` | Request path used for route matching, defaults to `/` |
+| `options.plugin` | `string \| undefined` | Handler plugin name, such as `webui`, `fast-v3`, `fast-v2`, or `fast` |
 
-**Returns:** Rendered HTML string. Throws on error.
+Returns nothing on success. Throws on protocol, state, plugin, callback, or render errors.
 
-### `build_and_render(files, stateJson, entry)`
+### Additional handler exports
 
-Parse virtual files and render in a single call. This is the primary API for the playground, where no filesystem is available.
+| Export | Description |
+|--------|-------------|
+| `render_partial(protocolBytes, stateJson, entry, requestPath, inventoryHex)` | Returns the JSON partial-navigation response with `state` included |
+| `protocol_tokens(protocolBytes)` | Returns the protocol CSS token names as a JavaScript array |
+| `render_component_templates(protocolBytes, componentTagsJson, inventoryHex)` | Returns template and style payloads for requested components |
+
+## Parser-only API
+
+Use the parser bundle when browser code needs to compile an in-memory file map into protocol bytes.
 
 ```js
-import init, { build_and_render } from './webui_wasm.js';
+import init, { build_protocol } from './wasm/parser/webui_wasm_parser.js';
 
 await init();
 
 const files = {
-  'index.html': '<h1>Hello, {{name}}!</h1>',
-  'my-card.html': '<div class="card"><slot></slot></div>',
-  'my-card.css': '.card { border: 1px solid #ccc; }'
+  'index.html': '<h1>{{title}}</h1>',
+  'my-card.html': '<p><slot></slot></p>',
+  'my-card.css': 'p { color: red; }',
 };
-const stateJson = '{"name": "WebUI"}';
 
-const html = build_and_render(files, stateJson, 'index.html');
-// → '<h1>Hello, WebUI!</h1>'
+const protocolBytes = build_protocol(files, 'index.html');
 ```
-
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `files` | `Record<string, string>` | Map of filenames to content |
-| `stateJson` | `string` | JSON string with the render state |
-| `entry` | `string` | Entry HTML filename (e.g., `"index.html"`) |
-
-**Returns:** Rendered HTML string. Throws on error.
-
-**Component discovery:** HTML files with a hyphen in the name are automatically registered as components (e.g., `my-card.html` → `<my-card>`). Matching `.css` files are paired and inlined via `<style>` tags.
 
 ### `build_protocol(files, entry)`
 
-Parse virtual files into a WebUI protocol without rendering. Returns the serialized protocol as a JSON string.
-
-```js
-import init, { build_protocol } from './webui_wasm.js';
-
-await init();
-
-const files = {
-  'index.html': '<h1>{{title}}</h1>'
-};
-
-const protocolJson = build_protocol(files, 'index.html');
-// Use with render() later
-```
-
-**Parameters:**
+Parse virtual files into a WebUI protocol without rendering.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `files` | `Record<string, string>` | Map of filenames to content |
 | `entry` | `string` | Entry HTML filename |
 
-**Returns:** JSON string of the `WebUIProtocol`.
+Returns protobuf-serialized `WebUIProtocol` as a `Uint8Array`. Throws on missing entry files, invalid templates, invalid component authoring, or protocol serialization errors.
 
-## Using Plugins
+Component discovery follows the virtual file map convention: HTML files with a hyphen in the name are registered as components, such as `my-card.html` for `<my-card>`. Matching `.css` files are paired and inlined with `CssStrategy::Style`.
 
-Pass a plugin identifier (see [Plugins](/guide/concepts/plugins/)) as the `plugin` parameter to enable hydration markers:
+## Combined API
+
+Use the combined bundle when you want parser and handler exports from one module.
 
 ```js
-const html = render(protocolJson, stateJson, 'webui');
+import init, { build_protocol, render } from './wasm/all/webui_wasm_all.js';
+
+await init();
+
+const protocolBytes = build_protocol(files, 'index.html');
+let html = '';
+render(protocolBytes, stateJson, (chunk) => {
+  html += chunk;
+}, { entry: 'index.html', requestPath: '/' });
 ```
 
-The plugin runs the same parser/handler code used by the CLI; output is byte-identical to a server-side render with the same plugin selected.
+The documentation playground imports this combined bundle and currently uses `build_protocol` followed by `render` so it can measure compile and render time separately.
 
-## Playground Integration
-
-The documentation playground uses `build_and_render` to provide a live editing experience:
-
-1. User edits template HTML, component files, and state JSON in the browser
-2. On each change, `build_and_render` is called with the virtual files
-3. The rendered HTML is displayed in a preview pane
-
-This provides instant feedback with the exact same parser and handler used in production builds.
-
-## Differences from Server-Side Rendering
+## Differences from server-side rendering
 
 | Aspect | Server (CLI / Rust / Node) | WASM (Browser) |
 |--------|---------------------------|----------------|
-| Protocol format | Protobuf binary | JSON |
-| CSS strategy | Link (default) or style | Always inline |
-| File I/O | Filesystem | Virtual file map |
-| Streaming | Yes (callback-based) | No (returns full string) |
-| Plugin support | Yes | Yes |
+| Protocol format | Protobuf binary | Protobuf bytes |
+| CSS strategy | Link by default, Style or Module when configured | Style for virtual file builds |
+| File I/O | Filesystem and component discovery sources | Virtual file map |
+| Streaming | Supported by native handlers | `render()` calls a JavaScript chunk callback |
+| Bundle choice | Native crates/addons | Handler-only, parser-only, or combined WASM |

--- a/xtask/src/build_wasm.rs
+++ b/xtask/src/build_wasm.rs
@@ -3,18 +3,48 @@
 
 //! WASM playground build task.
 //!
-//! Builds the `webui-wasm` crate to WebAssembly via `wasm-pack` and writes the
-//! generated bundle into the documentation playground's public assets.
+//! Builds the `webui-wasm` crate to WebAssembly via `wasm-pack` and writes
+//! handler, parser, and combined bundles into the documentation public assets.
 
 use crate::util::{ensure_cargo_install, ensure_rustup_target};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-/// Build the webui-wasm package for the playground.
+pub(crate) const WASM_OUTPUT_DIR: &str = "docs/.webui-press/public/wasm";
+
+struct WasmVariant {
+    label: &'static str,
+    out_dir: &'static str,
+    out_name: &'static str,
+    features: &'static str,
+}
+
+const WASM_VARIANTS: &[WasmVariant] = &[
+    WasmVariant {
+        label: "all",
+        out_dir: "all",
+        out_name: "webui_wasm_all",
+        features: "all",
+    },
+    WasmVariant {
+        label: "handler",
+        out_dir: "handler",
+        out_name: "webui_wasm_handler",
+        features: "handler",
+    },
+    WasmVariant {
+        label: "parser",
+        out_dir: "parser",
+        out_name: "webui_wasm_parser",
+        features: "parser",
+    },
+];
+
+/// Build the webui-wasm packages for docs and release artifacts.
 pub fn run() -> Result<(), String> {
     let crate_dir = Path::new("crates/webui-wasm");
-    let out_dir = Path::new("docs/.webui-press/public/wasm");
+    let out_dir = Path::new(WASM_OUTPUT_DIR);
 
     // 1. Ensure wasm-pack is installed (auto-install if missing)
     ensure_cargo_install("wasm-pack", "wasm-pack")?;
@@ -28,7 +58,18 @@ pub fn run() -> Result<(), String> {
             .map_err(|e| format!("Failed to clean {}: {}", out_dir.display(), e))?;
     }
 
-    // 4. Run wasm-pack build
+    // 4. Run wasm-pack build for each feature set
+    for variant in WASM_VARIANTS {
+        build_variant(crate_dir, out_dir, variant)?;
+    }
+
+    Ok(())
+}
+
+fn build_variant(crate_dir: &Path, out_root: &Path, variant: &WasmVariant) -> Result<(), String> {
+    let variant_out_dir = out_root.join(variant.out_dir);
+    let out_dir_arg = format!("../../{}", variant_out_dir.display());
+
     let mut cmd = Command::new("wasm-pack");
     cmd.args([
         "build",
@@ -36,7 +77,12 @@ pub fn run() -> Result<(), String> {
         "--target",
         "web",
         "--out-dir",
-        &format!("../../{}", out_dir.display()),
+        &out_dir_arg,
+        "--out-name",
+        variant.out_name,
+        "--no-default-features",
+        "--features",
+        variant.features,
     ]);
 
     // Suppress wasm-pack's verbose output — show only on failure
@@ -54,30 +100,32 @@ pub fn run() -> Result<(), String> {
         if let Ok(s) = String::from_utf8(output.stderr) {
             msg.push_str(&s);
         }
-        return Err(format!("wasm-pack failed:\n{msg}"));
+        return Err(format!("wasm-pack failed for {}:\n{msg}", variant.label));
     }
 
     // 5. Remove wasm-pack generated .gitignore
-    let gitignore = out_dir.join(".gitignore");
+    let gitignore = variant_out_dir.join(".gitignore");
     if gitignore.exists() {
         let _ = fs::remove_file(&gitignore);
     }
 
     // 6. Report
-    let wasm_path = out_dir.join("webui_wasm_bg.wasm");
-    if let Ok(meta) = fs::metadata(&wasm_path) {
-        let size_kb = meta.len() / 1024;
-        eprintln!(
-            "  {} Output: {}",
-            console::style("✔").green(),
-            console::style(out_dir.display()).bold()
-        );
-        eprintln!(
-            "  {} Size:   {}",
-            console::style("✔").green(),
-            console::style(format!("{} KB", size_kb)).bold()
-        );
-    }
+    let wasm_path = variant_out_dir.join(format!("{}_bg.wasm", variant.out_name));
+    let meta = fs::metadata(&wasm_path)
+        .map_err(|e| format!("missing expected WASM output {}: {e}", wasm_path.display()))?;
+    let size_kb = meta.len() / 1024;
+    eprintln!(
+        "  {} [{}] Output: {}",
+        console::style("✔").green(),
+        console::style(variant.label).bold(),
+        console::style(variant_out_dir.display()).bold()
+    );
+    eprintln!(
+        "  {} [{}] Size:   {}",
+        console::style("✔").green(),
+        console::style(variant.label).bold(),
+        console::style(format!("{} KB", size_kb)).bold()
+    );
 
     Ok(())
 }

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -9,7 +9,7 @@
 //! - `publish/npm/`     — `.tgz` tarballs from `pnpm pack`
 //! - `publish/nuget/`   — `.nupkg` files from `dotnet pack`
 //! - `publish/crates/`  — `.crate` files from `cargo package`
-//! - `publish/wasm/`    — WASM module + JS glue
+//! - `publish/wasm/`    — WASM modules + JS glue
 
 use crate::util::{build_command, run_command_quiet};
 use crate::version;
@@ -766,35 +766,20 @@ fn pack_rust_crates(root: &Path) -> Result<(), String> {
 
 // ── Phase 5: WASM artifacts ─────────────────────────────────────────────
 
-/// Build WASM and copy artifacts to `publish/wasm/`.
+/// Build WASM variants and copy artifacts to `publish/wasm/`.
 fn stage_wasm_artifacts(root: &Path) -> Result<(), String> {
     let wasm_out = root.join("publish").join("wasm");
 
     // Build WASM using the existing build_wasm module
     crate::build_wasm::run()?;
 
-    // Copy the built WASM files to publish/wasm/
-    let wasm_source = root.join("docs").join("public").join("wasm");
-    for filename in &["webui_wasm_bg.wasm", "webui_wasm.js"] {
-        let src = wasm_source.join(filename);
-        if src.exists() {
-            let dest = wasm_out.join(filename);
-            fs::copy(&src, &dest)
-                .map_err(|e| format!("failed to copy {} to publish/wasm/: {e}", filename))?;
-            eprintln!(
-                "  {} [wasm] {}",
-                console::style("✔").green(),
-                console::style(filename).bold(),
-            );
-        } else {
-            eprintln!(
-                "  {} [wasm] {} not found at {}",
-                console::style("⚠").yellow(),
-                filename,
-                wasm_source.display(),
-            );
-        }
-    }
+    let wasm_source = root.join(crate::build_wasm::WASM_OUTPUT_DIR);
+    let copied = copy_directory_contents(&wasm_source, &wasm_out)?;
+    eprintln!(
+        "  {} [wasm] staged {} file(s)",
+        console::style("✔").green(),
+        console::style(copied).bold(),
+    );
 
     Ok(())
 }
@@ -919,6 +904,45 @@ fn copy_files_with_extension(src_dir: &Path, dest_dir: &Path, ext: &str) -> Resu
         }
     }
     Ok(())
+}
+
+/// Copy all files under `src_dir` into `dest_dir`, preserving subdirectories.
+fn copy_directory_contents(src_dir: &Path, dest_dir: &Path) -> Result<u32, String> {
+    if !src_dir.exists() {
+        return Err(format!("WASM output not found at {}", src_dir.display()));
+    }
+
+    let mut copied = 0;
+    let mut stack = Vec::with_capacity(4);
+    stack.push((src_dir.to_path_buf(), dest_dir.to_path_buf()));
+
+    while let Some((current_src, current_dest)) = stack.pop() {
+        fs::create_dir_all(&current_dest)
+            .map_err(|e| format!("failed to create {}: {e}", current_dest.display()))?;
+        let entries = fs::read_dir(&current_src)
+            .map_err(|e| format!("failed to read {}: {e}", current_src.display()))?;
+
+        for entry in entries {
+            let entry = entry
+                .map_err(|e| format!("failed to read {} entry: {e}", current_src.display()))?;
+            let path = entry.path();
+            let dest = current_dest.join(entry.file_name());
+            if path.is_dir() {
+                stack.push((path, dest));
+            } else if path.is_file() {
+                fs::copy(&path, &dest).map_err(|e| {
+                    format!(
+                        "failed to copy {} → {}: {e}",
+                        path.display(),
+                        dest.display()
+                    )
+                })?;
+                copied += 1;
+            }
+        }
+    }
+
+    Ok(copied)
 }
 
 #[cfg(test)]
@@ -1056,6 +1080,39 @@ mod tests {
 
         assert!(dest.path().join("pkg.crate").exists());
         assert!(!dest.path().join("other.txt").exists());
+    }
+
+    #[test]
+    fn test_copy_directory_contents_preserves_subdirectories() {
+        let src = tempfile::TempDir::new().unwrap();
+        let dest = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(src.path().join("handler")).unwrap();
+        fs::write(
+            src.path().join("handler").join("webui_wasm_handler.js"),
+            "js",
+        )
+        .unwrap();
+        fs::write(
+            src.path()
+                .join("handler")
+                .join("webui_wasm_handler_bg.wasm"),
+            "wasm",
+        )
+        .unwrap();
+
+        let copied = copy_directory_contents(src.path(), dest.path()).unwrap();
+
+        assert_eq!(copied, 2);
+        assert!(dest
+            .path()
+            .join("handler")
+            .join("webui_wasm_handler.js")
+            .exists());
+        assert!(dest
+            .path()
+            .join("handler")
+            .join("webui_wasm_handler_bg.wasm")
+            .exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Split `microsoft-webui-wasm` into feature-gated `handler`, `parser`, and default `all` bundles.
- Changed the WASM protocol boundary to protobuf bytes (`Uint8Array`) so handler-only consumers can render `protocol.bin` directly without JSON conversion.
- Updated `cargo xtask build-wasm`, CI verification, release staging, the docs playground, `DESIGN.md`, and integration docs for the new bundle layout.

Closes #338

## WASM bundle sizes

| Variant | File | Ungzipped | Gzip | Brotli |
|---|---:|---:|---:|---:|
| all | `webui_wasm_all.js` | 24.2 KiB | 4.9 KiB | 4.3 KiB |
| all | `webui_wasm_all_bg.wasm` | 707.0 KiB | 256.4 KiB | 199.2 KiB |
| handler | `webui_wasm_handler.js` | 14.2 KiB | 3.1 KiB | 2.7 KiB |
| handler | `webui_wasm_handler_bg.wasm` | 379.6 KiB | 143.0 KiB | 115.4 KiB |
| parser | `webui_wasm_parser.js` | 15.0 KiB | 3.7 KiB | 3.2 KiB |
| parser | `webui_wasm_parser_bg.wasm` | 427.6 KiB | 168.4 KiB | 136.1 KiB |

## Validation

- `CI=true cargo xtask check`
