### PR TITLE
chore: align NuGet compliance metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,8 +236,9 @@ jobs:
 
       # Create GitHub Release with all artifacts. NuGet artifacts are staged
       # here for manual nuget.org publishing until ESRP supports automated
-      # NuGet publishing for this project. Manual publish still requires the
-      # approved NuGet owner account and signing/certificate process.
+      # NuGet publishing for this project. Manual publish still requires
+      # approved Microsoft package ownership, Microsoft-certificate signing for
+      # each .nupkg, and signed Authenticode-capable package contents.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1533,9 +1533,9 @@ The `Microsoft.WebUI` package is the managed .NET binding for `webui-ffi`. It ta
 
 Native assets are split into `Microsoft.WebUI.Runtime.<rid>` packages for each supported RID. The runtime packages share `dotnet/runtime/README.md`, include NuGet release notes pointing to the GitHub release notes, and carry the matching `runtimes/<rid>/native` asset. The managed package references every runtime package so NuGet restores them transitively; .NET then resolves `webui_ffi` from the matching native asset. `WEBUI_LIB_PATH` remains the override for custom local native builds.
 
-`dotnet/Directory.Build.props` applies repository metadata, Source Link, and `.snupkg` symbol package generation to packable .NET projects. `cargo xtask publish` runs `dotnet pack` on `dotnet/Microsoft.WebUI.sln` and stages both `.nupkg` and `.snupkg` files under `publish/nuget`.
+`dotnet/Directory.Build.props` applies NuGet metadata to packable .NET projects: `Authors=Microsoft`, `PackageOwners=Microsoft`, a package license URL with `PackageRequireLicenseAcceptance=true`, project and repository URLs, Source Link, release notes links, discoverability tags, the required `© Microsoft Corporation. All rights reserved.` copyright notice, and `.snupkg` symbol package generation. `cargo xtask publish` runs `dotnet pack` on `dotnet/Microsoft.WebUI.sln` and stages both `.nupkg` and `.snupkg` files under `publish/nuget`.
 
-NuGet publishing is not automated by ESRP today. Release workflows attach staged NuGet artifacts to GitHub Releases for manual/externally tracked nuget.org publishing with the approved owner and signing process.
+NuGet publishing is not automated by ESRP today. Release workflows attach staged NuGet artifacts to GitHub Releases for manual/externally tracked nuget.org publishing. Before nuget.org publishing, ownership must be limited to the approved Microsoft package owner/co-owner accounts, every Authenticode-signable file in the package must be signed, and each `.nupkg` must be signed with the Microsoft certificate through the approved signing process.
 
 ### Documentation Guidelines
 - Using `vitepress` in `docs/`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ dotnet add package Microsoft.WebUI
 ```
 
 The NuGet package restores platform-specific `Microsoft.WebUI.Runtime.*` native assets transitively. Release builds stage `.nupkg` and `.snupkg` artifacts with repository metadata and Source Link; nuget.org publishing is manual until ESRP automation supports this project.
+NuGet metadata uses `Authors=Microsoft`, the `Microsoft` package owner, a stable project URL, a package license URL with license acceptance required, release notes links, discoverability tags, and the required `© Microsoft Corporation. All rights reserved.` copyright notice. Before nuget.org publishing, staged packages and Authenticode-signable contents must be signed with a Microsoft certificate through the approved signing process.
 
 ## Learn
 

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -3,7 +3,9 @@
     <Version>0.0.17</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageOwners>Microsoft</PackageOwners>
+    <PackageLicenseUrl>https://github.com/microsoft/webui/blob/main/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/microsoft/webui</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/webui</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -12,9 +14,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' or '$(TF_BUILD)' == 'true'">true</ContinuousIntegrationBuild>
-    <Copyright>Copyright (c) Microsoft Corporation</Copyright>
-    <Description>WebUI — high-performance server-side rendering without JavaScript runtimes.</Description>
-    <PackageTags>webui</PackageTags>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Description>WebUI is a high-performance server-side rendering framework without JavaScript runtimes.</Description>
+    <PackageReleaseNotes>See https://github.com/microsoft/webui/releases for release notes.</PackageReleaseNotes>
+    <PackageTags>webui dotnet server-side-rendering ssr templates web-components ffi</PackageTags>
     <!-- PackageIcon will be set once an approved 128x128 transparent PNG is available. -->
   </PropertyGroup>
   <PropertyGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').StartsWith('Microsoft.WebUI.Runtime.'))">

--- a/dotnet/runtime/README.md
+++ b/dotnet/runtime/README.md
@@ -29,4 +29,4 @@ See the [WebUI repository](https://github.com/microsoft/webui) for full usage gu
 
 ## License
 
-MIT - Copyright (c) Microsoft Corporation.
+MIT. NuGet package metadata uses © Microsoft Corporation. All rights reserved.

--- a/dotnet/src/Microsoft.WebUI/README.md
+++ b/dotnet/src/Microsoft.WebUI/README.md
@@ -82,7 +82,7 @@ The managed package depends on all supported `Microsoft.WebUI.Runtime.<rid>` pac
 
 ### Package Metadata
 
-Packed NuGet artifacts include this README, repository metadata, Source Link, and `.snupkg` symbol packages. Release workflows stage `.nupkg` and `.snupkg` files; nuget.org publishing remains manual/externally tracked until ESRP supports automated NuGet publishing for this project.
+Packed NuGet artifacts include this README, repository metadata, Source Link, a package license URL with license acceptance required, release notes links, discoverability tags, the `© Microsoft Corporation. All rights reserved.` notice, and `.snupkg` symbol packages. Release workflows stage `.nupkg` and `.snupkg` files; nuget.org publishing remains manual/externally tracked until ESRP supports automated NuGet publishing for this project. Before publishing, staged packages and Authenticode-signable contents must be signed with a Microsoft certificate through the approved signing process.
 
 ### Manual Native Library Path
 
@@ -106,4 +106,4 @@ cargo xtask dotnet
 
 ## License
 
-MIT
+MIT. NuGet package metadata uses © Microsoft Corporation. All rights reserved.

--- a/dotnet/tool/Microsoft.WebUI.Tool/Microsoft.WebUI.Tool.csproj
+++ b/dotnet/tool/Microsoft.WebUI.Tool/Microsoft.WebUI.Tool.csproj
@@ -11,5 +11,6 @@
     <ToolCommandName>webui</ToolCommandName>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>WebUI CLI tool for building and inspecting WebUI templates.</Description>
+    <PackageTags>webui dotnet tool cli templates server-side-rendering</PackageTags>
   </PropertyGroup>
 </Project>

--- a/dotnet/tool/Microsoft.WebUI.Tool/README.md
+++ b/dotnet/tool/Microsoft.WebUI.Tool/README.md
@@ -8,7 +8,7 @@ CLI tool for building and inspecting WebUI templates.
 dotnet tool install -g Microsoft.WebUI.Tool
 ```
 
-NuGet artifacts for this tool include repository metadata, Source Link, and `.snupkg` symbols. Release workflows stage the artifacts for manual nuget.org publishing until ESRP supports automated NuGet publishing for this project.
+NuGet artifacts for this tool include this README, repository metadata, Source Link, a package license URL with license acceptance required, release notes links, discoverability tags, the `© Microsoft Corporation. All rights reserved.` notice, and `.snupkg` symbols. Release workflows stage the artifacts for manual nuget.org publishing until ESRP supports automated NuGet publishing for this project. Before publishing, staged packages and Authenticode-signable contents must be signed with a Microsoft certificate through the approved signing process.
 
 ## Usage
 
@@ -32,4 +32,4 @@ The tool locates the native `webui` binary using:
 
 ## License
 
-MIT
+MIT. NuGet package metadata uses © Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
## Summary

- Align shared .NET package metadata with Microsoft NuGet compliance requirements for authorship, ownership metadata, license URL, required license acceptance, release notes, tags, project/repository URLs, and copyright.
- Document the required Microsoft package ownership, Microsoft-certificate package signing, and Authenticode-capable content signing gates before manual nuget.org publishing.
- Add tool-specific NuGet tags while keeping runtime packages on their runtime-specific metadata.

## Validation

- cargo xtask check
- Checked nuget.org package IDs; no Microsoft.WebUI NuGet packages are currently published, so there were no existing package signatures to inspect.
- Checked the source checkout for staged NuGet/native artifacts; none were present to signature-check locally.