### PR TITLE
chore: add runtime NuGet package metadata

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1531,7 +1531,7 @@ The `@microsoft/webui` npm package follows the esbuild single-package model:
 
 The `Microsoft.WebUI` package is the managed .NET binding for `webui-ffi`. It targets `net8.0` and `net9.0`, packs `dotnet/src/Microsoft.WebUI/README.md`, and publishes XML documentation generated from public API comments.
 
-Native assets are split into `Microsoft.WebUI.Runtime.<rid>` packages for each supported RID. The managed package references every runtime package so NuGet restores them transitively; .NET then resolves `webui_ffi` from the matching `runtimes/<rid>/native` asset. `WEBUI_LIB_PATH` remains the override for custom local native builds.
+Native assets are split into `Microsoft.WebUI.Runtime.<rid>` packages for each supported RID. The runtime packages share `dotnet/runtime/README.md`, include NuGet release notes pointing to the GitHub release notes, and carry the matching `runtimes/<rid>/native` asset. The managed package references every runtime package so NuGet restores them transitively; .NET then resolves `webui_ffi` from the matching native asset. `WEBUI_LIB_PATH` remains the override for custom local native builds.
 
 `dotnet/Directory.Build.props` applies repository metadata, Source Link, and `.snupkg` symbol package generation to packable .NET projects. `cargo xtask publish` runs `dotnet pack` on `dotnet/Microsoft.WebUI.sln` and stages both `.nupkg` and `.snupkg` files under `publish/nuget`.
 

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -17,6 +17,12 @@
     <PackageTags>webui</PackageTags>
     <!-- PackageIcon will be set once an approved 128x128 transparent PNG is available. -->
   </PropertyGroup>
+  <PropertyGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Microsoft.WebUI.Runtime.'))">
+    <IsWebUIRuntimePackage>true</IsWebUIRuntimePackage>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>WebUI native runtime assets for this release. See https://github.com/microsoft/webui/releases for release notes.</PackageReleaseNotes>
+    <PackageTags>webui dotnet native runtime ffi server-side-rendering</PackageTags>
+  </PropertyGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Microsoft.WebUI.Tests'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/dotnet/Directory.Build.targets
+++ b/dotnet/Directory.Build.targets
@@ -1,5 +1,9 @@
 <Project>
-  <ItemGroup Condition="'$(PackageReadmeFile)' != '' and Exists('$(MSBuildProjectDirectory)\$(PackageReadmeFile)')">
-    <None Include="$(MSBuildProjectDirectory)\$(PackageReadmeFile)" Pack="true" PackagePath="/" />
+  <PropertyGroup>
+    <PackageReadmeSourceFile Condition="'$(PackageReadmeFile)' != '' and Exists('$(MSBuildProjectDirectory)/$(PackageReadmeFile)')">$(MSBuildProjectDirectory)/$(PackageReadmeFile)</PackageReadmeSourceFile>
+    <PackageReadmeSourceFile Condition="'$(PackageReadmeSourceFile)' == '' and '$(PackageReadmeFile)' != '' and '$(IsWebUIRuntimePackage)' == 'true' and Exists('$(MSBuildThisFileDirectory)runtime/$(PackageReadmeFile)')">$(MSBuildThisFileDirectory)runtime/$(PackageReadmeFile)</PackageReadmeSourceFile>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(PackageReadmeSourceFile)' != ''">
+    <None Include="$(PackageReadmeSourceFile)" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/dotnet/runtime/README.md
+++ b/dotnet/runtime/README.md
@@ -23,6 +23,10 @@ Reference a runtime package directly only when you are manually assembling nativ
 | macOS x64 | `Microsoft.WebUI.Runtime.osx-x64` |
 | macOS ARM64 | `Microsoft.WebUI.Runtime.osx-arm64` |
 
+## Documentation
+
+See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.
+
 ## License
 
-MIT
+MIT - Copyright (c) Microsoft Corporation.

--- a/dotnet/runtime/README.md
+++ b/dotnet/runtime/README.md
@@ -1,0 +1,28 @@
+# Microsoft.WebUI.Runtime
+
+Native runtime packages for Microsoft.WebUI.
+
+`Microsoft.WebUI.Runtime.<rid>` packages carry the RID-specific `webui_ffi` native library under `runtimes/<rid>/native`. They do not contain managed APIs. The managed `Microsoft.WebUI` package depends on these runtime packages so NuGet restores the native asset for each supported platform.
+
+Most applications should install the managed package:
+
+```bash
+dotnet add package Microsoft.WebUI
+```
+
+Reference a runtime package directly only when you are manually assembling native assets for custom packaging or testing.
+
+## Supported packages
+
+| Runtime | Package |
+|---------|---------|
+| Windows x64 | `Microsoft.WebUI.Runtime.win-x64` |
+| Windows ARM64 | `Microsoft.WebUI.Runtime.win-arm64` |
+| Linux x64 | `Microsoft.WebUI.Runtime.linux-x64` |
+| Linux ARM64 | `Microsoft.WebUI.Runtime.linux-arm64` |
+| macOS x64 | `Microsoft.WebUI.Runtime.osx-x64` |
+| macOS ARM64 | `Microsoft.WebUI.Runtime.osx-arm64` |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Add shared README metadata for RID-specific Microsoft.WebUI.Runtime packages.
- Add runtime package release notes and richer NuGet tags while keeping PackageIcon pending until an approved icon exists.
- Update NuGet readme packing targets so runtime packages can pack the shared runtime README at the package root.
- Document runtime package metadata behavior in DESIGN.md.

## Validation
- Static runtime NuGet metadata checks passed.
- cargo xtask check passed.