### PR TITLE
chore: bump version to 0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "actix-web",
  "awc",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "cbindgen",
  "microsoft-webui-handler",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "clap",
  "criterion",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "criterion",
  "prost",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.17"
+version = "0.0.18"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.17", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.17" }
+microsoft-webui = { path = "../webui", version = "0.0.18", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.18" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.18" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.18" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 console = { workspace = true }
@@ -37,7 +37,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.18" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.18" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -24,9 +24,9 @@ parser = ["dep:microsoft-webui-parser"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.18", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.17" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.18" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.18" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.18" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.17" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui = { path = "../webui", version = "0.0.18" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.18", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,8 +26,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.18" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.18" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,10 +19,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.17", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
+microsoft-webui = { path = "../webui", version = "0.0.18", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.18" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.18" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.17" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.18" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.17" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.18" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.18", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,11 +18,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.17" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.17" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.17" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.18" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.18" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.18" }
 thiserror = { workspace = true }
 serde_json = { workspace = true }
 bytes = { workspace = true }
@@ -43,8 +43,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.17" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.17" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.18" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.18" }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.17</Version>
+    <Version>0.0.18</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration. 15KB minified, compiled-template path mapping, no hydration markers.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.17"
+  "version": "0.0.18"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.18`.

Previous release tag: `v0.0.17`

## Changes since `v0.0.17`

Features:

- Static components can now ship ESM assets #360
- CSS theme tokens are validated during builds #372
- WebUI Press supports per-page script bundling #373
- WebUI Press template assets are embedded in the binary and client bundling was fixed #375
- WebUI Press gains shared state across pages #376
- Source-owned static host islands are now supported #377
- Hydration now warns when observable state disagrees with the SSR DOM #382

Fixes:

- WebUI Press search results are more accurate #368
- npm components declared in WebUI Press config are now discovered #371
- CSS `<link>` tags using the Link strategy are emitted in document order #385
- In-page anchors are emitted page-absolute so `<base href>` no longer hijacks them #383
- Windows verbatim path prefixes are stripped from JS import specifiers #386

Maintenance:

- `cargo xtask check` passes on Windows #357
- NuGet compliance metadata is aligned #363
- Added a local Windows cross-build helper #366
- Upgraded Cargo + pnpm dependencies to latest #384

## Validation

- `cargo xtask check` — lint (license-headers, fmt, clippy, proto drift), deny, test, and wasm build all passed. The final native `build` step was blocked locally by a running `webui-press` dev server holding `target/debug/webui-press.exe`; this commit only changes version strings, and CI will re-run the full gate.