### PR TITLE
fix: preserve conditional SSR hydration ranges

### DIFF
--- a/packages/webui-framework/src/element/markers.test.ts
+++ b/packages/webui-framework/src/element/markers.test.ts
@@ -158,6 +158,14 @@ describe('nextElement', () => {
     assert.strictEqual(result, null);
   });
 
+  test('returns null when hitting <!--/wc--> before an element', () => {
+    const marker = { nodeType: COMMENT, data: 'wc', nextSibling: null } as MockNode;
+    const wcEnd = { nodeType: COMMENT, data: '/wc', nextSibling: null } as MockNode;
+    marker.nextSibling = wcEnd;
+
+    assert.strictEqual(nextElement(marker as unknown as Comment), null);
+  });
+
   test('returns null when hitting next <!--wi--> before an element', () => {
     const marker = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;
     const wi2 = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;

--- a/packages/webui-framework/src/element/markers.ts
+++ b/packages/webui-framework/src/element/markers.ts
@@ -56,7 +56,7 @@ export function nextElement(marker: Comment): Element | null {
     if (node.nodeType === 1 /* ELEMENT_NODE */) return node as Element;
     if (node.nodeType === 8 /* COMMENT_NODE */) {
       const data = (node as Comment).data;
-      if (data === MARKER_REPEAT_END || data === MARKER_REPEAT_ITEM) return null;
+      if (data === MARKER_REPEAT_END || data === MARKER_REPEAT_ITEM || data === MARKER_COND_END) return null;
     }
     node = node.nextSibling;
   }

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -1154,7 +1154,6 @@ export class TemplateElement extends HTMLElement {
         const [parentPath] = slotMeta;
         const ssrParent = this.$resolveSSR(ssrRoot, tplDom, parentPath, pathStart) ?? ssrRoot;
         const blockMeta = this.$block(blockIndex);
-        const shown = (condition as CompiledCondition)[0](this.$resolver, scope);
         let condInstance: TemplateInstance | null = null;
 
         // Reset cursor when parent changes between iterations
@@ -1177,18 +1176,12 @@ export class TemplateElement extends HTMLElement {
         }
         if (marker) lastCondMarker = marker;
 
-        // SSR hydration: if the marker exists, the server rendered this
-        // conditional — hydrate its content regardless of the current
-        // condition value.  Complex properties from parent bindings may
-        // not have arrived yet (the parent hydrates after children), so
-        // the condition could evaluate to false even though the server
-        // rendered it as true.  Trust the SSR DOM and wire it up; the
-        // condition will re-evaluate correctly once all data is set.
-        const ssrContentPresent = marker && blockMeta && this.$hasContentAfterMarker(condAnchor, MARKER_COND_END);
-        if (blockMeta && (shown || ssrContentPresent)) {
-          if (marker) {
-            condInstance = this.$hydrateCondContent(condAnchor, blockMeta, scope);
-          }
+        // Trust the SSR marker range regardless of the current condition.
+        // Parent bindings may not have arrived yet, so the client value can
+        // temporarily disagree with SSR. An empty range must stay empty rather
+        // than claiming the first static sibling after <!--/wc-->.
+        if (marker && blockMeta) {
+          condInstance = this.$hydrateCondContent(condAnchor, blockMeta, scope);
         }
 
         // Collect <!--/wc--> end marker for deferred removal.
@@ -1353,16 +1346,40 @@ export class TemplateElement extends HTMLElement {
 
   // ── SSR helpers ───────────────────────────────────────────────
 
-  /** Collect sibling nodes between a start marker and an end marker comment. */
-  private $collectBetween(start: Comment, endData: string): Node[] {
+  /** Collect a conditional range through its matching closing marker. */
+  private $collectConditionalRange(start: Comment): Node[] {
     const nodes: Node[] = [];
+    let depth = 0;
     let node: Node | null = start.nextSibling;
     while (node) {
-      if (node.nodeType === 8 && (node as Comment).data === endData) break;
+      if (node.nodeType === 8) {
+        const data = (node as Comment).data;
+        if (data === MARKER_COND_START) {
+          depth++;
+        } else if (data === MARKER_COND_END) {
+          if (depth === 0) break;
+          depth--;
+        }
+      }
       nodes.push(node);
       node = node.nextSibling;
     }
     return nodes;
+  }
+
+  /** Return whether a compiled block has structural slots beside its root element. */
+  private $hasRootStructuralSlot(meta: TemplateBlockMeta): boolean {
+    if (meta.c) {
+      for (let i = 0; i < meta.c.length; i++) {
+        if (meta.c[i][2][0].length === 0) return true;
+      }
+    }
+    if (meta.r) {
+      for (let i = 0; i < meta.r.length; i++) {
+        if (meta.r[i][3][0].length === 0) return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -1376,7 +1393,7 @@ export class TemplateElement extends HTMLElement {
   ): TemplateInstance | null {
     const rootTag = this.$rootTag(blockMeta);
     const tplDom = getTemplateDom(blockMeta);
-    if (rootTag && tplDom.children.length === 1) {
+    if (rootTag && tplDom.children.length === 1 && !this.$hasRootStructuralSlot(blockMeta)) {
       // Single-root optimisation: hydrate the element in-place (pathStart=1).
       const el = nextElement(condAnchor);
       if (el) {
@@ -1389,8 +1406,8 @@ export class TemplateElement extends HTMLElement {
       }
       return null;
     }
-    // Multi-root or text-only conditional: collect nodes between <!--wc--> and <!--/wc-->
-    const condNodes = this.$collectBetween(condAnchor, MARKER_COND_END);
+    // Multi-root, text-only, or root-level structural content needs the full range.
+    const condNodes = this.$collectConditionalRange(condAnchor);
     if (condNodes.length === 0) return null;
     const wrapper = document.createElement('div');
     for (let cn = 0; cn < condNodes.length; cn++) wrapper.appendChild(condNodes[cn]);
@@ -1418,24 +1435,6 @@ export class TemplateElement extends HTMLElement {
       child = child.nextSibling;
     }
     return null;
-  }
-
-  /**
-   * Check whether there is non-marker content between a conditional
-   * start anchor and its closing marker.  Used during SSR hydration to
-   * detect server-rendered conditional content even when the runtime
-   * condition value has not been set yet (e.g. complex property from a
-   * parent repeat binding that hydrates after its children).
-   */
-  private $hasContentAfterMarker(anchor: Comment, endData: string): boolean {
-    let sibling = anchor.nextSibling;
-    while (sibling) {
-      if (sibling.nodeType === 8 && (sibling as Comment).data === endData) {
-        return false; // reached end marker with no content in between
-      }
-      return true; // any non-end-marker node = content present
-    }
-    return false;
   }
 
   /**

--- a/packages/webui-framework/tests/fixtures/conditional/conditional.spec.ts
+++ b/packages/webui-framework/tests/fixtures/conditional/conditional.spec.ts
@@ -8,8 +8,10 @@ test.describe('conditional fixture', () => {
     await page.goto('/conditional/fixture.html');
     await page.waitForSelector('test-conditional');
     await page.waitForFunction(() => {
-      const el = document.querySelector('test-conditional');
-      return el && (el as any).$ready === true;
+      const conditional = document.querySelector('test-conditional');
+      const ranges = document.querySelector('test-conditional-hydration-ranges');
+      return conditional && (conditional as any).$ready === true
+        && ranges && (ranges as any).$ready === true;
     });
   });
 
@@ -33,6 +35,34 @@ test.describe('conditional fixture', () => {
 
     await page.locator('test-conditional-client .toggle').click();
     await expect(page.locator('test-conditional-client .details')).toHaveText('Details');
+  });
+
+  test('keeps a static sibling outside an empty SSR conditional', async ({ page }) => {
+    const host = page.locator('test-conditional-hydration-ranges');
+    await expect(host.locator('.mismatch-details')).toHaveCount(0);
+    await expect(host.locator('.static-sibling')).toHaveText('Static sibling');
+
+    await host.locator('.mismatch-toggle').click();
+    await expect(host.locator('.mismatch-details')).toHaveCount(0);
+    await expect(host.locator('.static-sibling')).toHaveText('Static sibling');
+
+    await host.locator('.mismatch-toggle').click();
+    await expect(host.locator('.mismatch-details')).toHaveText('Client-only details');
+    await expect(host.locator('.static-sibling')).toHaveText('Static sibling');
+  });
+
+  test('hydrates nested marker ranges without stale or duplicated roots', async ({ page }) => {
+    const host = page.locator('test-conditional-hydration-ranges');
+    await expect(host.locator('.nested-details')).toHaveCount(0);
+    await expect(host.locator('.outer-details')).toHaveText('Outer details');
+
+    await host.locator('.outer-toggle').click();
+    await expect(host.locator('.outer-details')).toHaveCount(0);
+    await expect(host.locator('.static-sibling')).toHaveText('Static sibling');
+
+    await host.locator('.outer-toggle').click();
+    await expect(host.locator('.outer-details')).toHaveCount(1);
+    await expect(host.locator('.nested-details')).toHaveCount(0);
   });
 
   test('toggles boolean attributes reactively', async ({ page }) => {

--- a/packages/webui-framework/tests/fixtures/conditional/element.ts
+++ b/packages/webui-framework/tests/fixtures/conditional/element.ts
@@ -28,3 +28,22 @@ export class TestConditionalClient extends WebUIElement {
 
 TestConditionalClient.define('test-conditional-client');
 
+export class TestConditionalHydrationRanges extends WebUIElement {
+  @observable clientOnlyOpen = true;
+  @observable outerOpen = true;
+  @observable innerOpen = false;
+
+  protected $shouldApplySSRBootstrapState(): boolean {
+    return false;
+  }
+
+  toggleClientOnlyOpen(): void {
+    this.clientOnlyOpen = !this.clientOnlyOpen;
+  }
+
+  toggleOuterOpen(): void {
+    this.outerOpen = !this.outerOpen;
+  }
+}
+
+TestConditionalHydrationRanges.define('test-conditional-hydration-ranges');

--- a/packages/webui-framework/tests/fixtures/conditional/src/index.html
+++ b/packages/webui-framework/tests/fixtures/conditional/src/index.html
@@ -7,5 +7,6 @@
 <body>
   <test-conditional></test-conditional>
   <test-conditional-client></test-conditional-client>
+  <test-conditional-hydration-ranges></test-conditional-hydration-ranges>
 </body>
 </html>

--- a/packages/webui-framework/tests/fixtures/conditional/src/test-conditional-hydration-ranges/test-conditional-hydration-ranges.html
+++ b/packages/webui-framework/tests/fixtures/conditional/src/test-conditional-hydration-ranges/test-conditional-hydration-ranges.html
@@ -1,0 +1,12 @@
+<button class="mismatch-toggle" @click="{toggleClientOnlyOpen()}">Toggle mismatch</button>
+<if condition="clientOnlyOpen">
+  <span class="mismatch-details">Client-only details</span>
+</if>
+<button class="outer-toggle" @click="{toggleOuterOpen()}">Toggle outer</button>
+<if condition="outerOpen">
+  <if condition="innerOpen">
+    <span class="nested-details">Nested details</span>
+  </if>
+  <div class="outer-details">Outer details</div>
+</if>
+<div class="static-sibling">Static sibling</div>

--- a/packages/webui-framework/tests/fixtures/conditional/state.json
+++ b/packages/webui-framework/tests/fixtures/conditional/state.json
@@ -2,5 +2,8 @@
   "open": true,
   "busy": false,
   "details": "Details",
-  "count": 1
+  "count": 1,
+  "clientOnlyOpen": false,
+  "outerOpen": true,
+  "innerOpen": false
 }


### PR DESCRIPTION
## Summary

- Keep empty server-rendered conditional ranges from adopting static siblings that appear after their closing marker.
- Match the correct outer closing marker when conditional ranges are nested.
- Preserve the allocation-free single-root hydration path, using the nesting-aware range fallback only for root-level structural content.

## Why this is needed

The server marks each conditional body with `<!--wc-->` and `<!--/wc-->`. Those comments are ownership boundaries: only nodes between them belong to the conditional.

During hydration, client state can temporarily disagree with the server because a parent property may not have reached the child yet. Consider an SSR-false conditional followed by unrelated static content:

```html
<!--wc-->
<!--/wc-->
<div class="static-sibling">Static sibling</div>
```

Previously, the single-root lookup skipped comments without treating `<!--/wc-->` as a boundary. It could therefore claim `.static-sibling` as the conditional body. A later state change could remove that static element or create duplicate conditional content.

Nested ranges need the same ownership guarantee:

```html
<!--wc outer-->
  <!--wc inner-->
  <!--/wc inner-->
  <div class="outer-details">Outer details</div>
<!--/wc outer-->
```

Stopping at the inner closing marker loses the outer conditional's real content. The fallback now tracks nesting until the matching outer marker, so toggling the outer condition removes and restores exactly its own nodes.

## Validation

- Added a unit regression for stopping element lookup at `<!--/wc-->`.
- Added real-pipeline browser coverage for empty and nested SSR conditional ranges.
- `cargo xtask check` passes.