### PR TITLE
feat: add service worker serverless example

### DIFF
--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -883,9 +883,7 @@ export class DocsPlayground extends WebUIElement {
       const t1 = performance.now();
       const stateJson = this.fileByName(this.stateFile)?.content || "{}";
       let html = "";
-      let chunks = 0;
       this.wasm.render(proto, stateJson, (chunk) => {
-        chunks += 1;
         html += chunk;
       }, { entry: this.entry, requestPath: "/" });
       const t2 = performance.now();

--- a/docs/.webui-press/config.json
+++ b/docs/.webui-press/config.json
@@ -191,6 +191,10 @@
             "link": "/guide/concepts/css-tokens"
           },
           {
+            "text": "Serverless Architecture",
+            "link": "/guide/serverless-architecture"
+          },
+          {
             "text": "Plugins",
             "link": "/guide/concepts/plugins/"
           }
@@ -259,8 +263,8 @@
       },
       {
         "icon": "🔄",
-        "title": "Truly isomorphic",
-        "description": "Same Web Components run on the server and the client. The server renders dynamic, per-request HTML by filling compiled templates with live state, with no JavaScript runtime needed. The browser streams a fully-rendered page, then hydrates the same components against the existing DOM. Isomorphic apps without the Node.js dependency."
+        "title": "Isomorphic anywhere",
+        "description": "Same Web Components can render on a fast native server, at the edge, or in a service worker. Cache the compiled UI on a CDN, stream dynamic state through the lightweight handler, then hydrate against the existing DOM. Isomorphic apps without making Node.js the rendering boundary."
       },
       {
         "icon": "🧩",

--- a/docs/guide/integrations/wasm.md
+++ b/docs/guide/integrations/wasm.md
@@ -53,6 +53,10 @@ Render a pre-built WebUI protocol with state data.
 
 Returns nothing on success. Throws on protocol, state, plugin, callback, or render errors.
 
+For a complete static/CDN service worker example using this callback to write a
+`ReadableStream` and mirror `--theme` token injection in the browser, see
+[Serverless Architecture](/guide/serverless-architecture).
+
 ### Additional handler exports
 
 | Export | Description |

--- a/docs/guide/serverless-architecture.md
+++ b/docs/guide/serverless-architecture.md
@@ -1,0 +1,118 @@
+# Serverless Architecture
+
+The [`examples/app/service-worker`](https://github.com/microsoft/webui/tree/main/examples/app/service-worker)
+example demonstrates a high-value WebUI architecture: cache the UI on a CDN and
+pay dynamic compute cost only for state.
+
+The expensive part of SSR is usually rebuilding the same page shell over and
+over. WebUI changes that split. The HTML structure and component styles compile
+once into `protocol.bin`, which can be cached next to the handler-only WASM
+bundle. On each navigation, the browser service worker fetches only public JSON
+state, renders fragments locally with the lightweight WASM handler, and streams
+HTML into the page as each API response arrives.
+
+That means the origin or serverless function does not render HTML. It only
+serves state. The UI, protocol, theme, and WASM handler can all live behind CDN
+cache.
+
+## Sequence
+
+```text
+Browser        Service Worker        CDN / Edge Cache        Public APIs        webui_wasm_handler
+   |                 |                       |                    |                    |
+   | GET /           |                       |                    |                    |
+   |---------------------------------------->|                    |                    |
+   | index.html + app.js                    |                    |                    |
+   |<----------------------------------------|                    |                    |
+   | register()      |                       |                    |                    |
+   |---------------->|                       |                    |                    |
+   | claim clients   |                       |                    |                    |
+   |<----------------|                       |                    |                    |
+   | navigate /      |                       |                    |                    |
+   |---------------->|                       |                    |                    |
+   |                 | GET /protocol.bin     |                    |                    |
+   |                 |---------------------->|                    |                    |
+   |                 | cached protocol       |                    |                    |
+   |                 |<----------------------|                    |                    |
+   |                 | GET /wasm/handler/... |                    |                    |
+   |                 |---------------------->|                    |                    |
+   |                 | cached handler WASM   |                    |                    |
+   |                 |<----------------------|                    |                    |
+   |                 | GET /theme.css        |                    |                    |
+   |                 |---------------------->|                    |                    |
+   |                 | cached theme CSS      |                    |                    |
+   |                 |<----------------------|                    |                    |
+   |                 | GET /api/*.json       |------------------->|                    |
+   |                 | JSON state            |<-------------------|                    |
+   |                 | render(state chunk)   |                    |------------------->|
+   |                 | onChunk(rendered HTML)|                    |<-------------------|
+   | stream fragment |                       |                    |                    |
+   |<----------------|                       |                    |                    |
+```
+
+## Why this is different
+
+| Traditional SSR | WebUI service worker streaming |
+|-----------------|--------------------------------|
+| Server renders HTML per request | CDN serves cached protocol and WASM |
+| Dynamic compute repeats the UI shell | Dynamic compute returns only JSON state |
+| First byte waits for server render | Service worker can stream fragments as APIs resolve |
+| App server owns HTML rendering | Browser owns rendering through the handler-only WASM bundle |
+
+This architecture is especially useful for public-data sites, dashboards, docs
+portals, marketing pages with personalized sections, and any serverless app
+where the UI changes far less often than the state.
+
+## Local code map
+
+| Path | What to inspect |
+|------|-----------------|
+| `examples/app/service-worker/src/*.html` | WebUI fragments compiled into `protocol.bin` |
+| `examples/app/service-worker/src/*.css` | Component CSS embedded into streamed light-DOM fragments |
+| `examples/app/service-worker/src/bootstrap.html` | Static first-load page stamped with build-time theme declarations |
+| `examples/app/service-worker/src/service-worker.ts` | Navigation interception, state fetches, WASM render callback, `ReadableStream` writes |
+| `examples/app/service-worker/src/payload.ts` | Public API payload validation and URL sanitization |
+| `examples/app/service-worker/scripts/inject-theme.ts` | Build-time equivalent of `webui serve --theme` token injection |
+| `examples/app/service-worker/public/api/*.json` | Demo public state APIs |
+| `examples/app/service-worker/tests/service-worker.spec.ts` | Browser test for service worker control and stream order |
+
+## Key design choices
+
+1. **Handler-only WASM.** The browser uses `webui_wasm_handler`, not the parser
+   bundle. Parsing happens at build time.
+2. **Cached UI protocol.** `protocol.bin` is a static artifact. It can be served
+   with long-lived CDN caching and invalidated only when UI changes.
+3. **Dynamic state only.** API endpoints return JSON state. They do not build
+   HTML and do not need a JavaScript rendering runtime.
+4. **Callback streaming.** `render(protocolBytes, stateJson, onChunk, options)`
+   calls `onChunk(html)` for each handler write. The service worker writes those
+   chunks directly to a `ReadableStream`.
+5. **Light DOM fragments.** The example builds with `--dom light` because the
+   service worker appends independent fragments into a single document stream.
+6. **Shared theme tokens.** `scripts/inject-theme.ts` mirrors
+   `webui serve --theme=@microsoft/webui-examples-theme` at build time. It reads
+   `protocol.bin`, gets the protocol token list, and writes trusted token
+   declarations into `public/index.html` and `public/theme.css`.
+7. **State validation boundary.** Public API state is validated before render.
+   URL-bearing fields allow only `https:` or same-origin links.
+
+## Run it
+
+```bash
+pnpm --filter service-worker-example build
+cd examples/app/service-worker
+pnpm start
+```
+
+Open `http://localhost:4175/`. The first load installs the service worker and
+reloads. The next navigation is streamed by the service worker.
+
+## Test it
+
+```bash
+pnpm --filter service-worker-example test
+```
+
+The Playwright test verifies service worker control, visible rendered chunks,
+async chunk ordering, theme declaration streaming, no standalone `styles.css`
+request, and no browser console errors.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ Current entries:
 | `app/contact-book-manager` | Full CRUD contact manager with WebUI Framework + router + Node API |
 | `app/commerce` | WebUI Framework hydration app with a Rust backend for commerce demo app, dozens of controls |
 | `app/routes` | Nested declarative routing demo showing 4-level deep routes, full server side and client handoff |
+| `app/service-worker` | Static/CDN service worker app using `webui_wasm_handler` to stream WASM-rendered chunks from public API state |
 | `integration/node` | Node.js integration via native addon |
 | `integration/rust` | Rust integration via `webui-handler` |
 
@@ -47,3 +48,4 @@ See integration-specific READMEs:
 
 - [integration/node/README.md](integration/node/README.md)
 - [integration/rust/README.md](integration/rust/README.md)
+- [app/service-worker/README.md](app/service-worker/README.md)

--- a/examples/app/calculator/package.json
+++ b/examples/app/calculator/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "build": "pnpm run build:deps && pnpm run build:server && pnpm run build:client",
+    "build:deps": "pnpm --filter @microsoft/webui-framework run build",
     "build:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --minify",
     "build:server": "cargo run -p microsoft-webui-cli -- build ./src --plugin=webui --out ./dist",
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",

--- a/examples/app/commerce/package.json
+++ b/examples/app/commerce/package.json
@@ -4,8 +4,11 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --format=esm --splitting --sourcemap --minify",
+    "build": "pnpm run build:deps && pnpm run build:protocol && pnpm run build:client && pnpm run build:server",
     "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --plugin=webui --css module --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outdir=dist --format=esm --splitting --sourcemap --minify",
+    "build:server": "cargo check -p marketplace-api",
     "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
     "start:server": "cargo run -p marketplace-api -- --port 3004 --no-tls --css=module",
     "start": "cargo xtask dev commerce",

--- a/examples/app/contact-book-manager/package.json
+++ b/examples/app/contact-book-manager/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap ",
+    "build": "pnpm run build:deps && pnpm run build:protocol && pnpm run build:client",
     "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --plugin=webui --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap",
     "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outdir=dist --splitting --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --state ./data/state.json --theme=@microsoft/webui-examples-theme --plugin=webui --servedir ./dist --port 3003 --api-port 3013 --watch",
     "start:api": "esbuild server/api.ts --bundle --platform=node --format=esm --outfile=dist/api.js --packages=external && node dist/api.js",

--- a/examples/app/hello-world/package.json
+++ b/examples/app/hello-world/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "build": "pnpm run build:protocol && pnpm run build:client",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap",
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --state ./data/state.json --theme=@microsoft/webui-examples-theme --servedir ./dist --port 3000 --watch",
     "start": "cargo xtask dev hello-world",

--- a/examples/app/routes/package.json
+++ b/examples/app/routes/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "pnpm run build:deps && esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap",
+    "build": "pnpm run build:deps && pnpm run build:protocol && pnpm run build:client",
     "build:deps": "pnpm --filter @microsoft/webui-framework --filter @microsoft/webui-router run build",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --plugin=webui --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap",
     "start:client": "pnpm run build:deps && esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:api": "cd server && pnpm start",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --plugin=webui --servedir ./dist --port 3008 --api-port 3018 --watch",

--- a/examples/app/service-worker/.gitignore
+++ b/examples/app/service-worker/.gitignore
@@ -1,0 +1,8 @@
+dist-scripts/
+public/protocol.bin
+public/wasm/
+public/app.js
+public/payload.js
+public/service-worker.js
+public/theme.css
+public/*.js.map

--- a/examples/app/service-worker/README.md
+++ b/examples/app/service-worker/README.md
@@ -1,0 +1,105 @@
+# WebUI service worker integration
+
+This example shows a static/CDN-style deployment where a service worker uses the
+handler-only WebUI WASM bundle to render HTML in the browser.
+
+The browser loads only static assets:
+
+- `protocol.bin` generated at build time
+- `webui_wasm_handler.js` plus its `.wasm` payload
+- public JSON files under `/api/`
+- a service worker that streams the navigation response
+
+No application server is required. The service worker fetches public API state,
+renders the matching WebUI fragment with `webui_wasm_handler.render()`, and
+enqueues each rendered section into a `ReadableStream` as soon as that API
+response resolves.
+
+Because the example renders public API data, the service worker validates URL
+fields before calling the handler. Keep that boundary in copied code so
+untrusted API state cannot inject unsafe link schemes.
+
+## Build
+
+From the repository root:
+
+```bash
+pnpm --filter service-worker-example build
+```
+
+The build step:
+
+1. Compiles `src/` to `public/protocol.bin` with light DOM output.
+2. Bundles the TypeScript helper scripts into `dist-scripts/`.
+3. Copies the handler-only WASM bundle into `public/wasm/handler/`.
+4. Type-checks the browser, worker, test, and script TypeScript.
+5. Injects resolved theme CSS into `public/index.html` from `protocol.bin`
+   token metadata.
+6. Bundles `src/app.ts`, `src/payload.ts`, and `src/service-worker.ts` into
+   `public/`.
+7. Renders every sample API payload once through the WASM handler.
+
+The streamed UI uses normal WebUI component files: every `src/*.html` fragment
+has a paired `src/*.css` file. The app is built with `--css style --dom light`,
+so component CSS is embedded in the rendered fragments and no standalone
+`public/styles.css` file is needed.
+
+For design consistency, the service worker uses
+`@microsoft/webui-examples-theme`, the same shared token package used by
+`webui serve --theme=@microsoft/webui-examples-theme`. Because this app renders
+in a static service worker instead of `webui serve`, `scripts/inject-theme.ts`
+reads `public/protocol.bin`, asks the WASM handler for the protocol token list,
+and writes trusted token declarations into `public/index.html` and
+`public/theme.css` at build time.
+Runtime API state never carries theme CSS.
+
+If the handler WASM bundle has not been generated yet, the copy helper runs:
+
+```bash
+cargo xtask build-wasm
+```
+
+## Run
+
+```bash
+cd examples/app/service-worker
+pnpm start
+```
+
+Open `http://localhost:4175/`. The first load installs the service worker and
+reloads. The service worker then intercepts the navigation and streams HTML
+sections as the API JSON files complete.
+
+## Test
+
+```bash
+pnpm --filter service-worker-example test
+```
+
+The Playwright smoke test verifies that the page is controlled by the service
+worker, renders all WebUI chunks, and receives the chunks in async completion
+order rather than source order. Each chunk is wrapped with a `data-chunk`
+marker so the stream order is visible and easy to assert.
+
+## Why this matters
+
+This pattern is useful when HTML shell assets live on a CDN and all data comes
+from public APIs. The serverless edge path can be:
+
+1. CDN serves static files.
+2. Browser service worker loads `protocol.bin`.
+3. Public APIs return JSON state.
+4. WebUI WASM handler renders HTML chunks locally.
+5. The service worker streams the response to the page.
+
+## Source layout
+
+| Path | Purpose |
+|------|---------|
+| `src/*.html` | WebUI fragments compiled into `public/protocol.bin` |
+| `src/*.css` | Component styles embedded into rendered light-DOM fragments |
+| `src/bootstrap.html` | Static first-load page stamped into `public/index.html` with build-time theme declarations |
+| `src/*.ts` | TypeScript browser runtime, service worker, and payload validation |
+| `public/api/*.json` | Public API state payloads used by each fragment |
+| `scripts/*.ts` | Build helpers for copying WASM, injecting theme CSS, and smoke-rendering payloads |
+| `tsconfig*.json` | Strict TypeScript configs for browser/runtime and worker contexts |

--- a/examples/app/service-worker/package.json
+++ b/examples/app/service-worker/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "service-worker-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "pnpm run build:scripts && pnpm run build:protocol && pnpm run copy:wasm && pnpm run inject:theme && pnpm run typecheck && pnpm run build:client && pnpm run check:render",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --out ./public/protocol.bin --plugin=webui --css style --dom light",
+    "build:scripts": "esbuild scripts/copy-wasm.ts scripts/inject-theme.ts scripts/check-render.ts scripts/serve.ts --bundle --outdir=dist-scripts --platform=node --format=esm --target=node22 --external:../public/wasm/handler/webui_wasm_handler.js",
+    "copy:wasm": "node dist-scripts/copy-wasm.js",
+    "inject:theme": "node dist-scripts/inject-theme.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.worker.json",
+    "build:client": "esbuild src/app.ts src/service-worker.ts --bundle --outdir=public --format=esm --target=es2022 --external:./wasm/handler/webui_wasm_handler.js",
+    "check:render": "node dist-scripts/check-render.js",
+    "start:server": "pnpm run build && node dist-scripts/serve.js --port 4175",
+    "start:client": "esbuild src/app.ts src/service-worker.ts --bundle --outdir=public --format=esm --target=es2022 --external:./wasm/handler/webui_wasm_handler.js --watch",
+    "start": "cargo xtask dev service-worker",
+    "test": "pnpm run build && playwright test"
+  },
+  "devDependencies": {
+    "@microsoft/webui-examples-theme": "workspace:*",
+    "@playwright/test": "catalog:",
+    "@types/node": "catalog:",
+    "esbuild": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/app/service-worker/playwright.config.ts
+++ b/examples/app/service-worker/playwright.config.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4175',
+  },
+  webServer: {
+    command: 'node dist-scripts/serve.js --port 4175',
+    url: 'http://127.0.0.1:4175',
+    reuseExistingServer: !process.env['CI'],
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+});

--- a/examples/app/service-worker/public/api/activity.json
+++ b/examples/app/service-worker/public/api/activity.json
@@ -1,0 +1,22 @@
+{
+  "entry": "activity-panel",
+  "delayMs": 760,
+  "state": {
+    "label": "Public API: /api/activity.json",
+    "title": "Streaming timeline",
+    "events": [
+      {
+        "name": "Install",
+        "detail": "The browser installs the module service worker from the CDN."
+      },
+      {
+        "name": "Fetch",
+        "detail": "The service worker requests protocol.bin and public JSON state files."
+      },
+      {
+        "name": "Render",
+        "detail": "Each state response is rendered by webui_wasm_handler and enqueued into the stream."
+      }
+    ]
+  }
+}

--- a/examples/app/service-worker/public/api/hero.json
+++ b/examples/app/service-worker/public/api/hero.json
@@ -1,0 +1,11 @@
+{
+  "entry": "hero-panel",
+  "delayMs": 420,
+  "state": {
+    "region": "Public API: /api/hero.json",
+    "headline": "Serverless HTML without an app server",
+    "detail": "A service worker loads protocol.bin from the CDN, fetches JSON state, renders a WebUI fragment in WASM, and streams it into the navigation response.",
+    "ctaHref": "https://github.com/microsoft/webui",
+    "ctaLabel": "View WebUI on GitHub"
+  }
+}

--- a/examples/app/service-worker/public/api/metrics.json
+++ b/examples/app/service-worker/public/api/metrics.json
@@ -1,0 +1,22 @@
+{
+  "entry": "metrics-panel",
+  "delayMs": 160,
+  "state": {
+    "label": "Public API: /api/metrics.json",
+    "title": "Chunks render as async state resolves",
+    "metrics": [
+      {
+        "value": "1",
+        "label": "protocol.bin file"
+      },
+      {
+        "value": "3",
+        "label": "WASM bundle variants"
+      },
+      {
+        "value": "0",
+        "label": "application servers"
+      }
+    ]
+  }
+}

--- a/examples/app/service-worker/public/api/shell.json
+++ b/examples/app/service-worker/public/api/shell.json
@@ -1,0 +1,9 @@
+{
+  "entry": "shell-panel",
+  "delayMs": 0,
+  "state": {
+    "eyebrow": "Static CDN shell",
+    "title": "WebUI rendered in a service worker",
+    "summary": "The shell starts streaming immediately. Each section below is rendered by the handler-only WASM bundle after its public API state arrives."
+  }
+}

--- a/examples/app/service-worker/public/index.html
+++ b/examples/app/service-worker/public/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebUI Service Worker Streaming</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+            --border-radius-pill: 10px;
+      --border-radius-xl: 12px;
+      --color-brand-accent: #bfdbfe;
+      --color-brand-light: #e0f2fe;
+      --color-brand-primary: #0078d4;
+      --color-brand-primary-hover: #106ebe;
+      --color-danger: #dc2626;
+      --color-danger-light: #fee2e2;
+      --color-neutral-200: #e5e7eb;
+      --color-neutral-50: #f0f2f5;
+      --color-neutral-700: #374151;
+      --color-neutral-800: #1a1a1a;
+      --color-neutral-950: #111827;
+      --color-white: #fff;
+      --font-family-base: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      --font-size-3xl: 28px;
+      --font-size-m: 14px;
+      --font-size-xl: 18px;
+      --font-size-xs: 12px;
+      --font-size-xxl: 24px;
+      --line-height-base: 1.6;
+      --shadow-s: 0 1px 3px rgba(0, 0, 0, 0.08);
+      --spacing-4xl: 48px;
+      --spacing-l: 16px;
+      --spacing-m: 12px;
+      --spacing-s: 8px;
+      --spacing-xl: 20px;
+      --spacing-xs: 4px;
+      --spacing-xxl: 24px;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+              --border-radius-pill: 10px;
+      --border-radius-xl: 12px;
+      --color-brand-accent: #1e40af;
+      --color-brand-light: #1e3a5f;
+      --color-brand-primary: #3b82f6;
+      --color-brand-primary-hover: #60a5fa;
+      --color-danger: #ef4444;
+      --color-danger-light: #450a0a;
+      --color-neutral-200: #1f2937;
+      --color-neutral-50: #0a0a0a;
+      --color-neutral-700: #d1d5db;
+      --color-neutral-800: #e5e7eb;
+      --color-neutral-950: #fafafa;
+      --color-white: #171717;
+      --font-family-base: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      --font-size-3xl: 28px;
+      --font-size-m: 14px;
+      --font-size-xl: 18px;
+      --font-size-xs: 12px;
+      --font-size-xxl: 24px;
+      --line-height-base: 1.6;
+      --shadow-s: 0 1px 3px rgba(0, 0, 0, 0.3);
+      --spacing-4xl: 48px;
+      --spacing-l: 16px;
+      --spacing-m: 12px;
+      --spacing-s: 8px;
+      --spacing-xl: 20px;
+      --spacing-xs: 4px;
+      --spacing-xxl: 24px;
+      }
+    }
+
+    body {
+      display: grid;
+      min-height: 100vh;
+      margin: 0;
+      place-items: center;
+      background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.35), transparent 32rem), linear-gradient(135deg, #020617 0%, #111827 45%, #172554 100%);
+    }
+
+    main {
+      width: min(720px, calc(100% - 32px));
+      padding: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 24px;
+      background: rgba(15, 23, 42, 0.78);
+      box-shadow: 0 24px 80px rgba(2, 6, 23, 0.4);
+    }
+
+    .eyebrow,
+    .hint {
+      color: #93c5fd;
+    }
+  </style>
+</head>
+
+<body class="bootstrap">
+  <main class="bootstrap-panel">
+    <p class="eyebrow">WebUI WASM handler</p>
+    <h1>Installing service worker renderer</h1>
+    <p data-status>Preparing the browser-side renderer...</p>
+    <p class="hint">
+      This page reloads once the service worker controls the tab. The next
+      navigation is streamed from WebUI fragments rendered in WASM.
+    </p>
+  </main>
+  <script type="module" src="./app.js"></script>
+</body>
+
+</html>

--- a/examples/app/service-worker/scripts/check-render.ts
+++ b/examples/app/service-worker/scripts/check-render.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { readFile } from "fs/promises";
+import assert from "node:assert/strict";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import { sanitizePayload } from "../src/payload.js";
+import initWasm, { render } from "../public/wasm/handler/webui_wasm_handler.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const exampleRoot = resolve(here, "..");
+const protocolPath = resolve(exampleRoot, "public/protocol.bin");
+const wasmPath = resolve(exampleRoot, "public/wasm/handler/webui_wasm_handler_bg.wasm");
+const themeCssPath = resolve(exampleRoot, "public/theme.css");
+const apiFiles = ["shell", "hero", "metrics", "activity"];
+const baseUrl = new URL("http://localhost:4175/");
+
+await initWasm({ module_or_path: await readFile(wasmPath) });
+
+const protocol = new Uint8Array(await readFile(protocolPath));
+
+for (const name of apiFiles) {
+  const payload = JSON.parse(
+    await readFile(resolve(exampleRoot, `public/api/${name}.json`), "utf-8"),
+  );
+  const sanitized = sanitizePayload(payload, `api/${name}.json`, baseUrl);
+  let html = "";
+  const onChunk = (chunk: string): void => {
+    html += chunk;
+  };
+  render(
+    protocol,
+    JSON.stringify(sanitized.state),
+    onChunk,
+    { entry: sanitized.entry, requestPath: "/", plugin: "webui" },
+  );
+  if (!html.includes("card")) {
+    throw new Error(`Rendered ${sanitized.entry} did not include expected card markup`);
+  }
+  if (!html.includes("<style>")) {
+    throw new Error(`Rendered ${sanitized.entry} did not include component CSS`);
+  }
+  if (html.includes("styles.css")) {
+    throw new Error(`Rendered ${sanitized.entry} referenced the removed standalone stylesheet`);
+  }
+}
+
+const bootstrapHtml = await readFile(resolve(exampleRoot, "public/index.html"), "utf-8");
+assert.match(bootstrapHtml, /--color-brand-primary: #0078d4;/);
+assert.doesNotMatch(bootstrapHtml, /WEBUI_THEME_(LIGHT|DARK)/);
+
+const themeCss = await readFile(themeCssPath, "utf-8");
+assert.match(themeCss, /--color-brand-primary: #0078d4;/);
+assert.doesNotMatch(themeCss, /WEBUI_THEME_(LIGHT|DARK)/);
+
+assert.throws(
+  () =>
+    sanitizePayload(
+      {
+        entry: "hero-panel",
+        state: { ctaHref: "javascript:alert(1)" },
+      },
+      "api/unsafe.json",
+      baseUrl,
+    ),
+  /unsupported link scheme/,
+);
+
+console.log(`Validated ${apiFiles.length} service worker render chunks`);

--- a/examples/app/service-worker/scripts/copy-wasm.ts
+++ b/examples/app/service-worker/scripts/copy-wasm.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { access, copyFile, mkdir, rm } from "fs/promises";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const exampleRoot = resolve(here, "..");
+const repoRoot = resolve(exampleRoot, "../../..");
+const sourceDir = resolve(repoRoot, "docs/.webui-press/public/wasm/handler");
+const destDir = resolve(exampleRoot, "public/wasm/handler");
+const runtimeFiles = [
+  "webui_wasm_handler.js",
+  "webui_wasm_handler_bg.wasm",
+  "webui_wasm_handler.d.ts",
+  "webui_wasm_handler_bg.wasm.d.ts",
+];
+
+await main();
+
+async function main(): Promise<void> {
+  await ensureHandlerWasm();
+  await rm(destDir, { recursive: true, force: true });
+  await mkdir(destDir, { recursive: true });
+  for (const file of runtimeFiles) {
+    await copyFile(resolve(sourceDir, file), resolve(destDir, file));
+  }
+
+  console.log(`Copied handler WASM bundle to ${destDir}`);
+}
+
+async function ensureHandlerWasm(): Promise<void> {
+  try {
+    await access(resolve(sourceDir, "webui_wasm_handler.js"));
+    await access(resolve(sourceDir, "webui_wasm_handler_bg.wasm"));
+    return;
+  } catch {
+    const result: SpawnSyncReturns<Buffer> = spawnSync(
+      "cargo",
+      ["xtask", "build-wasm"],
+      {
+        cwd: repoRoot,
+        stdio: "inherit",
+      },
+    );
+    if (result.status !== 0) {
+      throw new Error("cargo xtask build-wasm failed");
+    }
+  }
+}

--- a/examples/app/service-worker/scripts/inject-theme.ts
+++ b/examples/app/service-worker/scripts/inject-theme.ts
@@ -45,6 +45,15 @@ function resolveTheme(themeName: string, requiredTokens: string[]): string {
     throw new Error(`Theme '${themeName}' is missing from @microsoft/webui-examples-theme`);
   }
 
+  const missing = requiredTokens.filter(
+    (token) => !Object.prototype.hasOwnProperty.call(theme, token),
+  );
+  if (missing.length > 0) {
+    console.warn(
+      `Theme '${themeName}' is missing ${missing.length} protocol token(s): ${missing.join(", ")}`,
+    );
+  }
+
   return requiredTokens
     .filter((token) => Object.prototype.hasOwnProperty.call(theme, token))
     .sort((left, right) => left.localeCompare(right))

--- a/examples/app/service-worker/scripts/inject-theme.ts
+++ b/examples/app/service-worker/scripts/inject-theme.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { readFile, writeFile } from "fs/promises";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import themeJson from "@microsoft/webui-examples-theme/tokens.json";
+import initWasm, { protocol_tokens } from "../public/wasm/handler/webui_wasm_handler.js";
+
+interface ThemeFile {
+  themes: Record<string, Record<string, string>>;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const exampleRoot = resolve(here, "..");
+const protocolPath = resolve(exampleRoot, "public/protocol.bin");
+const bootstrapPath = resolve(exampleRoot, "src/bootstrap.html");
+const indexPath = resolve(exampleRoot, "public/index.html");
+const themeCssPath = resolve(exampleRoot, "public/theme.css");
+const wasmPath = resolve(exampleRoot, "public/wasm/handler/webui_wasm_handler_bg.wasm");
+const themeFile: ThemeFile = themeJson;
+
+await initWasm({ module_or_path: await readFile(wasmPath) });
+
+const protocol = new Uint8Array(await readFile(protocolPath));
+const requiredTokens = protocol_tokens(protocol) as string[];
+const html = await readFile(bootstrapPath, "utf-8");
+const lightCss = resolveTheme("light", requiredTokens);
+const darkCss = resolveTheme("dark", requiredTokens);
+const themed = html
+  .replace("<!--WEBUI_THEME_LIGHT-->", lightCss)
+  .replace("<!--WEBUI_THEME_DARK-->", darkCss);
+
+if (themed === html) {
+  throw new Error("Theme placeholders were not replaced in public/index.html");
+}
+
+await writeFile(indexPath, themed);
+await writeFile(themeCssPath, buildThemeStylesheet(lightCss, darkCss));
+console.log(`Injected ${requiredTokens.length} protocol token(s) into public/index.html`);
+
+function resolveTheme(themeName: string, requiredTokens: string[]): string {
+  const theme = themeFile.themes[themeName];
+  if (!theme) {
+    throw new Error(`Theme '${themeName}' is missing from @microsoft/webui-examples-theme`);
+  }
+
+  return requiredTokens
+    .filter((token) => Object.prototype.hasOwnProperty.call(theme, token))
+    .sort((left, right) => left.localeCompare(right))
+    .map((token) => `      --${token}: ${theme[token]};`)
+    .join("\n");
+}
+
+function buildThemeStylesheet(lightCss: string, darkCss: string): string {
+  return `:root {
+  color-scheme: light dark;
+${lightCss}
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+${darkCss}
+  }
+}
+`;
+}

--- a/examples/app/service-worker/scripts/inject-theme.ts
+++ b/examples/app/service-worker/scripts/inject-theme.ts
@@ -32,7 +32,7 @@ const themed = html
   .replace("<!--WEBUI_THEME_DARK-->", darkCss);
 
 if (themed === html) {
-  throw new Error("Theme placeholders were not replaced in public/index.html");
+  throw new Error("Theme placeholders were not replaced in src/bootstrap.html");
 }
 
 await writeFile(indexPath, themed);

--- a/examples/app/service-worker/scripts/serve.ts
+++ b/examples/app/service-worker/scripts/serve.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createReadStream } from "fs";
+import { stat } from "fs/promises";
+import { createServer, type ServerResponse } from "http";
+import { extname, isAbsolute, relative, resolve, sep } from "path";
+import { fileURLToPath } from "url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const publicDir = resolve(here, "../public");
+const port = parsePort(process.argv);
+
+const server = createServer(async (request, response) => {
+  try {
+    const requestUrl = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+    const filePath = resolvePublicPath(requestUrl.pathname);
+    const info = await stat(filePath);
+    if (!info.isFile()) {
+      respondText(response, 404, "not found");
+      return;
+    }
+
+    response.writeHead(200, {
+      "Content-Type": contentType(filePath),
+      "Cache-Control": "no-store",
+    });
+    createReadStream(filePath).pipe(response);
+  } catch (error) {
+    respondText(response, statusForError(error), "not found");
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`service-worker example serving http://127.0.0.1:${port}/`);
+});
+
+function parsePort(args: string[]): number {
+  const index = args.indexOf("--port");
+  const raw = index >= 0 ? args[index + 1] : "4175";
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65_535) {
+    throw new Error(`Invalid --port value: ${raw ?? "(missing)"}`);
+  }
+  return parsed;
+}
+
+function resolvePublicPath(pathname: string): string {
+  const decoded = decodeURIComponent(pathname);
+  const withIndex = decoded.endsWith("/") ? `${decoded}index.html` : decoded;
+  const filePath = resolve(publicDir, `.${withIndex}`);
+  const rel = relative(publicDir, filePath);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw Object.assign(new Error("forbidden"), { statusCode: 403 });
+  }
+  return filePath;
+}
+
+function contentType(filePath: string): string {
+  switch (extname(filePath)) {
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".wasm":
+      return "application/wasm";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function statusForError(error: unknown): number {
+  if (isStatusError(error)) {
+    return error.statusCode;
+  }
+  if (isNodeError(error) && error.code === "ENOENT") {
+    return 404;
+  }
+  return 500;
+}
+
+function respondText(response: ServerResponse, statusCode: number, text: string): void {
+  response.writeHead(statusCode, {
+    "Content-Type": "text/plain; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  response.end(text);
+}
+
+function isStatusError(error: unknown): error is { statusCode: number } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error;
+}

--- a/examples/app/service-worker/src/app.ts
+++ b/examples/app/service-worker/src/app.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+const statusEl = document.querySelector<HTMLElement>('[data-status]');
+
+function setStatus(message: string): void {
+  if (statusEl) {
+    statusEl.textContent = message;
+  }
+}
+
+async function registerServiceWorker(): Promise<void> {
+  if (!('serviceWorker' in navigator)) {
+    setStatus('This browser does not support service workers.');
+    return;
+  }
+
+  const registration = await navigator.serviceWorker.register('./service-worker.js', {
+    type: 'module',
+  });
+  await navigator.serviceWorker.ready;
+
+  setStatus(`Service worker ready (${registration.scope}). Reloading into the stream...`);
+  location.reload();
+}
+
+registerServiceWorker().catch((error) => {
+  setStatus(`Service worker failed: ${error instanceof Error ? error.message : String(error)}`);
+});

--- a/examples/app/service-worker/src/bootstrap.html
+++ b/examples/app/service-worker/src/bootstrap.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebUI Service Worker Streaming</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      <!--WEBUI_THEME_LIGHT-->
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+        <!--WEBUI_THEME_DARK-->
+      }
+    }
+
+    body {
+      display: grid;
+      min-height: 100vh;
+      margin: 0;
+      place-items: center;
+      background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.35), transparent 32rem), linear-gradient(135deg, #020617 0%, #111827 45%, #172554 100%);
+    }
+
+    main {
+      width: min(720px, calc(100% - 32px));
+      padding: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 24px;
+      background: rgba(15, 23, 42, 0.78);
+      box-shadow: 0 24px 80px rgba(2, 6, 23, 0.4);
+    }
+
+    .eyebrow,
+    .hint {
+      color: #93c5fd;
+    }
+  </style>
+</head>
+
+<body class="bootstrap">
+  <main class="bootstrap-panel">
+    <p class="eyebrow">WebUI WASM handler</p>
+    <h1>Installing service worker renderer</h1>
+    <p data-status>Preparing the browser-side renderer...</p>
+    <p class="hint">
+      This page reloads once the service worker controls the tab. The next
+      navigation is streamed from WebUI fragments rendered in WASM.
+    </p>
+  </main>
+  <script type="module" src="./app.js"></script>
+</body>
+
+</html>

--- a/examples/app/service-worker/src/components/activity-panel.css
+++ b/examples/app/service-worker/src/components/activity-panel.css
@@ -1,0 +1,20 @@
+.activity {
+  display: grid;
+  gap: var(--spacing-m);
+  margin: var(--spacing-xl) 0 0;
+  padding-left: var(--spacing-xxl);
+}
+
+.activity li {
+  padding-left: var(--spacing-s);
+}
+
+.activity strong {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  color: var(--color-neutral-950);
+}
+
+.activity span {
+  color: var(--color-neutral-700);
+}

--- a/examples/app/service-worker/src/components/activity-panel.html
+++ b/examples/app/service-worker/src/components/activity-panel.html
@@ -1,0 +1,12 @@
+<section class="card activity-card">
+  <p class="eyebrow">{{label}}</p>
+  <h2>{{title}}</h2>
+  <ol class="activity">
+    <for each="event in events">
+      <li>
+        <strong>{{event.name}}</strong>
+        <span>{{event.detail}}</span>
+      </li>
+    </for>
+  </ol>
+</section>

--- a/examples/app/service-worker/src/components/hero-panel.css
+++ b/examples/app/service-worker/src/components/hero-panel.css
@@ -1,0 +1,14 @@
+.button {
+  display: inline-flex;
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-m) var(--spacing-xl);
+  border-radius: var(--border-radius-pill);
+  color: var(--color-white);
+  background: var(--color-brand-primary);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.button:hover {
+  background: var(--color-brand-primary-hover);
+}

--- a/examples/app/service-worker/src/components/hero-panel.html
+++ b/examples/app/service-worker/src/components/hero-panel.html
@@ -1,0 +1,6 @@
+<section class="card hero-card">
+  <p class="eyebrow">{{region}}</p>
+  <h2>{{headline}}</h2>
+  <p>{{detail}}</p>
+  <a class="button" href="{{ctaHref}}">{{ctaLabel}}</a>
+</section>

--- a/examples/app/service-worker/src/components/metrics-panel.css
+++ b/examples/app/service-worker/src/components/metrics-panel.css
@@ -1,0 +1,22 @@
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-m);
+  margin-top: var(--spacing-xl);
+}
+
+.metric {
+  padding: var(--spacing-l);
+  border-radius: var(--border-radius-xl);
+  background: var(--color-brand-light);
+}
+
+.metric strong {
+  display: block;
+  color: var(--color-brand-primary);
+  font-size: var(--font-size-3xl);
+}
+
+.metric span {
+  color: var(--color-neutral-700);
+}

--- a/examples/app/service-worker/src/components/metrics-panel.html
+++ b/examples/app/service-worker/src/components/metrics-panel.html
@@ -1,0 +1,12 @@
+<section class="card metrics-card">
+  <p class="eyebrow">{{label}}</p>
+  <h2>{{title}}</h2>
+  <div class="metrics">
+    <for each="metric in metrics">
+      <article class="metric">
+        <strong>{{metric.value}}</strong>
+        <span>{{metric.label}}</span>
+      </article>
+    </for>
+  </div>
+</section>

--- a/examples/app/service-worker/src/components/shell-panel.css
+++ b/examples/app/service-worker/src/components/shell-panel.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-neutral-50);
+  color: var(--color-neutral-800);
+  font-family: var(--font-family-base);
+  line-height: var(--line-height-base);
+}
+
+.page {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: var(--spacing-4xl) 0;
+}
+
+.stream-note {
+  margin-bottom: var(--spacing-l);
+  color: var(--color-brand-primary);
+  font-size: var(--font-size-m);
+}
+
+.stream-chunk {
+  display: block;
+}
+
+.stream-chunk::before {
+  content: "streamed chunk: " attr(data-chunk);
+  display: inline-flex;
+  margin: var(--spacing-m) 0 0;
+  padding: var(--spacing-xs) var(--spacing-m);
+  border: 1px solid var(--color-brand-accent);
+  border-radius: var(--border-radius-pill);
+  color: var(--color-brand-primary);
+  background: var(--color-brand-light);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card {
+  margin: var(--spacing-l) 0;
+  padding: var(--spacing-xxl);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: var(--border-radius-xl);
+  background: var(--color-white);
+  box-shadow: var(--shadow-s);
+}
+
+.eyebrow {
+  margin: 0 0 var(--spacing-s);
+  color: var(--color-brand-primary);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0 0 var(--spacing-m);
+  line-height: 1.05;
+}
+
+h1 {
+  color: var(--color-neutral-950);
+  font-size: clamp(var(--font-size-xxl), 5vw, 4rem);
+}
+
+h2 {
+  color: var(--color-neutral-950);
+  font-size: clamp(var(--font-size-xl), 3vw, var(--font-size-3xl));
+}
+
+p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--color-neutral-700);
+  line-height: var(--line-height-base);
+}
+
+.error-card {
+  border-color: var(--color-danger);
+  background: var(--color-danger-light);
+}

--- a/examples/app/service-worker/src/components/shell-panel.html
+++ b/examples/app/service-worker/src/components/shell-panel.html
@@ -1,0 +1,5 @@
+<section class="card shell-card">
+  <p class="eyebrow">{{eyebrow}}</p>
+  <h1>{{title}}</h1>
+  <p>{{summary}}</p>
+</section>

--- a/examples/app/service-worker/src/index.html
+++ b/examples/app/service-worker/src/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>WebUI Service Worker Streaming</title>
+</head>
+
+<body>
+  <shell-panel></shell-panel>
+  <hero-panel></hero-panel>
+  <metrics-panel></metrics-panel>
+  <activity-panel></activity-panel>
+</body>
+
+</html>

--- a/examples/app/service-worker/src/payload.ts
+++ b/examples/app/service-worker/src/payload.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const API_CHUNKS = [
+  { label: 'shell', path: 'api/shell.json' },
+  { label: 'hero', path: 'api/hero.json' },
+  { label: 'metrics', path: 'api/metrics.json' },
+  { label: 'activity', path: 'api/activity.json' },
+] as const;
+
+const ENTRY_IDS = new Set([
+  'shell-panel',
+  'hero-panel',
+  'metrics-panel',
+  'activity-panel',
+]);
+const MAX_DEMO_DELAY_MS = 2_000;
+
+export type ApiChunk = (typeof API_CHUNKS)[number];
+
+export interface ApiPayload {
+  entry: string;
+  state: Record<string, unknown>;
+  delayMs: number;
+}
+
+export function sanitizePayload(
+  payload: unknown,
+  sourcePath: string,
+  baseUrl: URL,
+): ApiPayload {
+  if (!isRecord(payload)) {
+    throw new Error(`Invalid API payload from ${sourcePath}: expected object`);
+  }
+
+  const entry = readEntry(payload, sourcePath);
+  const state = readState(payload, sourcePath);
+  const delayMs = readDelay(payload['delayMs']);
+
+  if (typeof state['ctaHref'] === 'string') {
+    state['ctaHref'] = sanitizeHref(state['ctaHref'], sourcePath, baseUrl);
+  }
+
+  return { entry, state, delayMs };
+}
+
+function readEntry(payload: Record<string, unknown>, sourcePath: string): string {
+  const entry = payload['entry'];
+  if (typeof entry !== 'string' || !ENTRY_IDS.has(entry)) {
+    throw new Error(`Invalid API payload from ${sourcePath}: unsupported entry`);
+  }
+  return entry;
+}
+
+function readState(payload: Record<string, unknown>, sourcePath: string): Record<string, unknown> {
+  const state = payload['state'];
+  if (!isRecord(state)) {
+    throw new Error(`Invalid API payload from ${sourcePath}: missing state object`);
+  }
+  return { ...state };
+}
+
+function readDelay(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(value, 0), MAX_DEMO_DELAY_MS);
+}
+
+function sanitizeHref(value: string, sourcePath: string, baseUrl: URL): string {
+  const parsed = new URL(value, baseUrl);
+  if (parsed.protocol === 'https:' || parsed.origin === baseUrl.origin) {
+    return parsed.href;
+  }
+  throw new Error(`Invalid API payload from ${sourcePath}: unsupported link scheme`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/examples/app/service-worker/src/payload.ts
+++ b/examples/app/service-worker/src/payload.ts
@@ -68,7 +68,12 @@ function readDelay(value: unknown): number {
 }
 
 function sanitizeHref(value: string, sourcePath: string, baseUrl: URL): string {
-  const parsed = new URL(value, baseUrl);
+  let parsed: URL;
+  try {
+    parsed = new URL(value, baseUrl);
+  } catch {
+    throw new Error(`Invalid API payload from ${sourcePath}: invalid url`);
+  }
   if (parsed.protocol === 'https:' || parsed.origin === baseUrl.origin) {
     return parsed.href;
   }

--- a/examples/app/service-worker/src/service-worker.ts
+++ b/examples/app/service-worker/src/service-worker.ts
@@ -98,7 +98,7 @@ async function loadProtocol(): Promise<Uint8Array> {
 
 function loadWasm(): Promise<unknown> {
   if (!wasmReady) {
-    const ready = initWasm().catch((error: unknown) => {
+    const ready = Promise.resolve(initWasm()).catch((error: unknown) => {
       wasmReady = undefined;
       throw error;
     });

--- a/examples/app/service-worker/src/service-worker.ts
+++ b/examples/app/service-worker/src/service-worker.ts
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/// <reference lib="webworker" />
+
+import { API_CHUNKS, sanitizePayload, type ApiChunk, type ApiPayload } from './payload.js';
+import initWasm, { render } from './wasm/handler/webui_wasm_handler.js';
+
+declare const self: ServiceWorkerGlobalScope;
+
+const baseUrl = new URL("./", self.location.href);
+const protocolUrl = new URL("protocol.bin", baseUrl);
+const themeCssUrl = new URL("theme.css", baseUrl);
+const encoder = new TextEncoder();
+let wasmReady: Promise<unknown> | undefined;
+let protocolReady: Promise<Uint8Array> | undefined;
+let themeCssReady: Promise<string> | undefined;
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event: ExtendableEvent) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", (event: FetchEvent) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(streamNavigation());
+  }
+});
+
+async function streamNavigation(): Promise<Response> {
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamHtml(controller);
+      } catch (error) {
+        controller.enqueue(encode(renderError(error)));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+async function streamHtml(controller: ReadableStreamDefaultController<Uint8Array>): Promise<void> {
+  const themeCss = await loadThemeCss();
+  controller.enqueue(encode(documentStart(themeCss)));
+
+  const protocol = await loadProtocol();
+  controller.enqueue(encode("<!-- protocol-ready -->\n"));
+
+  await streamChunksAsReady(controller, protocol);
+  controller.enqueue(encode(documentEnd()));
+}
+
+async function loadThemeCss(): Promise<string> {
+  if (!themeCssReady) {
+    themeCssReady = fetch(themeCssUrl, { cache: "no-cache" })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load ${themeCssUrl.pathname}: ${response.status}`);
+        }
+        return response.text();
+      })
+      .catch((error) => {
+        themeCssReady = undefined;
+        throw error;
+      });
+  }
+  return themeCssReady;
+}
+
+async function loadProtocol(): Promise<Uint8Array> {
+  if (!protocolReady) {
+    protocolReady = (async () => {
+      await loadWasm();
+      const response = await fetch(protocolUrl, { cache: "no-cache" });
+      if (!response.ok) {
+        throw new Error(`Failed to load ${protocolUrl.pathname}: ${response.status}`);
+      }
+      return new Uint8Array(await response.arrayBuffer());
+    })().catch((error) => {
+      protocolReady = undefined;
+      throw error;
+    });
+  }
+  return protocolReady;
+}
+
+function loadWasm(): Promise<unknown> {
+  if (!wasmReady) {
+    const ready = initWasm().catch((error: unknown) => {
+      wasmReady = undefined;
+      throw error;
+    });
+    wasmReady = ready;
+    return ready;
+  }
+  return wasmReady;
+}
+
+async function streamChunksAsReady(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  protocol: Uint8Array,
+): Promise<void> {
+  const pending = API_CHUNKS.map((chunk) =>
+    fetchChunk(chunk).then((payload) => ({ chunk, payload })),
+  );
+
+  while (pending.length > 0) {
+    const indexed = pending.map((promise, index) =>
+      promise.then((result) => ({ index, result })),
+    );
+    const { index, result } = await Promise.race(indexed);
+    pending.splice(index, 1);
+
+    controller.enqueue(
+      encode(`<div class="stream-chunk" data-chunk="${result.chunk.label}">\n`),
+    );
+    render(
+      protocol,
+      JSON.stringify(result.payload.state),
+      (chunk: string) => controller.enqueue(encode(chunk)),
+      {
+        entry: result.payload.entry,
+        requestPath: '/',
+        plugin: 'webui',
+      },
+    );
+    controller.enqueue(encode("\n</div>\n"));
+  }
+}
+
+async function fetchChunk(chunk: ApiChunk): Promise<ApiPayload> {
+  const url = new URL(chunk.path, baseUrl);
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    cache: 'no-cache',
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to load ${url.pathname}: ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const sanitized = sanitizePayload(payload, chunk.path, baseUrl);
+  await delay(sanitized.delayMs);
+  return sanitized;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function encode(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+function documentStart(themeCss: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebUI Service Worker Streaming</title>
+  <style>${themeCss}</style>
+</head>
+<body>
+  <main class="page">
+    <div class="stream-note">Streaming from service worker + WebUI WASM handler</div>
+`;
+}
+
+function documentEnd(): string {
+  return `  </main>
+</body>
+</html>
+`;
+}
+
+function renderError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `<section class="card error-card"><h1>Render failed</h1><p>${escapeHtml(message)}</p></section>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/examples/app/service-worker/src/wasm/handler/webui_wasm_handler.d.ts
+++ b/examples/app/service-worker/src/wasm/handler/webui_wasm_handler.d.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export default function init(
+  module?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module | {
+    module_or_path?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+  },
+): Promise<unknown>;
+
+export function render(
+  protocolBytes: Uint8Array,
+  stateJson: string,
+  onChunk: (html: string) => void,
+  options?: {
+    entry?: string;
+    requestPath?: string;
+    plugin?: string;
+  },
+): void;

--- a/examples/app/service-worker/tests/service-worker.spec.ts
+++ b/examples/app/service-worker/tests/service-worker.spec.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect, test } from '@playwright/test';
+
+test('streams WebUI-rendered chunks from a service worker', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  const requestedUrls: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('request', (request) => {
+    requestedUrls.push(request.url());
+  });
+
+  await page.goto('/').catch(() => {
+    // The bootstrap page reloads once the service worker takes control.
+  });
+  await page.waitForFunction(() => navigator.serviceWorker.controller !== null);
+
+  await expect(page.getByRole('heading', { name: 'WebUI rendered in a service worker' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Serverless HTML without an app server' })).toBeVisible();
+  await expect(page.getByText('Chunks render as async state resolves')).toBeVisible();
+  await expect(page.getByText('Streaming timeline')).toBeVisible();
+  await expect(page.locator('.error-card')).toHaveCount(0);
+
+  const headings = await page.locator('.card h1, .card h2').allTextContents();
+  const shell = headings.indexOf('WebUI rendered in a service worker');
+  const metrics = headings.indexOf('Chunks render as async state resolves');
+  const hero = headings.indexOf('Serverless HTML without an app server');
+  const activity = headings.indexOf('Streaming timeline');
+
+  await expect(page.locator('.stream-chunk')).toHaveCount(4);
+  const chunkOrder = await page.locator('.stream-chunk').evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute('data-chunk')),
+  );
+  expect(chunkOrder).toEqual(['shell', 'metrics', 'hero', 'activity']);
+
+  expect(shell).toBeGreaterThan(-1);
+  expect(metrics).toBeGreaterThan(shell);
+  expect(hero).toBeGreaterThan(metrics);
+  expect(activity).toBeGreaterThan(hero);
+
+  await expect(page.locator('style')).toHaveCount(5);
+  const themeCss = await page.locator('style').first().evaluate((node) => node.textContent ?? '');
+  expect(themeCss).toContain('--color-brand-primary: #0078d4;');
+  expect(requestedUrls.some((url) => url.endsWith('/styles.css'))).toBe(false);
+  expect(consoleErrors).toEqual([]);
+});

--- a/examples/app/service-worker/tsconfig.json
+++ b/examples/app/service-worker/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "declaration": false,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"],
+    "noEmit": true
+  },
+  "include": [
+    "playwright.config.ts",
+    "scripts/**/*.ts",
+    "src/app.ts",
+    "src/payload.ts",
+    "tests/**/*.ts",
+    "public/wasm/handler/*.d.ts"
+  ]
+}

--- a/examples/app/service-worker/tsconfig.worker.json
+++ b/examples/app/service-worker/tsconfig.worker.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "WebWorker"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "declaration": false,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "resolveJsonModule": true,
+    "types": [],
+    "noEmit": true
+  },
+  "include": [
+    "src/payload.ts",
+    "src/service-worker.ts",
+    "src/wasm/handler/*.d.ts"
+  ]
+}

--- a/examples/app/todo-fast/package.json
+++ b/examples/app/todo-fast/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json",
+    "build": "pnpm run build:protocol && pnpm run build:client",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --plugin=fast-v3 --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json",
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --state ./data/state.json --theme=@microsoft/webui-examples-theme --plugin=fast-v3 --servedir ./dist --port 3001 --watch",
     "start": "cargo xtask dev todo-fast"

--- a/examples/app/todo-webui/package.json
+++ b/examples/app/todo-webui/package.json
@@ -4,7 +4,10 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json --minify",
+    "build": "pnpm run build:deps && pnpm run build:protocol && pnpm run build:client",
+    "build:deps": "pnpm --filter @microsoft/webui-framework run build",
+    "build:protocol": "cargo run -p microsoft-webui-cli -- build ./src --plugin=webui --out ./dist",
+    "build:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json --minify",
     "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
     "start:server": "cargo run -p microsoft-webui-cli -- serve ./src --state ./data/state.json --plugin=webui --servedir ./dist --port 3006 --watch",
     "start": "cargo xtask dev todo-webui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,24 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  examples/app/service-worker:
+    devDependencies:
+      '@microsoft/webui-examples-theme':
+        specifier: workspace:*
+        version: link:../../../packages/webui-examples-theme
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.58.2
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.3.5
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.28.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   examples/app/todo-fast:
     devDependencies:
       '@microsoft/fast-element':

--- a/xtask/src/build_examples.rs
+++ b/xtask/src/build_examples.rs
@@ -3,9 +3,13 @@
 
 //! Examples build tasks.
 
-use crate::util::{collect_child_dirs, display_name, run_command, run_command_quiet};
+use crate::util::{
+    build_command, collect_child_dirs, display_name, run_command, run_command_quiet,
+};
+use std::fs;
 use std::path::Path;
 use std::process::ExitCode;
+use std::process::Stdio;
 
 // ── Integration builds ──────────────────────────────────────────────────
 
@@ -119,36 +123,15 @@ pub fn run_app_builds() -> Result<(), String> {
         .map(|app_dir| {
             thread::spawn(move || {
                 let app_name = display_name(&app_dir);
-                let src_dir = app_dir.join("src");
-                if !src_dir.is_dir() {
+                if !has_script(&app_dir, "build") {
                     return Err(format!(
-                        "app '{}' is missing src directory at {}",
+                        "app '{}' is missing a package.json build script at {}",
                         app_name,
-                        src_dir.display()
+                        app_dir.join("package.json").display()
                     ));
                 }
 
-                let output_dir = app_dir.join("dist");
-                let src_str = src_dir.to_string_lossy().to_string();
-                let output_str = output_dir.to_string_lossy().to_string();
-
-                let mut args: Vec<&str> = vec![
-                    "run",
-                    "-p",
-                    "microsoft-webui-cli",
-                    "--",
-                    "build",
-                    &src_str,
-                    "--out",
-                    &output_str,
-                ];
-
-                if app_name.ends_with("-fast") {
-                    args.push("--plugin");
-                    args.push("fast-v3");
-                }
-
-                run_command_quiet("cargo", &args, None)
+                run_app_build_script(&app_dir)
                     .map_err(|message| format!("app '{}' build failed: {}", app_name, message))?;
 
                 eprintln!("  {} app: {}", console::style("•").dim(), app_name);
@@ -176,6 +159,48 @@ pub fn run_app_builds() -> Result<(), String> {
 pub fn run_example_builds() -> Result<(), String> {
     run_integration_builds()?;
     run_app_builds()
+}
+
+fn run_app_build_script(app_dir: &Path) -> Result<(), String> {
+    let mut command = build_command("pnpm", &["run", "build"]);
+    command
+        .current_dir(app_dir)
+        .env("CARGO_INCREMENTAL", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match command.output() {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => {
+            let mut msg = String::new();
+            if let Ok(s) = String::from_utf8(output.stdout) {
+                msg.push_str(&s);
+            }
+            if let Ok(s) = String::from_utf8(output.stderr) {
+                msg.push_str(&s);
+            }
+            if msg.is_empty() {
+                msg = format!("exit code {}", output.status.code().unwrap_or(1));
+            }
+            Err(msg)
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+/// Check whether an app package declares a non-empty npm script.
+fn has_script(app_dir: &Path, script: &str) -> bool {
+    let Ok(content) = fs::read_to_string(app_dir.join("package.json")) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    value
+        .get("scripts")
+        .and_then(|scripts| scripts.get(script))
+        .and_then(|script_value| script_value.as_str())
+        .is_some_and(|script_text| !script_text.is_empty())
 }
 
 // ── Run integration with app ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Introduces a serverless WebUI architecture example where the compiled UI is static and cacheable, while dynamic compute only returns JSON state.

The new `examples/app/service-worker` app demonstrates how to:

- serve `protocol.bin`, handler-only WASM, bootstrap HTML, and theme CSS from static/CDN assets
- use the lightweight `webui_wasm_handler` bundle in a browser service worker
- stream rendered light-DOM fragments through a `ReadableStream` as public API JSON resolves
- resolve shared design tokens at build time from protocol token metadata instead of carrying theme CSS in runtime state
- keep public API payloads validated before render, including safe URL scheme checks

## Architecture

The important design shift is that serverless compute no longer renders HTML. WebUI compiles the UI shape once into `protocol.bin`; the CDN can cache that alongside the handler-only WASM bundle. On navigation, the service worker loads cached UI assets, fetches dynamic state from public APIs, renders fragments locally with the WASM handler callback API, and streams chunks into the response.

This makes the dynamic cost proportional to state generation, not repeated SSR of the same page shell.

## Changes

- Added `examples/app/service-worker` with WebUI templates, paired component CSS, TypeScript service worker runtime, static API payloads, and Playwright coverage.
- Added build-time theme injection from `protocol.bin` token metadata via `scripts/inject-theme.ts`.
- Added a `Serverless Architecture` docs guide under the Guides sidebar with a sequence diagram and local code map.
- Updated the WASM integration docs to point to the serverless architecture guide.
- Added package-owned `build` scripts across app examples and simplified `xtask build-examples` to run `pnpm run build` for every app while preserving `CARGO_INCREMENTAL=0` for nested Cargo commands.
- Removed temporary docs playground diagnostics from the WASM callback investigation.

## Validation

- `pnpm --filter service-worker-example test`
- `pnpm --filter @webui/docs... build`
- `cargo test -p xtask`
- `cargo xtask build-examples`
- `CI=true cargo xtask check`

Fixes #345