### PR TITLE
fix(webui-press): strip Windows verbatim prefix from JS import specifiers

### DIFF
--- a/crates/webui-press/src/bundler.rs
+++ b/crates/webui-press/src/bundler.rs
@@ -363,8 +363,28 @@ pub(crate) struct BundleOptions<'a> {
     pub(crate) content_dir: &'a Path,
 }
 
+/// Convert a filesystem path to a forward-slash string for use as an ES module
+/// specifier or esbuild argument.
+///
+/// On Windows, [`Path::canonicalize`] returns verbatim (`\\?\`-prefixed) paths.
+/// Emitting one as-is normalizes to `//?/C:/…`, which neither esbuild nor the
+/// browser can resolve, so bundled component scripts silently fail to load and
+/// custom elements never register. Strip the verbatim prefix first so esbuild
+/// resolves and inlines the entry exactly as it does with clean Unix paths. On
+/// non-Windows paths (no verbatim prefix) this is a plain separator swap.
 fn path_for_js(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let raw = path.to_string_lossy();
+    if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        // `\\?\UNC\server\share\…` denotes the UNC path `\\server\share\…`.
+        let mut out = String::with_capacity(rest.len() + 2);
+        out.push_str("//");
+        for ch in rest.chars() {
+            out.push(if ch == '\\' { '/' } else { ch });
+        }
+        return out;
+    }
+    let body = raw.strip_prefix(r"\\?\").unwrap_or(raw.as_ref());
+    body.replace('\\', "/")
 }
 
 fn push_import_once(entry: &mut String, imports: &mut HashSet<String>, specifier: &str) {
@@ -1524,6 +1544,25 @@ mod tests {
 
     fn test_hash(s: &str) -> u64 {
         fxhash_bytes(s.as_bytes())
+    }
+
+    #[test]
+    fn path_for_js_strips_windows_verbatim_prefix() {
+        // `canonicalize()` on Windows yields `\\?\`-prefixed verbatim paths.
+        // Left intact they normalize to `//?/C:/…`, which esbuild and browsers
+        // cannot resolve, so component scripts never load. These are pure
+        // string transforms and assert identically on every platform.
+        assert_eq!(
+            path_for_js(Path::new(r"\\?\C:\tmp\webui-press\template\index.ts")),
+            "C:/tmp/webui-press/template/index.ts"
+        );
+        assert_eq!(
+            path_for_js(Path::new(r"\\?\UNC\server\share\index.ts")),
+            "//server/share/index.ts"
+        );
+        // Plain paths (no verbatim prefix) keep their existing behavior.
+        assert_eq!(path_for_js(Path::new(r"C:\a\b.ts")), "C:/a/b.ts");
+        assert_eq!(path_for_js(Path::new("/tmp/a/b.ts")), "/tmp/a/b.ts");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On Windows, `webui-press` produces a broken client bundle: custom elements (e.g. `docs-search`) never register, so any hydration/registration-dependent behavior silently fails. The docs `docs-search` E2E tests that call `waitForDocsSearch` time out, and the browser console shows:

```
Failed to resolve module specifier "//?/C:/Users/.../Temp/webui-press-<hash>/template/index.ts".
Invalid relative url or base scheme isn't hierarchical.
```

## Root cause

`webui-press` extracts its embedded component templates to a temp dir and references those sources by **absolute path** in the esbuild entry wrapper (this is by design and works fine on Unix, where the wrapper says `import "/tmp/.../index.ts"`; esbuild resolves and inlines them).

The paths are produced by `path_for_js`:

```rust
fn path_for_js(path: &Path) -> String {
    path.to_string_lossy().replace('\\', "/")
}
```

On Windows, `Path::canonicalize` returns a **verbatim** (`\\?\`-prefixed) path — e.g. `\\?\C:\...\index.ts`. After the separator swap this becomes `//?/C:/...`, which **esbuild's resolver rejects**. Instead of inlining the entry, esbuild leaves the raw `import "//?/C:/..."` in `dist/index.js`, and the browser then can't resolve it — so the component script never runs and the element never registers.

This is a **Windows-only, pre-existing** bug (unrelated to any dependency versions); Linux/CI was unaffected because Unix `canonicalize` has no verbatim prefix.

## Fix

Strip the `\\?\` (and `\\?\UNC\`) verbatim prefix in `path_for_js` before normalizing separators, so esbuild resolves and inlines entries exactly as it does with clean Unix paths. This is the single choke point feeding both the `import` specifiers and the esbuild `--outdir`/`--outbase`/entry arguments, so one change covers all of them. On paths without a verbatim prefix the behavior is unchanged.

After the fix, the shipped bundle contains only relative chunk imports (e.g. `./assets/chunk-*.js`) on every platform — no absolute/temp paths leak into `dist`.

## Testing

- **New unit test** `path_for_js_strips_windows_verbatim_prefix` (portable — pure string transforms, asserts identically on all platforms).
- **webui-press docs-search suite: 5/5 pass** on Windows (previously 2 pass / 3 timeout).
- Verified at runtime: `customElements.get('docs-search')` is now defined with zero console/page errors on the affected pages.
- Confirmed `dist/*.js` contains **zero** absolute/verbatim/temp paths after the fix.
- Full `cargo xtask check` gate green.