### PR TITLE
chore: bump version to 0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "actix-web",
  "awc",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "cbindgen",
  "microsoft-webui-handler",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "clap",
  "criterion",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "criterion",
  "prost",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.16"
+version = "0.0.17"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.16", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.16" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.16" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.16" }
+microsoft-webui = { path = "../webui", version = "0.0.17", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.17" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -37,7 +37,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.17" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.16" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.17" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.17" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.16" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui = { path = "../webui", version = "0.0.17" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,7 +26,7 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -34,7 +34,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,9 +19,9 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.16", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.16" }
+microsoft-webui = { path = "../webui", version = "0.0.17", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -44,6 +44,6 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.16" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.17" }
 actix-web = { workspace = true }
 tokio = { workspace = true }

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -806,7 +806,7 @@ fn bundle_components(
 
     let out_file = site_dir.join("components.js");
 
-    let status = std::process::Command::new("npx")
+    let status = std::process::Command::new(npx_command())
         .arg("esbuild")
         .arg("--bundle")
         .arg("--format=esm")
@@ -826,7 +826,7 @@ fn bundle_components(
             }
             child.wait_with_output()
         })
-        .map_err(|e| Error::Build(format!("esbuild failed: {e}")))?;
+        .map_err(|e| Error::Build(format!("npx esbuild failed: {e}")))?;
 
     if !status.status.success() {
         let stderr = String::from_utf8_lossy(&status.stderr);
@@ -834,6 +834,16 @@ fn bundle_components(
     }
 
     Ok(ts_files.len())
+}
+
+#[cfg(windows)]
+fn npx_command() -> &'static str {
+    "npx.cmd"
+}
+
+#[cfg(not(windows))]
+fn npx_command() -> &'static str {
+    "npx"
 }
 
 const PRE_BLOCK_MARKER_PREFIX: &str = "<span data-webui-press-pre-block=\"";
@@ -932,6 +942,14 @@ mod tests {
     use super::*;
 
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn npx_command_uses_platform_executable() {
+        #[cfg(windows)]
+        assert_eq!(npx_command(), "npx.cmd");
+        #[cfg(not(windows))]
+        assert_eq!(npx_command(), "npx");
+    }
 
     // --- truncate_utf8 ---------------------------------------------------
 

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.16" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,10 +18,10 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.16" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.16" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
@@ -41,8 +41,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.16" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.16" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
 
 [[bench]]
 name = "contact_book_bench"

--- a/crates/webui/examples/streaming_resource_bench.rs
+++ b/crates/webui/examples/streaming_resource_bench.rs
@@ -20,13 +20,14 @@
 //!
 //! * **allocations**  — count of `alloc` calls (custom GlobalAlloc)
 //! * **bytes allocated** — total bytes requested
-//! * **CPU user time** — `getrusage(RUSAGE_SELF).ru_utime` delta
-//! * **peak RSS** — `ru_maxrss` high-water mark
+//! * **CPU user time** — `getrusage(RUSAGE_SELF).ru_utime` delta on Unix
+//! * **peak RSS** — `ru_maxrss` high-water mark on Unix
 //!
 //! Unlike criterion (which only reports wall-clock), this gives a
 //! direct allocator-level view useful for verifying that the streaming
 //! writer's "zero per-write allocation" claim actually holds in the
-//! production path.
+//! production path. CPU and RSS columns are reported as zero on platforms
+//! without `getrusage`.
 //!
 //! Usage:
 //!
@@ -36,8 +37,8 @@
 
 #![allow(missing_docs)]
 // SAFETY EXEMPTION: This is a benchmark example, not library code.
-// `GlobalAlloc` and `libc::getrusage` require `unsafe` blocks; their
-// callers here have correct contracts (forwarding to System allocator
+// `GlobalAlloc` and, on Unix, `libc::getrusage` require `unsafe` blocks;
+// their callers here have correct contracts (forwarding to System allocator
 // with original layouts; `rusage` is fully zero-initialised before the
 // FFI call). The workspace `unsafe_code = "deny"` lint applies to
 // production library code; benchmarking infrastructure is exempted at
@@ -106,7 +107,7 @@ fn alloc_snapshot() -> (usize, usize) {
     )
 }
 
-// ── getrusage helpers ─────────────────────────────────────────────────
+// ── Resource usage helpers ─────────────────────────────────────────────
 
 #[derive(Copy, Clone)]
 struct Rusage {
@@ -114,10 +115,12 @@ struct Rusage {
     sys_cpu: Duration,
     /// Maximum resident set size, in bytes (macOS) or KB (Linux).
     /// Normalised by `max_rss_bytes`.
+    #[cfg(unix)]
     max_rss_raw: i64,
 }
 
 impl Rusage {
+    #[cfg(unix)]
     fn now() -> Self {
         let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
         // SAFETY: `usage` is a valid mutable pointer to a fully-initialised
@@ -131,15 +134,31 @@ impl Rusage {
         }
     }
 
+    #[cfg(not(unix))]
+    fn now() -> Self {
+        Self {
+            user_cpu: Duration::ZERO,
+            sys_cpu: Duration::ZERO,
+        }
+    }
+
     fn max_rss_bytes(&self) -> i64 {
-        if cfg!(target_os = "macos") {
+        #[cfg(all(unix, target_os = "macos"))]
+        {
             self.max_rss_raw
-        } else {
+        }
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
             self.max_rss_raw * 1024
+        }
+        #[cfg(not(unix))]
+        {
+            0
         }
     }
 }
 
+#[cfg(unix)]
 fn timeval_to_duration(tv: libc::timeval) -> Duration {
     let secs = tv.tv_sec as u64;
     let usecs = tv.tv_usec as u32;
@@ -735,8 +754,8 @@ fn main() {
         iters_per_scale
     );
     println!(
-        "RSS column = process-wide high-water mark observed at end of phase \
-         (cumulative across all phases, only meaningful as a peak)."
+        "RSS column = process-wide high-water mark on Unix; 0 on platforms \
+         without getrusage."
     );
     print_header();
 
@@ -790,10 +809,15 @@ fn main() {
     println!();
     println!("Notes:");
     println!("  * `allocs/run` and `bytes/run` are exact (custom GlobalAlloc).");
-    println!("  * `user µs/run` is `getrusage(RUSAGE_SELF).ru_utime` delta / iters.");
-    println!("  * `process RSS` is the high-water mark for the whole process at");
-    println!("    phase end. Per-iteration RSS is not directly observable; use");
-    println!("    `bytes/run` to compare per-render heap pressure across paths.");
+    if cfg!(unix) {
+        println!("  * `user µs/run` is `getrusage(RUSAGE_SELF).ru_utime` delta / iters.");
+        println!("  * `process RSS` is the high-water mark for the whole process at");
+        println!("    phase end. Per-iteration RSS is not directly observable; use");
+        println!("    `bytes/run` to compare per-render heap pressure across paths.");
+    } else {
+        println!("  * `user µs/run`, `sys µs/run`, and `process RSS` are unavailable");
+        println!("    on this platform and reported as 0.");
+    }
 
     match mode {
         Mode::Print => {}
@@ -817,5 +841,16 @@ fn delta_to_row(label: &str, delta: ResourceDelta) -> SnapshotRow {
         sys_cpu_us_per_run: pi.sys_cpu_us,
         wall_us_per_run: pi.wall_us,
         rss_high_water_bytes: pi.rss_bytes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rusage;
+
+    #[test]
+    fn captures_resource_snapshot_on_current_platform() {
+        let usage = Rusage::now();
+        let _ = usage.max_rss_bytes();
     }
 }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.16</Version>
+    <Version>0.0.17</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.17`.

Previous release tag: `v0.0.16`

## Changes since `v0.0.16`

Fixes:

- plugin template compilation preserves root attributes when emitting hydrated templates (fix: preserve plugin template root attributes #359).

Maintenance:

- runtime NuGet packages include package metadata needed for publishing (chore: add runtime NuGet package metadata #355).

## Validation

- `cargo xtask check`