### PR TITLE
fix: discover npm components declared in webui-press config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ dependencies = [
  "html-escape",
  "microsoft-webui",
  "microsoft-webui-dev-server",
+ "microsoft-webui-discovery",
  "microsoft-webui-handler",
  "microsoft-webui-tokens",
  "rayon",

--- a/crates/webui-discovery/src/lib.rs
+++ b/crates/webui-discovery/src/lib.rs
@@ -52,15 +52,31 @@ enum ComponentSource {
 /// - Starts with `.`, `/`, `\`, or contains a drive letter (Windows) → path
 /// - Everything else → npm package
 fn classify_source(source: &str) -> ComponentSource {
-    if source.starts_with('.')
-        || source.starts_with('/')
-        || source.starts_with('\\')
-        || (cfg!(windows) && source.len() >= 2 && source.as_bytes()[1] == b':')
-    {
+    if is_local_source(source) {
         ComponentSource::Path(PathBuf::from(source))
     } else {
         ComponentSource::NpmPackage(source.to_string())
     }
+}
+
+/// Returns `true` when a `--components` source string denotes a local
+/// filesystem path rather than an npm package name or scope.
+///
+/// A source is a local path when it starts with `.`, `/`, `\`, or a Windows
+/// drive letter (e.g. `C:\...`). Everything else — bare names like
+/// `my-widget` and scopes like `@scope` / `@scope/pkg` — is an npm package.
+///
+/// This is the single source of truth for the classification; callers that
+/// pre-resolve sources before handing them to [`discover_source`] (such as
+/// `webui-press`, which must resolve local paths against its own working
+/// directory while leaving npm names bare) should use it instead of
+/// re-implementing the check.
+#[must_use]
+pub fn is_local_source(source: &str) -> bool {
+    source.starts_with('.')
+        || source.starts_with('/')
+        || source.starts_with('\\')
+        || (cfg!(windows) && source.len() >= 2 && source.as_bytes()[1] == b':')
 }
 
 /// Discover components from a single source and register them into a component registry.
@@ -201,5 +217,18 @@ mod tests {
             classify_source("C:\\components"),
             ComponentSource::Path(_)
         ));
+    }
+
+    #[test]
+    fn test_is_local_source() {
+        // Local paths
+        assert!(is_local_source("./libs/shared"));
+        assert!(is_local_source("../components"));
+        assert!(is_local_source("/absolute/path"));
+        assert!(is_local_source("\\unc\\path"));
+        // npm packages / scopes
+        assert!(!is_local_source("my-widget"));
+        assert!(!is_local_source("@reactive-ui"));
+        assert!(!is_local_source("@scope/button"));
     }
 }

--- a/crates/webui-discovery/src/npm.rs
+++ b/crates/webui-discovery/src/npm.rs
@@ -37,6 +37,24 @@ fn find_node_modules(start: &Path) -> Result<PathBuf> {
     );
 }
 
+/// Find `node_modules/` by walking up from `primary`, falling back to a
+/// walk up from `fallback` when the primary search comes up empty.
+///
+/// The fallback rescues callers whose primary search root lives outside
+/// any project tree. For example, `webui-press` builds each docs page in a
+/// synthesized scratch directory under the system temp folder, which has no
+/// `node_modules` ancestor; the project's `node_modules` is instead reached
+/// from the process working directory the command was invoked in. The error
+/// from the primary search is preserved when both roots fail.
+fn find_node_modules_with_fallback(primary: &Path, fallback: &Path) -> Result<PathBuf> {
+    find_node_modules(primary).or_else(|primary_err| {
+        if fallback == primary {
+            return Err(primary_err);
+        }
+        find_node_modules(fallback).map_err(|_| primary_err)
+    })
+}
+
 /// Check if a package name is a bare scope (e.g., `@reactive-ui` without a sub-package).
 fn is_bare_scope(name: &str) -> bool {
     name.starts_with('@') && !name.contains('/')
@@ -79,10 +97,16 @@ fn read_to_string_limited(path: &Path, max_size: u64) -> Result<String> {
 /// Resolve an npm package or scope to discovered components.
 pub fn resolve(
     name: &str,
-    cwd: &Path,
+    search_dir: &Path,
     cache: &mut DiscoveryCache,
 ) -> Result<Vec<DiscoveredComponent>> {
-    let node_modules = find_node_modules(cwd)?;
+    // Walk up from the build's app directory first, then fall back to the
+    // process working directory. The fallback covers callers whose app
+    // directory lives outside the project (e.g. a system-temp scratch dir),
+    // where the project's `node_modules` is only reachable from the cwd the
+    // command was invoked in.
+    let fallback = std::env::current_dir().unwrap_or_else(|_| search_dir.to_path_buf());
+    let node_modules = find_node_modules_with_fallback(search_dir, &fallback)?;
 
     if is_bare_scope(name) {
         resolve_scoped(name, &node_modules, cache)
@@ -376,6 +400,36 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = find_node_modules(tmp.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_node_modules_fallback_used_when_primary_empty() {
+        let primary = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        let nm = project.path().join("node_modules");
+        fs::create_dir_all(&nm).unwrap();
+
+        let found = find_node_modules_with_fallback(primary.path(), project.path()).unwrap();
+        assert_eq!(found, nm);
+    }
+
+    #[test]
+    fn test_find_node_modules_fallback_prefers_primary() {
+        let primary = TempDir::new().unwrap();
+        let nm_primary = primary.path().join("node_modules");
+        fs::create_dir_all(&nm_primary).unwrap();
+        let project = TempDir::new().unwrap();
+        fs::create_dir_all(project.path().join("node_modules")).unwrap();
+
+        let found = find_node_modules_with_fallback(primary.path(), project.path()).unwrap();
+        assert_eq!(found, nm_primary);
+    }
+
+    #[test]
+    fn test_find_node_modules_fallback_errors_when_neither_has_it() {
+        let primary = TempDir::new().unwrap();
+        let fallback = TempDir::new().unwrap();
+        assert!(find_node_modules_with_fallback(primary.path(), fallback.path()).is_err());
     }
 
     #[test]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 microsoft-webui = { path = "../webui", version = "0.0.17", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
 microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
 

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -88,6 +88,20 @@ fn inject_theme_tokens(
     Ok(())
 }
 
+/// Resolve a configured component source for the per-page builds.
+///
+/// Local paths are made absolute against `cwd` (the project root) because
+/// `webui-discovery` resolves relative paths against the synthesized per-page
+/// app directory, not the project. npm package names and scopes (e.g.
+/// `@mai-ui`) are left bare so discovery resolves them from `node_modules`.
+fn resolve_config_component_source(source: &str, cwd: &Path) -> String {
+    if webui_discovery::is_local_source(source) {
+        cwd.join(source).to_string_lossy().to_string()
+    } else {
+        source.to_string()
+    }
+}
+
 // ── Output helpers ──────────────────────────────────────────────
 //
 // Mirrors the styling vocabulary in `crates/webui-cli/src/utils/output.rs`
@@ -266,6 +280,7 @@ pub fn build_docs_with_cache(
 
     // Step 2: Resolve component sources for the per-page builds
     let mut component_sources: Vec<String> = Vec::new();
+    let cwd = std::env::current_dir().unwrap_or_default();
     // Built-in component library (e.g. crates/webui-press/components/)
     let builtin_components = template_dir.parent().map(|p| p.join("components"));
     if let Some(ref bc) = builtin_components {
@@ -273,11 +288,12 @@ pub fn build_docs_with_cache(
             component_sources.push(bc.to_string_lossy().to_string());
         }
     }
-    // User component dirs from config
-    if let Some(ref user_dirs) = config.components {
-        for d in user_dirs {
-            let abs = std::env::current_dir().unwrap_or_default().join(d);
-            component_sources.push(abs.to_string_lossy().to_string());
+    // User component sources from config. Local paths are resolved against
+    // the current project root; npm package names/scopes must stay bare so
+    // webui-discovery resolves them from node_modules.
+    if let Some(ref user_sources) = config.components {
+        for source in user_sources {
+            component_sources.push(resolve_config_component_source(source, &cwd));
         }
     }
     // Template-local components (e.g. docs-search, docs-theme-toggle living
@@ -1230,6 +1246,31 @@ mod tests {
         assert_eq!(npx_command(), "npx.cmd");
         #[cfg(not(windows))]
         assert_eq!(npx_command(), "npx");
+    }
+
+    #[test]
+    fn config_component_source_preserves_npm_packages() {
+        let cwd = Path::new("project");
+
+        assert_eq!(resolve_config_component_source("@mai-ui", cwd), "@mai-ui");
+        assert_eq!(
+            resolve_config_component_source("@mai-ui/button", cwd),
+            "@mai-ui/button"
+        );
+        assert_eq!(
+            resolve_config_component_source("plain-widget", cwd),
+            "plain-widget"
+        );
+    }
+
+    #[test]
+    fn config_component_source_resolves_local_paths() {
+        let cwd = Path::new("project");
+
+        assert_eq!(
+            std::path::PathBuf::from(resolve_config_component_source("./components", cwd)),
+            cwd.join("./components")
+        );
     }
 
     // --- truncate_utf8 ---------------------------------------------------


### PR DESCRIPTION
Closes #370.

## Problem

External components declared as **npm packages** in a `webui-press` `config.json` `components` array (e.g. `"@mai-ui"`) were never discovered — the build failed with either `Component path not found: /<project>/@mai-ui` or `Could not find node_modules/ directory (searched upward from /var/folders/...)`.

Two coupled causes:

1. **webui-press mangled the specifier.** Every configured source was resolved with `current_dir().join(source)`, turning the npm specifier `@mai-ui` into an absolute path `/<project>/@mai-ui`. `webui-discovery` then classified it as a local path and failed.
2. **Discovery anchored at the wrong directory.** npm discovery walks up for `node_modules/` from the build **app directory**. `webui-press` renders each page from a synthesized scratch dir in the **system temp folder**, which has no `node_modules` ancestor — so even a correctly-bare `@scope` could not be resolved.

## Changes

**`webui-discovery`**
- Add `find_node_modules_with_fallback(primary, fallback)`, used by `resolve()`: walk up from the app directory first, then from the process working directory (the project root the command was invoked in). The primary error is preserved when both fail. Normal `webui build`/`serve` is unaffected — the app dir is already inside the project, so the fallback never triggers there.
- Expose `pub fn is_local_source(&str) -> bool` as the single source of truth for path-vs-npm classification; `classify_source` now delegates to it.

**`webui-press`**
- Resolve configured component sources through `webui_discovery::is_local_source`: npm names/scopes stay bare (so discovery resolves them from `node_modules`), while local paths are still made absolute against the project root. Adds `microsoft-webui-discovery` as a direct dependency.

## Why this approach

Discovery already receives the app directory; the only gap is that `webui-press`'s app dir is a throwaway scratch dir outside the project. A cwd fallback fixes that at the source without a new `BuildOptions` field and without relocating scratch into the project tree (which would otherwise need to be git-ignored and watcher-ignored).

## Testing

- `cargo test -p microsoft-webui-discovery` (34 passed) and `-p microsoft-webui-press` (45 passed), including new tests for the fallback resolver, `is_local_source`, and webui-press config source resolution.
- `cargo fmt` + `cargo clippy` clean on both crates.
- End-to-end: a press site with `"@mai-ui"` in config now builds and renders all 15 `<mai-*>` tags (button, link, text-input, spinner, divider, dropdown, listbox, menu-button, menu-item, menu-list, option, tab, tablist, tree, tree-item).

## Compatibility

Behavior-preserving for existing builds. The fallback only adds a resolution path when the primary walk-up finds no `node_modules`; it never overrides a successful primary match. `is_local_source` is purely a refactor of existing classification logic.
