### PR TITLE
fix: make docs home page scrollbar span full page width

### DIFF
--- a/crates/webui-press/template/docs.css
+++ b/crates/webui-press/template/docs.css
@@ -602,6 +602,11 @@ body {
 
 /* ── Homepage ───────────────────────────────────────── */
 
+.home-container {
+  max-width: 1152px;
+  margin: 0 auto;
+}
+
 .home-hero {
   text-align: center;
   padding: var(--docs-space-l) 0 var(--docs-space-2xl);

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -104,45 +104,47 @@
   </header>
 
   <if condition="page.isHome">
-    <main class="main-content" tabindex="-1" style="max-width:1152px;margin:0 auto;">
-      <if condition="hero">
-        <div class="home-hero">
-          <h1>{{site.title}}</h1>
-          <if condition="hero.text">
-            <p class="hero-text">{{hero.text}}</p>
+    <main class="main-content" tabindex="-1">
+      <div class="home-container">
+        <if condition="hero">
+          <div class="home-hero">
+            <h1>{{site.title}}</h1>
+            <if condition="hero.text">
+              <p class="hero-text">{{hero.text}}</p>
+            </if>
+            <p class="tagline">{{hero.tagline}}</p>
+            <div class="home-actions">
+              <for each="action in hero.actions">
+                <if condition="action.brand">
+                  <a href="{{action.link}}" class="btn-brand">{{action.text}}</a>
+                </if>
+                <if condition="!action.brand">
+                  <a href="{{action.link}}" class="btn-alt">{{action.text}}</a>
+                </if>
+              </for>
+            </div>
+          </div>
+          <if condition="hero.manifesto">
+            <p class="hero-manifesto">{{hero.manifesto}}</p>
           </if>
-          <p class="tagline">{{hero.tagline}}</p>
-          <div class="home-actions">
-            <for each="action in hero.actions">
-              <if condition="action.brand">
-                <a href="{{action.link}}" class="btn-brand">{{action.text}}</a>
-              </if>
-              <if condition="!action.brand">
-                <a href="{{action.link}}" class="btn-alt">{{action.text}}</a>
-              </if>
+          <div class="features-grid">
+            <for each="feature in hero.features">
+              <div class="feature-card">
+                <div class="feature-card-header">
+                  <div class="feature-icon">{{feature.icon}}</div>
+                  <h3>{{feature.title}}</h3>
+                </div>
+                <p>{{feature.description}}</p>
+              </div>
             </for>
           </div>
-        </div>
-        <if condition="hero.manifesto">
-          <p class="hero-manifesto">{{hero.manifesto}}</p>
         </if>
-        <div class="features-grid">
-          <for each="feature in hero.features">
-            <div class="feature-card">
-              <div class="feature-card-header">
-                <div class="feature-icon">{{feature.icon}}</div>
-                <h3>{{feature.title}}</h3>
-              </div>
-              <p>{{feature.description}}</p>
-            </div>
-          </for>
-        </div>
-      </if>
-      <if condition="footer">
-        <footer class="site-footer">
-          {{{footer.html}}}
-        </footer>
-      </if>
+        <if condition="footer">
+          <footer class="site-footer">
+            {{{footer.html}}}
+          </footer>
+        </if>
+      </div>
     </main>
   </if>
 


### PR DESCRIPTION
## Summary

The docs home page (`/docs`) rendered its vertical scrollbar inset from the page's right edge instead of at the page edge.

The home `<main class="main-content">` owns the page's vertical scrollbar (`overflow-y: auto`), but it also carried an inline `style="max-width:1152px;margin:0 auto;"`. That centered the scroll container at 1152px, so its scrollbar floated inside that box rather than at the page edge.

## Fix

- Remove the inline `max-width`/`margin` from `.main-content` on the home page so it fills its parent and owns the scrollbar at the page's right edge.
- Move the width constraint onto a new inner `.home-container` wrapper (`max-width: 1152px; margin: 0 auto;`) so the hero, feature grid, and footer stay centered.

Only the `webui-press` docs-site template assets changed (`docs.css`, `index.html`); no Rust, public API, protocol, or CLI behavior is affected. Non-home pages already use `.main-content` at full width and are untouched.

## Verification

- Rebuilt the docs site and confirmed the generated `dist/index.html` / `dist/docs.css` reflect the change.
- In-browser at a wide viewport: `.main-content` now spans the full page width with its ~15px scrollbar flush at the right edge (`right === pageWidth`); `.home-container` stays 1152px centered. Mobile width and a non-home guide page render correctly with no console errors.

Closes #374
