### PR TITLE
chore: Fix native runtime NuGet symbol packing

### DIFF
--- a/dotnet/runtime/Microsoft.WebUI.Runtime.linux-arm64/Microsoft.WebUI.Runtime.linux-arm64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.linux-arm64/Microsoft.WebUI.Runtime.linux-arm64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
     <Description>WebUI native runtime for Linux ARM64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->

--- a/dotnet/runtime/Microsoft.WebUI.Runtime.linux-x64/Microsoft.WebUI.Runtime.linux-x64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.linux-x64/Microsoft.WebUI.Runtime.linux-x64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <Description>WebUI native runtime for Linux x64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->

--- a/dotnet/runtime/Microsoft.WebUI.Runtime.osx-arm64/Microsoft.WebUI.Runtime.osx-arm64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.osx-arm64/Microsoft.WebUI.Runtime.osx-arm64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
     <Description>WebUI native runtime for macOS ARM64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->

--- a/dotnet/runtime/Microsoft.WebUI.Runtime.osx-x64/Microsoft.WebUI.Runtime.osx-x64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.osx-x64/Microsoft.WebUI.Runtime.osx-x64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <Description>WebUI native runtime for macOS x64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->

--- a/dotnet/runtime/Microsoft.WebUI.Runtime.win-arm64/Microsoft.WebUI.Runtime.win-arm64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.win-arm64/Microsoft.WebUI.Runtime.win-arm64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <Description>WebUI native runtime for Windows ARM64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->

--- a/dotnet/runtime/Microsoft.WebUI.Runtime.win-x64/Microsoft.WebUI.Runtime.win-x64.csproj
+++ b/dotnet/runtime/Microsoft.WebUI.Runtime.win-x64/Microsoft.WebUI.Runtime.win-x64.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Description>WebUI native runtime for Windows x64.</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IncludeSymbols>false</IncludeSymbols>
     <IsPackable>true</IsPackable>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <!-- No managed code in this package -->


### PR DESCRIPTION
Disable symbol package generation for native-only runtime packages so dotnet pack does not attempt to create empty .snupkg artifacts.