### PR TITLE
fix: warn when hydration leaves observable state disagreeing with SSR DOM (#379)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1597,6 +1597,21 @@ WebUI Framework hydration assumes the SSR DOM, hydration markers, and compiled m
   in the initial render belongs in the SSR state; assign anything else after
   `super.connectedCallback()`. Components that follow this rule allocate nothing
   on the hot path — the tracking `Set` stays `null` and the check early-returns.
+  The diagnostic is **development-only**. Its comparators and message string live
+  in `hydration-mismatch.ts` behind the `reportHydrationMismatch` entry point,
+  reached solely through a dynamic `import()` gated by the module-local `DEV`
+  constant — derived from the compile-time flag `__WEBUI_DEV__` as
+  `typeof __WEBUI_DEV__ === 'undefined' || __WEBUI_DEV__`, so an **undefined** flag
+  defaults the diagnostic **on** (raw ESM, the framework's own `tsc` output, and
+  unit tests keep the warning without any bundler cooperation). When a bundler
+  folds `__WEBUI_DEV__` to `false`, `DEV` folds with it: `$checkHydrationMismatch`
+  empties and its lone `import()` is dead-code-eliminated, dropping the whole
+  diagnostic module — comparison code *and* strings — from the output. The dynamic
+  import is load-bearing: esbuild fixes static-import reachability before
+  constant-folding and never re-runs tree-shaking, so a static import would ship
+  even when its only caller folds away. `webui-press build` injects
+  `--define:__WEBUI_DEV__=false` automatically (and `serve` leaves it undefined);
+  apps that bundle their own client define the flag as `false` for production.
 - Missing HTML-only custom elements that need host attribute or router state
   reactivity are marked in compiled template metadata with `th: 1`. Importing
   `@microsoft/webui-framework` installs the static host runtime; the router

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1577,6 +1577,26 @@ WebUI Framework hydration assumes the SSR DOM, hydration markers, and compiled m
   appending nodes to the connected DOM. Child components therefore observe
   initial parent `:` property bindings in `connectedCallback`, while later parent
   updates remain live.
+- **Hydration-mismatch diagnostic (#379).** SSR hydration is single-pass: the
+  runtime wires bindings to the server-rendered DOM and trusts it (it never runs
+  a first binding pass over SSR roots). A reactive write that lands while the
+  element is connected but before hydration finishes — an `@observable` field
+  initializer, a constructor assignment, or an assignment before
+  `super.connectedCallback()` — updates the backing field but cannot touch the
+  DOM yet, so the value is dropped and the element's own observable ends up
+  disagreeing with its DOM (silently, and inconsistently with client-side
+  rendering). The runtime records those pre-ready write paths and, once hydrated,
+  performs a **read-only** comparison of each against the server-rendered DOM. If
+  any disagree it emits a single `console.warn` naming the properties and the
+  host tag — the same hydration-mismatch signal React, Vue, Svelte, and Solid
+  produce. It does **not** reconcile: patching would repair only the
+  post-hydration state while leaving the first server paint wrong, and would
+  erode the SSR-trust invariant that lets a child hydrate parent-delayed `:`
+  bindings before the parent sets them (#286), so complex `:` bindings are exempt
+  from the comparison. The lifecycle rule for authors: a value that must appear
+  in the initial render belongs in the SSR state; assign anything else after
+  `super.connectedCallback()`. Components that follow this rule allocate nothing
+  on the hot path — the tracking `Set` stays `null` and the check early-returns.
 - Missing HTML-only custom elements that need host attribute or router state
   reactivity are marked in compiled template metadata with `th: 1`. Importing
   `@microsoft/webui-framework` installs the static host runtime; the router

--- a/crates/webui-press/src/bundler.rs
+++ b/crates/webui-press/src/bundler.rs
@@ -1080,6 +1080,12 @@ fn esbuild_args(
     args.push("--log-level=warning".to_string());
     if !opts.dev_mode {
         args.push("--minify".to_string());
+        // Fold the framework's `__WEBUI_DEV__` flag to `false` for production
+        // builds so development-only diagnostics — e.g. the hydration-mismatch
+        // warning in `@microsoft/webui-framework` — and the modules they gate
+        // are dead-code eliminated from the bundle. Pushed before any user
+        // `define` entries below so an explicit `bundler.define` can override it.
+        args.push("--define:__WEBUI_DEV__=false".to_string());
     }
     if let Some(cfg) = opts.bundler_config {
         push_external_args(&mut args, &cfg.external, &aliases);
@@ -1619,6 +1625,58 @@ mod tests {
         let args = esbuild_args(&opts, &[], Path::new("/tmp/webui-press-bundle"));
 
         assert!(args.contains(&format!("--tsconfig-raw={WEBUI_TSCONFIG_RAW}")));
+    }
+
+    #[test]
+    fn esbuild_args_folds_webui_dev_flag_for_production_only() {
+        fn opts<'a>(
+            site_dir: &'a Path,
+            config_dir: &'a Path,
+            dev_mode: bool,
+            cfg: Option<&'a BundlerConfig>,
+        ) -> BundleOptions<'a> {
+            BundleOptions {
+                site_dir,
+                node_modules: None,
+                root_bundle: None,
+                page_bundles: &[],
+                bundler_config: cfg,
+                dev_mode,
+                config_dir,
+                content_dir: site_dir,
+            }
+        }
+        let site_dir = Path::new("/site");
+        let config_dir = Path::new("/site/.webui-press");
+        let tmp = Path::new("/tmp/b");
+        let define = "--define:__WEBUI_DEV__=false".to_string();
+
+        // Production build: the flag is folded to `false` so the framework's
+        // dev-only diagnostics (and the module gating them) tree-shake out.
+        let prod = esbuild_args(&opts(site_dir, config_dir, false, None), &[], tmp);
+        assert!(prod.contains(&define));
+
+        // Development build (`webui-press serve`): the flag is left undefined so
+        // the `typeof` guard defaults it to on and diagnostics run.
+        let dev = esbuild_args(&opts(site_dir, config_dir, true, None), &[], tmp);
+        assert!(!dev.iter().any(|arg| arg.contains("__WEBUI_DEV__")));
+
+        // A user-supplied define wins: esbuild honors the last `--define` for a
+        // key, so our production default must be emitted before user defines.
+        let mut cfg = BundlerConfig::default();
+        cfg.define
+            .insert("__WEBUI_DEV__".to_string(), "true".to_string());
+        let overridden = esbuild_args(&opts(site_dir, config_dir, false, Some(&cfg)), &[], tmp);
+        let ours = overridden.iter().position(|arg| arg == &define);
+        let theirs = overridden
+            .iter()
+            .position(|arg| arg == "--define:__WEBUI_DEV__=true");
+        assert!(ours.is_some(), "framework default define should be present");
+        assert!(theirs.is_some(), "user override define should be present");
+        assert!(
+            ours < theirs,
+            "framework default must precede the user override so esbuild's last-wins keeps the user's value",
+        );
     }
 
     #[test]

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -961,7 +961,10 @@ The handler resolves `tokens.light` from the state, outputting:
     `super.connectedCallback()` cannot reach the DOM — the write is dropped and
     the runtime logs a `[WebUI] Hydration mismatch` warning. If the value must
     appear in the first render, put it in the SSR state JSON; otherwise assign it
-    after `super.connectedCallback()`.
+    after `super.connectedCallback()`. The warning is development-only — it is
+    stripped from production bundles via the `__WEBUI_DEV__` compile-time flag
+    (`webui-press build` sets `__WEBUI_DEV__=false` automatically; self-bundled
+    apps add the define for production).
 
 ## Common Patterns
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -955,6 +955,14 @@ The handler resolves `tokens.light` from the state, outputting:
     state your TypeScript changes, and use template bindings for DOM output.
     Use `w-ref` only for imperative DOM access (focus, scroll, etc.).
 
+11. **No `@observable` writes before `super.connectedCallback()`.** During SSR
+    hydration the server-rendered DOM is trusted and not re-rendered, so a value
+    set in a field initializer, the `constructor`, or before
+    `super.connectedCallback()` cannot reach the DOM — the write is dropped and
+    the runtime logs a `[WebUI] Hydration mismatch` warning. If the value must
+    appear in the first render, put it in the SSR state JSON; otherwise assign it
+    after `super.connectedCallback()`.
+
 ## Common Patterns
 
 ### Toggle visibility

--- a/docs/guide/concepts/interactivity.md
+++ b/docs/guide/concepts/interactivity.md
@@ -519,6 +519,41 @@ The framework detects the existing Declarative Shadow DOM roots and upgrades ele
 
 From this point on, interactions are handled entirely on the client. Changes to `@observable` properties trigger targeted DOM updates without a server round-trip.
 
+### Setting observable state during setup
+
+The server owns the first paint, and the framework **trusts** the HTML it produced — hydration wires bindings to the existing DOM instead of re-rendering it. A value you write *before hydration finishes* — in an `@observable` field initializer, the `constructor`, or before you call `super.connectedCallback()` — updates the property's backing field but cannot touch the DOM yet, so it is dropped. Your element's state then silently disagrees with what is on screen.
+
+When the framework detects this it logs a development warning naming the properties, so the mismatch is never silent:
+
+```
+[WebUI] Hydration mismatch on <my-counter>: "count" changed at or before
+super.connectedCallback() to a value that differs from the server-rendered DOM…
+```
+
+Follow one rule to stay correct:
+
+- **A value that must appear in the first render belongs in the SSR state.** Provide it in the JSON state so the server renders it; the client then hydrates against a matching DOM.
+- **Assign anything else after `super.connectedCallback()`**, where `@observable` writes flow through live bindings.
+
+```ts
+export class MyCounter extends WebUIElement {
+  @observable count = 0;
+
+  connectedCallback(): void {
+    // ✗ Wrong: runs before hydration — dropped, and warns.
+    // this.count = 3;
+
+    super.connectedCallback();
+
+    // ✓ Correct: runs after hydration — updates the DOM reactively.
+    this.count = 3;
+  }
+}
+```
+
+If `count` should already read `3` in the server-rendered HTML, seed it in the SSR state instead of assigning it on the client at all.
+
+
 ## When NOT to Hydrate
 
 Not every component needs JavaScript. Hydrating a component that has no interactivity adds unnecessary bytes and processing time.

--- a/docs/guide/concepts/interactivity.md
+++ b/docs/guide/concepts/interactivity.md
@@ -553,6 +553,29 @@ export class MyCounter extends WebUIElement {
 
 If `count` should already read `3` in the server-rendered HTML, seed it in the SSR state instead of assigning it on the client at all.
 
+#### The warning is development-only
+
+This diagnostic is a **development aid** — its comparison code *and* its message strings are removed from production bundles, so it never costs your users anything. It is gated by a compile-time flag, **`__WEBUI_DEV__`**, and loaded through a dynamic `import()`, so when the flag is `false` a bundler dead-code-eliminates the entire diagnostic module.
+
+The flag is **on by default**. You never enable it — you only turn it *off* for production:
+
+- **Using `webui-press`?** Nothing to do. `webui-press build` sets `__WEBUI_DEV__` to `false` for you, and `webui-press serve` leaves it on.
+- **Bundling client JavaScript yourself?** Define the flag as `false` in your **production** build. Leave it out of development builds — when the flag is absent the framework defaults it to on, so you always get the warning while developing.
+
+```bash
+# esbuild: production build only
+esbuild app.ts --bundle --minify --define:__WEBUI_DEV__=false
+```
+
+| Bundler | Production setting |
+| --- | --- |
+| esbuild | `--define:__WEBUI_DEV__=false` |
+| Vite / Rollup / rolldown | `define: { __WEBUI_DEV__: 'false' }` |
+| webpack / Rspack | `new DefinePlugin({ __WEBUI_DEV__: 'false' })` |
+| swc | `jsc.transform.optimizer.globals.vars: { __WEBUI_DEV__: 'false' }` |
+
+Only the literal `false` turns the diagnostics off. Any other value — or leaving the flag undefined — keeps them on, so a forgotten define can never silently hide a real mismatch during development.
+
 
 ## When NOT to Hydrate
 

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -129,6 +129,14 @@ parent-provided property in `connectedCallback`. If the parent value is not set,
 the child may initialize its own fallback there, and later parent updates still
 flow through the live binding.
 
+During SSR hydration the framework trusts the server-rendered DOM and does not
+re-render it. An `@observable` written before hydration finishes — in a field
+initializer, the `constructor`, or before `super.connectedCallback()` — cannot
+update that DOM, so the write is dropped and the runtime logs a
+`[WebUI] Hydration mismatch` warning naming the properties. Seed such values in
+the SSR state, or assign them after `super.connectedCallback()`. See the
+[Interactivity Guide](https://microsoft.github.io/webui/guide/concepts/interactivity#setting-observable-state-during-setup).
+
 ### DOM strategy (`--dom`)
 
 The `--dom` flag controls how the server renders component content:

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -134,7 +134,10 @@ re-render it. An `@observable` written before hydration finishes — in a field
 initializer, the `constructor`, or before `super.connectedCallback()` — cannot
 update that DOM, so the write is dropped and the runtime logs a
 `[WebUI] Hydration mismatch` warning naming the properties. Seed such values in
-the SSR state, or assign them after `super.connectedCallback()`. See the
+the SSR state, or assign them after `super.connectedCallback()`. The warning is
+development-only and is dead-code-eliminated from production bundles via the
+`__WEBUI_DEV__` compile-time flag (on by default; `webui-press build` sets it to
+`false`). See the
 [Interactivity Guide](https://microsoft.github.io/webui/guide/concepts/interactivity#setting-observable-state-during-setup).
 
 ### DOM strategy (`--dom`)

--- a/packages/webui-framework/src/hydration-mismatch.test.ts
+++ b/packages/webui-framework/src/hydration-mismatch.test.ts
@@ -23,6 +23,7 @@ import {
   type MismatchContext,
   type PathBindings,
   repeatDiffersFromDom,
+  resetHydrationMismatchWarnings,
   textDiffersFromDom,
   warnHydrationMismatch,
 } from './hydration-mismatch.js';
@@ -77,15 +78,15 @@ describe('textDiffersFromDom', () => {
     assert.equal(textDiffersFromDom(b, makeCtx({}, 'a-c')), true);
   });
 
-  test('raw binding compares against the parent innerHTML', () => {
+  test('raw bindings are skipped (innerHTML re-serialization is unreliable)', () => {
     const b = {
       node: { data: 'stale' } as unknown as Text,
       path: 'html',
       raw: true,
       rawParent: fakeEl({}, '<b>x</b>'),
     } as TextBinding;
-    assert.equal(textDiffersFromDom(b, makeCtx({ html: '<b>x</b>' })), false);
-    assert.equal(textDiffersFromDom(b, makeCtx({ html: '<b>y</b>' })), true);
+    // Even with a divergent value, raw bindings never report a mismatch.
+    assert.equal(textDiffersFromDom(b, makeCtx({ html: '<b>y</b>' })), false);
   });
 
   test('binding with neither path nor parts never differs', () => {
@@ -263,19 +264,38 @@ describe('warnHydrationMismatch', () => {
     return calls;
   }
 
-  test('warns once per tag even when called repeatedly', () => {
+  test('warns once per (tag, path-set) even when called repeatedly', () => {
+    resetHydrationMismatchWarnings();
     const calls = captureWarn(() => {
-      warnHydrationMismatch('x-dedup-a', ['show']);
-      warnHydrationMismatch('x-dedup-a', ['show']);
-      warnHydrationMismatch('x-dedup-a', ['value']);
+      warnHydrationMismatch('x-dedup', ['show']);
+      warnHydrationMismatch('x-dedup', ['show']);
     });
     assert.equal(calls.length, 1);
   });
 
-  test('warns separately for distinct tags', () => {
+  test('path-set order does not affect dedup', () => {
+    resetHydrationMismatchWarnings();
     const calls = captureWarn(() => {
-      warnHydrationMismatch('x-dedup-b', ['show']);
-      warnHydrationMismatch('x-dedup-c', ['show']);
+      warnHydrationMismatch('x-order', ['show', 'value']);
+      warnHydrationMismatch('x-order', ['value', 'show']);
+    });
+    assert.equal(calls.length, 1);
+  });
+
+  test('a genuinely different mismatch on the same tag still warns', () => {
+    resetHydrationMismatchWarnings();
+    const calls = captureWarn(() => {
+      warnHydrationMismatch('x-diff', ['show']);
+      warnHydrationMismatch('x-diff', ['value']);
+    });
+    assert.equal(calls.length, 2);
+  });
+
+  test('warns separately for distinct tags', () => {
+    resetHydrationMismatchWarnings();
+    const calls = captureWarn(() => {
+      warnHydrationMismatch('x-tag-a', ['show']);
+      warnHydrationMismatch('x-tag-b', ['show']);
     });
     assert.equal(calls.length, 2);
   });

--- a/packages/webui-framework/src/hydration-mismatch.test.ts
+++ b/packages/webui-framework/src/hydration-mismatch.test.ts
@@ -23,6 +23,7 @@ import {
   type MismatchContext,
   type PathBindings,
   repeatDiffersFromDom,
+  reportHydrationMismatch,
   resetHydrationMismatchWarnings,
   textDiffersFromDom,
   warnHydrationMismatch,
@@ -298,5 +299,75 @@ describe('warnHydrationMismatch', () => {
       warnHydrationMismatch('x-tag-b', ['show']);
     });
     assert.equal(calls.length, 2);
+  });
+});
+
+// ── reportHydrationMismatch (dynamic-import entry point) ─────────
+
+describe('reportHydrationMismatch', () => {
+  function captureWarn(fn: () => void): string[] {
+    const original = console.warn;
+    const calls: string[] = [];
+    console.warn = (msg?: unknown) => { calls.push(String(msg)); };
+    try {
+      fn();
+    } finally {
+      console.warn = original;
+    }
+    return calls;
+  }
+
+  function disagreeingEntry(): PathBindings {
+    return {
+      ...emptyEntry,
+      attrs: [{ element: fakeEl({ 'data-value': '' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value' }],
+    };
+  }
+
+  function agreeingEntry(): PathBindings {
+    return {
+      ...emptyEntry,
+      attrs: [{ element: fakeEl({ 'data-value': '3' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value' }],
+    };
+  }
+
+  test('warns once naming the diverged path when an entry disagrees', () => {
+    resetHydrationMismatchWarnings();
+    const index = new Map<string, PathBindings>([['value', disagreeingEntry()]]);
+    const calls = captureWarn(() => {
+      reportHydrationMismatch('x-report', new Set(['value']), index, makeCtx({ value: '3' }));
+    });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /<x-report>/);
+    assert.match(calls[0], /"value"/);
+  });
+
+  test('stays silent when every recorded write agrees with the DOM', () => {
+    resetHydrationMismatchWarnings();
+    const index = new Map<string, PathBindings>([['value', agreeingEntry()]]);
+    const calls = captureWarn(() => {
+      reportHydrationMismatch('x-agree', new Set(['value']), index, makeCtx({ value: '3' }));
+    });
+    assert.equal(calls.length, 0);
+  });
+
+  test('stays silent when there are no recorded writes', () => {
+    resetHydrationMismatchWarnings();
+    const index = new Map<string, PathBindings>([['value', disagreeingEntry()]]);
+    const calls = captureWarn(() => {
+      reportHydrationMismatch('x-empty', new Set(), index, makeCtx({ value: '3' }));
+    });
+    assert.equal(calls.length, 0);
+  });
+
+  test('skips write paths absent from the index and reports only real divergences', () => {
+    resetHydrationMismatchWarnings();
+    const index = new Map<string, PathBindings>([['value', disagreeingEntry()]]);
+    const calls = captureWarn(() => {
+      reportHydrationMismatch('x-mixed', new Set(['missing', 'value']), index, makeCtx({ value: '3' }));
+    });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0], /"value"/);
+    assert.doesNotMatch(calls[0], /missing/);
   });
 });

--- a/packages/webui-framework/src/hydration-mismatch.test.ts
+++ b/packages/webui-framework/src/hydration-mismatch.test.ts
@@ -1,0 +1,282 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import type { CompiledCondition } from './template.js';
+import {
+  ATTR_KIND_ATTRIBUTE,
+  ATTR_KIND_BOOLEAN,
+  ATTR_KIND_COMPLEX,
+  ATTR_KIND_TEMPLATE,
+  type AttrBinding,
+  type CondBinding,
+  type RepeatBinding,
+  type TemplateInstance,
+  type TextBinding,
+} from './element/types.js';
+import {
+  attrDiffersFromDom,
+  bindingsDisagreeWithDom,
+  condDiffersFromDom,
+  formatHydrationMismatch,
+  type MismatchContext,
+  type PathBindings,
+  repeatDiffersFromDom,
+  textDiffersFromDom,
+  warnHydrationMismatch,
+} from './hydration-mismatch.js';
+
+// ── Fakes ───────────────────────────────────────────────────────
+// The comparators only read getAttribute/hasAttribute, Text.data,
+// Element.innerHTML, and instance counts, so plain objects suffice — no DOM.
+
+function fakeEl(attrs: Record<string, string> = {}, innerHTML = ''): Element {
+  return {
+    getAttribute: (n: string) => (n in attrs ? attrs[n] : null),
+    hasAttribute: (n: string) => n in attrs,
+    innerHTML,
+  } as unknown as Element;
+}
+
+function makeCtx(values: Record<string, unknown> = {}, parts = ''): MismatchContext {
+  return {
+    resolver: (p) => values[p],
+    resolveValue: (p) => values[p],
+    resolveParts: () => parts,
+  };
+}
+
+function cond(fn: (resolve: (p: string, s?: unknown) => unknown) => boolean): CompiledCondition {
+  return [(resolve: (p: string, s?: unknown) => unknown) => fn(resolve), []] as unknown as CompiledCondition;
+}
+
+const emptyEntry: PathBindings = { texts: [], attrs: [], conds: [], repeats: [] };
+
+// ── textDiffersFromDom ──────────────────────────────────────────
+
+describe('textDiffersFromDom', () => {
+  test('path binding matching the DOM does not differ', () => {
+    const b = { node: { data: '3' } as unknown as Text, path: 'value' } as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx({ value: '3' })), false);
+  });
+
+  test('path binding diverging from the DOM differs', () => {
+    const b = { node: { data: '' } as unknown as Text, path: 'value' } as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx({ value: '3' })), true);
+  });
+
+  test('null resolves to empty string, matching an empty text node', () => {
+    const b = { node: { data: '' } as unknown as Text, path: 'value' } as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx({ value: null })), false);
+  });
+
+  test('parts binding compares the resolved template string', () => {
+    const b = { node: { data: 'a-b' } as unknown as Text, parts: ['x'] } as unknown as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx({}, 'a-b')), false);
+    assert.equal(textDiffersFromDom(b, makeCtx({}, 'a-c')), true);
+  });
+
+  test('raw binding compares against the parent innerHTML', () => {
+    const b = {
+      node: { data: 'stale' } as unknown as Text,
+      path: 'html',
+      raw: true,
+      rawParent: fakeEl({}, '<b>x</b>'),
+    } as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx({ html: '<b>x</b>' })), false);
+    assert.equal(textDiffersFromDom(b, makeCtx({ html: '<b>y</b>' })), true);
+  });
+
+  test('binding with neither path nor parts never differs', () => {
+    const b = { node: { data: 'anything' } as unknown as Text } as TextBinding;
+    assert.equal(textDiffersFromDom(b, makeCtx()), false);
+  });
+});
+
+// ── attrDiffersFromDom ──────────────────────────────────────────
+
+describe('attrDiffersFromDom', () => {
+  test('complex :prop bindings are always trusted (never differ)', () => {
+    // #286: a child may hydrate before the parent assigns the complex prop.
+    const b: AttrBinding = { element: fakeEl(), name: 'data', kind: ATTR_KIND_COMPLEX, path: 'obj' };
+    assert.equal(attrDiffersFromDom(b, makeCtx({ obj: { a: 1 } })), false);
+  });
+
+  test('boolean attribute compares presence against the condition', () => {
+    const present: AttrBinding = {
+      element: fakeEl({ disabled: '' }), name: 'disabled', kind: ATTR_KIND_BOOLEAN,
+      condition: cond(() => true),
+    };
+    assert.equal(attrDiffersFromDom(present, makeCtx()), false);
+
+    const shouldBePresent: AttrBinding = {
+      element: fakeEl({}), name: 'disabled', kind: ATTR_KIND_BOOLEAN,
+      condition: cond(() => true),
+    };
+    assert.equal(attrDiffersFromDom(shouldBePresent, makeCtx()), true);
+  });
+
+  test('template attribute compares the resolved parts string', () => {
+    const match: AttrBinding = {
+      element: fakeEl({ 'data-x': 'a-b' }), name: 'data-x', kind: ATTR_KIND_TEMPLATE, parts: ['x'],
+    };
+    assert.equal(attrDiffersFromDom(match, makeCtx({}, 'a-b')), false);
+
+    const differ: AttrBinding = {
+      element: fakeEl({ 'data-x': 'a-b' }), name: 'data-x', kind: ATTR_KIND_TEMPLATE, parts: ['x'],
+    };
+    assert.equal(attrDiffersFromDom(differ, makeCtx({}, 'a-c')), true);
+  });
+
+  test('plain attribute compares the stringified value', () => {
+    const match: AttrBinding = {
+      element: fakeEl({ 'data-value': '3' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value',
+    };
+    assert.equal(attrDiffersFromDom(match, makeCtx({ value: '3' })), false);
+
+    const differ: AttrBinding = {
+      element: fakeEl({ 'data-value': '' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value',
+    };
+    assert.equal(attrDiffersFromDom(differ, makeCtx({ value: '3' })), true);
+  });
+
+  test('form-control value/checked/selected are skipped', () => {
+    for (const name of ['value', 'checked', 'selected']) {
+      const b: AttrBinding = {
+        element: fakeEl({}), name, kind: ATTR_KIND_ATTRIBUTE, path: 'v',
+      };
+      assert.equal(attrDiffersFromDom(b, makeCtx({ v: 'x' })), false, name);
+    }
+  });
+});
+
+// ── condDiffersFromDom ──────────────────────────────────────────
+
+describe('condDiffersFromDom', () => {
+  const instance = {} as unknown as TemplateInstance;
+
+  test('rendered block with a true condition does not differ', () => {
+    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, instance };
+    assert.equal(condDiffersFromDom(c, makeCtx()), false);
+  });
+
+  test('absent block with a false condition does not differ', () => {
+    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, instance: null };
+    assert.equal(condDiffersFromDom(c, makeCtx()), false);
+  });
+
+  test('absent block with a true condition differs (server dropped it)', () => {
+    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, instance: null };
+    assert.equal(condDiffersFromDom(c, makeCtx()), true);
+  });
+
+  test('rendered block with a false condition differs', () => {
+    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, instance };
+    assert.equal(condDiffersFromDom(c, makeCtx()), true);
+  });
+
+  test('render-invariant value change does not differ', () => {
+    // count 5 -> 3 both satisfy `count > 0`; the block stays rendered, so a
+    // value-only comparison would false-positive but a presence check must not.
+    const gtZero = cond((r) => (r('count') as number) > 0);
+    const c: CondBinding = { condition: gtZero, blockIndex: 0, anchor: {} as Comment, instance };
+    assert.equal(condDiffersFromDom(c, makeCtx({ count: 3 })), false);
+  });
+});
+
+// ── repeatDiffersFromDom ────────────────────────────────────────
+
+function repeat(collection: string, instanceCount: number): RepeatBinding {
+  return {
+    markerId: 0, collection, itemVar: 'item', blockIndex: 0,
+    container: null, start: null, end: null,
+    owner: {} as unknown as TemplateInstance,
+    instances: Array.from({ length: instanceCount }, () => ({})) as unknown as RepeatBinding['instances'],
+    rootTag: null,
+  };
+}
+
+describe('repeatDiffersFromDom', () => {
+  test('matching lengths do not differ', () => {
+    assert.equal(repeatDiffersFromDom(repeat('items', 2), makeCtx({ items: [1, 2] })), false);
+  });
+
+  test('length mismatch differs', () => {
+    assert.equal(repeatDiffersFromDom(repeat('items', 2), makeCtx({ items: [1, 2, 3] })), true);
+  });
+
+  test('non-array collection is treated as length zero', () => {
+    assert.equal(repeatDiffersFromDom(repeat('items', 0), makeCtx({ items: undefined })), false);
+    assert.equal(repeatDiffersFromDom(repeat('items', 1), makeCtx({ items: undefined })), true);
+  });
+});
+
+// ── bindingsDisagreeWithDom ─────────────────────────────────────
+
+describe('bindingsDisagreeWithDom', () => {
+  test('returns false when every binding agrees', () => {
+    const entry: PathBindings = {
+      ...emptyEntry,
+      attrs: [{ element: fakeEl({ 'data-value': '3' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value' }],
+    };
+    assert.equal(bindingsDisagreeWithDom(entry, makeCtx({ value: '3' })), false);
+  });
+
+  test('returns true when any binding disagrees', () => {
+    const entry: PathBindings = {
+      ...emptyEntry,
+      attrs: [{ element: fakeEl({ 'data-value': '' }), name: 'data-value', kind: ATTR_KIND_ATTRIBUTE, path: 'value' }],
+    };
+    assert.equal(bindingsDisagreeWithDom(entry, makeCtx({ value: '3' })), true);
+  });
+
+  test('empty entry never disagrees', () => {
+    assert.equal(bindingsDisagreeWithDom(emptyEntry, makeCtx()), false);
+  });
+});
+
+// ── formatHydrationMismatch ─────────────────────────────────────
+
+describe('formatHydrationMismatch', () => {
+  test('names the tag, quotes each path, and gives the two fixes', () => {
+    const msg = formatHydrationMismatch('x-widget', ['show', 'value']);
+    assert.match(msg, /<x-widget>/);
+    assert.match(msg, /"show", "value"/);
+    assert.match(msg, /super\.connectedCallback\(\)/);
+    assert.match(msg, /SSR state/);
+  });
+});
+
+// ── warnHydrationMismatch (per-tag dedup) ───────────────────────
+
+describe('warnHydrationMismatch', () => {
+  function captureWarn(fn: () => void): string[] {
+    const original = console.warn;
+    const calls: string[] = [];
+    console.warn = (msg?: unknown) => { calls.push(String(msg)); };
+    try {
+      fn();
+    } finally {
+      console.warn = original;
+    }
+    return calls;
+  }
+
+  test('warns once per tag even when called repeatedly', () => {
+    const calls = captureWarn(() => {
+      warnHydrationMismatch('x-dedup-a', ['show']);
+      warnHydrationMismatch('x-dedup-a', ['show']);
+      warnHydrationMismatch('x-dedup-a', ['value']);
+    });
+    assert.equal(calls.length, 1);
+  });
+
+  test('warns separately for distinct tags', () => {
+    const calls = captureWarn(() => {
+      warnHydrationMismatch('x-dedup-b', ['show']);
+      warnHydrationMismatch('x-dedup-c', ['show']);
+    });
+    assert.equal(calls.length, 2);
+  });
+});

--- a/packages/webui-framework/src/hydration-mismatch.ts
+++ b/packages/webui-framework/src/hydration-mismatch.ts
@@ -61,6 +61,30 @@ export interface PathBindings {
 }
 
 /**
+ * Entry point invoked by `TemplateElement` through a dynamic `import()`.
+ *
+ * Compares each recorded pre-ready write path against the SSR DOM and, if any
+ * diverged, emits the hydration-mismatch warning once. Routing the element
+ * through this function keeps every comparator and the message string in this
+ * module, reached only via that dynamic import — so a production bundler drops
+ * the whole module when `__WEBUI_DEV__` folds `DEV` to `false` (see
+ * `template-element.ts`). The comparison is read-only; it never mutates the DOM.
+ */
+export function reportHydrationMismatch(
+  tag: string,
+  writes: ReadonlySet<string>,
+  index: ReadonlyMap<string, PathBindings>,
+  ctx: MismatchContext,
+): void {
+  const mismatched: string[] = [];
+  for (const path of writes) {
+    const entry = index.get(path);
+    if (entry && bindingsDisagreeWithDom(entry, ctx)) mismatched.push(path);
+  }
+  if (mismatched.length !== 0) warnHydrationMismatch(tag, mismatched);
+}
+
+/**
  * True when any binding for a recorded pre-ready write disagrees with the DOM.
  * Stops at the first disagreement — the caller only needs to know whether the
  * observable diverged, not every binding that did.

--- a/packages/webui-framework/src/hydration-mismatch.ts
+++ b/packages/webui-framework/src/hydration-mismatch.ts
@@ -74,8 +74,13 @@ export function bindingsDisagreeWithDom(entry: PathBindings, ctx: MismatchContex
   return false;
 }
 
-/** Text binding: compare the resolved value against the rendered text/HTML. */
+/** Text binding: compare the resolved value against the rendered text. */
 export function textDiffersFromDom(b: TextBinding, ctx: MismatchContext): boolean {
+  // Raw `{{{expr}}}` bindings render via innerHTML, which the browser
+  // re-serializes on read (quote style, entity/attribute normalization, void
+  // elements), so a value that truly matches SSR can compare unequal. Skip
+  // them rather than emit a false mismatch.
+  if (b.raw) return false;
   let expected: string;
   if (b.parts) {
     expected = ctx.resolveParts(b.parts, b.scope);
@@ -85,8 +90,7 @@ export function textDiffersFromDom(b: TextBinding, ctx: MismatchContext): boolea
   } else {
     return false;
   }
-  const actual = b.raw && b.rawParent ? b.rawParent.innerHTML : b.node.data;
-  return actual !== expected;
+  return b.node.data !== expected;
 }
 
 /** Attribute binding: compare per kind, skipping cases SSR legitimately owns. */
@@ -120,7 +124,14 @@ export function condDiffersFromDom(c: CondBinding, ctx: MismatchContext): boolea
   return (c.instance != null) !== !!c.condition[0](ctx.resolver, c.scope);
 }
 
-/** Repeat binding: compare the collection length against the rendered items. */
+/**
+ * Repeat binding: compare the collection length against the rendered item
+ * count. Length is an intentional proxy — a same-length content or order change
+ * is not flagged, which keeps this cold-path check O(1) per repeat. Non-array
+ * values coerce to length 0, mirroring the renderer (`element/diff.ts` and the
+ * hydration path both treat non-arrays as empty), so the comparison stays
+ * consistent with what was actually rendered.
+ */
 export function repeatDiffersFromDom(r: RepeatBinding, ctx: MismatchContext): boolean {
   const resolved = ctx.resolveValue(r.collection, r.scope);
   const expectedLength = Array.isArray(resolved) ? resolved.length : 0;
@@ -140,15 +151,25 @@ export function formatHydrationMismatch(tag: string, paths: string[]): string {
 }
 
 /**
- * Tags already warned about in this document. A mismatch shared by many
- * instances of the same component (e.g. a list of 100 identical items) is one
- * authoring bug, so it reports once per tag instead of per instance.
+ * `(tag, path-set)` pairs already warned about in this document. Deduping on
+ * the exact set of diverged paths — not just the tag — keeps a repeated
+ * instance of the same bug quiet while still letting a genuinely different
+ * later mismatch on the same component surface.
  */
-const warnedMismatchTags = new Set<string>();
+const warnedMismatches = new Set<string>();
 
-/** Emit the hydration-mismatch warning once per tag. */
+/** Emit the hydration-mismatch warning once per `(tag, diverged-path-set)`. */
 export function warnHydrationMismatch(tag: string, paths: string[]): void {
-  if (warnedMismatchTags.has(tag)) return;
-  warnedMismatchTags.add(tag);
+  const key = `${tag}\u0000${[...paths].sort().join('\u0000')}`;
+  if (warnedMismatches.has(key)) return;
+  warnedMismatches.add(key);
   console.warn(formatHydrationMismatch(tag, paths));
+}
+
+/**
+ * Clear the dedup cache. Test-only: warnings dedupe for the lifetime of the
+ * document, so tests call this to assert warning behavior in isolation.
+ */
+export function resetHydrationMismatchWarnings(): void {
+  warnedMismatches.clear();
 }

--- a/packages/webui-framework/src/hydration-mismatch.ts
+++ b/packages/webui-framework/src/hydration-mismatch.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Hydration-mismatch diagnostic (issue #379).
+ *
+ * A reactive write that runs while an element is connected but before hydration
+ * finishes — a `@observable` field initializer, the `constructor`, or code
+ * before `super.connectedCallback()` — is dropped by `TemplateElement.$update`'s
+ * pre-ready guard: the backing field changes, but the server-rendered DOM is
+ * trusted and left untouched. That leaves the element's own observable
+ * disagreeing with its DOM — silently, and inconsistently with client-side
+ * rendering.
+ *
+ * The framework does NOT reconcile trusted SSR content: patching the DOM would
+ * only repair the post-hydration state while leaving the first server paint
+ * wrong, and it would erode the SSR-trust invariant (#286). Instead
+ * `TemplateElement` records the pre-ready write paths and, once hydrated, calls
+ * into this module to report any that disagree with the DOM — the same
+ * hydration-mismatch signal React, Vue, Svelte, and Solid emit.
+ *
+ * This module is intentionally free of element internals: the comparisons are
+ * pure functions over binding objects plus a small resolver context, so they
+ * unit-test in isolation (see `hydration-mismatch.test.ts`) and keep the core
+ * `template-element.ts` focused on lifecycle wiring. The comparisons are
+ * read-only — they never mutate the DOM.
+ */
+
+import type { CompiledAttrPart } from './template.js';
+import {
+  ATTR_KIND_BOOLEAN,
+  ATTR_KIND_COMPLEX,
+  ATTR_KIND_TEMPLATE,
+  type AttrBinding,
+  type CondBinding,
+  type RepeatBinding,
+  type ScopeFrame,
+  type TextBinding,
+} from './element/types.js';
+
+/**
+ * The slice of `TemplateElement` the comparators need to evaluate a binding's
+ * current (post-write) value. Supplied by the element so this module never
+ * reaches into private state.
+ */
+export interface MismatchContext {
+  /** Resolver handed to compiled condition functions (`condition[0]`). */
+  resolver: (path: string, scope?: unknown) => unknown;
+  /** Resolve a template-part list (`data-x="{{a}}-{{b}}"`) to its string value. */
+  resolveParts: (parts: CompiledAttrPart[], scope?: ScopeFrame) => string;
+  /** Resolve a single property path to its current value. */
+  resolveValue: (path: string, scope?: ScopeFrame) => unknown;
+}
+
+/** Bindings for one observable root, grouped by kind (the path-index entry). */
+export interface PathBindings {
+  texts: TextBinding[];
+  attrs: AttrBinding[];
+  conds: CondBinding[];
+  repeats: RepeatBinding[];
+}
+
+/**
+ * True when any binding for a recorded pre-ready write disagrees with the DOM.
+ * Stops at the first disagreement — the caller only needs to know whether the
+ * observable diverged, not every binding that did.
+ */
+export function bindingsDisagreeWithDom(entry: PathBindings, ctx: MismatchContext): boolean {
+  const { texts, attrs, conds, repeats } = entry;
+  for (let i = 0; i < texts.length; i++) if (textDiffersFromDom(texts[i], ctx)) return true;
+  for (let i = 0; i < attrs.length; i++) if (attrDiffersFromDom(attrs[i], ctx)) return true;
+  for (let i = 0; i < conds.length; i++) if (condDiffersFromDom(conds[i], ctx)) return true;
+  for (let i = 0; i < repeats.length; i++) if (repeatDiffersFromDom(repeats[i], ctx)) return true;
+  return false;
+}
+
+/** Text binding: compare the resolved value against the rendered text/HTML. */
+export function textDiffersFromDom(b: TextBinding, ctx: MismatchContext): boolean {
+  let expected: string;
+  if (b.parts) {
+    expected = ctx.resolveParts(b.parts, b.scope);
+  } else if (b.path) {
+    const raw = ctx.resolveValue(b.path, b.scope);
+    expected = raw == null ? '' : String(raw);
+  } else {
+    return false;
+  }
+  const actual = b.raw && b.rawParent ? b.rawParent.innerHTML : b.node.data;
+  return actual !== expected;
+}
+
+/** Attribute binding: compare per kind, skipping cases SSR legitimately owns. */
+export function attrDiffersFromDom(b: AttrBinding, ctx: MismatchContext): boolean {
+  const el = b.element;
+  switch (b.kind) {
+    // Complex `:prop` bindings carry parent-delayed object data that a child
+    // legitimately hydrates before the parent sets it — SSR is trusted (#286).
+    case ATTR_KIND_COMPLEX:
+      return false;
+    case ATTR_KIND_BOOLEAN:
+      return el.hasAttribute(b.name) !== !!b.condition![0](ctx.resolver, b.scope);
+    case ATTR_KIND_TEMPLATE:
+      return (el.getAttribute(b.name) ?? '') !== ctx.resolveParts(b.parts!, b.scope);
+    default: {
+      // Form-control properties diverge from their attribute after user
+      // interaction, so an attribute comparison would be misleading.
+      if (b.name === 'value' || b.name === 'checked' || b.name === 'selected') return false;
+      const v = ctx.resolveValue(b.path!, b.scope);
+      return (el.getAttribute(b.name) ?? '') !== (v == null ? '' : String(v));
+    }
+  }
+}
+
+/**
+ * Conditional binding: compare rendered PRESENCE, not the raw value. A pre-ready
+ * write that changes the value but not the condition result (e.g. `count` 5→3
+ * under `count > 0`) leaves the DOM correct and must not warn.
+ */
+export function condDiffersFromDom(c: CondBinding, ctx: MismatchContext): boolean {
+  return (c.instance != null) !== !!c.condition[0](ctx.resolver, c.scope);
+}
+
+/** Repeat binding: compare the collection length against the rendered items. */
+export function repeatDiffersFromDom(r: RepeatBinding, ctx: MismatchContext): boolean {
+  const resolved = ctx.resolveValue(r.collection, r.scope);
+  const expectedLength = Array.isArray(resolved) ? resolved.length : 0;
+  return expectedLength !== r.instances.length;
+}
+
+/** Build the developer-facing warning text for a set of diverged observables. */
+export function formatHydrationMismatch(tag: string, paths: string[]): string {
+  const list = paths.map((p) => `"${p}"`).join(', ');
+  return (
+    `[WebUI] Hydration mismatch on <${tag}>: ` +
+    `${list} changed at or before super.connectedCallback() to a value that ` +
+    `differs from the server-rendered DOM. The DOM keeps the server value ` +
+    `(SSR content is trusted), so the element's state and DOM disagree. ` +
+    `Add the value to the SSR state, or assign it after super.connectedCallback().`
+  );
+}
+
+/**
+ * Tags already warned about in this document. A mismatch shared by many
+ * instances of the same component (e.g. a list of 100 identical items) is one
+ * authoring bug, so it reports once per tag instead of per instance.
+ */
+const warnedMismatchTags = new Set<string>();
+
+/** Emit the hydration-mismatch warning once per tag. */
+export function warnHydrationMismatch(tag: string, paths: string[]): void {
+  if (warnedMismatchTags.has(tag)) return;
+  warnedMismatchTags.add(tag);
+  console.warn(formatHydrationMismatch(tag, paths));
+}

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -254,6 +254,12 @@ export class TemplateElement extends HTMLElement {
   private $templateState: Record<string, unknown> | null = null;
   private $dirtyPaths: Set<string> | null = null;
   private $pendingFlush = false;
+  /** Observable paths written while connected but before hydration finished
+   *  (constructor, `@observable` field initializer, or before
+   *  `super.connectedCallback()`). Checked against the SSR DOM at `$ready` to
+   *  surface hydration mismatches (issue #379). Stays `null` for components
+   *  that follow the lifecycle, so the common path allocates nothing. */
+  private $preReadyWrites: Set<string> | null = null;
   /** Cached condition resolver — avoids allocating a closure per evaluation. */
   private $resolver = (p: string, s?: unknown): unknown => this.$resolveValue(p, s as ScopeFrame | undefined);
   private $pathIndex?: Map<string, {
@@ -375,6 +381,12 @@ export class TemplateElement extends HTMLElement {
     this.$ready = true;
     this.$syncAuthoredAttributes();
 
+    // SSR only: warn when a pre-ready write left an observable disagreeing
+    // with the server-rendered DOM. Client-created components have no SSR
+    // content to diverge from.
+    if (isSSR) this.$checkHydrationMismatch();
+    else this.$preReadyWrites = null;
+
     // Client-created components: flush current attr/observable values
     // into the freshly-wired template DOM. Call $updateInstance directly
     // to avoid the $update() path-index build — it will be lazy-built
@@ -414,6 +426,7 @@ export class TemplateElement extends HTMLElement {
     this.$wildcardBindings = undefined;
     this.$dirtyPaths = null;
     this.$pendingFlush = false;
+    this.$preReadyWrites = null;
     this.$ready = false;
   }
 
@@ -568,7 +581,13 @@ export class TemplateElement extends HTMLElement {
 
   /** Reactive update — called by @observable/@attr setters. */
   $update(path?: string): void {
-    if (!this.$ready || !this.$root) return;
+    if (!this.$ready || !this.$root) {
+      // A reactive write arrived while connected but before hydration
+      // completed. `$update` cannot touch the DOM yet, so record the path and
+      // check it against the SSR DOM once hydrated (see #379).
+      if (path && this.isConnected) this.$recordPreReadyWrite(path);
+      return;
+    }
 
     // Lazy-build path index on first update (deferred from hydration)
     if (!this.$pathIndex) this.$buildPathIndex();
@@ -625,6 +644,108 @@ export class TemplateElement extends HTMLElement {
     }
 
     this.$pendingFlush = false;
+  }
+
+  // ── Hydration mismatch diagnostic (#379) ──────────────────────
+  // A reactive write that runs while the element is connected but before
+  // hydration finishes (constructor, `@observable` field initializer, or
+  // before `super.connectedCallback()`) is dropped by `$update`'s pre-ready
+  // guard: the backing field changes, but the SSR DOM is trusted and left
+  // untouched. That leaves the element's own observable disagreeing with its
+  // DOM — silently, and inconsistently with client-side rendering.
+  //
+  // The framework does not reconcile trusted SSR content here: patching the
+  // DOM would only repair the post-hydration state while leaving the first
+  // server paint wrong, and it would erode the SSR-trust invariant (#286).
+  // Instead it records the pre-ready writes and, once hydrated, reports any
+  // that disagree with the server-rendered DOM — the same hydration-mismatch
+  // signal React, Vue, Svelte, and Solid emit. The check is read-only and
+  // runs only when a connected pre-ready write was recorded.
+
+  private $recordPreReadyWrite(path: string): void {
+    if (!this.$preReadyWrites) this.$preReadyWrites = new Set();
+    this.$preReadyWrites.add(path);
+  }
+
+  private $checkHydrationMismatch(): void {
+    const writes = this.$preReadyWrites;
+    this.$preReadyWrites = null;
+    if (!writes || writes.size === 0 || !this.$root) return;
+    if (!this.$pathIndex) this.$buildPathIndex();
+    const mismatched: string[] = [];
+    for (const path of writes) {
+      const entry = this.$pathIndex?.get(path);
+      if (entry && this.$bindingsDisagreeWithDom(entry)) mismatched.push(path);
+    }
+    if (mismatched.length !== 0) this.$warnHydrationMismatch(mismatched);
+  }
+
+  private $bindingsDisagreeWithDom(entry: {
+    texts: TextBinding[]; attrs: AttrBinding[];
+    conds: CondBinding[]; repeats: RepeatBinding[];
+  }): boolean {
+    const { texts, attrs, conds, repeats } = entry;
+    for (let i = 0; i < texts.length; i++) if (this.$textDiffersFromDom(texts[i])) return true;
+    for (let i = 0; i < attrs.length; i++) if (this.$attrDiffersFromDom(attrs[i])) return true;
+    for (let i = 0; i < conds.length; i++) if (this.$condDiffersFromDom(conds[i])) return true;
+    for (let i = 0; i < repeats.length; i++) if (this.$repeatDiffersFromDom(repeats[i])) return true;
+    return false;
+  }
+
+  private $textDiffersFromDom(b: TextBinding): boolean {
+    let expected: string;
+    if (b.parts) {
+      expected = this.$resolveParts(b.parts, b.scope);
+    } else if (b.path) {
+      const raw = this.$resolveValue(b.path, b.scope);
+      expected = raw == null ? '' : String(raw);
+    } else {
+      return false;
+    }
+    const actual = b.raw && b.rawParent ? b.rawParent.innerHTML : b.node.data;
+    return actual !== expected;
+  }
+
+  private $attrDiffersFromDom(b: AttrBinding): boolean {
+    const el = b.element;
+    switch (b.kind) {
+      // Complex `:prop` bindings carry parent-delayed object data that a child
+      // legitimately hydrates before the parent sets it — SSR is trusted (#286).
+      case ATTR_KIND_COMPLEX:
+        return false;
+      case ATTR_KIND_BOOLEAN:
+        return el.hasAttribute(b.name) !== !!b.condition![0](this.$resolver, b.scope);
+      case ATTR_KIND_TEMPLATE:
+        return (el.getAttribute(b.name) ?? '') !== this.$resolveParts(b.parts!, b.scope);
+      default: {
+        // Form-control properties diverge from their attribute after user
+        // interaction, so an attribute comparison would be misleading.
+        if (b.name === 'value' || b.name === 'checked' || b.name === 'selected') return false;
+        const v = this.$resolveValue(b.path!, b.scope);
+        return (el.getAttribute(b.name) ?? '') !== (v == null ? '' : String(v));
+      }
+    }
+  }
+
+  private $condDiffersFromDom(c: CondBinding): boolean {
+    return (c.instance != null) !== !!c.condition[0](this.$resolver, c.scope);
+  }
+
+  private $repeatDiffersFromDom(r: RepeatBinding): boolean {
+    const resolved = this.$resolveValue(r.collection, r.scope);
+    const expectedLength = Array.isArray(resolved) ? resolved.length : 0;
+    return expectedLength !== r.instances.length;
+  }
+
+  private $warnHydrationMismatch(paths: string[]): void {
+    const list = paths.map((p) => `"${p}"`).join(', ');
+    console.warn(
+      `[WebUI] Hydration mismatch on <${this.tagName.toLowerCase()}>: ` +
+      `${list} changed at or before super.connectedCallback() to a value that ` +
+      `differs from the server-rendered DOM. The DOM keeps the server value ` +
+      `(SSR content is trusted), so the element's state and DOM disagree. ` +
+      `Add the value to the SSR state, or assign it after super.connectedCallback().`,
+    );
   }
 
   // ── DOM resolution: client-created path ───────────────────────

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -82,6 +82,11 @@ import type {
   TemplateInstance,
   TextBinding,
 } from './element/types.js';
+import {
+  bindingsDisagreeWithDom,
+  warnHydrationMismatch,
+  type MismatchContext,
+} from './hydration-mismatch.js';
 
 // ── Caches ──────────────────────────────────────────────────────
 
@@ -650,17 +655,10 @@ export class TemplateElement extends HTMLElement {
   // A reactive write that runs while the element is connected but before
   // hydration finishes (constructor, `@observable` field initializer, or
   // before `super.connectedCallback()`) is dropped by `$update`'s pre-ready
-  // guard: the backing field changes, but the SSR DOM is trusted and left
-  // untouched. That leaves the element's own observable disagreeing with its
-  // DOM — silently, and inconsistently with client-side rendering.
-  //
-  // The framework does not reconcile trusted SSR content here: patching the
-  // DOM would only repair the post-hydration state while leaving the first
-  // server paint wrong, and it would erode the SSR-trust invariant (#286).
-  // Instead it records the pre-ready writes and, once hydrated, reports any
-  // that disagree with the server-rendered DOM — the same hydration-mismatch
-  // signal React, Vue, Svelte, and Solid emit. The check is read-only and
-  // runs only when a connected pre-ready write was recorded.
+  // guard. Record such writes and, once hydrated, report any that disagree
+  // with the trusted SSR DOM. The read-only comparison lives in
+  // `hydration-mismatch.ts` (see that module for the full rationale); this
+  // class only records the writes and supplies a resolver context.
 
   private $recordPreReadyWrite(path: string): void {
     if (!this.$preReadyWrites) this.$preReadyWrites = new Set();
@@ -672,80 +670,21 @@ export class TemplateElement extends HTMLElement {
     this.$preReadyWrites = null;
     if (!writes || writes.size === 0 || !this.$root) return;
     if (!this.$pathIndex) this.$buildPathIndex();
+    const index = this.$pathIndex;
+    if (!index) return;
+    const ctx: MismatchContext = {
+      resolver: this.$resolver,
+      resolveParts: (parts, scope) => this.$resolveParts(parts, scope),
+      resolveValue: (path, scope) => this.$resolveValue(path, scope),
+    };
     const mismatched: string[] = [];
     for (const path of writes) {
-      const entry = this.$pathIndex?.get(path);
-      if (entry && this.$bindingsDisagreeWithDom(entry)) mismatched.push(path);
+      const entry = index.get(path);
+      if (entry && bindingsDisagreeWithDom(entry, ctx)) mismatched.push(path);
     }
-    if (mismatched.length !== 0) this.$warnHydrationMismatch(mismatched);
-  }
-
-  private $bindingsDisagreeWithDom(entry: {
-    texts: TextBinding[]; attrs: AttrBinding[];
-    conds: CondBinding[]; repeats: RepeatBinding[];
-  }): boolean {
-    const { texts, attrs, conds, repeats } = entry;
-    for (let i = 0; i < texts.length; i++) if (this.$textDiffersFromDom(texts[i])) return true;
-    for (let i = 0; i < attrs.length; i++) if (this.$attrDiffersFromDom(attrs[i])) return true;
-    for (let i = 0; i < conds.length; i++) if (this.$condDiffersFromDom(conds[i])) return true;
-    for (let i = 0; i < repeats.length; i++) if (this.$repeatDiffersFromDom(repeats[i])) return true;
-    return false;
-  }
-
-  private $textDiffersFromDom(b: TextBinding): boolean {
-    let expected: string;
-    if (b.parts) {
-      expected = this.$resolveParts(b.parts, b.scope);
-    } else if (b.path) {
-      const raw = this.$resolveValue(b.path, b.scope);
-      expected = raw == null ? '' : String(raw);
-    } else {
-      return false;
+    if (mismatched.length !== 0) {
+      warnHydrationMismatch(this.tagName.toLowerCase(), mismatched);
     }
-    const actual = b.raw && b.rawParent ? b.rawParent.innerHTML : b.node.data;
-    return actual !== expected;
-  }
-
-  private $attrDiffersFromDom(b: AttrBinding): boolean {
-    const el = b.element;
-    switch (b.kind) {
-      // Complex `:prop` bindings carry parent-delayed object data that a child
-      // legitimately hydrates before the parent sets it — SSR is trusted (#286).
-      case ATTR_KIND_COMPLEX:
-        return false;
-      case ATTR_KIND_BOOLEAN:
-        return el.hasAttribute(b.name) !== !!b.condition![0](this.$resolver, b.scope);
-      case ATTR_KIND_TEMPLATE:
-        return (el.getAttribute(b.name) ?? '') !== this.$resolveParts(b.parts!, b.scope);
-      default: {
-        // Form-control properties diverge from their attribute after user
-        // interaction, so an attribute comparison would be misleading.
-        if (b.name === 'value' || b.name === 'checked' || b.name === 'selected') return false;
-        const v = this.$resolveValue(b.path!, b.scope);
-        return (el.getAttribute(b.name) ?? '') !== (v == null ? '' : String(v));
-      }
-    }
-  }
-
-  private $condDiffersFromDom(c: CondBinding): boolean {
-    return (c.instance != null) !== !!c.condition[0](this.$resolver, c.scope);
-  }
-
-  private $repeatDiffersFromDom(r: RepeatBinding): boolean {
-    const resolved = this.$resolveValue(r.collection, r.scope);
-    const expectedLength = Array.isArray(resolved) ? resolved.length : 0;
-    return expectedLength !== r.instances.length;
-  }
-
-  private $warnHydrationMismatch(paths: string[]): void {
-    const list = paths.map((p) => `"${p}"`).join(', ');
-    console.warn(
-      `[WebUI] Hydration mismatch on <${this.tagName.toLowerCase()}>: ` +
-      `${list} changed at or before super.connectedCallback() to a value that ` +
-      `differs from the server-rendered DOM. The DOM keeps the server value ` +
-      `(SSR content is trusted), so the element's state and DOM disagree. ` +
-      `Add the value to the SSR state, or assign it after super.connectedCallback().`,
-    );
   }
 
   // ── DOM resolution: client-created path ───────────────────────

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -82,11 +82,36 @@ import type {
   TemplateInstance,
   TextBinding,
 } from './element/types.js';
-import {
-  bindingsDisagreeWithDom,
-  warnHydrationMismatch,
-  type MismatchContext,
-} from './hydration-mismatch.js';
+// Type-only import: erased at compile time, so it never creates a runtime edge
+// to the diagnostic module. That module's runtime code is reached solely through
+// the dynamic `import()` in `$checkHydrationMismatch`, which is what lets a
+// production bundler drop it (see the `__WEBUI_DEV__` note below).
+import type { MismatchContext } from './hydration-mismatch.js';
+
+// ── Development build flag ──────────────────────────────────────
+// `__WEBUI_DEV__` is a compile-time constant a bundler folds to a literal
+// (`esbuild --define:__WEBUI_DEV__=false`, webpack/rspack `DefinePlugin`, Vite
+// and Rollup/rolldown `define`, swc `globals.vars`). `webui-press` folds it to
+// `false` for `build` (production) and leaves it undefined for `serve` (dev).
+//
+// When it folds to `false`, `DEV` folds too: every `if (DEV)` / `if (!DEV)
+// return` branch below becomes dead code, and the *sole* dynamic `import()` of
+// `hydration-mismatch.ts` is DCE'd. Because that import is the only reference to
+// the module, dropping it orphans the chunk and the bundler removes the whole
+// diagnostic (comparators + message string) from the output — not just its
+// runtime cost. A static import would NOT strip: esbuild fixes module
+// reachability before constant-folding and never re-runs tree-shaking, so a
+// statically-imported module survives even when its only caller is folded away.
+//
+// The `typeof` guard keeps this safe when the flag is undefined (raw ESM, the
+// framework's own `tsc` output, unit tests, un-defined esbuild builds): `typeof`
+// on an undeclared identifier yields `"undefined"` instead of throwing a
+// ReferenceError, so `DEV` defaults to `true` (diagnostics on). Declared and
+// consumed module-locally on purpose — esbuild folds a module-local `const`
+// reliably, whereas an imported constant is not inlined across module
+// boundaries, which would defeat the stripping.
+declare const __WEBUI_DEV__: boolean;
+const DEV: boolean = typeof __WEBUI_DEV__ === 'undefined' || __WEBUI_DEV__;
 
 // ── Caches ──────────────────────────────────────────────────────
 
@@ -388,8 +413,9 @@ export class TemplateElement extends HTMLElement {
 
     // SSR only: warn when a pre-ready write left an observable disagreeing
     // with the server-rendered DOM. Client-created components have no SSR
-    // content to diverge from.
-    if (isSSR) this.$checkHydrationMismatch();
+    // content to diverge from. `DEV` gates the call so production bundles
+    // (`--define:__WEBUI_DEV__=false`) drop it entirely.
+    if (isSSR && DEV) this.$checkHydrationMismatch();
     else this.$preReadyWrites = null;
 
     // Client-created components: flush current attr/observable values
@@ -589,8 +615,9 @@ export class TemplateElement extends HTMLElement {
     if (!this.$ready || !this.$root) {
       // A reactive write arrived while connected but before hydration
       // completed. `$update` cannot touch the DOM yet, so record the path and
-      // check it against the SSR DOM once hydrated (see #379).
-      if (path && this.isConnected) this.$recordPreReadyWrite(path);
+      // check it against the SSR DOM once hydrated (see #379). `DEV` gates the
+      // recording so production bundles never allocate the tracking Set.
+      if (DEV && path && this.isConnected) this.$recordPreReadyWrite(path);
       return;
     }
 
@@ -664,6 +691,15 @@ export class TemplateElement extends HTMLElement {
   // field of every observable present in the SSR state before this runs, so
   // those reconcile to the server value and cannot disagree. In practice the
   // diagnostic only fires for observables omitted from the SSR state.
+  //
+  // Production stripping: the comparators and message string live in
+  // `hydration-mismatch.ts`, reached only through the dynamic `import()` in
+  // `$checkHydrationMismatch`. When a bundler folds `__WEBUI_DEV__` to `false`,
+  // `DEV` becomes a constant, the `if (!DEV) return` empties this method, and
+  // the now-dead `import()` is DCE'd — orphaning the diagnostic chunk so the
+  // bundler drops it. The `if (!DEV) return` is load-bearing: class methods are
+  // never tree-shaken, so without it the method body (and its `import()`) would
+  // survive. See the `__WEBUI_DEV__` note near the top of this file.
 
   private $recordPreReadyWrite(path: string): void {
     if (!this.$preReadyWrites) this.$preReadyWrites = new Set();
@@ -671,6 +707,7 @@ export class TemplateElement extends HTMLElement {
   }
 
   private $checkHydrationMismatch(): void {
+    if (!DEV) return;
     const writes = this.$preReadyWrites;
     this.$preReadyWrites = null;
     if (!writes || writes.size === 0 || !this.$root) return;
@@ -682,14 +719,17 @@ export class TemplateElement extends HTMLElement {
       resolveParts: (parts, scope) => this.$resolveParts(parts, scope),
       resolveValue: (path, scope) => this.$resolveValue(path, scope),
     };
-    const mismatched: string[] = [];
-    for (const path of writes) {
-      const entry = index.get(path);
-      if (entry && bindingsDisagreeWithDom(entry, ctx)) mismatched.push(path);
-    }
-    if (mismatched.length !== 0) {
-      warnHydrationMismatch(this.tagName.toLowerCase(), mismatched);
-    }
+    const tag = this.tagName.toLowerCase();
+    // Defer the read-only comparison to the dynamically-imported diagnostic
+    // module. `writes`, `index`, and `ctx` are captured synchronously here; the
+    // SSR DOM they compare against does not change between `$ready` and the
+    // microtask on which the import resolves, so the result is unaffected by the
+    // deferral. In production `DEV` folds to `false`, so this method's body — and
+    // therefore this sole `import()` — is eliminated, dropping the diagnostic
+    // module from the bundle (see the `__WEBUI_DEV__` note near the top).
+    void import('./hydration-mismatch.js').then((m) =>
+      m.reportHydrationMismatch(tag, writes, index, ctx),
+    );
   }
 
   // ── DOM resolution: client-created path ───────────────────────

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -659,6 +659,11 @@ export class TemplateElement extends HTMLElement {
   // with the trusted SSR DOM. The read-only comparison lives in
   // `hydration-mismatch.ts` (see that module for the full rationale); this
   // class only records the writes and supplies a resolver context.
+  //
+  // Note: `$applySSRState` (in `$mount`) has already overwritten the backing
+  // field of every observable present in the SSR state before this runs, so
+  // those reconcile to the server value and cannot disagree. In practice the
+  // diagnostic only fires for observables omitted from the SSR state.
 
   private $recordPreReadyWrite(path: string): void {
     if (!this.$preReadyWrites) this.$preReadyWrites = new Set();

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/element.ts
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/element.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Fixtures for issue #379: hydration must surface (not silently swallow) an
+ * observable whose value, set at or before `super.connectedCallback()`,
+ * disagrees with the server-rendered DOM.
+ *
+ * Each component renders a conditional (`<if condition="show">`) and a
+ * template attribute (`data-value="{{value}}"`). The SSR state omits `show`
+ * and `value`, so the server renders the conditional empty and the attribute
+ * blank. The components differ only in WHEN they assign the observables.
+ */
+
+import { WebUIElement, observable } from '../../../src/index.js';
+
+/**
+ * `@observable` field default differs from SSR state. The initializer runs
+ * during construction (before hydration), so the value is dropped and the DOM
+ * disagrees. Expect a hydration-mismatch warning.
+ */
+export class MismatchFieldDefault extends WebUIElement {
+  @observable show = true;
+  @observable value = '3';
+}
+MismatchFieldDefault.define('mismatch-field-default');
+
+/** Assigns in the constructor — before hydration. Expect a warning. */
+export class MismatchConstructor extends WebUIElement {
+  @observable show = false;
+  @observable value = '';
+
+  constructor() {
+    super();
+    this.show = true;
+    this.value = '3';
+  }
+}
+MismatchConstructor.define('mismatch-constructor');
+
+/** Assigns before `super.connectedCallback()`. Expect a warning. */
+export class MismatchBeforeSuper extends WebUIElement {
+  @observable show = false;
+  @observable value = '';
+
+  connectedCallback(): void {
+    this.show = true;
+    this.value = '3';
+    super.connectedCallback();
+  }
+}
+MismatchBeforeSuper.define('mismatch-before-super');
+
+/** Assigns after `super.connectedCallback()`. No warning; the DOM updates. */
+export class MismatchAfterSuper extends WebUIElement {
+  @observable show = false;
+  @observable value = '';
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.show = true;
+    this.value = '3';
+  }
+}
+MismatchAfterSuper.define('mismatch-after-super');
+
+/** Assigns in a deferred task. No warning; the DOM updates. */
+export class MismatchDeferred extends WebUIElement {
+  @observable show = false;
+  @observable value = '';
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    setTimeout(() => {
+      this.show = true;
+      this.value = '3';
+    }, 0);
+  }
+}
+MismatchDeferred.define('mismatch-deferred');
+
+/**
+ * `@observable` field defaults that ARE seeded into SSR state (see state.json),
+ * so the server already rendered them. A pre-ready write that matches the
+ * server must NOT warn.
+ */
+export class MismatchSeeded extends WebUIElement {
+  @observable seededShow = true;
+  @observable seededValue = '3';
+}
+MismatchSeeded.define('mismatch-seeded');

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/hydration-mismatch.spec.ts
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/hydration-mismatch.spec.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Regression test for issue #379.
+ *
+ * When an observable is assigned at or before `super.connectedCallback()` to a
+ * value that differs from the server-rendered DOM, the framework trusts the SSR
+ * content (it does NOT reconcile) but emits a dev-facing hydration-mismatch
+ * warning — the same signal React/Vue/Svelte/Solid produce. Assignments made
+ * after `super.connectedCallback()`, deferred assignments, and pre-ready
+ * assignments that match seeded SSR state must stay silent.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const MISMATCH = 'Hydration mismatch';
+
+const ALL_TAGS = [
+  'mismatch-field-default',
+  'mismatch-constructor',
+  'mismatch-before-super',
+  'mismatch-after-super',
+  'mismatch-deferred',
+  'mismatch-seeded',
+] as const;
+
+test.describe('hydration-mismatch (#379)', () => {
+  let warnings: string[];
+
+  test.beforeEach(async ({ page }) => {
+    warnings = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning') warnings.push(msg.text());
+    });
+
+    await page.goto('/hydration-mismatch/fixture.html');
+
+    await page.waitForFunction((tags) => {
+      return tags.every((t) => (document.querySelector(t) as { $ready?: boolean } | null)?.$ready === true);
+    }, ALL_TAGS as unknown as string[]);
+
+    // The deferred component assigns in a post-ready task; wait for it to land.
+    await page.waitForSelector('mismatch-deferred .content');
+  });
+
+  const warningsFor = (tag: string): string[] =>
+    warnings.filter((w) => w.includes(MISMATCH) && w.includes(`<${tag}>`));
+
+  test('warns exactly once per pre-ready timing and stays silent otherwise', async () => {
+    await expect.poll(() => warnings.filter((w) => w.includes(MISMATCH)).length).toBe(3);
+
+    expect(warningsFor('mismatch-field-default')).toHaveLength(1);
+    expect(warningsFor('mismatch-constructor')).toHaveLength(1);
+    expect(warningsFor('mismatch-before-super')).toHaveLength(1);
+
+    expect(warningsFor('mismatch-after-super')).toHaveLength(0);
+    expect(warningsFor('mismatch-deferred')).toHaveLength(0);
+    expect(warningsFor('mismatch-seeded')).toHaveLength(0);
+  });
+
+  test('the warning names the mismatched observables', async () => {
+    await expect.poll(() => warningsFor('mismatch-constructor').length).toBe(1);
+    const [warning] = warningsFor('mismatch-constructor');
+    expect(warning).toContain('"show"');
+    expect(warning).toContain('"value"');
+    expect(warning).toContain('super.connectedCallback()');
+  });
+
+  test('SSR DOM is trusted, not reconciled, for pre-ready mismatches', async ({ page }) => {
+    for (const tag of ['mismatch-field-default', 'mismatch-constructor', 'mismatch-before-super']) {
+      // Conditional content stays absent (server rendered it empty).
+      expect(await page.locator(`${tag} .content`).count()).toBe(0);
+      // Bound attribute keeps the server value, not the client "3".
+      expect(await page.locator(`${tag} .box`).getAttribute('data-value')).not.toBe('3');
+    }
+  });
+
+  test('element state holds the client value even though the DOM does not (the #379 divergence)', async ({ page }) => {
+    const state = await page.evaluate(() => {
+      const el = document.querySelector('mismatch-field-default') as { show?: boolean; value?: string } | null;
+      return { show: el?.show, value: el?.value };
+    });
+    expect(state).toEqual({ show: true, value: '3' });
+    expect(await page.locator('mismatch-field-default .content').count()).toBe(0);
+  });
+
+  test('post-super and deferred assignments update the DOM', async ({ page }) => {
+    for (const tag of ['mismatch-after-super', 'mismatch-deferred']) {
+      await expect(page.locator(`${tag} .content`)).toHaveText('CONTENT');
+      expect(await page.locator(`${tag} .box`).getAttribute('data-value')).toBe('3');
+    }
+  });
+
+  test('seeded pre-ready values match the server render and do not warn', async ({ page }) => {
+    await expect(page.locator('mismatch-seeded .content')).toHaveText('CONTENT');
+    expect(await page.locator('mismatch-seeded .box').getAttribute('data-value')).toBe('3');
+    expect(warningsFor('mismatch-seeded')).toHaveLength(0);
+  });
+});

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/index.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Hydration Mismatch Fixture</title>
+</head>
+<body>
+  <mismatch-field-default id="field-default"></mismatch-field-default>
+  <mismatch-constructor id="constructor"></mismatch-constructor>
+  <mismatch-before-super id="before-super"></mismatch-before-super>
+  <mismatch-after-super id="after-super"></mismatch-after-super>
+  <mismatch-deferred id="deferred"></mismatch-deferred>
+  <mismatch-seeded id="seeded"></mismatch-seeded>
+</body>
+</html>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-after-super/mismatch-after-super.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-after-super/mismatch-after-super.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{value}}">
+  <if condition="show"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-before-super/mismatch-before-super.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-before-super/mismatch-before-super.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{value}}">
+  <if condition="show"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-constructor/mismatch-constructor.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-constructor/mismatch-constructor.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{value}}">
+  <if condition="show"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-deferred/mismatch-deferred.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-deferred/mismatch-deferred.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{value}}">
+  <if condition="show"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-field-default/mismatch-field-default.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-field-default/mismatch-field-default.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{value}}">
+  <if condition="show"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-seeded/mismatch-seeded.html
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/src/mismatch-seeded/mismatch-seeded.html
@@ -1,0 +1,3 @@
+<div class="box" data-value="{{seededValue}}">
+  <if condition="seededShow"><span class="content">CONTENT</span></if>
+</div>

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/state.json
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/state.json
@@ -1,0 +1,4 @@
+{
+  "seededShow": true,
+  "seededValue": "3"
+}

--- a/packages/webui-framework/tests/fixtures/hydration-mismatch/webui.config.json
+++ b/packages/webui-framework/tests/fixtures/hydration-mismatch/webui.config.json
@@ -1,0 +1,3 @@
+{
+  "script": "module"
+}

--- a/packages/webui-test-support/src/fixture-render.ts
+++ b/packages/webui-test-support/src/fixture-render.ts
@@ -101,7 +101,12 @@ function renderOne(fixturePath: string, name: string): RenderedFixture | null {
   const scriptPath = hasAuthoredEntry
     ? `/dist/${name}/element.js`
     : '/dist/static-host.js';
-  const scriptTag = `<script src="${scriptPath}"></script>`;
+  // Real WebUI apps load client islands as ES modules (`<script type="module">`),
+  // which are deferred until after the document is parsed. Fixtures can opt into
+  // that production-faithful timing with `"script": "module"` in webui.config.json;
+  // otherwise a classic (parser-blocking) script is injected for back-compat.
+  const scriptType = fixtureConfig.script === 'module' ? ' type="module"' : '';
+  const scriptTag = `<script${scriptType} src="${scriptPath}"></script>`;
   const bodyEnd = html.lastIndexOf('</body>');
   if (bodyEnd !== -1) {
     html = html.slice(0, bodyEnd) + scriptTag + html.slice(bodyEnd);


### PR DESCRIPTION
## Summary

Fixes #379. After SSR hydration, an element's public observable state could permanently and silently disagree with its own DOM. Any reactive write that runs while the element is *connected but not yet hydrated* — a `@observable` field initializer, the `constructor`, or code before `super.connectedCallback()` — updates the backing field but is dropped by `$update`'s pre-ready guard, which trusts the server-rendered DOM and leaves it untouched. Because the reactive setter no-ops when the same value is re-assigned later, the mismatch never self-heals: the element reports `show === true` while the DOM shows nothing, with no error and inconsistently with client-side rendering.

## Approach

The framework **intentionally does not reconcile** trusted SSR content. Patching the DOM after the fact would still leave the first server paint wrong and would erode the SSR-trust invariant that #286 relies on (a child may legitimately hydrate a complex `:prop` before its parent assigns it). Instead, this PR emits a **hydration-mismatch warning** — the same signal React, Vue, Svelte, and Solid produce — naming exactly which observables diverged and how to fix it: seed the value through SSR state, or assign it after `super.connectedCallback()`.

The check is **read-only**, **allocation-free on the correct path** (the tracking `Set` stays `null` for well-behaved components), and **precise**: it warns only when a recorded pre-ready write yields rendered output that actually differs from the DOM. It deliberately stays silent for render-invariant changes (e.g. `count` 5→3 under `count > 0`), unbound observables, complex `:prop` bindings (#286), and form-control `value`/`checked`/`selected`.

## What changed

- **Diagnostic runtime** (`template-element.ts`) — records connected pre-ready write paths and, once hydrated, compares each against the DOM, emitting one `console.warn` per component tag.
- **Extracted module** (`hydration-mismatch.ts`) — the pure SSR/DOM comparators live in their own file as free functions over a small resolver context, keeping the core class focused on lifecycle wiring and the rationale beside the code. Includes per-tag dedup so a mismatch shared by many instances reports once.
- **Tests** — a 6-component Playwright regression fixture (constructor / field-initializer / before-super warn; after-super / deferred / seeded stay silent) proves end-to-end behavior and fails on `main`; 25 unit tests directly assert the comparators' precision (render-invariant, `:prop`/form-control skips, template/boolean/plain attrs, text parts/raw, repeat length, dedup).
- **Docs** — `DESIGN.md`, the interactivity guide, `docs/ai.md`, and the framework README document the setup-timing rule.
- **Chore** — bumps `crossbeam-epoch` 0.9.18 → 0.9.20 (Cargo.lock only) to clear RUSTSEC-2026-0204, which was blocking the `cargo deny` gate.

## Behavior / contract

No change for correct components and **no DOM mutation** — SSR output stays authoritative. The only new behavior is a warning when an element's own observable state contradicts the server DOM after hydration.

## Validation

- Framework unit tests: **86 pass** (25 new)
- Full Playwright E2E: **132 passed / 2 pre-existing skips**; #286 complex-prop intact
- `cargo xtask check`: **all checks pass** (fmt, clippy, deny, test, build, wasm, examples, bench, docs)

Closes #379