### PR TITLE
feat: add shared state to WebUI Press

### DIFF
--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -251,6 +251,8 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
     "html": "Released under the MIT License."
   },
 
+  "stateFile": "./state/site.json",
+
   "customPages": {
     "/playground/": {
       "layout": "full",
@@ -268,6 +270,34 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
 - **`sidebar`** is the default sidebar shown on pages that don't match a `sidebarGroups` prefix.
 - **`sidebarGroups`** maps URL prefixes to sidebar definitions. The longest matching prefix wins. A page at `/guide/concepts/` uses the `/guide/` sidebar.
 - **`prev`/`next`** links at the bottom of a page are derived from the active sidebar's flat link order.
+
+### Shared state
+
+Use top-level `state` or `stateFile` when every page needs the same project data:
+
+```json
+{
+  "stateFile": "./state/site.json"
+}
+```
+
+The JSON must be an object and is merged into every page's render state, so
+components and Markdown-authored custom elements can bind to it directly:
+
+```html
+<span>{{release.version}}</span>
+```
+
+Shared state cannot override reserved docs keys such as `site`, `navigation`,
+`sidebar`, `page`, `hero`, `footer`, `prev`, `next`, `pageData`,
+`headTags`, `label`, or `icon`. Global state is applied first. Custom page
+state is applied afterward for that page, so non-reserved custom page keys can
+override global keys.
+
+The merged render state is embedded into each generated page's `#webui-data`
+hydration block. Do not put secrets in `state` or `stateFile`, and keep shared
+state small. Large global JSON files are duplicated into every output page; use
+custom page state or static JSON assets for large page-specific datasets.
 
 ### `head` injection
 

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -290,7 +290,7 @@ components and Markdown-authored custom elements can bind to it directly:
 
 Shared state cannot override reserved docs keys such as `site`, `navigation`,
 `sidebar`, `page`, `hero`, `footer`, `prev`, `next`, `pageData`,
-`headTags`, `label`, or `icon`. Global state is applied first. Custom page
+`headTags`, `tokens`, `label`, or `icon`. Global state is applied first. Custom page
 state is applied afterward for that page, so non-reserved custom page keys can
 override global keys.
 

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -22,9 +22,10 @@ use crate::bundler::{
     page_bundle_signature, resolve_config_component_source, resolve_node_modules, BundleOptions,
     BundleResult, BundleThread, PageBundleEntry, RootBundleEntry, ScriptSource,
 };
-use crate::content::process_content;
+use crate::content::process_content_with_states;
 use crate::error::{Error, Result};
 use crate::markdown::Highlighter;
+use crate::state::{load_render_states, merge_page_state};
 use crate::types::{BuildStats, DocsConfig};
 
 /// Persistent state held by the dev server across rebuilds. The dev
@@ -96,6 +97,53 @@ fn inject_theme_tokens(
         .map_err(|e| Error::Build(format!("Failed to resolve theme tokens: {e}")))?;
     webui_tokens::inject_into_state(state, &resolved);
     Ok(())
+}
+
+struct NotFoundStateInput<'a> {
+    config: &'a DocsConfig,
+    base_path: &'a str,
+    nav: Value,
+    footer: Value,
+    content: &'a str,
+    head_injection: &'a str,
+    global_state: Option<&'a Value>,
+}
+
+fn build_not_found_state(input: NotFoundStateInput<'_>) -> Value {
+    let state = json_obj([
+        (
+            "site",
+            json_obj([
+                ("title", Value::String(input.config.site.title.clone())),
+                ("base", Value::String(input.base_path.to_string())),
+            ]),
+        ),
+        ("navigation", input.nav),
+        ("sidebar", json_obj([("sections", Value::Array(vec![]))])),
+        (
+            "page",
+            json_obj([
+                ("title", Value::String("Page Not Found".to_string())),
+                (
+                    "description",
+                    Value::String("The page you're looking for doesn't exist.".to_string()),
+                ),
+                ("content", Value::String(input.content.to_string())),
+                ("isHome", Value::Bool(false)),
+                ("layout", Value::String("doc".to_string())),
+            ]),
+        ),
+        ("hero", Value::Null),
+        ("footer", input.footer),
+        ("prev", Value::Null),
+        ("next", Value::Null),
+        ("pageData", Value::Null),
+        ("headTags", Value::String(input.head_injection.to_string())),
+        ("label", Value::String("Copy".to_string())),
+        ("icon", Value::String("🌙".to_string())),
+    ]);
+
+    merge_page_state(state, input.global_state, None)
 }
 
 // ── Output helpers ──────────────────────────────────────────────
@@ -267,9 +315,9 @@ pub fn build_docs_with_cache(
     // Step 1: Process content. Highlighter is cached across rebuilds —
     // syntect's default syntax/theme load is ~30-50ms which we don't want
     // to pay every keystroke.
+    let render_states = load_render_states(config, config_dir)?;
     let highlighter = cache.highlighter.take().unwrap_or_default();
-
-    let pages = process_content(config, config_dir, &highlighter, &head_injection)?;
+    let pages = process_content_with_states(config, &highlighter, &head_injection, &render_states)?;
 
     // Restore the highlighter for the next rebuild.
     cache.highlighter = Some(highlighter);
@@ -645,37 +693,15 @@ pub fn build_docs_with_cache(
         .map(|f| json_obj([("html", Value::String(f.html.clone()))]))
         .unwrap_or(Value::Null);
 
-    let mut not_found_state = json_obj([
-        (
-            "site",
-            json_obj([
-                ("title", Value::String(config.site.title.clone())),
-                ("base", Value::String(base_path.to_string())),
-            ]),
-        ),
-        ("navigation", nav_val),
-        ("sidebar", json_obj([("sections", Value::Array(vec![]))])),
-        (
-            "page",
-            json_obj([
-                ("title", Value::String("Page Not Found".to_string())),
-                (
-                    "description",
-                    Value::String("The page you're looking for doesn't exist.".to_string()),
-                ),
-                ("content", Value::String(not_found_content.clone())),
-                ("isHome", Value::Bool(false)),
-                ("layout", Value::String("doc".to_string())),
-            ]),
-        ),
-        ("hero", Value::Null),
-        ("footer", footer_val),
-        ("prev", Value::Null),
-        ("next", Value::Null),
-    ]);
-    not_found_state["headTags"] = Value::String(head_injection);
-    not_found_state["label"] = Value::String("Copy".to_string());
-    not_found_state["icon"] = Value::String("🌙".to_string());
+    let mut not_found_state = build_not_found_state(NotFoundStateInput {
+        config,
+        base_path,
+        nav: nav_val,
+        footer: footer_val,
+        content: &not_found_content,
+        head_injection: &head_injection,
+        global_state: render_states.global(),
+    });
 
     let not_found_html = template_html.replace("{{{page.content}}}", &not_found_content);
     let nf_tmp = std::env::temp_dir().join(format!(
@@ -1366,7 +1392,54 @@ fn fxhash_bytes(bytes: &[u8]) -> u64 {
 mod tests {
     use super::*;
 
-    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+    type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    fn test_obj<const N: usize>(entries: [(&str, Value); N]) -> Value {
+        let mut map = Map::with_capacity(N);
+        for (key, value) in entries {
+            map.insert(key.to_string(), value);
+        }
+        Value::Object(map)
+    }
+
+    fn string_value(value: &str) -> Value {
+        Value::String(value.to_string())
+    }
+
+    fn docs_config() -> TestResult<DocsConfig> {
+        let config = serde_json::from_str(
+            r#"{
+                "site": { "title": "Docs" },
+                "basePath": "/",
+                "contentDir": ".",
+                "nav": [],
+                "sidebar": []
+            }"#,
+        )?;
+        Ok(config)
+    }
+
+    #[test]
+    fn not_found_state_includes_global_state() -> TestResult {
+        let config = docs_config()?;
+        let global = test_obj([("release", test_obj([("version", string_value("v1.2.3"))]))]);
+
+        let state = build_not_found_state(NotFoundStateInput {
+            config: &config,
+            base_path: "/",
+            nav: Value::Array(vec![]),
+            footer: Value::Null,
+            content: "<h1>404</h1>",
+            head_injection: "<meta name=\"docs\">",
+            global_state: Some(&global),
+        });
+
+        assert_eq!(state["release"]["version"], "v1.2.3");
+        assert_eq!(state["page"]["title"], "Page Not Found");
+        assert_eq!(state["pageData"], Value::Null);
+        assert_eq!(state["headTags"], "<meta name=\"docs\">");
+        Ok(())
+    }
 
     // --- truncate_utf8 ---------------------------------------------------
 

--- a/crates/webui-press/src/bundler.rs
+++ b/crates/webui-press/src/bundler.rs
@@ -1787,13 +1787,12 @@ mod tests {
         }
         fs::create_dir_all(root.join(".webui-press"))?;
         let allowed_roots = allowed_script_roots(&root.join(".webui-press"), &root)?;
+        let absolute_import = root.join("secret.js").to_string_lossy().replace('\\', "/");
+        let code = format!("console.log('before'); import \"{absolute_import}\";");
 
-        let Err(err) = validate_inline_script_imports(
-            "console.log('before'); import \"/tmp/secret.js\";",
-            &root.join(".webui-press"),
-            &allowed_roots,
-            None,
-        ) else {
+        let Err(err) =
+            validate_inline_script_imports(&code, &root.join(".webui-press"), &allowed_roots, None)
+        else {
             panic!("absolute import should be rejected");
         };
 

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -11,6 +11,7 @@ use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
 use crate::markdown::{render_markdown, Highlighter};
+use crate::state::{load_render_states, merge_page_state, LoadedStates};
 use crate::types::{DocsConfig, PageDescriptor, SidebarItem, SidebarSection};
 
 /// Normalize a config link (e.g. `/guide/intro/` or `/guide/intro`) to a
@@ -47,22 +48,6 @@ fn json_obj<const N: usize>(entries: [(&str, Value); N]) -> Value {
     }
     Value::Object(map)
 }
-
-/// Top-level state keys reserved by the docs renderer. Custom-page `stateFile`
-/// objects whose top-level fields are flattened onto the page state must not
-/// shadow these names — collisions are silently skipped so the canonical docs
-/// state always wins.
-const RESERVED_STATE_KEYS: &[&str] = &[
-    "site",
-    "navigation",
-    "sidebar",
-    "page",
-    "hero",
-    "footer",
-    "prev",
-    "next",
-    "pageData",
-];
 
 /// Parsed frontmatter from a markdown file.
 #[derive(Debug)]
@@ -321,62 +306,6 @@ fn find_sidebar_text(url_path: &str, config: &DocsConfig) -> Option<String> {
     None
 }
 
-/// Resolve and load every custom page's `stateFile` once, returning a map keyed
-/// by the custom-page link (e.g. `/playground/`) holding the parsed JSON value.
-/// Inline `state` values are passed through untouched.
-///
-/// State files are cached by canonical filesystem path so that two custom pages
-/// pointing at the same file only read and parse it once.
-fn load_custom_page_states(
-    config: &DocsConfig,
-    config_dir: &Path,
-) -> Result<HashMap<String, Value>> {
-    let mut cache: HashMap<std::path::PathBuf, Value> = HashMap::new();
-    let mut out: HashMap<String, Value> = HashMap::with_capacity(config.custom_pages.len());
-
-    for (link, page) in &config.custom_pages {
-        let inline = page.inline_state();
-        let path = page.state_file();
-
-        if inline.is_some() && path.is_some() {
-            return Err(crate::error::Error::Build(format!(
-                "Custom page {link}: 'state' and 'stateFile' are mutually exclusive — pick one."
-            )));
-        }
-
-        if let Some(value) = inline {
-            out.insert(link.clone(), value.clone());
-            continue;
-        }
-
-        if let Some(rel) = path {
-            let abs = config_dir.join(rel);
-            let key = fs::canonicalize(&abs).unwrap_or_else(|_| abs.clone());
-            let value = if let Some(cached) = cache.get(&key) {
-                cached.clone()
-            } else {
-                let raw = fs::read_to_string(&abs).map_err(|e| {
-                    crate::error::Error::Build(format!(
-                        "Custom page {link}: cannot read stateFile {}: {e}",
-                        abs.display()
-                    ))
-                })?;
-                let parsed: Value = serde_json::from_str(&raw).map_err(|e| {
-                    crate::error::Error::Build(format!(
-                        "Custom page {link}: stateFile {} is not valid JSON: {e}",
-                        abs.display()
-                    ))
-                })?;
-                cache.insert(key, parsed.clone());
-                parsed
-            };
-            out.insert(link.clone(), value);
-        }
-    }
-
-    Ok(out)
-}
-
 /// Process all content files and return page descriptors.
 ///
 /// `config_dir` is the directory containing `config.json`; relative paths
@@ -386,17 +315,25 @@ fn load_custom_page_states(
 /// `head_injection` is the fully-resolved `<head>` snippet (CSS link
 /// tags + `config.head` entries). It MUST be computed before this call
 /// so the descriptor is render-ready.
+#[allow(dead_code)] // Public library API; the binary uses preloaded state for 404 parity.
 pub fn process_content(
     config: &DocsConfig,
     config_dir: &Path,
     highlighter: &Highlighter,
     head_injection: &str,
 ) -> Result<Vec<PageDescriptor>> {
+    let states = load_render_states(config, config_dir)?;
+    process_content_with_states(config, highlighter, head_injection, &states)
+}
+
+pub(crate) fn process_content_with_states(
+    config: &DocsConfig,
+    highlighter: &Highlighter,
+    head_injection: &str,
+    states: &LoadedStates,
+) -> Result<Vec<PageDescriptor>> {
     let content_dir = Path::new(&config.content_dir);
     let base_path = &config.base_path;
-
-    // Load custom-page state once before the parallel pipeline.
-    let custom_states = load_custom_page_states(config, config_dir)?;
 
     let nav_links: Vec<Value> = config
         .nav
@@ -468,6 +405,7 @@ pub fn process_content(
                     .custom_pages
                     .get(&logical_path)
                     .or_else(|| config.custom_pages.get(logical_path.trim_end_matches('/')));
+                let custom_state = states.custom_page_state(&logical_path);
 
                 if let Some(entry) = custom_entry {
                     html = entry.html().to_string();
@@ -603,45 +541,17 @@ pub fn process_content(
                     ("footer", footer_val),
                     ("prev", Value::Null),
                     ("next", Value::Null),
-                    (
-                        "pageData",
-                        custom_states
-                            .get(&logical_path)
-                            .or_else(|| custom_states.get(logical_path.trim_end_matches('/')))
-                            .cloned()
-                            .unwrap_or(Value::Null),
-                    ),
+                    ("pageData", custom_state.cloned().unwrap_or(Value::Null)),
                     ("headTags", Value::String(head_injection.to_string())),
                     ("label", Value::String("Copy".to_string())),
                     ("icon", Value::String("🌙".to_string())),
                 ]);
 
-                // Flatten the loaded custom-page state object onto the top-level
-                // page state so component templates can bind directly to its
-                // fields (e.g. `<for each="item in files">`). This is what enables
-                // SSR for components driven by a `stateFile`. Reserved keys are
-                // never overwritten.
-                let state = if let Some(Value::Object(extra)) = custom_states
-                    .get(&logical_path)
-                    .or_else(|| custom_states.get(logical_path.trim_end_matches('/')))
-                {
-                    let mut map = match state {
-                        Value::Object(m) => m,
-                        other => {
-                            let mut m = Map::new();
-                            m.insert("_root".to_string(), other);
-                            m
-                        }
-                    };
-                    for (k, v) in extra {
-                        if !RESERVED_STATE_KEYS.contains(&k.as_str()) && !map.contains_key(k) {
-                            map.insert(k.clone(), v.clone());
-                        }
-                    }
-                    Value::Object(map)
-                } else {
-                    state
-                };
+                // Flatten shared state first, then custom-page state. Component
+                // templates can bind directly to these fields (e.g.
+                // `<for each="item in files">`) while reserved docs keys keep
+                // their canonical values.
+                let state = merge_page_state(state, states.global(), custom_state);
 
                 Ok((
                     idx,

--- a/crates/webui-press/src/lib.rs
+++ b/crates/webui-press/src/lib.rs
@@ -12,6 +12,7 @@ pub mod content;
 pub mod error;
 pub mod markdown;
 pub mod serve;
+mod state;
 pub mod types;
 
 pub use build::build_docs;

--- a/crates/webui-press/src/main.rs
+++ b/crates/webui-press/src/main.rs
@@ -17,6 +17,7 @@ mod content;
 mod error;
 mod markdown;
 mod serve;
+mod state;
 mod types;
 
 use std::fs;

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -55,6 +55,7 @@ const RESERVED_STATE_KEYS: &[&str] = &[
     "next",
     "pageData",
     "headTags",
+    "tokens",
     "label",
     "icon",
 ];
@@ -392,10 +393,12 @@ mod tests {
         let custom = test_obj([
             ("site", test_obj([("title", string_value("Override"))])),
             ("headTags", string_value("<script>bad()</script>")),
+            ("tokens", string_value("not-token-css")),
         ]);
 
         let merged = merge_page_state(base, None, Some(&custom));
         assert_eq!(merged["site"]["title"], "Docs");
         assert_eq!(merged["headTags"], "<meta name=\"docs\">");
+        assert_eq!(merged.get("tokens"), None);
     }
 }

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -1,0 +1,391 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Shared state loading and merge policy for WebUI Press builds.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+use crate::types::DocsConfig;
+
+/// Loaded render state inputs shared by all generated pages.
+#[derive(Debug, Default)]
+pub(crate) struct LoadedStates {
+    global: Option<Value>,
+    custom_pages: HashMap<String, Value>,
+}
+
+impl LoadedStates {
+    pub(crate) fn global(&self) -> Option<&Value> {
+        self.global.as_ref()
+    }
+
+    pub(crate) fn custom_page_state(&self, logical_path: &str) -> Option<&Value> {
+        self.custom_pages
+            .get(logical_path)
+            .or_else(|| self.custom_pages.get(logical_path.trim_end_matches('/')))
+            .or_else(|| {
+                if logical_path.ends_with('/') {
+                    None
+                } else {
+                    let mut with_slash = String::with_capacity(logical_path.len() + 1);
+                    with_slash.push_str(logical_path);
+                    with_slash.push('/');
+                    self.custom_pages.get(with_slash.as_str())
+                }
+            })
+    }
+}
+
+/// Top-level state keys reserved by the docs renderer. Global and custom-page
+/// state objects whose top-level fields are flattened onto the page state must
+/// not shadow these names so the canonical docs state always wins.
+const RESERVED_STATE_KEYS: &[&str] = &[
+    "site",
+    "navigation",
+    "sidebar",
+    "page",
+    "hero",
+    "footer",
+    "prev",
+    "next",
+    "pageData",
+    "headTags",
+    "label",
+    "icon",
+];
+
+struct StateLoader {
+    cache: HashMap<PathBuf, Value>,
+}
+
+impl StateLoader {
+    fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+        }
+    }
+
+    fn load_state_value(
+        &mut self,
+        label: &str,
+        inline: Option<&Value>,
+        path: Option<&str>,
+        config_dir: &Path,
+    ) -> Result<Option<Value>> {
+        if inline.is_some() && path.is_some() {
+            return Err(Error::Build(format!(
+                "{label}: 'state' and 'stateFile' are mutually exclusive - pick one."
+            )));
+        }
+
+        if let Some(value) = inline {
+            return Ok(Some(value.clone()));
+        }
+
+        let Some(rel) = path else {
+            return Ok(None);
+        };
+
+        let abs = config_dir.join(rel);
+        let key = fs::canonicalize(&abs).unwrap_or_else(|_| abs.clone());
+        if let Some(cached) = self.cache.get(&key) {
+            return Ok(Some(cached.clone()));
+        }
+
+        let raw = fs::read_to_string(&abs).map_err(|e| {
+            Error::Build(format!(
+                "{label}: cannot read stateFile {}: {e}",
+                abs.display()
+            ))
+        })?;
+        let parsed: Value = serde_json::from_str(&raw).map_err(|e| {
+            Error::Build(format!(
+                "{label}: stateFile {} is not valid JSON: {e}",
+                abs.display()
+            ))
+        })?;
+        self.cache.insert(key, parsed.clone());
+        Ok(Some(parsed))
+    }
+
+    fn load_global_state(
+        &mut self,
+        config: &DocsConfig,
+        config_dir: &Path,
+    ) -> Result<Option<Value>> {
+        let Some(value) = self.load_state_value(
+            "Global state",
+            config.state.as_ref(),
+            config.state_file.as_deref(),
+            config_dir,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        if !value.is_object() {
+            return Err(Error::Build(
+                "Global state: state must be a JSON object.".to_string(),
+            ));
+        }
+
+        Ok(Some(value))
+    }
+
+    fn load_custom_page_states(
+        &mut self,
+        config: &DocsConfig,
+        config_dir: &Path,
+    ) -> Result<HashMap<String, Value>> {
+        let mut out: HashMap<String, Value> = HashMap::with_capacity(config.custom_pages.len());
+
+        for (link, page) in &config.custom_pages {
+            if let Some(value) = self.load_state_value(
+                &format!("Custom page {link}"),
+                page.inline_state(),
+                page.state_file(),
+                config_dir,
+            )? {
+                out.insert(link.clone(), value);
+            }
+        }
+
+        Ok(out)
+    }
+}
+
+pub(crate) fn load_render_states(config: &DocsConfig, config_dir: &Path) -> Result<LoadedStates> {
+    let mut loader = StateLoader::new();
+    let global = loader.load_global_state(config, config_dir)?;
+    let custom_pages = loader.load_custom_page_states(config, config_dir)?;
+    Ok(LoadedStates {
+        global,
+        custom_pages,
+    })
+}
+
+/// Merge docs state with global state first and custom-page state second.
+///
+/// Global state fills missing non-reserved top-level keys. Custom-page state is
+/// applied afterward and may replace global keys, but reserved docs keys are
+/// never replaced.
+pub(crate) fn merge_page_state(
+    mut state: Value,
+    global: Option<&Value>,
+    custom_page: Option<&Value>,
+) -> Value {
+    merge_top_level_state(&mut state, global, false);
+    merge_top_level_state(&mut state, custom_page, true);
+    state
+}
+
+fn merge_top_level_state(state: &mut Value, extra: Option<&Value>, overwrite_existing: bool) {
+    let Some(extra) = extra.and_then(Value::as_object) else {
+        return;
+    };
+
+    let Value::Object(map) = state else {
+        return;
+    };
+
+    for (key, value) in extra {
+        if RESERVED_STATE_KEYS.contains(&key.as_str()) {
+            continue;
+        }
+        if overwrite_existing || !map.contains_key(key) {
+            map.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{CustomPage, SiteConfig};
+    use serde_json::Map;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    type TestResult<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn empty_config() -> DocsConfig {
+        DocsConfig {
+            site: SiteConfig {
+                title: "Docs".to_string(),
+                description: String::new(),
+            },
+            base_path: "/".to_string(),
+            content_dir: ".".to_string(),
+            out_dir: "./dist".to_string(),
+            public_dir: "./public".to_string(),
+            css: None,
+            theme: None,
+            components: None,
+            head: Vec::new(),
+            nav: Vec::new(),
+            sidebar: Vec::new(),
+            sidebar_groups: std::collections::BTreeMap::new(),
+            custom_pages: HashMap::new(),
+            state: None,
+            state_file: None,
+            hero: None,
+            footer: None,
+            bundler: None,
+        }
+    }
+
+    fn test_obj<const N: usize>(entries: [(&str, Value); N]) -> Value {
+        let mut map = Map::with_capacity(N);
+        for (key, value) in entries {
+            map.insert(key.to_string(), value);
+        }
+        Value::Object(map)
+    }
+
+    fn string_value(value: &str) -> Value {
+        Value::String(value.to_string())
+    }
+
+    fn temp_config_dir(name: &str) -> TestResult<PathBuf> {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("webui-press-{name}-{}-{id}", std::process::id()));
+        fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+
+    #[test]
+    fn load_render_states_reads_global_state_file_object() -> TestResult {
+        let dir = temp_config_dir("global-state-file")?;
+        fs::create_dir_all(dir.join("state"))?;
+        fs::write(
+            dir.join("state/site.json"),
+            r#"{ "release": { "version": "v1.2.3" } }"#,
+        )?;
+
+        let mut config = empty_config();
+        config.state_file = Some("./state/site.json".to_string());
+
+        let states = load_render_states(&config, &dir)?;
+        let state = states.global().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "missing global state")
+        })?;
+        assert_eq!(state["release"]["version"], "v1.2.3");
+
+        fs::remove_dir_all(dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn load_render_states_rejects_global_state_and_state_file_together() {
+        let mut config = empty_config();
+        config.state = Some(test_obj([(
+            "release",
+            test_obj([("version", string_value("v1.2.3"))]),
+        )]));
+        config.state_file = Some("./state/site.json".to_string());
+
+        let error = load_render_states(&config, Path::new(".")).err();
+        let Some(error) = error else {
+            panic!("expected mutually exclusive state error");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("'state' and 'stateFile' are mutually exclusive"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn load_render_states_requires_global_json_object() {
+        let mut config = empty_config();
+        config.state = Some(Value::Array(vec![
+            string_value("not"),
+            string_value("object"),
+        ]));
+
+        let error = load_render_states(&config, Path::new(".")).err();
+        let Some(error) = error else {
+            panic!("expected object validation error");
+        };
+        assert!(
+            error.to_string().contains("state must be a JSON object"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn load_render_states_reads_custom_page_state_file() -> TestResult {
+        let dir = temp_config_dir("custom-state-file")?;
+        fs::create_dir_all(dir.join("state"))?;
+        fs::write(
+            dir.join("state/playground.json"),
+            r#"{ "files": ["a.rs"] }"#,
+        )?;
+
+        let mut config = empty_config();
+        config.custom_pages.insert(
+            "/playground/".to_string(),
+            CustomPage::Full {
+                html: "<docs-playground></docs-playground>".to_string(),
+                layout: Some("full".to_string()),
+                state: None,
+                state_file: Some("./state/playground.json".to_string()),
+                script_file: None,
+            },
+        );
+
+        let states = load_render_states(&config, &dir)?;
+        let state = states.custom_page_state("/playground").ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "missing custom state")
+        })?;
+        assert_eq!(state["files"][0], "a.rs");
+
+        fs::remove_dir_all(dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn merge_page_state_applies_global_then_custom_page_state() {
+        let base = test_obj([
+            ("site", test_obj([("title", string_value("Docs"))])),
+            ("headTags", string_value("<meta name=\"docs\">")),
+        ]);
+        let global = test_obj([
+            ("release", test_obj([("version", string_value("global"))])),
+            ("shared", string_value("global")),
+        ]);
+        let custom = test_obj([
+            ("release", test_obj([("version", string_value("custom"))])),
+            ("local", string_value("custom")),
+        ]);
+
+        let merged = merge_page_state(base, Some(&global), Some(&custom));
+        assert_eq!(merged["release"]["version"], "custom");
+        assert_eq!(merged["shared"], "global");
+        assert_eq!(merged["local"], "custom");
+    }
+
+    #[test]
+    fn merge_page_state_keeps_reserved_docs_keys() {
+        let base = test_obj([
+            ("site", test_obj([("title", string_value("Docs"))])),
+            ("headTags", string_value("<meta name=\"docs\">")),
+        ]);
+        let custom = test_obj([
+            ("site", test_obj([("title", string_value("Override"))])),
+            ("headTags", string_value("<script>bad()</script>")),
+        ]);
+
+        let merged = merge_page_state(base, None, Some(&custom));
+        assert_eq!(merged["site"]["title"], "Docs");
+        assert_eq!(merged["headTags"], "<meta name=\"docs\">");
+    }
+}

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -101,6 +101,7 @@ impl StateLoader {
 
         let abs = config_dir.join(rel_path);
         let key = fs::canonicalize(&abs).unwrap_or_else(|_| abs.clone());
+        if let Some(cached) = self.cache.get(&key) {
             return Ok(Some(cached.clone()));
         }
 
@@ -323,7 +324,9 @@ mod tests {
             panic!("expected object validation error");
         };
         assert!(
-            error.to_string().contains("state must be a JSON object"),
+            error
+                .to_string()
+                .contains("state/stateFile must be a JSON object"),
             "{error}"
         );
     }

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -130,7 +130,7 @@ impl StateLoader {
 
         if !value.is_object() {
             return Err(Error::Build(
-                "Global state: state must be a JSON object.".to_string(),
+                "Global state: state/stateFile must be a JSON object.".to_string(),
             ));
         }
 

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -91,9 +91,16 @@ impl StateLoader {
             return Ok(None);
         };
 
-        let abs = config_dir.join(rel);
+        let rel_path = Path::new(rel);
+        if rel_path.is_absolute() {
+            return Err(Error::Build(format!(
+                "{label}: stateFile must be a path relative to config.json, got absolute path {}",
+                rel_path.display()
+            )));
+        }
+
+        let abs = config_dir.join(rel_path);
         let key = fs::canonicalize(&abs).unwrap_or_else(|_| abs.clone());
-        if let Some(cached) = self.cache.get(&key) {
             return Ok(Some(cached.clone()));
         }
 

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -26,7 +26,7 @@ pub struct DocsConfig {
     #[serde(default)]
     pub custom_pages: std::collections::HashMap<String, CustomPage>,
     /// Inline JSON object merged into every page's render state. Mutually
-    /// exclusive with `state_file`.
+    /// exclusive with `stateFile`.
     pub state: Option<serde_json::Value>,
     /// Path (relative to `config.json`) of a JSON object merged into every
     /// page's render state. Mutually exclusive with `state`.

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -25,6 +25,12 @@ pub struct DocsConfig {
     pub sidebar_groups: std::collections::BTreeMap<String, Vec<SidebarSection>>,
     #[serde(default)]
     pub custom_pages: std::collections::HashMap<String, CustomPage>,
+    /// Inline JSON object merged into every page's render state. Mutually
+    /// exclusive with `state_file`.
+    pub state: Option<serde_json::Value>,
+    /// Path (relative to `config.json`) of a JSON object merged into every
+    /// page's render state. Mutually exclusive with `state`.
+    pub state_file: Option<String>,
     pub hero: Option<HeroConfig>,
     pub footer: Option<FooterConfig>,
     /// Optional JavaScript bundler configuration (overrides defaults).


### PR DESCRIPTION
Add top-level state/stateFile loading for global render state and merge it into every generated page, including the 404 page.

Move shared and custom page state loading into a dedicated module with tests for merge precedence, reserved key protection, and state file validation.

This is needed so we can add dynamic data to press styled components with no custom pages.