### PR TITLE
chore: bump version to 0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "actix-web",
  "awc",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "cbindgen",
  "microsoft-webui-handler",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "clap",
  "criterion",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "criterion",
  "prost",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.15"
+version = "0.0.16"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.15", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.15" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.15" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.15" }
+microsoft-webui = { path = "../webui", version = "0.0.16", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.16" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.16" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.16" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -37,7 +37,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.16" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.15" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.16" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.16" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.15" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui = { path = "../webui", version = "0.0.16" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,7 +26,7 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -34,7 +34,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.15", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.15" }
+microsoft-webui = { path = "../webui", version = "0.0.16", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.16" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -44,6 +44,6 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.15" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.16" }
 actix-web = { workspace = true }
 tokio = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.15" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.15" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.15" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.16" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
@@ -41,8 +41,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.15" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.15" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.15</Version>
+    <Version>0.0.16</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.15"
+  "version": "0.0.16"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.16`.

Previous release tag: `v0.0.15`

## Changes since `v0.0.15`

Features:

- docs playground authoring is more interactive with inline file creation/renaming, shareable URLs, file icons, richer preview states, and structured in-place build error panels (feat: improve docs playground with inline edit and sharing #333, feat: surface build errors in the docs playground #341).
- build-time diagnostics now include stable codes, source locations, snippets, actionable help, suggestions, JSON output, and differentiated CLI exit codes (feat: actionable build-time diagnostics with codes, JSON output, and suggestions #340).
- parser performance and WASM size improve substantially after replacing tree-sitter with a deterministic HTML/CSS scanner and explicit guardrails (perf: replace tree-sitter with a deterministic HTML/CSS scanner #337).
- WASM delivery now offers split parser, handler, and all bundles with a protobuf byte boundary, plus a service-worker serverless example that renders from static protocol assets and handler-only WASM (Split WASM parser and handler bundles #344, feat: add service worker serverless example #347).
- examples and docs components move further onto WebUI-native patterns with the upgraded calculator app and expanded webui-press theme token/component support (feat: upgrade calculator example framework #336, feat: improve webui-press theming and components #348).
- SSR metadata now separates JSON-safe data into an inert `webui-data` block while preserving executable plugin side channels such as `templateFns` (feat: split SSR metadata into JSON data block #350).

Fixes:

- webui-press code blocks preserve slotted `<pre><code>` content after parser comment stripping (Fix webui-press code block slot restoration #334).
- render-only design tokens stay available for SSR CSS but are omitted from client `webui-data.state` across CLI and FFI render paths (fix: omit render-only tokens from client state #351).

Docs:

- NuGet, .NET, installation, integration, and design documentation were refreshed for managed package publishing and RID-specific runtime packages (chore: Prepare NuGet packages for publishing #343).

Maintenance:

- release preparation now has a reusable local bump-version skill for versioning, validation, and bucketed PR notes (chore: add bump-version release skill #332).
- NuGet packages gained publish-readiness metadata, symbol packages, Source Link, package README packing, runtime dependencies, and publish staging (chore: Prepare NuGet packages for publishing #343).
- esbuild was updated to 0.28.1, including the upstream local dev-server path traversal fix (chore(deps): bump esbuild from 0.27.3 to 0.28.1 #342).

## Validation

- `cargo xtask check`
