### PR TITLE
fix: improve webui-press search results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,7 @@ dependencies = [
  "clap",
  "comrak",
  "console",
+ "html-escape",
  "microsoft-webui",
  "microsoft-webui-dev-server",
  "microsoft-webui-handler",

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -42,6 +42,7 @@ rayon = { workspace = true }
 
 # Utilities
 thiserror = { workspace = true }
+html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
 microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.17" }

--- a/crates/webui-press/package.json
+++ b/crates/webui-press/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@webui/webui-press",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild \"**/*.test.ts\" --bundle --platform=node --format=esm --packages=external --outbase=. --outdir=dist-test --out-extension:.js=.mjs",
+    "test": "pnpm --filter @webui/docs... build && pnpm run build && node --test dist-test/**/*.test.mjs"
+  },
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "esbuild": "catalog:"
+  }
+}

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -697,42 +697,323 @@ pub(crate) fn truncate_utf8(s: &str, max: usize) -> &str {
     &s[..end]
 }
 
+#[derive(Default)]
+struct SearchText {
+    content: String,
+    headings: Vec<SearchHeading>,
+}
+
+/// Heading metadata emitted into `search-index.json`.
+///
+/// The client search UI uses this to create separate, anchor-linked rows for
+/// matching sections (`Page > Heading`) without re-parsing page HTML at runtime.
+struct SearchHeading {
+    text: String,
+    anchor: String,
+    level: u8,
+}
+
+/// Mutable heading capture state while scanning rendered HTML.
+struct CurrentHeading {
+    text: String,
+    anchor: String,
+    level: u8,
+}
+
+struct HtmlTag<'a> {
+    name: &'a str,
+    is_end: bool,
+}
+
 /// Build a single search-index entry for a page. Strips HTML tags,
-/// collapses whitespace, and truncates to 500 bytes. Called once per
-/// page during descriptor construction in `process_content` so cache
-/// hits carry their entry forward verbatim.
+/// decodes escaped text, captures headings for weighted ranking,
+/// collapses whitespace, and truncates body content to 500 bytes.
 pub(crate) fn build_search_entry(title: &str, path: &str, html: &str) -> Value {
-    let mut clean = String::with_capacity(html.len() / 2);
-    let mut in_tag = false;
-    for ch in html.chars() {
-        match ch {
-            '<' => in_tag = true,
-            '>' => {
-                in_tag = false;
-                clean.push(' ');
-            }
-            _ if !in_tag => clean.push(ch),
-            _ => {}
-        }
-    }
-    // split_whitespace collapses arbitrary runs; we re-emit a single
-    // space between tokens. Avoiding `collect::<Vec<_>>().join(" ")` so
-    // we don't allocate an intermediate vector for sequential access.
-    let mut content = String::with_capacity(clean.len());
-    let mut first = true;
-    for tok in clean.split_whitespace() {
-        if !first {
-            content.push(' ');
-        }
-        content.push_str(tok);
-        first = false;
-    }
+    let search_text = extract_search_text(html);
+    let content = normalize_search_text(&search_text.content);
     let truncated = truncate_utf8(&content, 500);
+    let headings: Vec<Value> = search_text
+        .headings
+        .into_iter()
+        .map(|heading| {
+            json_obj([
+                ("text", Value::String(heading.text)),
+                ("anchor", Value::String(heading.anchor)),
+                (
+                    "level",
+                    Value::Number(serde_json::Number::from(u64::from(heading.level))),
+                ),
+            ])
+        })
+        .collect();
     json_obj([
         ("title", Value::String(title.to_string())),
         ("path", Value::String(path.to_string())),
         ("content", Value::String(truncated.to_string())),
+        ("headings", Value::Array(headings)),
     ])
+}
+
+fn extract_search_text(html: &str) -> SearchText {
+    let mut text = SearchText {
+        content: String::with_capacity(html.len() / 2),
+        headings: Vec::with_capacity(8),
+    };
+    let mut current_heading: Option<CurrentHeading> = None;
+    let mut skip_header_anchor = 0usize;
+    let mut cursor = 0;
+
+    while cursor < html.len() {
+        let remaining = &html[cursor..];
+        let Some(tag_offset) = remaining.find('<') else {
+            push_search_text(
+                &mut text,
+                current_heading.as_mut(),
+                skip_header_anchor,
+                remaining,
+            );
+            break;
+        };
+        let text_end = cursor + tag_offset;
+        push_search_text(
+            &mut text,
+            current_heading.as_mut(),
+            skip_header_anchor,
+            &html[cursor..text_end],
+        );
+        let tag_start = text_end + 1;
+        let Some(tag_len) = html[tag_start..].find('>') else {
+            push_search_text(
+                &mut text,
+                current_heading.as_mut(),
+                skip_header_anchor,
+                &html[text_end..],
+            );
+            break;
+        };
+        let tag_end = tag_start + tag_len;
+        handle_search_tag(
+            &html[tag_start..tag_end],
+            &mut text,
+            &mut current_heading,
+            &mut skip_header_anchor,
+        );
+        cursor = tag_end + 1;
+    }
+
+    text
+}
+
+fn handle_search_tag(
+    raw_tag: &str,
+    text: &mut SearchText,
+    current_heading: &mut Option<CurrentHeading>,
+    skip_header_anchor: &mut usize,
+) {
+    if let Some(tag) = parse_html_tag(raw_tag) {
+        if tag.is_end {
+            handle_end_tag(tag.name, text, current_heading, skip_header_anchor);
+        } else {
+            handle_start_tag(tag.name, raw_tag, current_heading, skip_header_anchor);
+        }
+    }
+    push_search_space(text, current_heading.as_mut(), *skip_header_anchor);
+}
+
+fn handle_start_tag(
+    name: &str,
+    raw_tag: &str,
+    current_heading: &mut Option<CurrentHeading>,
+    skip_header_anchor: &mut usize,
+) {
+    if let Some(level) = heading_level(name) {
+        *current_heading = Some(CurrentHeading {
+            text: String::with_capacity(64),
+            anchor: attr_value(raw_tag, "id").unwrap_or("").to_string(),
+            level,
+        });
+    } else if name.eq_ignore_ascii_case("a") && raw_tag.contains("header-anchor") {
+        *skip_header_anchor += 1;
+    }
+}
+
+fn handle_end_tag(
+    name: &str,
+    text: &mut SearchText,
+    current_heading: &mut Option<CurrentHeading>,
+    skip_header_anchor: &mut usize,
+) {
+    if name.eq_ignore_ascii_case("a") && *skip_header_anchor > 0 {
+        *skip_header_anchor -= 1;
+    }
+    if heading_level(name).is_some() {
+        if let Some(raw_heading) = current_heading.take() {
+            let heading_text = normalize_search_text(&raw_heading.text);
+            if !heading_text.is_empty() {
+                text.headings.push(SearchHeading {
+                    text: heading_text,
+                    anchor: raw_heading.anchor,
+                    level: raw_heading.level,
+                });
+            }
+        }
+    }
+}
+
+fn parse_html_tag(raw: &str) -> Option<HtmlTag<'_>> {
+    let mut tag = raw.trim_start();
+    if tag.starts_with('!') || tag.starts_with('?') {
+        return None;
+    }
+    let is_end = tag.starts_with('/');
+    if is_end {
+        tag = tag[1..].trim_start();
+    }
+
+    let mut name_end = 0;
+    for (idx, byte) in tag.bytes().enumerate() {
+        if byte.is_ascii_alphanumeric() || byte == b'-' {
+            name_end = idx + 1;
+        } else {
+            break;
+        }
+    }
+    if name_end == 0 {
+        return None;
+    }
+    Some(HtmlTag {
+        name: &tag[..name_end],
+        is_end,
+    })
+}
+
+/// Return a heading level for `h1` through `h6`.
+///
+/// The scanner works on tag names from already-rendered markdown, so an ASCII
+/// byte check is sufficient and avoids allocating a lowercased copy.
+fn heading_level(name: &str) -> Option<u8> {
+    let bytes = name.as_bytes();
+    if bytes.len() == 2 && bytes[0].eq_ignore_ascii_case(&b'h') && (b'1'..=b'6').contains(&bytes[1])
+    {
+        Some(bytes[1] - b'0')
+    } else {
+        None
+    }
+}
+
+/// Extract an HTML attribute value from a rendered start tag without a DOM
+/// parser.
+///
+/// Search indexing runs once per page at build time, but it still avoids regex
+/// and allocation-heavy parsing. This helper handles quoted and unquoted values
+/// because heading IDs are generated as ordinary HTML attributes.
+fn attr_value<'a>(raw_tag: &'a str, attr_name: &str) -> Option<&'a str> {
+    let bytes = raw_tag.as_bytes();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+
+        let name_start = cursor;
+        while bytes.get(cursor).is_some_and(|b| is_attr_name_byte(*b)) {
+            cursor += 1;
+        }
+        if name_start == cursor {
+            cursor += 1;
+            continue;
+        }
+        let name = &raw_tag[name_start..cursor];
+
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'=') {
+            continue;
+        }
+        cursor += 1;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+
+        let (value_start, value_end) = attr_value_range(raw_tag, cursor);
+        if name.eq_ignore_ascii_case(attr_name) {
+            return Some(&raw_tag[value_start..value_end]);
+        }
+        cursor = value_end.saturating_add(1);
+    }
+
+    None
+}
+
+fn is_attr_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':')
+}
+
+fn attr_value_range(raw_tag: &str, cursor: usize) -> (usize, usize) {
+    let bytes = raw_tag.as_bytes();
+    match bytes.get(cursor).copied() {
+        Some(b'"' | b'\'') => {
+            let quote = bytes[cursor];
+            let value_start = cursor + 1;
+            let value_end = raw_tag[value_start..]
+                .find(char::from(quote))
+                .map_or(raw_tag.len(), |offset| value_start + offset);
+            (value_start, value_end)
+        }
+        Some(_) => {
+            let value_start = cursor;
+            let value_end = raw_tag[value_start..]
+                .find(char::is_whitespace)
+                .map_or(raw_tag.len(), |offset| value_start + offset);
+            (value_start, value_end)
+        }
+        None => (raw_tag.len(), raw_tag.len()),
+    }
+}
+
+fn push_search_text(
+    text: &mut SearchText,
+    current_heading: Option<&mut CurrentHeading>,
+    skip_header_anchor: usize,
+    value: &str,
+) {
+    if skip_header_anchor > 0 {
+        return;
+    }
+    text.content.push_str(value);
+    if let Some(heading) = current_heading {
+        heading.text.push_str(value);
+    }
+}
+
+fn push_search_space(
+    text: &mut SearchText,
+    current_heading: Option<&mut CurrentHeading>,
+    skip_header_anchor: usize,
+) {
+    if skip_header_anchor > 0 {
+        return;
+    }
+    text.content.push(' ');
+    if let Some(heading) = current_heading {
+        heading.text.push(' ');
+    }
+}
+
+fn normalize_search_text(raw: &str) -> String {
+    let decoded = html_escape::decode_html_entities(raw);
+    let mut normalized = String::with_capacity(decoded.len());
+    let mut first = true;
+    for token in decoded.split_whitespace() {
+        if !first {
+            normalized.push(' ');
+        }
+        normalized.push_str(token);
+        first = false;
+    }
+    normalized
 }
 
 fn is_component_ts_file(path: &Path) -> bool {
@@ -1102,6 +1383,34 @@ mod tests {
             "only hydration entry files should be bundled"
         );
         Ok(())
+    }
+
+    #[test]
+    fn build_search_entry_decodes_code_text_and_captures_headings() {
+        let entry = build_search_entry(
+            "`<for>` Loop Directive",
+            "/guide/concepts/directives/for/",
+            r##"<h1 id="for"><code>&lt;for&gt;</code> Loop Directive <a class="header-anchor" href="#for">#</a></h1><p>Use <code>&lt;for&gt;</code> loops.</p><h2 id="syntax">Syntax <a class="header-anchor" href="#syntax">#</a></h2><h3 id="nested">Nested Search <a class="header-anchor" href="#nested">#</a></h3>"##,
+        );
+
+        assert_eq!(entry["title"].as_str(), Some("`<for>` Loop Directive"));
+        assert_eq!(
+            entry["content"].as_str(),
+            Some("<for> Loop Directive Use <for> loops. Syntax Nested Search")
+        );
+        let Some(headings) = entry["headings"].as_array() else {
+            panic!("headings should be an array: {entry:?}");
+        };
+        assert_eq!(headings.len(), 3);
+        assert_eq!(headings[0]["text"].as_str(), Some("<for> Loop Directive"));
+        assert_eq!(headings[0]["anchor"].as_str(), Some("for"));
+        assert_eq!(headings[0]["level"].as_u64(), Some(1));
+        assert_eq!(headings[1]["text"].as_str(), Some("Syntax"));
+        assert_eq!(headings[1]["anchor"].as_str(), Some("syntax"));
+        assert_eq!(headings[1]["level"].as_u64(), Some(2));
+        assert_eq!(headings[2]["text"].as_str(), Some("Nested Search"));
+        assert_eq!(headings[2]["anchor"].as_str(), Some("nested"));
+        assert_eq!(headings[2]["level"].as_u64(), Some(3));
     }
 
     // --- fxhash ----------------------------------------------------------

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -211,39 +211,19 @@ pub fn render_markdown(
 
     let root = parse_document(&arena, content, &options);
 
-    // Two-pass approach: collect node pointers first, then modify.
-    // This avoids modifying the tree during iteration.
+    // Multi-pass approach: collect node pointers first, then modify.
+    // This avoids modifying the tree during iteration and lets heading
+    // rendering see original code-span nodes before they are converted to raw
+    // HTML for WebUI template-signal escaping.
 
-    // Pass 1: Replace code blocks and rewrite internal links
+    // Pass 1: Rewrite internal links before custom heading rendering.
     for node in root.descendants() {
         let mut data = node.data.borrow_mut();
-        match &mut data.value {
-            NodeValue::CodeBlock(ref mut block) => {
-                let lang = if block.info.is_empty() {
-                    "text"
-                } else {
-                    block.info.split_whitespace().next().unwrap_or("text")
-                };
-                let highlighted = highlighter.highlight_code(&block.literal, lang);
-                data.value = NodeValue::HtmlInline(highlighted);
+        if let NodeValue::Link(ref mut link) = data.value {
+            // Prepend base_path to absolute internal links
+            if link.url.starts_with('/') && !link.url.starts_with(base_path) && base_path != "/" {
+                link.url = format!("{}{}", base_path.trim_end_matches('/'), &link.url);
             }
-            NodeValue::Code(ref code) => {
-                // Replace inline code with pre-escaped HTML so `{{...}}` inside
-                // code spans is not interpreted as a WebUI signal binding.
-                let mut html = String::with_capacity(code.literal.len() + 13);
-                html.push_str("<code>");
-                emit_escaped(&mut html, &code.literal);
-                html.push_str("</code>");
-                data.value = NodeValue::HtmlInline(html);
-            }
-            NodeValue::Link(ref mut link) => {
-                // Prepend base_path to absolute internal links
-                if link.url.starts_with('/') && !link.url.starts_with(base_path) && base_path != "/"
-                {
-                    link.url = format!("{}{}", base_path.trim_end_matches('/'), &link.url);
-                }
-            }
-            _ => {}
         }
     }
 
@@ -272,6 +252,33 @@ pub fn render_markdown(
             child.detach();
         }
         node.data.borrow_mut().value = NodeValue::HtmlInline(html);
+    }
+
+    // Pass 3: Replace code blocks and inline code after heading extraction,
+    // so headings can still collect code-span literals for display and slugs.
+    for node in root.descendants() {
+        let mut data = node.data.borrow_mut();
+        match &mut data.value {
+            NodeValue::CodeBlock(ref mut block) => {
+                let lang = if block.info.is_empty() {
+                    "text"
+                } else {
+                    block.info.split_whitespace().next().unwrap_or("text")
+                };
+                let highlighted = highlighter.highlight_code(&block.literal, lang);
+                data.value = NodeValue::HtmlInline(highlighted);
+            }
+            NodeValue::Code(ref code) => {
+                // Replace inline code with pre-escaped HTML so `{{...}}` inside
+                // code spans is not interpreted as a WebUI signal binding.
+                let mut html = String::with_capacity(code.literal.len() + 13);
+                html.push_str("<code>");
+                emit_escaped(&mut html, &code.literal);
+                html.push_str("</code>");
+                data.value = NodeValue::HtmlInline(html);
+            }
+            _ => {}
+        }
     }
 
     let mut html = String::with_capacity(content.len());
@@ -320,6 +327,22 @@ mod tests {
         assert!(
             !html.contains("{{value}}"),
             "raw `{{{{value}}}}` must not survive: {html}"
+        );
+    }
+
+    #[test]
+    fn heading_inline_code_survives_custom_anchor_rendering() {
+        let h = Highlighter::new();
+        let html = match render_markdown("# `<for>` Loop Directive\n", &h, "/") {
+            Ok(html) => html,
+            Err(e) => panic!("render_markdown should succeed: {e}"),
+        };
+
+        assert!(
+            html.contains(
+                r##"<h1 id="for-loop-directive"><code>&lt;for&gt;</code> Loop Directive"##
+            ),
+            "heading inline code should render as code: {html}"
         );
     }
 

--- a/crates/webui-press/template/docs-search/docs-search.css
+++ b/crates/webui-press/template/docs-search/docs-search.css
@@ -117,17 +117,47 @@ input::placeholder {
 
 .result-title {
   font-weight: var(--docs-font-weight-semibold);
-  font-size: var(--docs-font-size-m);
+  font-size: 0;
   margin-bottom: 2px;
 }
 
+.result-title .result-segment {
+  font-size: var(--docs-font-size-m);
+}
+
+.result-title code.result-segment {
+  font-family: var(--docs-font-mono);
+  font-size: var(--docs-font-size-s);
+  background: var(--docs-color-bg-alt);
+  border: 1px solid var(--docs-color-border);
+  border-radius: var(--docs-radius-s);
+  padding: 0 3px;
+}
+
+.result-title .result-separator {
+  color: var(--docs-color-text-3);
+  font-weight: var(--docs-font-weight-normal);
+  margin: 0 0.4em;
+}
+
+.result mark {
+  background: var(--docs-search-mark-bg);
+  border-radius: 2px;
+  color: inherit;
+  padding: 0;
+}
+
 .result-snippet {
-  font-size: var(--docs-font-size-xs);
+  font-size: 0;
   color: var(--docs-color-text-2);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.result-snippet .result-segment {
+  font-size: var(--docs-font-size-xs);
 }
 
 .empty {

--- a/crates/webui-press/template/docs-search/docs-search.html
+++ b/crates/webui-press/template/docs-search/docs-search.html
@@ -8,7 +8,35 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
       <input w-ref={searchInput} type="text" placeholder="Search documentation..." autocomplete="off" @input="{onInput()}" />
     </div>
-    <div class="results" w-ref={resultsEl}></div>
+    <div class="results">
+      <if condition="emptyMessage">
+        <div class="empty">{{emptyMessage}}</div>
+      </if>
+      <if condition="hasResults">
+        <for each="result in resultItems">
+          <a class="{{result.className}}" href="{{result.path}}">
+            <div class="result-title">
+              <for each="segment in result.titleSegments">
+                <if condition="segment.code">
+                  <if condition="segment.mark"><code class="result-segment"><mark>{{segment.text}}</mark></code></if>
+                  <if condition="!segment.mark"><code class="result-segment">{{segment.text}}</code></if>
+                </if>
+                <if condition="!segment.code">
+                  <if condition="segment.mark"><mark class="{{segment.className}}">{{segment.text}}</mark></if>
+                  <if condition="!segment.mark"><span class="{{segment.className}}">{{segment.text}}</span></if>
+                </if>
+              </for>
+            </div>
+            <div class="result-snippet">
+              <for each="segment in result.snippetSegments">
+                <if condition="segment.mark"><mark class="{{segment.className}}">{{segment.text}}</mark></if>
+                <if condition="!segment.mark"><span class="{{segment.className}}">{{segment.text}}</span></if>
+              </for>
+            </div>
+          </a>
+        </for>
+      </if>
+    </div>
     <div class="hint">↑↓ Navigate · Enter Select · Esc Close</div>
   </div>
 </dialog>

--- a/crates/webui-press/template/docs-search/docs-search.test.ts
+++ b/crates/webui-press/template/docs-search/docs-search.test.ts
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { chromium } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import test from 'node:test';
+
+const DIST = resolveDocsDist();
+
+const MIME_TYPES = new Map([
+  ['.css', 'text/css'],
+  ['.html', 'text/html'],
+  ['.js', 'text/javascript'],
+  ['.json', 'application/json'],
+  ['.svg', 'image/svg+xml'],
+  ['.wasm', 'application/wasm'],
+]);
+
+function resolveDocsDist(): string {
+  let current = process.cwd();
+  loop: while (true) {
+    const candidate = path.join(current, 'docs', 'dist');
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break loop;
+    }
+    current = parent;
+  }
+  return path.resolve(process.cwd(), 'docs', 'dist');
+}
+
+test('search results do not retain stale title segments while typing', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/integrations/wasm/`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
+
+  await page.locator('docs-search').evaluate(async (el) => {
+    el.openSearch();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+
+  const input = page.locator('docs-search').locator('input');
+  await input.type('asse', { delay: 50 });
+  await page.waitForTimeout(500);
+
+  const first = await page.locator('docs-search').evaluate((el) => {
+    const result = el.shadowRoot.querySelector('.result');
+    const title = result.querySelector('.result-title');
+    return {
+      href: result.getAttribute('href'),
+      normalizedTitle: title.textContent.replace(/\s+/g, ''),
+      marks: [...title.querySelectorAll('mark')].map((mark) => mark.textContent),
+    };
+  });
+
+  assert.equal(first.href, '/webui/guide/integrations/wasm');
+  assert.equal(first.normalizedTitle, 'WebUIWebAssembly');
+  assert.deepEqual(first.marks, ['Asse']);
+});
+
+test('heading search results use CSS spacing for breadcrumb separators', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/integrations/wasm/`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
+
+  await page.locator('docs-search').evaluate(async (el) => {
+    el.openSearch();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const input = el.shadowRoot.querySelector('input');
+    input.value = 'webassembly';
+    el.onInput();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const separator = await page.locator('docs-search').evaluate((el) => {
+    const item = [...el.shadowRoot.querySelectorAll('.result')].find((result) =>
+      result.getAttribute('href').includes('#webassembly'),
+    );
+    const sep = item.querySelector('.result-separator');
+    const style = getComputedStyle(sep);
+    return {
+      text: sep.textContent,
+      marginLeft: Number.parseFloat(style.marginLeft),
+      marginRight: Number.parseFloat(style.marginRight),
+      normalizedTitle: item
+        .querySelector('.result-title')
+        .textContent.replace(/\s+/g, ''),
+    };
+  });
+
+  assert.equal(separator.text, '>');
+  assert.equal(
+    separator.normalizedTitle,
+    'WebUIFramework-AIReference>WebAssembly',
+  );
+  assert.ok(separator.marginLeft > 0, `marginLeft=${separator.marginLeft}`);
+  assert.ok(separator.marginRight > 0, `marginRight=${separator.marginRight}`);
+});
+
+test('documentation pages scroll inside main content, not the window', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/concepts/components/`, {
+    waitUntil: 'networkidle',
+  });
+
+  await page.locator('.main-content').hover();
+  await page.mouse.wheel(0, 900);
+  await page.waitForTimeout(100);
+
+  const scroll = await page.evaluate(() => {
+    const main = document.querySelector('.main-content');
+    return {
+      windowY: window.scrollY,
+      documentY: document.scrollingElement.scrollTop,
+      mainY: main.scrollTop,
+      mainScrollable: main.scrollHeight > main.clientHeight,
+    };
+  });
+
+  assert.equal(scroll.windowY, 0);
+  assert.equal(scroll.documentY, 0);
+  assert.equal(scroll.mainScrollable, true);
+  assert.ok(scroll.mainY > 0, `mainY=${scroll.mainY}`);
+});
+
+test('documentation pages support keyboard and history scrolling', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/concepts/components/`, {
+    waitUntil: 'networkidle',
+  });
+
+  await page.keyboard.press('PageDown');
+  await page.waitForTimeout(100);
+
+  const afterPageDown = await page.evaluate(() => ({
+    windowY: window.scrollY,
+    mainY: document.querySelector('.main-content').scrollTop,
+  }));
+  assert.equal(afterPageDown.windowY, 0);
+  assert.ok(afterPageDown.mainY > 0, `mainY=${afterPageDown.mainY}`);
+
+  await page.goto(`${server.origin}/webui/guide/concepts/interactivity/`, {
+    waitUntil: 'networkidle',
+  });
+  await page.goBack({ waitUntil: 'networkidle' });
+
+  const restored = await page.evaluate(() => ({
+    windowY: window.scrollY,
+    mainY: document.querySelector('.main-content').scrollTop,
+  }));
+  assert.equal(restored.windowY, 0);
+  assert.ok(restored.mainY > 0, `mainY=${restored.mainY}`);
+});
+
+test('scrollbars and search highlights use theme-specific colors', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/integrations/wasm/`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
+
+  const light = await page.evaluate(() => {
+    const main = document.querySelector('.main-content');
+    const style = getComputedStyle(main);
+    return {
+      thumb: style.getPropertyValue('--docs-scrollbar-thumb').trim(),
+      track: style.getPropertyValue('--docs-scrollbar-track').trim(),
+    };
+  });
+
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  });
+
+  await page.locator('docs-search').evaluate(async (el) => {
+    el.openSearch();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const input = el.shadowRoot.querySelector('input');
+    input.value = 'asse';
+    el.onInput();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const dark = await page.locator('docs-search').evaluate((el) => {
+    const mark = el.shadowRoot.querySelector('mark');
+    const hostStyle = getComputedStyle(el);
+    return {
+      thumb: hostStyle.getPropertyValue('--docs-scrollbar-thumb').trim(),
+      track: hostStyle.getPropertyValue('--docs-scrollbar-track').trim(),
+      markBg: getComputedStyle(mark).backgroundColor,
+    };
+  });
+
+  assert.equal(light.thumb, '#9ca3af');
+  assert.equal(light.track, '#f3f4f6');
+  assert.equal(dark.thumb, '#4b5563');
+  assert.equal(dark.track, '#111827');
+  assert.equal(dark.markBg, 'rgb(183, 121, 31)');
+});
+
+async function waitForDocsSearch(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const el = document.querySelector('docs-search');
+    return (
+      el &&
+      customElements.get('docs-search') &&
+      el.shadowRoot &&
+      el.shadowRoot.querySelector('input')
+    );
+  });
+}
+
+async function startDocsServer(): Promise<{
+  origin: string;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url, 'http://local.test');
+    let urlPath = decodeURIComponent(requestUrl.pathname);
+    if (urlPath === '/webui') {
+      urlPath = '/';
+    } else if (urlPath.startsWith('/webui/')) {
+      urlPath = urlPath.slice('/webui'.length);
+    }
+
+    let filePath = path.join(DIST, urlPath);
+    if (!filePath.startsWith(DIST)) {
+      res.writeHead(403).end();
+      return;
+    }
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+    if (!fs.existsSync(filePath)) {
+      filePath = path.join(DIST, '404.html');
+    }
+
+    res.setHeader(
+      'Content-Type',
+      MIME_TYPES.get(path.extname(filePath)) || 'application/octet-stream',
+    );
+    fs.createReadStream(filePath).pipe(res);
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo | null;
+  assert.notEqual(address, null);
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise((resolve) => {
+        server.closeIdleConnections?.();
+        server.closeAllConnections?.();
+        server.close(resolve);
+      }),
+  };
+}

--- a/crates/webui-press/template/docs-search/docs-search.ts
+++ b/crates/webui-press/template/docs-search/docs-search.ts
@@ -1,21 +1,64 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { WebUIElement } from "@microsoft/webui-framework";
+import { WebUIElement, observable } from "@microsoft/webui-framework";
 
 interface SearchEntry {
   title: string;
   path: string;
   content: string;
+  headings?: SearchHeading[];
+}
+
+interface SearchHeading {
+  text: string;
+  anchor: string;
+  level: number;
+}
+
+interface RankedSearchEntry {
+  entry: SearchEntry;
+  heading?: SearchHeading;
+  path: string;
+  score: number;
+  snippet: string;
+  sortTitle: string;
+}
+
+interface HighlightSegment {
+  text: string;
+  code: boolean;
+  mark: boolean;
+  className: string;
+}
+
+interface SearchResultView {
+  path: string;
+  className: string;
+  titleSegments: HighlightSegment[];
+  snippetSegments: HighlightSegment[];
 }
 
 export class DocsSearch extends WebUIElement {
   searchInput!: HTMLInputElement;
-  resultsEl!: HTMLDivElement;
   dialog!: HTMLDialogElement;
+
+  @observable resultItems: SearchResultView[] = [];
+  @observable emptyMessage = "";
+  @observable hasResults = false;
 
   private index: SearchEntry[] | null = null;
   private activeIdx = -1;
+  // Each input change clears nested <for> result rows before re-inserting the
+  // next set. The version guard drops stale microtasks from rapid typing.
+  private renderVersion = 0;
+
+  // Keep title matches decisively above heading matches, and heading matches
+  // above body/path matches. Sorting remains deterministic via title/path ties.
+  private static readonly TITLE_WEIGHT = 10000;
+  private static readonly HEADING_WEIGHT = 1000;
+  private static readonly CONTENT_WEIGHT = 100;
+  private static readonly PATH_WEIGHT = 50;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -31,28 +74,25 @@ export class DocsSearch extends WebUIElement {
         this.openSearch();
       }
       if (!this.dialog.open) return;
-      const items = this.resultsEl.querySelectorAll(".result");
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        this.activeIdx = Math.min(this.activeIdx + 1, items.length - 1);
+        this.setActiveIdx(
+          Math.min(this.activeIdx + 1, this.resultItems.length - 1),
+        );
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        this.activeIdx = Math.max(this.activeIdx - 1, 0);
+        this.setActiveIdx(Math.max(this.activeIdx - 1, 0));
       }
-      items.forEach((el, i) =>
-        el.classList.toggle("active", i === this.activeIdx),
-      );
-      if (e.key === "Enter" && items[this.activeIdx]) {
-        window.location.href = (items[this.activeIdx] as HTMLAnchorElement).href;
+      if (e.key === "Enter" && this.resultItems[this.activeIdx]) {
+        window.location.href = this.resultItems[this.activeIdx].path;
       }
     });
   }
 
   openSearch(): void {
     this.dialog.showModal();
-    this.resultsEl.innerHTML =
-      '<div class="empty">Type to search...</div>';
+    this.setEmpty("Type to search...");
     this.activeIdx = -1;
     setTimeout(() => this.searchInput.focus(), 50);
     if (!this.index) {
@@ -68,55 +108,303 @@ export class DocsSearch extends WebUIElement {
   }
 
   onInput(): void {
-    const query = this.searchInput.value;
+    const query = this.searchInput.value.trim();
     if (!this.index || !query) {
-      this.resultsEl.innerHTML =
-        '<div class="empty">Type to search...</div>';
+      this.setEmpty("Type to search...");
       return;
     }
     const q = query.toLowerCase();
-    const matches = this.index
-      .filter(
-        (p) =>
-          p.title.toLowerCase().includes(q) ||
-          p.content.toLowerCase().includes(q),
-      )
-      .slice(0, 10);
+    const matches = this.rankMatches(q);
 
     if (matches.length === 0) {
-      this.resultsEl.innerHTML =
-        '<div class="empty">No results found</div>';
+      this.setEmpty("No results found");
       return;
     }
 
-    this.activeIdx = 0;
-    this.resultsEl.innerHTML = matches
-      .map((m, i) => {
-        let snippet = "";
-        const idx = m.content.toLowerCase().indexOf(q);
-        if (idx >= 0) {
-          const start = Math.max(0, idx - 40);
-          const end = Math.min(m.content.length, idx + q.length + 60);
-          snippet =
-            (start > 0 ? "..." : "") +
-            m.content.slice(start, end) +
-            (end < m.content.length ? "..." : "");
-        } else {
-          snippet = m.content.slice(0, 100) + "...";
-        }
-        return (
-          '<a class="result' +
-          (i === 0 ? " active" : "") +
-          '" href="' +
-          m.path +
-          '"><div class="result-title">' +
-          m.title +
-          '</div><div class="result-snippet">' +
-          snippet +
-          "</div></a>"
-        );
-      })
-      .join("");
+    this.scheduleResults(matches, q);
+  }
+
+  private setEmpty(message: string): void {
+    this.renderVersion += 1;
+    this.resultItems = [];
+    this.hasResults = false;
+    this.emptyMessage = message;
+  }
+
+  private scheduleResults(matches: RankedSearchEntry[], q: string): void {
+    const version = this.prepareResultReset();
+    queueMicrotask(() => {
+      if (version !== this.renderVersion) return;
+      this.activeIdx = 0;
+      this.setResultsNow(matches, q);
+    });
+  }
+
+  private prepareResultReset(): number {
+    this.renderVersion += 1;
+    this.resultItems = [];
+    this.hasResults = false;
+    this.emptyMessage = "";
+    return this.renderVersion;
+  }
+
+  private setResultsNow(matches: RankedSearchEntry[], q: string): void {
+    const resultItems: SearchResultView[] = [];
+    for (let i = 0; i < matches.length; i += 1) {
+      const match = matches[i];
+      resultItems.push({
+        path: match.path,
+        className: this.resultClassName(i),
+        titleSegments: this.buildTitleSegments(match, q),
+        snippetSegments: this.highlightSegments(match.snippet, q, false),
+      });
+    }
+    this.emptyMessage = "";
+    this.hasResults = true;
+    this.resultItems = resultItems;
+  }
+
+  private rankMatches(q: string): RankedSearchEntry[] {
+    const ranked: RankedSearchEntry[] = [];
+    const index = this.index;
+    if (!index) return ranked;
+
+    for (let i = 0; i < index.length; i += 1) {
+      const entry = index[i];
+      const pageScore = this.scorePage(entry, q);
+      if (pageScore > 0) {
+        ranked.push({
+          entry,
+          path: entry.path,
+          score: pageScore,
+          snippet: this.buildSnippet(entry.content, q),
+          sortTitle: entry.title,
+        });
+      }
+      this.pushHeadingMatches(ranked, entry, q);
+    }
+
+    ranked.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const titleOrder = a.sortTitle.localeCompare(b.sortTitle);
+      if (titleOrder !== 0) return titleOrder;
+      return a.path.localeCompare(b.path);
+    });
+    if (ranked.length > 10) {
+      ranked.length = 10;
+    }
+    return ranked;
+  }
+
+  private pushHeadingMatches(
+    ranked: RankedSearchEntry[],
+    entry: SearchEntry,
+    q: string,
+  ): void {
+    const headings = entry.headings;
+    if (!headings) return;
+
+    for (let i = 0; i < headings.length; i += 1) {
+      const heading = headings[i];
+      if (heading.level <= 1) continue;
+      const score = this.scoreText(
+        heading.text,
+        q,
+        this.headingWeight(heading.level),
+      );
+      if (score <= 0) continue;
+      ranked.push({
+        entry,
+        heading,
+        path: this.headingPath(entry, heading),
+        score,
+        snippet: this.buildSnippet(entry.content, q),
+        sortTitle: entry.title + " > " + heading.text,
+      });
+    }
+  }
+
+  private scorePage(entry: SearchEntry, q: string): number {
+    return (
+      this.scoreText(entry.title, q, DocsSearch.TITLE_WEIGHT) +
+      this.scoreText(entry.content, q, DocsSearch.CONTENT_WEIGHT) +
+      this.scoreText(entry.path, q, DocsSearch.PATH_WEIGHT)
+    );
+  }
+
+  private headingWeight(level: number): number {
+    return Math.max(
+      DocsSearch.HEADING_WEIGHT - Math.max(0, level - 2) * 100,
+      DocsSearch.CONTENT_WEIGHT + 1,
+    );
+  }
+
+  private headingPath(entry: SearchEntry, heading: SearchHeading): string {
+    if (!heading.anchor) {
+      return entry.path;
+    }
+    return entry.path + "#" + heading.anchor;
+  }
+
+  private scoreText(text: string, q: string, weight: number): number {
+    const lower = text.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx < 0) return 0;
+    if (lower === q) return weight * 4;
+    if (idx === 0) return weight * 3;
+    return weight * 2 - Math.min(idx, weight);
+  }
+
+  private buildSnippet(content: string, q: string): string {
+    const lower = content.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx < 0) {
+      return this.truncateSnippet(content, 100);
+    }
+    const start = Math.max(0, idx - 40);
+    const end = Math.min(content.length, idx + q.length + 60);
+    return (
+      (start > 0 ? "..." : "") +
+      content.slice(start, end) +
+      (end < content.length ? "..." : "")
+    );
+  }
+
+  private truncateSnippet(content: string, maxLength: number): string {
+    if (content.length <= maxLength) {
+      return content;
+    }
+    return content.slice(0, maxLength) + "...";
+  }
+
+  private setActiveIdx(idx: number): void {
+    if (this.resultItems.length === 0) {
+      this.activeIdx = -1;
+      return;
+    }
+    this.activeIdx = idx;
+    const updated: SearchResultView[] = [];
+    for (let i = 0; i < this.resultItems.length; i += 1) {
+      updated.push({
+        ...this.resultItems[i],
+        className: this.resultClassName(i),
+      });
+    }
+    this.resultItems = updated;
+  }
+
+  private resultClassName(index: number): string {
+    return index === this.activeIdx ? "result active" : "result";
+  }
+
+  private buildTitleSegments(
+    match: RankedSearchEntry,
+    q: string,
+  ): HighlightSegment[] {
+    const segments = this.inlineCodeSegments(match.entry.title, q);
+    if (match.heading) {
+      // Use a dedicated separator segment with CSS margins instead of " > ";
+      // browser whitespace collapsing makes leading/trailing inline spaces
+      // unreliable once template whitespace is zeroed out.
+      this.pushSeparatorSegment(segments);
+      this.pushHighlightedSegments(segments, match.heading.text, q, false);
+    }
+    return segments;
+  }
+
+  private inlineCodeSegments(text: string, q: string): HighlightSegment[] {
+    const segments: HighlightSegment[] = [];
+    let cursor = 0;
+    while (cursor < text.length) {
+      const start = text.indexOf("`", cursor);
+      if (start < 0) {
+        this.pushHighlightedSegments(segments, text.slice(cursor), q, false);
+        return segments;
+      }
+
+      this.pushHighlightedSegments(segments, text.slice(cursor, start), q, false);
+      const markerLength = this.countBackticks(text, start);
+      const marker = "`".repeat(markerLength);
+      const codeStart = start + markerLength;
+      const end = text.indexOf(marker, codeStart);
+      if (end < 0) {
+        this.pushHighlightedSegments(segments, text.slice(start), q, false);
+        return segments;
+      }
+
+      this.pushHighlightedSegments(
+        segments,
+        text.slice(codeStart, end),
+        q,
+        true,
+      );
+      cursor = end + markerLength;
+    }
+    return segments;
+  }
+
+  private highlightSegments(
+    text: string,
+    q: string,
+    code: boolean,
+  ): HighlightSegment[] {
+    const segments: HighlightSegment[] = [];
+    this.pushHighlightedSegments(segments, text, q, code);
+    return segments;
+  }
+
+  private pushHighlightedSegments(
+    segments: HighlightSegment[],
+    text: string,
+    q: string,
+    code: boolean,
+  ): void {
+    if (!text) return;
+    const lower = text.toLowerCase();
+    let cursor = 0;
+    while (cursor < text.length) {
+      const idx = lower.indexOf(q, cursor);
+      if (idx < 0) {
+        this.pushSegment(segments, text.slice(cursor), code, false);
+        return;
+      }
+      this.pushSegment(segments, text.slice(cursor, idx), code, false);
+      this.pushSegment(segments, text.slice(idx, idx + q.length), code, true);
+      cursor = idx + q.length;
+    }
+  }
+
+  private pushSegment(
+    segments: HighlightSegment[],
+    text: string,
+    code: boolean,
+    mark: boolean,
+  ): void {
+    if (text.length > 0) {
+      segments.push({
+        text,
+        code,
+        mark,
+        className: mark ? "result-segment result-highlight" : "result-segment",
+      });
+    }
+  }
+
+  private pushSeparatorSegment(segments: HighlightSegment[]): void {
+    segments.push({
+      text: ">",
+      code: false,
+      mark: false,
+      className: "result-segment result-separator",
+    });
+  }
+
+  private countBackticks(text: string, start: number): number {
+    let cursor = start;
+    while (cursor < text.length && text[cursor] === "`") {
+      cursor += 1;
+    }
+    return cursor - start;
   }
 }
 

--- a/crates/webui-press/template/docs.css
+++ b/crates/webui-press/template/docs.css
@@ -64,6 +64,10 @@
   --docs-color-brand-bg: #eef2ff;
   --docs-color-code-bg: #f6f8fa;
   --docs-color-code-text: #24292f;
+  --docs-scrollbar-thumb: #9ca3af;
+  --docs-scrollbar-thumb-hover: #6b7280;
+  --docs-scrollbar-track: #f3f4f6;
+  --docs-search-mark-bg: #ffe58a;
 
   /* ── Syntax highlighting (GitHub Light) ── */
   --docs-hl-keyword: #cf222e;
@@ -123,6 +127,10 @@
   --docs-color-brand-bg: rgba(129, 140, 248, 0.1);
   --docs-color-code-bg: #161b22;
   --docs-color-code-text: #e6edf3;
+  --docs-scrollbar-thumb: #4b5563;
+  --docs-scrollbar-thumb-hover: #6b7280;
+  --docs-scrollbar-track: #111827;
+  --docs-search-mark-bg: #b7791f;
   --docs-hl-keyword: #ff7b72;
   --docs-hl-string: #a5d6ff;
   --docs-hl-comment: #8b949e;
@@ -150,6 +158,10 @@
     --docs-color-brand-bg: rgba(129, 140, 248, 0.1);
     --docs-color-code-bg: #161b22;
     --docs-color-code-text: #e6edf3;
+    --docs-scrollbar-thumb: #4b5563;
+    --docs-scrollbar-thumb-hover: #6b7280;
+    --docs-scrollbar-track: #111827;
+    --docs-search-mark-bg: #b7791f;
     --docs-hl-keyword: #ff7b72;
     --docs-hl-string: #a5d6ff;
     --docs-hl-comment: #8b949e;
@@ -165,16 +177,57 @@
   }
 }
 
+html {
+  /* Keep browser chrome stable: docs pages scroll inside `.main-content`
+     while the sidebar keeps an independent scrollbar. */
+  height: 100%;
+  overflow: hidden;
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
   font-family: var(--docs-font-sans);
   color: var(--docs-color-text);
   background: var(--docs-color-bg);
   line-height: var(--docs-line-height);
   -webkit-font-smoothing: antialiased;
+}
+
+.sidebar,
+.main-content {
+  scrollbar-color: var(--docs-scrollbar-thumb) var(--docs-scrollbar-track);
+}
+
+.main-content:focus {
+  outline: none;
+}
+
+.sidebar::-webkit-scrollbar,
+.main-content::-webkit-scrollbar {
+  width: 12px;
+}
+
+.sidebar::-webkit-scrollbar-track,
+.main-content::-webkit-scrollbar-track {
+  background: var(--docs-scrollbar-track);
+}
+
+.sidebar::-webkit-scrollbar-thumb,
+.main-content::-webkit-scrollbar-thumb {
+  background: var(--docs-scrollbar-thumb);
+  border: 3px solid var(--docs-scrollbar-track);
+  border-radius: 999px;
+}
+
+.sidebar::-webkit-scrollbar-thumb:hover,
+.main-content::-webkit-scrollbar-thumb:hover {
+  background: var(--docs-scrollbar-thumb-hover);
 }
 
 /* ── Navigation ────────────────────────────────────── */
@@ -257,7 +310,8 @@ body {
   display: flex;
   max-width: var(--docs-max-width);
   margin: 0 auto;
-  min-height: calc(100vh - var(--docs-nav-height));
+  height: calc(100vh - var(--docs-nav-height));
+  min-height: 0;
 }
 
 /* ── Sidebar ───────────────────────────────────────── */
@@ -269,7 +323,7 @@ body {
   flex-shrink: 0;
   position: sticky;
   top: var(--docs-nav-height);
-  height: calc(100vh - var(--docs-nav-height));
+  height: 100%;
   overflow-y: auto;
 }
 
@@ -339,6 +393,9 @@ body {
 .main-content {
   flex: 1;
   min-width: 0;
+  min-height: 0;
+  height: calc(100vh - var(--docs-nav-height));
+  overflow-y: auto;
   padding: var(--docs-space-xl) var(--docs-space-2xl) var(--docs-space-3xl);
 }
 
@@ -773,6 +830,8 @@ body[data-layout="page"] .page-nav {
 body[data-layout="full"] .main-content {
   padding: 0;
   max-width: none;
+  height: 100%;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }

--- a/crates/webui-press/template/docs.css
+++ b/crates/webui-press/template/docs.css
@@ -578,6 +578,7 @@ body {
   justify-content: space-between;
   margin-top: var(--docs-space-2xl);
   padding-top: var(--docs-space-l);
+  padding-bottom: var(--docs-space-l);
   border-top: 1px solid var(--docs-color-border);
 }
 

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -43,18 +43,35 @@
   {{{headTags}}}
   <script>
     /* Preserve sidebar scroll across cross-document navigations.
-       Runs BEFORE pagereveal fires (and before first paint) so the
-       restored position is what view transitions animate to,
+       The page itself is not scrollable; sidebar and main-content own their
+       own scrollbars. Runs BEFORE pagereveal fires (and before first paint)
+       so restored positions are what view transitions animate to,
        eliminating the end-of-transition jump. */
     (function () {
-      var KEY = 'webui-press:sidebar-scroll';
+      var SIDEBAR_KEY = 'webui-press:sidebar-scroll';
+      var MAIN_KEY_PREFIX = 'webui-press:main-scroll:';
       function sidebar() { return document.querySelector('.sidebar'); }
-      function save() { var s = sidebar(); if (s) sessionStorage.setItem(KEY, s.scrollTop); }
+      function main() { return document.querySelector('.main-content'); }
+      function mainKey() { return MAIN_KEY_PREFIX + location.pathname + location.search; }
+      function save() {
+        var s = sidebar();
+        if (s) sessionStorage.setItem(SIDEBAR_KEY, s.scrollTop);
+        var m = main();
+        if (m) sessionStorage.setItem(mainKey(), m.scrollTop);
+      }
       function restore() {
         var s = sidebar();
-        if (!s) return;
-        var v = sessionStorage.getItem(KEY);
-        if (v !== null) s.scrollTop = +v;
+        var v = sessionStorage.getItem(SIDEBAR_KEY);
+        if (s && v !== null) s.scrollTop = +v;
+        var m = main();
+        if (!m) return;
+        if (!location.hash) {
+          var mv = sessionStorage.getItem(mainKey());
+          if (mv !== null) m.scrollTop = +mv;
+        }
+        if (document.activeElement === document.body) {
+          m.focus({ preventScroll: true });
+        }
       }
       window.addEventListener('pageswap', save);
       window.addEventListener('pagehide', save);
@@ -86,7 +103,7 @@
   </header>
 
   <if condition="page.isHome">
-    <main class="main-content" style="max-width:1152px;margin:0 auto;">
+    <main class="main-content" tabindex="-1" style="max-width:1152px;margin:0 auto;">
       <if condition="hero">
         <div class="home-hero">
           <h1>{{site.title}}</h1>
@@ -119,6 +136,11 @@
             </div>
           </for>
         </div>
+      </if>
+      <if condition="footer">
+        <footer class="site-footer">
+          {{{footer.html}}}
+        </footer>
       </if>
     </main>
   </if>
@@ -172,7 +194,7 @@
       </for>
     </aside>
 
-    <main class="main-content">
+    <main class="main-content" tabindex="-1">
       <article class="doc-content">
         {{{page.content}}}
       </article>
@@ -188,14 +210,13 @@
           <a href="{{next.link}}">{{next.text}} →</a>
         </if>
       </nav>
+      <if condition="footer">
+        <footer class="site-footer">
+          {{{footer.html}}}
+        </footer>
+      </if>
     </main>
   </div>
-  </if>
-
-  <if condition="footer">
-    <footer class="site-footer">
-      {{{footer.html}}}
-    </footer>
   </if>
 
   <script>

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -77,8 +77,9 @@
       window.addEventListener('pagehide', save);
       if ('onpagereveal' in window) {
         window.addEventListener('pagereveal', restore);
-      } else if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', restore);
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', restore, { once: true });
       } else {
         restore();
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,15 @@ importers:
         specifier: 'catalog:'
         version: 1.58.2
 
+  crates/webui-press:
+    devDependencies:
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.58.2
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.28.1
+
   docs:
     dependencies:
       '@codemirror/commands':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - crates/webui-press
   - docs
   - examples/**
   - packages/*

--- a/xtask/src/e2e.rs
+++ b/xtask/src/e2e.rs
@@ -152,6 +152,16 @@ const SUITES: &[PlaywrightSuite] = &[
         test_script: "test",
         update_snapshots_script: "test:update-snapshots",
     },
+    PlaywrightSuite {
+        name: "webui-press",
+        dir: "crates/webui-press",
+        ports: &[],
+        scripts: &[],
+        build_client: false,
+        pre_script: None,
+        test_script: "test",
+        update_snapshots_script: "test:update-snapshots",
+    },
 ];
 
 struct TestResult {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -562,10 +562,12 @@ impl Step {
         run: || {
             // Build the standalone webui-press binary
             run_command_quiet("cargo", &["build", "-p", "microsoft-webui-press"], None)?;
-            // `@webui/webui-press test` builds the docs package first, then
-            // compiles and runs all colocated webui-press `*.test.ts` browser
-            // tests against that fresh output.
-            run_command_quiet("pnpm", &["--filter", "@webui/webui-press", "test"], None)
+            // `@webui/docs...` builds the docs package AND all of its workspace
+            // dependencies (e.g. `@microsoft/webui-framework`'s tsc compile)
+            // so that esbuild can resolve their `exports` to real .js files.
+            // Without this, a fresh checkout would fail with
+            // "Could not resolve @microsoft/webui-framework".
+            run_command_quiet("pnpm", &["--filter", "@webui/docs...", "build"], None)
         },
     };
     const BENCH_VALIDATE: Self = Self {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -562,12 +562,10 @@ impl Step {
         run: || {
             // Build the standalone webui-press binary
             run_command_quiet("cargo", &["build", "-p", "microsoft-webui-press"], None)?;
-            // `@webui/docs...` builds the docs package AND all of its workspace
-            // dependencies (e.g. `@microsoft/webui-framework`'s tsc compile)
-            // so that esbuild can resolve their `exports` to real .js files.
-            // Without this, a fresh checkout would fail with
-            // "Could not resolve @microsoft/webui-framework".
-            run_command_quiet("pnpm", &["--filter", "@webui/docs...", "build"], None)
+            // `@webui/webui-press test` builds the docs package first, then
+            // compiles and runs all colocated webui-press `*.test.ts` browser
+            // tests against that fresh output.
+            run_command_quiet("pnpm", &["--filter", "@webui/webui-press", "test"], None)
         },
     };
     const BENCH_VALIDATE: Self = Self {


### PR DESCRIPTION
## Summary

Improve the built-in webui-press search experience and supporting docs shell behavior:

- Rebuild the search index extraction to decode escaped HTML text, preserve inline code in headings, and emit structured heading metadata with text, anchor, and level.
- Add weighted search ranking so page titles rank highest, matching section headings rank next, and body/path matches rank lower with deterministic tie-breaking.
- Render matching section headings as their own anchor-linked result rows, shown as page breadcrumbs such as `Page > Section`.
- Replace search result string interpolation with WebUI template state so titles/snippets render safely without `innerHTML`, including backtick code spans like `<for>`.
- Add safe match highlighting with theme-aware colors and a versioned two-phase render reset to prevent stale nested-loop DOM while typing quickly.
- Move docs page scrolling into `.main-content`, preserve sidebar/main scroll positions, support keyboard/page scrolling, and keep the browser viewport stable.
- Add darker themed scrollbars for sidebar/main content and a darker dark-mode search highlight.
- Add colocated TypeScript browser regression tests for docs-search behavior and wire all webui-press `*.test.ts` files into the docs gate via the new `@webui/webui-press` package script.

## Validation

- `cargo xtask check`