### PR TITLE
fix: move SSR state to data block

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -281,7 +281,20 @@ When the handler encounters `Fragment::Outlet`:
 3. Emit `<webui-outlet>` containing matched child `<webui-route>` with component, and hidden stubs for siblings.
 
 The handler also emits a `<meta name="webui-nonce">` tag in `<head>` for backward compatibility,
-and a nonce'd inline `<script>` containing a `window.__webui` object with the SSR metadata:
+and body-end bootstrap tags for the active handler plugin:
+
+1. **State data block** - `<script type="application/json" id="__webui_state">{state JSON}</script>`.
+   This block is written before any executable bootstrap script.
+2. **Metadata initializer** - a nonce'd `<script>` that materializes `window.__webui`
+   with route chain, inventory, nonce, CSS metadata, `templates`, and a lazy
+   `state` getter backed by the data block.
+3. **Template IIFEs** - appended to the same executable `<script>` when the active
+   plugin provides executable template JS.
+   The getter parses the data block on first read and replaces itself with the parsed value.
+   FAST v2/v3 opt out of route/template metadata and emit only the data block.
+
+The data block avoids parsing the state payload as executable JavaScript. When
+metadata is emitted, the getter preserves the same field-access shape:
 
 ```js
 window.__webui = {
@@ -292,7 +305,7 @@ window.__webui = {
   nonce: string,              // CSP nonce value
   css: string[],              // CSS link hrefs emitted during SSR
   styles: string[],           // module CSS specifiers emitted during SSR
-  state: object,              // SSR state for hydration (consumed by framework on load)
+  state: object,              // SSR state, exposed by a lazy data-block-backed getter when metadata is emitted
   templates: Record<string, TemplateMetadata>,  // component template metadata (populated by IIFEs)
 };
 ```
@@ -764,6 +777,12 @@ pub trait HandlerPlugin {
     fn on_repeat_item_start(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_repeat_item_end(&mut self, index: usize, writer: &mut dyn ResponseWriter) -> Result<()>;
     fn on_element_data(&mut self, data: &[u8], writer: &mut dyn ResponseWriter) -> Result<()>;
+    fn collect_template_js(
+        &self,
+        protocol: &WebUIProtocol,
+        components: &HashSet<String>,
+    ) -> Option<Vec<String>>;
+    fn needs_webui_bootstrap(&self) -> bool;
     fn write_route_component_state(
         &self,
         state: &serde_json::Value,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1266,7 +1266,7 @@ inject_token_css(state, css) → state["tokens"]["light"] = "..."
 1. **Filter**: Only tokens in `protocol.tokens` are kept.
 2. **Dependency closure**: Token values referencing other tokens via `var(--x)` trigger transitive inclusion. Uses an iterative BFS expansion followed by DFS cycle detection.
 3. **CSS generation**: Sorted `--name: value;` declarations. Output is deterministic.
-4. **State injection**: Per-theme CSS strings are set on `state.tokens.<theme>`, where `/*{{{tokens.<theme>}}}*/` signals resolve them during rendering.
+4. **State injection**: Per-theme CSS strings are set on `state.tokens.<theme>`, where `/*{{{tokens.<theme>}}}*/` signals resolve them during rendering. These render-only token strings are omitted from the emitted `__webui_state` client bootstrap.
 
 #### Package Resolution (`resolve_theme_path`)
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -1185,7 +1185,10 @@ mod tests {
     #[test]
     fn test_build_and_render_selects_fast_plugin_versions() {
         let app = create_app_dir(&[
-            ("index.html", "<my-card></my-card>"),
+            (
+                "index.html",
+                "<html><body><my-card></my-card></body></html>",
+            ),
             ("my-card.html", "<span>{{name}}</span>"),
             ("state.json", r#"{"name":"Alice"}"#),
         ]);
@@ -1214,14 +1217,26 @@ mod tests {
         let fast = render(Some(Plugin::Fast));
         assert!(fast.contains("<!--fe-b$$start$$0$$name$$fe-b-->"));
         assert!(!fast.contains("<!--fe:b-->"));
+        assert!(fast.contains("<script type=\"application/json\" id=\"__webui_state\">"));
+        assert!(!fast.contains("window.__webui"));
+        assert!(!fast.contains("\"chain\""));
+        assert!(!fast.contains("\"inventory\""));
 
         let fast_v2 = render(Some(Plugin::FastV2));
         assert!(fast_v2.contains("<!--fe-b$$start$$0$$name$$fe-b-->"));
         assert!(!fast_v2.contains("<!--fe:b-->"));
+        assert!(fast_v2.contains("<script type=\"application/json\" id=\"__webui_state\">"));
+        assert!(!fast_v2.contains("window.__webui"));
+        assert!(!fast_v2.contains("\"chain\""));
+        assert!(!fast_v2.contains("\"inventory\""));
 
         let fast_v3 = render(Some(Plugin::FastV3));
         assert!(fast_v3.contains("<!--fe:b-->"));
         assert!(!fast_v3.contains("<!--fe-b$$start$$"));
+        assert!(fast_v3.contains("<script type=\"application/json\" id=\"__webui_state\">"));
+        assert!(!fast_v3.contains("window.__webui"));
+        assert!(!fast_v3.contains("\"chain\""));
+        assert!(!fast_v3.contains("\"inventory\""));
     }
 
     #[test]

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -211,6 +211,7 @@ impl ResponseWriter for MemoryWriter {
 /// SSE endpoint path. Root-relative so the script works under any
 /// `<base href>` and across sub-path deployments.
 const HMR_ENDPOINT: &str = "/__webui/livereload";
+const CLIENT_STATE_OMIT_TOKENS: &[&str] = &["tokens"];
 
 /// Environment variable that, when set to a non-empty / non-"0" value,
 /// suppresses `--watch` mode at runtime. Used by `xtask e2e` so that
@@ -491,12 +492,11 @@ fn build_and_render(
     // Render to memory
     let mut writer = MemoryWriter::with_capacity(4096);
     let handler = create_handler(config.app_args.plugin);
-    handler.handle(
-        &build_result.protocol,
-        &state,
-        &RenderOptions::new(&config.app_args.entry, "/"),
-        &mut writer,
-    )?;
+    let mut options = RenderOptions::new(&config.app_args.entry, "/");
+    if config.token_css.is_some() {
+        options = options.with_client_state_omit_keys(CLIENT_STATE_OMIT_TOKENS);
+    }
+    handler.handle(&build_result.protocol, &state, &options, &mut writer)?;
 
     let html = match livereload {
         Some(lr) => lr.inject(&writer.buf),
@@ -679,6 +679,7 @@ async fn render_page_response(
         context.livereload.as_ref().map(|lr| lr.client_script_arc());
     let route_path = route_path.to_string();
     let chunk_pool = Arc::clone(&context.chunk_pool);
+    let omit_tokens_from_client_state = context.token_css.is_some();
 
     // Bounded channel: backpressure when client is slow, no unbounded
     // memory growth. Capacity is in chunks (≈ 4 KB each).
@@ -698,7 +699,10 @@ async fn render_page_response(
         // body_end boundary identified by the parser — zero scan cost,
         // no risk of false-marker mis-firing on `</body>` literals
         // appearing inside HTML comments / srcdoc / inline scripts.
-        let opts_owner = RenderOptions::new(&entry, &route_path);
+        let mut opts_owner = RenderOptions::new(&entry, &route_path);
+        if omit_tokens_from_client_state {
+            opts_owner = opts_owner.with_client_state_omit_keys(CLIENT_STATE_OMIT_TOKENS);
+        }
         let opts = match livereload_script.as_deref() {
             Some(script) => opts_owner.with_body_inject(script),
             None => opts_owner,
@@ -1180,6 +1184,42 @@ mod tests {
         let hmr = LiveReload::new(HMR_ENDPOINT);
         let BuildRenderResult { html, .. } = build_and_render(&config, Some(&hmr)).unwrap();
         assert!(html.contains("<p>WebUI</p>"));
+    }
+
+    #[test]
+    fn test_build_and_render_omits_injected_tokens_from_client_state() {
+        let app = create_app_dir(&[
+            (
+                "index.html",
+                "<html><body><style>/*{{{tokens.light}}}*/</style></body></html>",
+            ),
+            ("state.json", r#"{"name":"WebUI"}"#),
+        ]);
+        let config = RenderConfig {
+            app_args: AppArgs {
+                app: app.path().to_path_buf(),
+                entry: "index.html".to_string(),
+                css: CssStrategy::Link,
+                dom: DomStrategy::Shadow,
+                plugin: Some(Plugin::WebUI),
+                components: Vec::new(),
+                css_file_name_template: DEFAULT_CSS_FILE_NAME_TEMPLATE.to_string(),
+                css_public_base: None,
+                legal_comments: LegalComments::Inline,
+            },
+            app_dir: app.path().to_path_buf(),
+            state_file: Some(app.path().join("state.json")),
+            token_css: Some(HashMap::from([(
+                "light".to_string(),
+                "--color-brand: red;".to_string(),
+            )])),
+            base_path: None,
+        };
+
+        let BuildRenderResult { html, .. } = build_and_render(&config, None).unwrap();
+        assert!(html.contains("--color-brand: red;"));
+        assert!(html.contains(r#""name":"WebUI""#));
+        assert!(!html.contains(r#""tokens""#));
     }
 
     #[test]

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -42,6 +42,8 @@ use webui_handler::{RenderOptions, ResponseWriter, WebUIHandler};
 use webui_parser::HtmlParser;
 use webui_protocol::WebUIProtocol;
 
+const CLIENT_STATE_OMIT_TOKENS: &[&str] = &["tokens"];
+
 // ---------------------------------------------------------------------------
 // Thread-local error storage (POSIX dlerror() pattern)
 // ---------------------------------------------------------------------------
@@ -105,6 +107,10 @@ impl ResponseWriter for StringResponseWriter {
     fn end(&mut self) -> webui_handler::Result<()> {
         Ok(())
     }
+}
+
+fn render_options<'a>(entry: &'a str, request_path: &'a str) -> RenderOptions<'a> {
+    RenderOptions::new(entry, request_path).with_client_state_omit_keys(CLIENT_STATE_OMIT_TOKENS)
 }
 
 // ---------------------------------------------------------------------------
@@ -361,7 +367,7 @@ pub unsafe extern "C" fn webui_handler_render(
     };
 
     // Render
-    let mut options = RenderOptions::new(entry_str, path_str);
+    let mut options = render_options(entry_str, path_str);
     if let Some(ref nonce) = context.nonce {
         options = options.with_nonce(nonce);
     }
@@ -491,7 +497,7 @@ unsafe fn webui_render_impl(html: *const c_char, data_json: *const c_char) -> *m
     match handler.render(
         &protocol,
         &data,
-        &RenderOptions::new(entry_key, "/"),
+        &render_options(entry_key, "/"),
         &mut writer,
     ) {
         Ok(_) => match CString::new(writer.content) {
@@ -805,5 +811,86 @@ pub unsafe extern "C" fn webui_protocol_tokens(
             set_last_error("panic in webui_protocol_tokens");
             std::ptr::null_mut()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::disallowed_methods)]
+
+    use super::*;
+    use webui_protocol::{FragmentList, WebUIFragment};
+
+    fn take_string(ptr: *mut c_char) -> String {
+        assert!(!ptr.is_null());
+        // SAFETY: FFI functions return a valid null-terminated string on success.
+        let output = unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .expect("output should be UTF-8")
+            .to_string();
+        // SAFETY: `ptr` was returned by a WebUI FFI function.
+        unsafe { webui_free(ptr) };
+        output
+    }
+
+    #[test]
+    fn ffi_protocol_render_omits_tokens_from_client_state() {
+        let mut fragments = std::collections::HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><body><style>".to_string()),
+                    WebUIFragment::signal("tokens.light", true),
+                    WebUIFragment::raw("</style>".to_string()),
+                    WebUIFragment::signal("body_end", true),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let bytes = protocol.to_protobuf().expect("protocol should encode");
+        let state = CString::new(r#"{"name":"Alice","tokens":{"light":"--color-brand: red;"}}"#)
+            .expect("state CString");
+        let entry = CString::new("index.html").expect("entry CString");
+        let path = CString::new("/").expect("path CString");
+        let plugin = CString::new("webui").expect("plugin CString");
+        // SAFETY: `plugin` is a valid null-terminated string.
+        let handler = unsafe { webui_handler_create_with_plugin(plugin.as_ptr()) };
+        assert!(!handler.is_null());
+
+        // SAFETY: all pointers are valid for this call.
+        let ptr = unsafe {
+            webui_handler_render(
+                handler,
+                bytes.as_ptr(),
+                bytes.len(),
+                state.as_ptr(),
+                entry.as_ptr(),
+                path.as_ptr(),
+            )
+        };
+        // SAFETY: `handler` was returned by `webui_handler_create_with_plugin`.
+        unsafe { webui_handler_destroy(handler) };
+        let output = take_string(ptr);
+
+        assert!(output.contains("--color-brand: red;"));
+        assert!(output.contains(r#""name":"Alice""#));
+        assert!(!output.contains(r#""tokens""#));
+    }
+
+    #[cfg(feature = "parser")]
+    #[test]
+    fn ffi_html_render_resolves_tokens_for_ssr() {
+        let html = CString::new("<html><body><style>/*{{{tokens.light}}}*/</style></body></html>")
+            .expect("html CString");
+        let state = CString::new(r#"{"name":"Alice","tokens":{"light":"--color-brand: red;"}}"#)
+            .expect("state CString");
+
+        // SAFETY: all pointers are valid for this call.
+        let ptr = unsafe { webui_render(html.as_ptr(), state.as_ptr()) };
+        let output = take_string(ptr);
+
+        assert!(output.contains("--color-brand: red;"));
     }
 }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -7105,17 +7105,18 @@ mod tests {
     fn fast_v2_data_block_carries_nonce_when_csp_nonce_set() -> Result<()> {
         let protocol = fixture_route_with_body_end();
         let state = test_json!({"items": [{"title": "A"}]});
+        let nonce = std::process::id().to_string();
         let output = render_bootstrap_with_plugin(
             &protocol,
             &state,
             || Box::new(crate::plugin::fast_v2::FastV2HydrationPlugin::new()),
-            &RenderOptions::new("index.html", "/").with_nonce("test-nonce"),
+            &RenderOptions::new("index.html", "/").with_nonce(&nonce),
         )?;
 
-        assert!(output.contains(
-            "<script type=\"application/json\" id=\"__webui_state\" nonce=\"test-nonce\">"
-        ));
-        assert!(!output.contains("<script nonce=\"test-nonce\">window.__webui"));
+        assert!(output.contains(&format!(
+            "<script type=\"application/json\" id=\"__webui_state\" nonce=\"{nonce}\">"
+        )));
+        assert!(!output.contains(&format!("<script nonce=\"{nonce}\">window.__webui")));
         Ok(())
     }
 

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -259,13 +259,14 @@ struct WebUIProcessContext<'a> {
 }
 
 struct WebUiBootstrap<'a> {
-    state: &'a Value,
     chain: &'a [Value],
     inventory: &'a str,
     nonce: Option<&'a str>,
     css_hrefs: &'a [&'a str],
     style_specs: &'a [&'a str],
 }
+
+const STATE_DATA_BLOCK_ID: &str = "__webui_state";
 
 /// Get the component attribute name, stripping `:` prefix and converting to camelCase.
 ///
@@ -357,7 +358,7 @@ where
     write_script_safe_json(writer, value)
 }
 
-fn write_webui_bootstrap(
+fn write_webui_metadata_init(
     writer: &mut dyn ResponseWriter,
     bootstrap: WebUiBootstrap<'_>,
 ) -> Result<()> {
@@ -374,13 +375,41 @@ fn write_webui_bootstrap(
     if let Some(nonce) = bootstrap.nonce {
         write_json_field(writer, &mut wrote_field, "nonce", nonce)?;
     }
-    write_json_field(writer, &mut wrote_field, "state", bootstrap.state)?;
     if !bootstrap.style_specs.is_empty() {
         write_json_field(writer, &mut wrote_field, "styles", bootstrap.style_specs)?;
     }
     write_json_field_name(writer, &mut wrote_field, "templates")?;
     writer.write("{}")?;
     writer.write("}")
+}
+
+fn write_state_data_block(
+    writer: &mut dyn ResponseWriter,
+    state: &Value,
+    nonce: Option<&str>,
+) -> Result<()> {
+    writer.write("<script type=\"application/json\" id=\"")?;
+    writer.write(STATE_DATA_BLOCK_ID)?;
+    writer.write("\"")?;
+    if let Some(nonce) = nonce {
+        writer.write(" nonce=\"")?;
+        writer.write(nonce)?;
+        writer.write("\"")?;
+    }
+    writer.write(">")?;
+    write_script_safe_json(writer, state)?;
+    writer.write("</script>")
+}
+
+fn write_lazy_state_getter(writer: &mut dyn ResponseWriter) -> Result<()> {
+    writer.write(
+        "Object.defineProperty(window.__webui,\"state\",{configurable:true,enumerable:true,",
+    )?;
+    writer.write("get:function(){var e=document.getElementById(\"")?;
+    writer.write(STATE_DATA_BLOCK_ID)?;
+    writer.write("\");var v=e?JSON.parse(e.textContent):null;if(e)e.remove();")?;
+    writer.write("Object.defineProperty(this,\"state\",{value:v,configurable:true,")?;
+    writer.write("writable:true,enumerable:true});return v;}});")
 }
 
 fn resolve_value_from_sources<'ctx, 'state>(
@@ -1087,24 +1116,7 @@ impl WebUIHandler {
         if signal.raw && signal.value == "body_end" && !context.body_end_emitted {
             context.body_end_emitted = true;
             if context.plugin.is_some() {
-                // Build (or reuse cached) component → index map.
-                let comp_index = context.component_index_cache.get_or_insert_with(|| {
-                    crate::route_handler::build_component_index(context.protocol)
-                });
-
-                // Compute the inventory hex from actually rendered components.
-                let inventory_hex = crate::route_handler::encode_component_inventory(
-                    &context.rendered_components,
-                    comp_index,
-                );
-
-                // Emit templates for all REACHABLE components on the current route,
-                // not just those rendered in this SSR pass. Components inside false
-                // <if> blocks or empty <for> loops are reachable via client-side
-                // state changes and need their templates available without a server
-                // round-trip. The graph walker follows conditional and loop branches
-                // unconditionally, but only descends into the matched route chain —
-                // components on other routes are delivered via SPA partial navigation.
+                // Reachable templates are needed for client-side condition changes.
                 let reachable = crate::route_handler::collect_reachable_components_for_request(
                     context.protocol,
                     context.entry_id,
@@ -1112,33 +1124,12 @@ impl WebUIHandler {
                     &mut context.route_cache,
                 );
 
-                // Emit CSS module importmaps for reachable-but-unrendered
-                // components so the framework can adopt them when an `<if>`
-                // condition flips true client-side.
-                for name in &reachable {
-                    if !context.rendered_components.contains(name) {
-                        if let Some(css) = context
-                            .protocol
-                            .components
-                            .get(name)
-                            .map(|c| c.css.as_str())
-                            .filter(|s| !s.is_empty())
-                        {
-                            self.emit_css_module_importmap(name, css, context)?;
-                        }
-                    }
-                }
-
-                // Try to collect template JS sources for merging into the
-                // consolidated script block. If the plugin returns None
-                // (non-JS templates, e.g. FAST), fall back to separate emission.
                 let template_js = context
                     .plugin
                     .as_ref()
                     .and_then(|p| p.collect_template_js(context.protocol, &reachable));
 
                 if template_js.is_none() {
-                    // Non-JS templates (FAST plugins) - emit separately
                     if let Some(ref p) = context.plugin {
                         p.emit_templates(
                             context.protocol,
@@ -1149,93 +1140,112 @@ impl WebUIHandler {
                     }
                 }
 
-                // ── Consolidated SSR script block ──────────────────────────
-                //
-                // Merges all SSR metadata into a single <script> tag:
-                //   1. Bootstrap meta  (window.__webui: chain, inventory, nonce, css, styles, state, templates)
-                //   2. Template IIFEs  (write into window.__webui.templates)
-                //
-                // Single-script reduces HTML parse overhead and ensures all
-                // SSR metadata is available atomically before DOMContentLoaded.
+                let needs_webui_bootstrap = context
+                    .plugin
+                    .as_ref()
+                    .map(|p| p.needs_webui_bootstrap())
+                    .unwrap_or(true);
 
-                // Chain
-                let chain = crate::route_handler::collect_route_chain(
-                    context.protocol,
-                    context.entry_id,
-                    context.request_path,
-                    &mut context.route_cache,
-                );
-                let chain_json: Vec<Value> = chain
-                    .iter()
-                    .map(crate::route_handler::RouteChainEntry::to_json)
-                    .collect();
+                write_state_data_block(context.writer, context.state, context.nonce)?;
 
-                // CSS hrefs emitted during SSR (Link-strategy components)
-                let is_link = context.protocol.css_strategy() == webui_protocol::CssStrategy::Link;
-                let mut css_hrefs: Vec<&str> = Vec::new();
-                if is_link {
+                if needs_webui_bootstrap {
+                    let comp_index = context.component_index_cache.get_or_insert_with(|| {
+                        crate::route_handler::build_component_index(context.protocol)
+                    });
+
+                    let inventory_hex = crate::route_handler::encode_component_inventory(
+                        &context.rendered_components,
+                        comp_index,
+                    );
+
                     for name in &reachable {
-                        if let Some(href) = context
+                        if !context.rendered_components.contains(name) {
+                            if let Some(css) = context
+                                .protocol
+                                .components
+                                .get(name)
+                                .map(|c| c.css.as_str())
+                                .filter(|s| !s.is_empty())
+                            {
+                                self.emit_css_module_importmap(name, css, context)?;
+                            }
+                        }
+                    }
+
+                    let chain = crate::route_handler::collect_route_chain(
+                        context.protocol,
+                        context.entry_id,
+                        context.request_path,
+                        &mut context.route_cache,
+                    );
+                    let chain_json: Vec<Value> = chain
+                        .iter()
+                        .map(crate::route_handler::RouteChainEntry::to_json)
+                        .collect();
+
+                    let is_link =
+                        context.protocol.css_strategy() == webui_protocol::CssStrategy::Link;
+                    let mut css_hrefs: Vec<&str> = Vec::new();
+                    if is_link {
+                        for name in &reachable {
+                            if let Some(href) = context
+                                .protocol
+                                .components
+                                .get(name)
+                                .map(|c| c.css_href.as_str())
+                                .filter(|h| !h.is_empty())
+                            {
+                                css_hrefs.push(href);
+                            }
+                        }
+                    }
+
+                    let mut style_specs: Vec<&str> = Vec::new();
+                    for name in &reachable {
+                        if context
                             .protocol
                             .components
                             .get(name)
-                            .map(|c| c.css_href.as_str())
-                            .filter(|h| !h.is_empty())
+                            .map(|c| !c.css.is_empty())
+                            .unwrap_or(false)
                         {
-                            css_hrefs.push(href);
+                            style_specs.push(name);
                         }
                     }
-                }
 
-                // Module style specifiers emitted during SSR
-                let mut style_specs: Vec<&str> = Vec::new();
-                for name in &reachable {
-                    if context
-                        .protocol
-                        .components
-                        .get(name)
-                        .map(|c| !c.css.is_empty())
-                        .unwrap_or(false)
-                    {
-                        style_specs.push(name);
+                    if let Some(nonce) = context.nonce {
+                        context.writer.write("<script nonce=\"")?;
+                        context.writer.write(nonce)?;
+                        context.writer.write("\">")?;
+                    } else {
+                        context.writer.write("<script>")?;
                     }
-                }
 
-                // Open the consolidated <script> tag
-                if let Some(nonce) = context.nonce {
-                    context.writer.write("<script nonce=\"")?;
-                    context.writer.write(nonce)?;
-                    context.writer.write("\">")?;
-                } else {
-                    context.writer.write("<script>")?;
-                }
+                    context.writer.write("window.__webui=")?;
+                    write_webui_metadata_init(
+                        context.writer,
+                        WebUiBootstrap {
+                            chain: &chain_json,
+                            inventory: &inventory_hex,
+                            nonce: context.nonce,
+                            css_hrefs: &css_hrefs,
+                            style_specs: &style_specs,
+                        },
+                    )?;
+                    context.writer.write(";")?;
 
-                // 1. Emit window.__webui bootstrap object (chain, inventory,
-                //    nonce, css, styles, state — all in one JSON assignment)
-                context.writer.write("window.__webui=")?;
-                write_webui_bootstrap(
-                    context.writer,
-                    WebUiBootstrap {
-                        state: context.state,
-                        chain: &chain_json,
-                        inventory: &inventory_hex,
-                        nonce: context.nonce,
-                        css_hrefs: &css_hrefs,
-                        style_specs: &style_specs,
-                    },
-                )?;
-                context.writer.write(";")?;
+                    write_lazy_state_getter(context.writer)?;
 
-                // 2. Template IIFEs — write into window.__webui.templates
-                //    (parser-generated IIFEs reference this object directly)
-                if let Some(ref tmpls) = template_js {
-                    context.writer.write("\n")?;
-                    for tmpl in tmpls {
-                        context.writer.write(tmpl)?;
+                    // Parser-generated IIFEs write into window.__webui.templates.
+                    if let Some(ref tmpls) = template_js {
+                        context.writer.write("\n")?;
+                        for tmpl in tmpls {
+                            context.writer.write(tmpl)?;
+                        }
                     }
-                }
 
-                context.writer.write("</script>\n")?;
+                    context.writer.write("</script>\n")?;
+                }
             }
 
             // Per-render `body_inject` HTML — dev livereload script,
@@ -7027,6 +7037,128 @@ mod tests {
             ),
             "Unrendered (body_end) CSS module importmap tag should include nonce attribute in canonical order: {html}"
         );
+    }
+
+    fn fixture_route_with_body_end() -> WebUIProtocol {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><body><my-page>".to_string()),
+                    WebUIFragment::component("my-page"),
+                    WebUIFragment::raw("</my-page>".to_string()),
+                    WebUIFragment::signal("body_end", true),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+            },
+        );
+        fragments.insert(
+            "my-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Hello</p>".to_string())],
+            },
+        );
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol
+            .components
+            .entry("my-page".to_string())
+            .or_default()
+            .template = "<f-template name=\"my-page\"><p>Hello</p></f-template>".to_string();
+        protocol
+    }
+
+    fn render_bootstrap_with_plugin(
+        protocol: &WebUIProtocol,
+        state: &Value,
+        plugin: fn() -> Box<dyn HandlerPlugin>,
+        options: &RenderOptions<'_>,
+    ) -> Result<String> {
+        let handler = WebUIHandler::with_plugin(plugin);
+        let mut writer = TestWriter::new();
+        handler.handle(protocol, state, options, &mut writer)?;
+        Ok(writer.get_content().to_string())
+    }
+
+    #[test]
+    fn fast_v2_emits_state_as_json_data_block() -> Result<()> {
+        let protocol = fixture_route_with_body_end();
+        let state = test_json!({"items": [{"title": "A"}]});
+        let output = render_bootstrap_with_plugin(
+            &protocol,
+            &state,
+            || Box::new(crate::plugin::fast_v2::FastV2HydrationPlugin::new()),
+            &RenderOptions::new("index.html", "/"),
+        )?;
+
+        assert!(output.contains("<script type=\"application/json\" id=\"__webui_state\">"));
+        assert!(output.contains(r#"{"items":[{"title":"A"}]}"#));
+        assert!(!output.contains("window.__webui"));
+        assert!(!output.contains("Object.defineProperty"));
+        assert!(!output.contains("\"state\":{\"items\""));
+        assert!(!output.contains("\"chain\""));
+        assert!(!output.contains("\"inventory\""));
+        Ok(())
+    }
+
+    #[test]
+    fn fast_v2_data_block_carries_nonce_when_csp_nonce_set() -> Result<()> {
+        let protocol = fixture_route_with_body_end();
+        let state = test_json!({"items": [{"title": "A"}]});
+        let output = render_bootstrap_with_plugin(
+            &protocol,
+            &state,
+            || Box::new(crate::plugin::fast_v2::FastV2HydrationPlugin::new()),
+            &RenderOptions::new("index.html", "/").with_nonce("test-nonce"),
+        )?;
+
+        assert!(output.contains(
+            "<script type=\"application/json\" id=\"__webui_state\" nonce=\"test-nonce\">"
+        ));
+        assert!(!output.contains("<script nonce=\"test-nonce\">window.__webui"));
+        Ok(())
+    }
+
+    #[test]
+    fn fast_v2_data_block_escapes_inner_closing_script_tag() -> Result<()> {
+        let protocol = fixture_route_with_body_end();
+        let state = test_json!({"payload": "</script><script>alert(1)</script>"});
+        let output = render_bootstrap_with_plugin(
+            &protocol,
+            &state,
+            || Box::new(crate::plugin::fast_v2::FastV2HydrationPlugin::new()),
+            &RenderOptions::new("index.html", "/"),
+        )?;
+
+        assert!(output.contains("<\\/script><script>alert(1)<\\/script>"));
+        assert!(!output.contains("</script><script>alert(1)</script>"));
+        Ok(())
+    }
+
+    #[test]
+    fn webui_plugin_uses_state_data_block() -> Result<()> {
+        let mut protocol = fixture_route_with_body_end();
+        protocol
+            .components
+            .entry("my-page".to_string())
+            .or_default()
+            .template =
+            "(function(){var w=(window.__webui||(window.__webui={})).templates||(window.__webui.templates={});w['my-page']={h:'<p>Hello</p>'};})();\n".to_string();
+        let state = test_json!({"items": [{"title": "A"}]});
+        let output = render_bootstrap_with_plugin(
+            &protocol,
+            &state,
+            || Box::new(crate::plugin::webui::WebUIHydrationPlugin::new()),
+            &RenderOptions::new("index.html", "/"),
+        )?;
+
+        assert!(output.contains("<script type=\"application/json\" id=\"__webui_state\">"));
+        assert!(output.contains(r#"{"items":[{"title":"A"}]}"#));
+        assert!(output.contains("Object.defineProperty(window.__webui,\"state\""));
+        assert!(!output.contains("\"state\":{\"items\""));
+        assert!(output.contains("\"inventory\""));
+        assert!(output.contains("window.__webui="));
+        Ok(())
     }
 
     #[test]

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -26,6 +26,7 @@ pub use html_encode::encode_safe;
 
 use plugin::HandlerPlugin;
 use route_matcher::CompiledRouteCache;
+use serde::ser::SerializeMap;
 use serde::Serialize;
 use serde_json::Value;
 use std::borrow::Cow;
@@ -124,6 +125,9 @@ pub struct RenderOptions<'a> {
     /// snippets, OpenTelemetry trace IDs, etc.
     /// Same structural-boundary guarantee as [`head_inject`](Self::head_inject).
     pub body_inject: Option<&'a str>,
+    /// Top-level state keys available during SSR but omitted from
+    /// `__webui_state` client bootstrap serialization.
+    pub client_state_omit_keys: &'a [&'a str],
 }
 
 impl<'a> RenderOptions<'a> {
@@ -136,6 +140,7 @@ impl<'a> RenderOptions<'a> {
             nonce: None,
             head_inject: None,
             body_inject: None,
+            client_state_omit_keys: &[],
         }
     }
 
@@ -180,6 +185,16 @@ impl<'a> RenderOptions<'a> {
     #[must_use]
     pub fn with_body_inject(mut self, html: &'a str) -> Self {
         self.body_inject = if html.is_empty() { None } else { Some(html) };
+        self
+    }
+
+    /// Omit top-level state keys from the client-emitted `__webui_state` block.
+    ///
+    /// The full state remains available during SSR. This is for render-only
+    /// inputs such as injected design-token CSS.
+    #[must_use]
+    pub fn with_client_state_omit_keys(mut self, keys: &'a [&'a str]) -> Self {
+        self.client_state_omit_keys = keys;
         self
     }
 }
@@ -238,6 +253,8 @@ struct WebUIProcessContext<'a> {
     /// `</body>`), after the built-in template-IIFE emissions.
     /// Same zero-copy borrow as [`head_inject`](Self::head_inject).
     body_inject: Option<&'a str>,
+    /// Top-level state keys omitted from client bootstrap serialization.
+    client_state_omit_keys: &'a [&'a str],
     /// Tracks whether the `head_end` hook has already fired in this
     /// render. Defends against malformed protocols that emit the
     /// signal more than once (e.g., a template with multiple `<head>`
@@ -383,10 +400,40 @@ fn write_webui_metadata_init(
     writer.write("}")
 }
 
+struct ClientState<'a> {
+    value: &'a Value,
+    omit_keys: &'a [&'a str],
+}
+
+impl Serialize for ClientState<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Value::Object(map) = self.value else {
+            return self.value.serialize(serializer);
+        };
+
+        if self.omit_keys.is_empty() {
+            return self.value.serialize(serializer);
+        }
+
+        let mut out = serializer.serialize_map(None)?;
+        for (key, value) in map {
+            if self.omit_keys.iter().any(|omit| *omit == key) {
+                continue;
+            }
+            out.serialize_entry(key, value)?;
+        }
+        out.end()
+    }
+}
+
 fn write_state_data_block(
     writer: &mut dyn ResponseWriter,
     state: &Value,
     nonce: Option<&str>,
+    omit_keys: &[&str],
 ) -> Result<()> {
     writer.write("<script type=\"application/json\" id=\"")?;
     writer.write(STATE_DATA_BLOCK_ID)?;
@@ -397,7 +444,13 @@ fn write_state_data_block(
         writer.write("\"")?;
     }
     writer.write(">")?;
-    write_script_safe_json(writer, state)?;
+    write_script_safe_json(
+        writer,
+        &ClientState {
+            value: state,
+            omit_keys,
+        },
+    )?;
     writer.write("</script>")
 }
 
@@ -492,6 +545,7 @@ impl WebUIHandler {
             nonce: options.nonce.filter(|s| !s.is_empty()),
             head_inject: options.head_inject.filter(|s| !s.is_empty()),
             body_inject: options.body_inject.filter(|s| !s.is_empty()),
+            client_state_omit_keys: options.client_state_omit_keys,
             head_end_emitted: false,
             component_index_cache: None,
             body_end_emitted: false,
@@ -535,6 +589,7 @@ impl WebUIHandler {
             nonce: None,
             head_inject: None,
             body_inject: None,
+            client_state_omit_keys: &[],
             head_end_emitted: false,
             component_index_cache: None,
             body_end_emitted: false,
@@ -1146,7 +1201,12 @@ impl WebUIHandler {
                     .map(|p| p.needs_webui_bootstrap())
                     .unwrap_or(true);
 
-                write_state_data_block(context.writer, context.state, context.nonce)?;
+                write_state_data_block(
+                    context.writer,
+                    context.state,
+                    context.nonce,
+                    context.client_state_omit_keys,
+                )?;
 
                 if needs_webui_bootstrap {
                     let comp_index = context.component_index_cache.get_or_insert_with(|| {
@@ -1490,6 +1550,7 @@ impl WebUIHandler {
             nonce: options.nonce.filter(|s| !s.is_empty()),
             head_inject: options.head_inject.filter(|s| !s.is_empty()),
             body_inject: options.body_inject.filter(|s| !s.is_empty()),
+            client_state_omit_keys: options.client_state_omit_keys,
             head_end_emitted: false,
             component_index_cache: None,
             body_end_emitted: false,
@@ -7159,6 +7220,41 @@ mod tests {
         assert!(!output.contains("\"state\":{\"items\""));
         assert!(output.contains("\"inventory\""));
         assert!(output.contains("window.__webui="));
+        Ok(())
+    }
+
+    #[test]
+    fn client_state_omit_keys_preserves_ssr_resolution() -> Result<()> {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><body><style>".to_string()),
+                    WebUIFragment::signal("tokens.light", true),
+                    WebUIFragment::raw("</style>".to_string()),
+                    WebUIFragment::signal("body_end", true),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({
+            "name": "Alice",
+            "tokens": {
+                "light": "--color-brand: red;"
+            }
+        });
+        let output = render_bootstrap_with_plugin(
+            &protocol,
+            &state,
+            || Box::new(crate::plugin::webui::WebUIHydrationPlugin::new()),
+            &RenderOptions::new("index.html", "/").with_client_state_omit_keys(&["tokens"]),
+        )?;
+
+        assert!(output.contains("--color-brand: red;"));
+        assert!(output.contains(r#""name":"Alice""#));
+        assert!(!output.contains(r#""tokens""#));
         Ok(())
     }
 

--- a/crates/webui-handler/src/plugin/fast_v2.rs
+++ b/crates/webui-handler/src/plugin/fast_v2.rs
@@ -197,6 +197,10 @@ impl HandlerPlugin for FastV2HydrationPlugin {
     ) -> Result<()> {
         write_fast_route_component_state(state, writer)
     }
+
+    fn needs_webui_bootstrap(&self) -> bool {
+        false
+    }
 }
 
 fn write_fast_route_component_state(state: &Value, writer: &mut dyn ResponseWriter) -> Result<()> {

--- a/crates/webui-handler/src/plugin/fast_v3.rs
+++ b/crates/webui-handler/src/plugin/fast_v3.rs
@@ -166,6 +166,10 @@ impl HandlerPlugin for FastV3HydrationPlugin {
     ) -> Result<()> {
         write_fast_route_component_state(state, writer)
     }
+
+    fn needs_webui_bootstrap(&self) -> bool {
+        false
+    }
 }
 
 fn write_fast_route_component_state(state: &Value, writer: &mut dyn ResponseWriter) -> Result<()> {
@@ -519,6 +523,60 @@ mod tests {
             render_with_plugin(&protocol, &state, || Box::new(FastV3HydrationPlugin::new()));
         // Root scope is disabled — no markers at root level
         assert_eq!(output, "<p>Alice</p>");
+    }
+
+    #[test]
+    fn test_fast_state_only_bootstrap_skips_webui_metadata_script() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><body><my-page>".to_string()),
+                    WebUIFragment::component("my-page"),
+                    WebUIFragment::raw("</my-page>".to_string()),
+                    WebUIFragment::signal("body_end", true),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+            },
+        );
+        fragments.insert(
+            "my-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<p>Hello</p>".to_string())],
+            },
+        );
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol
+            .components
+            .entry("my-page".to_string())
+            .or_default()
+            .template = "<f-template name=\"my-page\"><p>Hello</p></f-template>".to_string();
+
+        let state = test_json!({"items": [{"name": "A"}]});
+        let output =
+            render_with_plugin(&protocol, &state, || Box::new(FastV3HydrationPlugin::new()));
+
+        assert!(
+            output.contains("<script type=\"application/json\" id=\"__webui_state\">"),
+            "FAST should keep the state data block: {output}"
+        );
+        assert!(
+            output.contains("<f-template name=\"my-page\">"),
+            "FAST should keep f-template emission: {output}"
+        );
+        assert!(
+            !output.contains("window.__webui"),
+            "FAST should not emit the WebUI bootstrap script: {output}"
+        );
+        assert!(
+            !output.contains("\"chain\""),
+            "FAST should not serialize WebUI router chain metadata: {output}"
+        );
+        assert!(
+            !output.contains("\"inventory\""),
+            "FAST should not serialize WebUI inventory metadata: {output}"
+        );
     }
 
     #[test]

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -114,6 +114,14 @@ pub trait HandlerPlugin {
     ) -> Option<Vec<String>> {
         None
     }
+
+    /// Whether this plugin needs the `window.__webui` metadata bootstrap
+    /// (`chain`, `inventory`, `nonce`, `css`, `styles`, `templates`).
+    ///
+    /// Plugins that only need the state data block can opt out.
+    fn needs_webui_bootstrap(&self) -> bool {
+        true
+    }
 }
 
 /// Default template emission: write each non-empty template verbatim.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -571,6 +571,11 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 | `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
 | `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
 
+SSR state is emitted as `<script type="application/json" id="__webui_state">`.
+When WebUI metadata is emitted, `window.__webui.state` is a lazy getter backed
+by that block. FAST v2/v3 skip WebUI route/template metadata and emit only the
+data block.
+
 ### Inspect
 
 ```bash

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -721,7 +721,8 @@ property declarations into the render state. Only available on `webui serve`.
    including nested `var()` fallbacks)
 3. Expands transitive `var()` references and detects cycles
 4. Generates CSS declaration strings per theme
-5. Injects into state as `state.tokens.light`, `state.tokens.dark`, etc.
+5. Injects into SSR state as `state.tokens.light`, `state.tokens.dark`, etc.
+   These render-only token strings are omitted from the emitted client state.
 
 **Multi-theme format:**
 ```json

--- a/docs/guide/concepts/plugins/index.md
+++ b/docs/guide/concepts/plugins/index.md
@@ -152,8 +152,15 @@ pub trait HandlerPlugin {
         state: &serde_json::Value,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()>;
+
+    /// Skip route/template metadata when the plugin only needs state.
+    fn needs_webui_bootstrap(&self) -> bool { true }
 }
 ```
+
+When metadata is emitted, SSR state is exposed through `window.__webui.state`,
+backed by the `__webui_state` JSON data block. FAST v2/v3 skip WebUI
+route/template metadata and emit only the data block.
 
 ## Next Steps
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -402,9 +402,10 @@ The server renders `<webui-route>` elements with these DOM attributes:
 
 Build-time attributes like `query`, `keep-alive`, `cache-tags`, and `invalidates` are **not** emitted as DOM attributes on `<webui-route>` elements. They are compiled into the binary protocol and delivered to the client via `window.__webui.chain` JSON data. The `<route>` source attributes remain valid and unchanged - the compiler just delivers them through JSON instead of the DOM.
 
-The server also emits a `window.__webui` script containing the SSR chain, template inventory, and CSS metadata. This replaces the previous `<meta name="webui-inventory">` tag (which is still supported as a fallback for older servers).
+The server emits a JSON state data block plus a `window.__webui` script containing the SSR chain, template inventory, and CSS metadata. This replaces the previous `<meta name="webui-inventory">` tag (which is still supported as a fallback for older servers).
 
 ```html
+<script type="application/json" id="__webui_state">{/* initial SSR state */}</script>
 <script>window.__webui = {
   chain: [
     { "component": "app-shell", "path": "/", "keepAlive": false },
@@ -414,8 +415,13 @@ The server also emits a `window.__webui` script containing the SSR chain, templa
   nonce: "abc123",
   css: ["/styles/main.css"],
   styles: ["app-shell", "topic-page"]
-};</script>
+};
+Object.defineProperty(window.__webui, "state", { /* lazy getter */ });
+</script>
 ```
+
+The lazy getter parses `__webui_state` on first read, so router consumers still
+read `window.__webui.state`.
 
 #### Client Hydration
 

--- a/docs/guide/integrations/ffi.md
+++ b/docs/guide/integrations/ffi.md
@@ -169,6 +169,10 @@ Render a pre-compiled WebUI protocol (protobuf binary) with JSON state data. Thi
 - **Returns** a heap-allocated string on success, or `NULL` on error.
 - The caller **must** free the returned string with `webui_free()`.
 
+The full render state is available during SSR. If the output includes
+`__webui_state`, top-level `tokens` is treated as render-only token CSS and is
+omitted from the client bootstrap state.
+
 ## Error Handling
 
 The FFI uses thread-local error storage following the POSIX `dlerror()` pattern:

--- a/examples/app/todo-fast/src/todo-app/todo-app.html
+++ b/examples/app/todo-fast/src/todo-app/todo-app.html
@@ -1,7 +1,4 @@
-<template shadowrootmode="open"
-  @toggle-item="{onToggleItem($e)}"
-  @delete-item="{onDeleteItem($e)}"
->
+<template shadowrootmode="open">
   <h1>{{title}}</h1>
 
   <div class="add-form">
@@ -14,7 +11,11 @@
     <button class="add-button" @click="{onAddClick()}">Add</button>
   </div>
 
-  <div class="todo-list">
+  <div
+    class="todo-list"
+    @toggle-item="{onToggleItem($e)}"
+    @delete-item="{onDeleteItem($e)}"
+  >
     <for each="item in items">
       <todo-item
         id="{{item.id}}"

--- a/examples/app/todo-fast/src/todo-app/todo-app.ts
+++ b/examples/app/todo-fast/src/todo-app/todo-app.ts
@@ -13,18 +13,20 @@ interface TodoItemData {
 
 export class TodoApp extends FASTElement {
   @attr title = '';
-  @observable items!: TodoItemData[];
-  @observable remainingCount!: number;
+  @observable items: TodoItemData[] = [];
+  @observable remainingCount = 0;
 
   addInput!: HTMLInputElement;
+
+  private prepared = false;
 
   private nextId = 100;
 
   connectedCallback(): void {
-    this.prepareFromDom();
+    this.prepareOnce();
     super.connectedCallback();
     void this.$fastController.isPrerendered.then(() => {
-      this.prepareFromDom();
+      this.prepareOnce();
     });
     console.log('TodoApp connected');
   }
@@ -34,9 +36,14 @@ export class TodoApp extends FASTElement {
     console.log('TodoApp disconnected');
   }
 
-  private prepareFromDom(): void {
+  private prepareOnce(): void {
+    if (this.prepared) return;
+    this.prepareFromDom();
+  }
+
+  private prepareFromDom(): boolean {
     const root = this.shadowRoot;
-    if (!root) return;
+    if (!root) return false;
 
     const items: TodoItemData[] = [];
     for (const el of root.querySelectorAll('todo-item')) {
@@ -46,18 +53,31 @@ export class TodoApp extends FASTElement {
         state: el.getAttribute('state') || 'pending',
       });
     }
+    this.setItems(items);
+    return true;
+  }
+
+  private setItems(items: TodoItemData[]): void {
     this.items = items;
     if (items.length > 0) {
-      this.nextId = Math.max(...items.map(i => Number(i.id) || 0)) + 1;
+      let maxId = 0;
+      for (const item of items) {
+        maxId = Math.max(maxId, Number(item.id) || 0);
+      }
+      this.nextId = maxId + 1;
     }
     this.updateCount();
+    this.prepared = true;
   }
 
   onToggleItem(e: CustomEvent<{id: string}>): void {
-    const item = this.items.find(i => i.id === e.detail.id);
-    if (item) {
-      item.state = item.state === 'done' ? 'pending' : 'done';
-    }
+    this.items = this.items.map(item => item.id === e.detail.id
+      ? {
+          id: item.id,
+          title: item.title,
+          state: item.state === 'done' ? 'pending' : 'done',
+        }
+      : item);
     this.updateCount();
   }
 
@@ -66,7 +86,7 @@ export class TodoApp extends FASTElement {
     this.updateCount();
   }
 
-  onAddKeydown(e: KeyboardEvent) {
+  onAddKeydown(e: KeyboardEvent): boolean {
     if (e.key === 'Enter') {
       this.addTodo();
     }

--- a/examples/app/todo-fast/src/todo-app/todo-app.ts
+++ b/examples/app/todo-fast/src/todo-app/todo-app.ts
@@ -13,20 +13,18 @@ interface TodoItemData {
 
 export class TodoApp extends FASTElement {
   @attr title = '';
-  @observable items: TodoItemData[] = [];
-  @observable remainingCount = 0;
+  @observable items!: TodoItemData[];
+  @observable remainingCount!: number;
 
   addInput!: HTMLInputElement;
-
-  private prepared = false;
 
   private nextId = 100;
 
   connectedCallback(): void {
-    this.prepareOnce();
+    this.prepareFromDom();
     super.connectedCallback();
     void this.$fastController.isPrerendered.then(() => {
-      this.prepareOnce();
+      this.prepareFromDom();
     });
     console.log('TodoApp connected');
   }
@@ -36,14 +34,9 @@ export class TodoApp extends FASTElement {
     console.log('TodoApp disconnected');
   }
 
-  private prepareOnce(): void {
-    if (this.prepared) return;
-    this.prepareFromDom();
-  }
-
-  private prepareFromDom(): boolean {
+  private prepareFromDom(): void {
     const root = this.shadowRoot;
-    if (!root) return false;
+    if (!root) return;
 
     const items: TodoItemData[] = [];
     for (const el of root.querySelectorAll('todo-item')) {
@@ -53,31 +46,18 @@ export class TodoApp extends FASTElement {
         state: el.getAttribute('state') || 'pending',
       });
     }
-    this.setItems(items);
-    return true;
-  }
-
-  private setItems(items: TodoItemData[]): void {
     this.items = items;
     if (items.length > 0) {
-      let maxId = 0;
-      for (const item of items) {
-        maxId = Math.max(maxId, Number(item.id) || 0);
-      }
-      this.nextId = maxId + 1;
+      this.nextId = Math.max(...items.map(i => Number(i.id) || 0)) + 1;
     }
     this.updateCount();
-    this.prepared = true;
   }
 
   onToggleItem(e: CustomEvent<{id: string}>): void {
-    this.items = this.items.map(item => item.id === e.detail.id
-      ? {
-          id: item.id,
-          title: item.title,
-          state: item.state === 'done' ? 'pending' : 'done',
-        }
-      : item);
+    const item = this.items.find(i => i.id === e.detail.id);
+    if (item) {
+      item.state = item.state === 'done' ? 'pending' : 'done';
+    }
     this.updateCount();
   }
 
@@ -86,7 +66,7 @@ export class TodoApp extends FASTElement {
     this.updateCount();
   }
 
-  onAddKeydown(e: KeyboardEvent): boolean {
+  onAddKeydown(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       this.addTodo();
     }

--- a/examples/app/todo-fast/src/todo-item/todo-item.html
+++ b/examples/app/todo-fast/src/todo-item/todo-item.html
@@ -1,7 +1,5 @@
-<template shadowrootmode="open"
-  @click="{onClick($e)}"
->
-  <div class="item">
+<template shadowrootmode="open">
+  <div class="item" @click="{onClick($e)}">
     <button class="toggle" data-action="toggle" title="Toggle complete">
       <if condition="state == 'done'">
         <span class="check">&#10003;</span>

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -524,7 +524,8 @@ The router is organized into 13 internal modules, each handling a single concern
 
 ## SSR Bootstrap (`window.__webui`)
 
-On first load, the server emits a `window.__webui` script containing SSR metadata:
+On first load, the server emits a JSON state data block plus a `window.__webui`
+script containing SSR metadata:
 
 ```typescript
 window.__webui = {
@@ -533,10 +534,11 @@ window.__webui = {
   nonce: "abc123",           // CSP nonce for injected scripts
   css: ["/styles/main.css"], // already-injected stylesheets
   styles: ["app-shell"],     // already-injected module styles
+  state: {/* lazy getter backed by __webui_state */},
 };
 ```
 
-The router reads this at startup, eliminating DOM walking and URLPattern usage. Older servers that emit `<meta name="webui-inventory">` are still supported as a fallback.
+The router reads this at startup, eliminating DOM walking and URLPattern usage. State is stored in `<script type="application/json" id="__webui_state">` and exposed through a lazy `window.__webui.state` getter. Older servers that emit `<meta name="webui-inventory">` are still supported as a fallback.
 
 ## Exports
 


### PR DESCRIPTION
## Summary
- Move SSR state to the `__webui_state` JSON data block.
- Keep WebUI metadata using a lazy `window.__webui.state` getter.
- Keep FAST output data-block-only.
- Omit render-only design tokens from client bootstrap state after SSR resolves them.
- Fix the broken todo-fast app by moving delegated events into the rendered DOM and restoring the app script behavior that was tested locally.

## Benchmark
8-iteration browser benchmark, 100KB state, 4x CPU:

| Scenario | Path | Bootstrap | DCL | Load | Bytes |
|---|---|---:|---:|---:|---:|
| Inline script | buffered | 2.3 ms | 83.3 ms | 83.5 ms | 125306 |
| Data block | buffered | 1.6 ms | 80.2 ms | 80.5 ms | 125312 |
| Inline script | streaming | 2.5 ms | 80.9 ms | 81.1 ms | 125306 |
| Data block | streaming | 1.5 ms | 34.8 ms | 40.1 ms | 125312 |

## Validation
- `cargo test -p microsoft-webui-handler client_state_omit_keys_preserves_ssr_resolution`
- `cargo test -p microsoft-webui-cli test_build_and_render_omits_injected_tokens_from_client_state`
- `cargo test -p microsoft-webui-ffi`
- `pnpm --dir docs build`
- `pnpm -C examples/app/todo-fast build`
- Example app build/smoke checks
- User-tested todo-fast locally after restoring `todo-app.ts`
- `cargo xtask check` reaches existing Windows `libc::rusage/getrusage` failure in `crates/webui/examples/streaming_resource_bench.rs`
