### PR TITLE
feat: add Node addon runtime benchmark

### DIFF
--- a/.github/skills/perf/SKILL.md
+++ b/.github/skills/perf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: perf
-description: Speed and memory performance rules for Rust crates, webui-framework, and webui-router.
+description: Speed and memory performance rules for Rust crates, the Node addon, webui-framework, and webui-router.
 ---
 
 # Performance
@@ -13,7 +13,7 @@ Use this skill when modifying any performance-sensitive code across the stack.
 
 ## Rust - speed rules
 
-These apply to `webui-handler`, `webui-state`, `webui-expressions`, `webui-parser`, `webui-protocol`, and `webui-ffi`.
+These apply to `webui-handler`, `webui-state`, `webui-expressions`, `webui-parser`, `webui-protocol`, `webui-ffi`, and `webui-node`.
 
 1. **No `format!()` in writer output.** Use sequential `writer.write()` calls. `format!` allocates a temporary `String` every invocation.
 2. **No `.to_string()` on `Cow`.** Write `Cow<str>` directly to avoid defeating zero-copy.
@@ -90,15 +90,18 @@ These apply to `packages/webui-router` (the client-side SPA router).
 
 ## Measuring
 
-### Rust benchmarks
+### Server benchmarks
 
 ```bash
 cargo bench -p microsoft-webui --bench contact_book_bench          # full run
 cargo bench -p microsoft-webui --bench contact_book_bench -- --test # quick validation
-cargo xtask bench all                                               # all crates
+cargo xtask bench all                                               # all Rust crates
+cargo xtask bench node-addon                                        # Node/V8/N-API boundary
 ```
 
-Compare **Render/1000 P50** before and after. Verify output **Bytes** is unchanged (same HTML = correct behavior).
+Compare **Render/1000 P50** before and after. For Node changes, save with
+`--save-baseline before` and compare with `--baseline before`. Verify output
+**Bytes** is unchanged (same HTML = correct behavior).
 
 ### Client performance
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -15,6 +15,7 @@ how to compare results.
 | `cargo xtask bench all` | criterion micro | ~5 min | per-fn wall-clock for parser, handler, protocol, expressions, state, webui (incl. streaming + contact-book) | full snapshot of every micro-bench |
 | `cargo xtask bench streaming` | criterion micro | ~60 s | writer-path wall-clock + first-chunk TTFB | inner-loop iteration on the streaming module |
 | `cargo xtask bench contact-book` | criterion micro | ~90 s | end-to-end render at 10/100/1000 contacts | inner-loop iteration on handler/state/expressions |
+| `cargo xtask bench node-addon` | Node/N-API | ~15 s after build | `Protocol` construction, buffered render, first callback, total stream time | changes to `webui-node` or the public Node wrapper |
 | `cargo xtask bench streaming-resource` | example | ~30 s | exact alloc count + bytes + getrusage CPU + RSS | proving zero-alloc claims; allocation regression hunting |
 | `cargo xtask bench streaming-e2e-ttfb` | example | ~10 s | HTTP-level TTFB / TTLB through actix | confirming wire-level streaming win |
 | `cargo xtask bench streaming-browser` | Playwright | ~30 s | real Chromium TTFB / FCP / LCP / DCL / load | proving user-perceived paint improvement |
@@ -40,6 +41,7 @@ Baselines are stored at `target/bench-baselines/`:
 * `streaming-resource-<name>.json`  — alloc + RSS + CPU table
 * `e2e-ttfb-<name>.json`            — HTTP TTFB/TTLB table
 * `browser-<name>.json`             — browser metrics table
+* `node-addon-<name>.json`          — Node/V8/N-API latency table
 * `target/criterion/<bench>/<name>` — criterion's native baseline
                                        directory tree
 
@@ -55,6 +57,7 @@ improvement; positive = regression.
 | streaming-resource (bytes, CPU) | < ±2% | > ±5% |
 | streaming-e2e-ttfb (loopback) | < ±10% | > ±20% |
 | streaming-browser (real Chromium) | < ±5% | > ±15% |
+| node-addon P50 (V8/N-API) | < ±5% | > ±10% |
 
 ## Anatomy of each bench
 
@@ -130,6 +133,28 @@ render scenario, streaming TTFB must be ≥5× lower than buffered
 TTFB. If that ever fails, something is fundamentally wrong with the
 implementation.
 
+### `node-addon` (Node.js + N-API)
+
+`examples/integration/node-addon-bench/` is a separate pnpm package
+that loads the release `microsoft-webui-node` artifact through the
+public `@microsoft/webui` API. Unlike a Rust benchmark, it includes
+V8/N-API string and callback crossings:
+
+- **Protocol construction** — Node `Buffer` to protobuf decode/index after the addon is loaded
+- **JSON-string render** — N-API conversion, JSON parse, Rust render,
+  and the returned JavaScript string
+- **Object render** — the same path plus public-wrapper
+  `JSON.stringify`
+- **Streaming first callback** — state conversion and JSON parse,
+  followed by rendering until JavaScript receives the first 16 KiB chunk
+- **Streaming total** — all callback crossings and complete render
+
+It uses the same Contact Book fixture and 10/100/1000 scales as the
+Rust end-to-end benchmark, rendering `/contacts` so output grows with
+the workload. The first-callback metric is in-process; it is not HTTP
+TTFB. The runner verifies buffered, object-state, and
+streamed output are byte-identical before collecting samples.
+
 ## Recommended PR workflow
 
 For any change touching `crates/webui/src/streaming.rs` or its
@@ -156,6 +181,19 @@ cargo xtask bench all --save-baseline before
 cargo xtask bench all --baseline before
 ```
 
+For changes touching `crates/webui-node/` or `packages/webui/` runtime
+render methods:
+
+```bash
+cargo xtask bench node-addon --save-baseline before
+# … change …
+cargo xtask bench node-addon --baseline before
+```
+
+Run both phases on the same machine and Node major version. Paste the
+P50 comparison table into the PR description; use P95/P99 to diagnose
+tail behavior rather than as a hard gate.
+
 The criterion `--baseline` flag emits the per-bench `change:` lines
 inline (e.g. `Performance has improved` / `regressed` / `within
 noise threshold`).
@@ -175,6 +213,8 @@ Each layer measures a different thing. A change can:
 - improve allocation count but regress wall-clock (allocator changes)
 - improve micro-bench wall-clock but regress browser FCP (chunk-size
   changes that hurt parser progressive rendering)
+- leave Rust render time unchanged but regress Node throughput through
+  extra N-API string copies or callback crossings
 - improve TTFB but introduce a memory leak (no cleanup of pool
   buffers on error paths)
 
@@ -208,6 +248,10 @@ benchmark. The bar:
 3. **Playwright** if the metric is browser-perceived (paint, layout,
    hydration time). Mirror the structure of
    `examples/integration/streaming-browser-bench/`.
+4. **External runtime package** if the boundary itself is under test
+   (Node/V8/N-API, a VM, or another host runtime). Mirror
+   `examples/integration/node-addon-bench/` and keep smoke validation
+   separate from release performance results.
 
 Wire it into `cargo xtask bench` so the standard before/after
 workflow works without users needing to know per-bench invocation

--- a/crates/webui-node/README.md
+++ b/crates/webui-node/README.md
@@ -6,6 +6,20 @@ Node.js native addon for the [WebUI](https://github.com/microsoft/webui) framewo
 
 `microsoft-webui-node` compiles to a platform-specific `.node` addon that exposes WebUI's rendering API to Node.js hosts (e.g. Express, Fastify) without spawning a subprocess.
 
+## Benchmark
+
+The runtime benchmark in
+[`examples/integration/node-addon-bench`](../../examples/integration/node-addon-bench)
+measures protocol construction, buffered rendering, and streaming callbacks across
+the real V8/N-API boundary:
+
+```bash
+cargo xtask bench node-addon
+```
+
+It supports the repository-wide `--save-baseline NAME` and `--baseline NAME`
+workflow documented in [`BENCHMARKS.md`](../../BENCHMARKS.md).
+
 ## Documentation
 
 See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.

--- a/crates/webui/benches/README.md
+++ b/crates/webui/benches/README.md
@@ -22,10 +22,12 @@ Two **examples** (in `crates/webui/examples/`) round out the suite:
 * **`streaming_e2e_ttfb_bench.rs`** — HTTP-level TTFB through a real
   actix-web server.
 
-A separate Playwright package handles browser-perceived metrics:
+Separate integration packages handle external-runtime metrics:
 
 * **`examples/integration/streaming-browser-bench/`** — TTFB / FCP /
   LCP / DCL / load measured by Chromium via `PerformanceObserver`.
+* **`examples/integration/node-addon-bench/`** — protocol construction,
+  buffered render, and streaming callback costs across V8/N-API.
 
 For the cross-bench picture and recommended workflow, see
 [`BENCHMARKS.md`](../../../BENCHMARKS.md) at the repo root.
@@ -39,6 +41,7 @@ For the cross-bench picture and recommended workflow, see
 | `cargo xtask bench streaming-resource` | run the resource-counting example |
 | `cargo xtask bench streaming-e2e-ttfb` | run the HTTP-level TTFB example |
 | `cargo xtask bench streaming-browser` | run the Playwright browser-metrics test |
+| `cargo xtask bench node-addon` | run the Node/V8/N-API addon benchmark |
 | `cargo xtask bench full` | run all four streaming-related benches in sequence |
 | `cargo xtask bench all` | run every criterion bench in the workspace |
 
@@ -80,6 +83,7 @@ Negative Δ% = improvement; positive = regression.
 | streaming-resource bytes/CPU | < ±2% | > ±5% |
 | streaming-e2e-ttfb (loopback) | < ±10% | > ±20% |
 | streaming-browser (real Chromium) | < ±5% | > ±15% |
+| node-addon P50 (V8/N-API) | < ±5% | > ±10% |
 
 For criterion's HTML reports with PDF/CDF plots and violin
 comparisons, open `target/criterion/report/index.html`.

--- a/docs/guide/concepts/performance.md
+++ b/docs/guide/concepts/performance.md
@@ -235,7 +235,7 @@ consistent performance:
 Use the built-in benchmark suite to measure performance on your own hardware:
 
 ```bash
-# Full benchmark suite (recommended)
+# All Rust Criterion benchmarks
 cargo xtask bench all
 
 # Individual crate benchmarks via xtask
@@ -254,13 +254,18 @@ cargo bench -p microsoft-webui-ffi --bench protocol_bench
 # Contact book end-to-end benchmark
 cargo bench -p microsoft-webui --bench contact_book_bench
 
+# Public Node API across the real V8/N-API boundary
+cargo xtask bench node-addon
+
 # Results with HTML reports
 ls target/criterion/report/index.html
 ```
 
-Each benchmark uses [Criterion.rs](https://github.com/bheisler/criterion.rs)
-for statistical rigor - results include confidence intervals, outlier
-detection, and comparison against previous runs.
+Rust microbenchmarks use
+[Criterion.rs](https://github.com/bheisler/criterion.rs) for confidence
+intervals, outlier detection, and comparison against previous runs. The Node
+addon benchmark uses `process.hrtime.bigint()` inside a real Node process and
+supports the same named before/after baseline workflow through `cargo xtask`.
 
 ## Measuring Hydration Performance
 
@@ -286,4 +291,5 @@ slow components and optimize them individually.
 
 - [SSR showdown source](https://github.com/microsoft/webui/tree/main/examples/integration/ssr-performance-showdown) - full benchmark harness and reproduction steps
 - [Contact book benchmark](https://github.com/microsoft/webui/tree/main/crates/webui/benches) - real-world application benchmark
+- [Node addon benchmark](https://github.com/microsoft/webui/tree/main/examples/integration/node-addon-bench) - V8/N-API boundary benchmark
 - [DESIGN.md](https://github.com/microsoft/webui/blob/main/DESIGN.md) - architectural performance principles

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ Current entries:
 | `app/routes` | Nested declarative routing demo showing 4-level deep routes, full server side and client handoff |
 | `app/service-worker` | Static/CDN service worker app using `webui_wasm_handler` to stream WASM-rendered chunks from public API state |
 | `integration/node` | Node.js integration via native addon |
+| `integration/node-addon-bench` | Node/V8/N-API runtime benchmark for the native addon |
 | `integration/rust` | Rust integration via `webui-handler` |
 
 ## Quick Start
@@ -49,5 +50,6 @@ Each app's `package.json` also exposes `pnpm start`, which delegates to the same
 See integration-specific READMEs:
 
 - [integration/node/README.md](integration/node/README.md)
+- [integration/node-addon-bench/README.md](integration/node-addon-bench/README.md)
 - [integration/rust/README.md](integration/rust/README.md)
 - [app/service-worker/README.md](app/service-worker/README.md)

--- a/examples/integration/node-addon-bench/README.md
+++ b/examples/integration/node-addon-bench/README.md
@@ -1,0 +1,123 @@
+# `node-addon-bench`
+
+Runtime metrics for the WebUI Node.js native addon.
+
+The runner calls the public `@microsoft/webui` package from a real Node.js
+process, so every measured render crosses the same V8/N-API boundary as a
+production Node host. It uses the Contact Book application and the same
+10/100/1000-contact scales as the Rust end-to-end benchmark.
+
+For the bench-suite-wide picture, see
+[`BENCHMARKS.md`](../../../BENCHMARKS.md) at the repository root.
+
+## Run
+
+```bash
+# Self-contained release benchmark (recommended)
+cargo xtask bench node-addon
+
+# Short correctness/wiring check against an already-built addon
+pnpm --filter node-addon-bench bench:quick
+```
+
+`cargo xtask bench node-addon` builds the release addon and
+`@microsoft/webui` package before starting Node. When running the package
+script directly, build them first:
+
+```bash
+cargo build --release -p microsoft-webui-node
+pnpm --filter @microsoft/webui build
+pnpm --filter node-addon-bench bench
+```
+
+A debug addon is rejected by normal benchmark commands. The runner's
+`--allow-debug` flag is only for local smoke checks; never use those numbers in
+a performance comparison.
+
+## Before/after comparison
+
+```bash
+# 1. Snapshot the current release numbers
+cargo xtask bench node-addon --save-baseline before
+
+# 2. Make the change ...
+
+# 3. Compare P50 and output shape with the snapshot
+cargo xtask bench node-addon --baseline before
+```
+
+Snapshots are written to
+`target/bench-baselines/node-addon-<name>.json`. The compare phase prints P50
+and output-size deltas plus streaming chunk counts. It also warns when the
+platform, Node major version, route, or protocol size differs from the
+baseline.
+
+Underneath, xtask maps the baseline flags to `WEBUI_BENCH_SAVE` and
+`WEBUI_BENCH_COMPARE`. They can also be set when invoking `pnpm run bench`
+directly.
+
+## What it measures
+
+| Case | Boundary included | What it tells you |
+|---|---|---|
+| `protocol/new` | Node `Buffer` -> N-API -> protobuf decode/index | `Protocol` construction after the addon is loaded |
+| `render/json-string/N` | JS string -> N-API -> JSON parse -> Rust render -> JS string | native request cost when state is already serialized |
+| `render/object/N` | `JSON.stringify` plus the JSON-string path | public-package cost for the common object-state API |
+| `render-stream/...`, `first-callback` | JS string -> N-API -> JSON parse -> render to first 16 KiB -> JS callback | latency until JavaScript receives the first chunk |
+| `render-stream/...`, `total` | the same input path plus all chunks and callbacks | complete streaming callback-path cost |
+
+Streaming uses pre-serialized state so callback-path changes are not conflated
+with `JSON.stringify`. The first-callback metric is an **in-process callback
+latency**, not HTTP TTFB or socket-flush latency. Use `streaming-e2e-ttfb` or
+`streaming-browser` for wire-level and browser-perceived metrics.
+
+## Not measured
+
+- addon/package module loading or reading protocol bytes from disk
+- the `build()` API (template compilation happens only during setup)
+- HTTP writes, socket flushes, or user callback work such as `response.write()`
+- Node event-loop delay, concurrent request throughput, RSS, or V8 heap usage
+
+Those need process/server-level benchmarks rather than this synchronous API
+runner.
+
+## Methodology and correctness guards
+
+- Builds the live Contact Book templates once before sampling.
+- Loads the application's checked-in `data/state.json` and repeats its contacts
+  to produce the 10/100/1000-contact workloads.
+- Renders the `/contacts` route so both state and HTML output scale with the
+  workload.
+- Reuses one decoded `Protocol` for all hot render cases.
+- Warms each operation before collecting samples.
+- Runs garbage collection once before each sample group when Node exposes it;
+  GC is not forced between individual operations.
+- Collects at least 20 samples per row and targets 750 ms of measurement time.
+- Reports workload sizes/chunk counts plus min, P50, P95, P99, and
+  mean-derived ops/s.
+- Verifies object-state and JSON-string renders are byte-identical.
+- Verifies concatenated streaming chunks exactly equal buffered output.
+- Rejects empty protocols, missing chunks, malformed baselines, unsafe baseline
+  names, and accidental debug measurements.
+
+For raw machine-readable output:
+
+```bash
+pnpm --filter node-addon-bench bench:json
+```
+
+## Why a separate integration package?
+
+This benchmark cannot be a Criterion target: calling the Rust functions from a
+Rust harness would bypass V8, JavaScript string conversion, N-API, and callback
+crossings. Keeping it next to `streaming-browser-bench` makes the external
+runtime requirement explicit while letting pnpm manage the public package
+under test.
+
+## Treat as signal vs noise
+
+Node process metrics are noisier than isolated Criterion measurements because
+V8 and garbage collection share the process. On the same machine and Node
+major version, treat P50 changes below +/-5% as noise and changes above +/-10%
+as a signal. Re-run changes in between; use P95/P99 to investigate tail
+behavior rather than as a hard regression gate.

--- a/examples/integration/node-addon-bench/bench.mjs
+++ b/examples/integration/node-addon-bench/bench.mjs
@@ -1,0 +1,718 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Runtime benchmark for the WebUI Node.js addon.
+ *
+ * This intentionally runs from Node rather than Criterion so every measured
+ * operation crosses the real V8/N-API boundary used by applications.
+ */
+
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ── Configuration ─────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONTACT_COUNTS = [10, 100, 1000];
+const RENDER_OPTIONS = Object.freeze({ requestPath: "/contacts" });
+const SNAPSHOT_SCHEMA = 1;
+const BASELINE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+// ── CLI parsing ───────────────────────────────────────────────────────
+
+function usage() {
+  console.log(`Usage: node bench.mjs [options]
+
+Options:
+  --quick        Run a short smoke benchmark
+  --json         Emit the raw report as JSON
+  --allow-debug  Permit a debug addon build (not representative)
+  --help         Show this help
+
+Baseline environment variables:
+  WEBUI_BENCH_SAVE=NAME     Save target/bench-baselines/node-addon-NAME.json
+  WEBUI_BENCH_COMPARE=NAME  Compare P50 and output shape with a saved baseline
+
+Build prerequisites:
+  cargo build --release -p microsoft-webui-node
+  pnpm --filter @microsoft/webui build`);
+}
+
+function parseArgs(argv) {
+  const known = new Set(["--quick", "--json", "--allow-debug", "--help"]);
+  for (const arg of argv) {
+    if (!known.has(arg)) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return {
+    quick: argv.includes("--quick") || process.env.WEBUI_BENCH_QUICK === "1",
+    json: argv.includes("--json"),
+    allowDebug: argv.includes("--allow-debug"),
+    help: argv.includes("--help"),
+    saveBaseline: process.env.WEBUI_BENCH_SAVE?.trim() || null,
+    compareBaseline: process.env.WEBUI_BENCH_COMPARE?.trim() || null,
+  };
+}
+
+function validateOptions(options) {
+  for (const [variable, name] of [
+    ["WEBUI_BENCH_SAVE", options.saveBaseline],
+    ["WEBUI_BENCH_COMPARE", options.compareBaseline],
+  ]) {
+    if (name !== null && !BASELINE_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `${variable} must be 1-64 characters using only letters, numbers, ` +
+          "dot, underscore, or hyphen",
+      );
+    }
+  }
+  if (options.saveBaseline && options.compareBaseline) {
+    throw new Error(
+      "WEBUI_BENCH_SAVE and WEBUI_BENCH_COMPARE cannot be used together",
+    );
+  }
+  if (options.quick && (options.saveBaseline || options.compareBaseline)) {
+    throw new Error("quick smoke results cannot be saved or compared as baselines");
+  }
+  if (options.json && (options.saveBaseline || options.compareBaseline)) {
+    throw new Error("--json cannot be combined with baseline save or compare mode");
+  }
+}
+
+// ── Contact Book fixture ──────────────────────────────────────────────
+
+function buildState(seedState, contactCount) {
+  assert.ok(
+    Array.isArray(seedState.contacts) && seedState.contacts.length > 0,
+    "contact-book state fixture has no contacts",
+  );
+  assert.ok(
+    Array.isArray(seedState.groups),
+    "contact-book state fixture has no groups",
+  );
+  const contacts = Array.from({ length: contactCount }, (_, index) => ({
+    ...seedState.contacts[index % seedState.contacts.length],
+    id: String(index + 1),
+  }));
+  const favoriteContacts = contacts.filter((contact) => contact.favorite);
+  return {
+    ...seedState,
+    page: "contacts",
+    totalContacts: contactCount,
+    totalFavorites: favoriteContacts.length,
+    totalGroups: seedState.groups.length,
+    contacts,
+    filteredContacts: contacts,
+    recentContacts: contacts.slice(-5),
+    favoriteContacts,
+    selectedContact: null,
+  };
+}
+
+// ── Sampling and statistics ───────────────────────────────────────────
+
+function percentile(sortedSamples, quantile) {
+  const index = Math.min(
+    sortedSamples.length - 1,
+    Math.max(0, Math.ceil(sortedSamples.length * quantile) - 1),
+  );
+  return sortedSamples[index];
+}
+
+function summarize(samples) {
+  assert.ok(samples.length > 0, "benchmark must collect at least one sample");
+  const sorted = [...samples].sort((left, right) => left - right);
+  const meanNs = samples.reduce((total, sample) => total + sample, 0) / samples.length;
+  return {
+    samples: samples.length,
+    minNs: sorted[0],
+    p50Ns: percentile(sorted, 0.5),
+    p95Ns: percentile(sorted, 0.95),
+    p99Ns: percentile(sorted, 0.99),
+    maxNs: sorted[sorted.length - 1],
+    meanNs,
+  };
+}
+
+function shouldContinue(sampleCount, elapsedNs, config) {
+  return (
+    sampleCount < config.minSamples ||
+    (sampleCount < config.maxSamples && elapsedNs < config.targetDurationNs)
+  );
+}
+
+function collectSyncSamples(operation, config) {
+  let lastValue;
+  for (let index = 0; index < config.warmupIterations; index += 1) {
+    operation();
+  }
+
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+
+  const samples = [];
+  let elapsedNs = 0;
+  do {
+    const start = process.hrtime.bigint();
+    lastValue = operation();
+    const durationNs = Number(process.hrtime.bigint() - start);
+    samples.push(durationNs);
+    elapsedNs += durationNs;
+  } while (shouldContinue(samples.length, elapsedNs, config));
+
+  // Keep the operation's result observably live through the measurement loop.
+  if (lastValue === undefined) {
+    throw new Error("benchmark operation unexpectedly returned undefined");
+  }
+
+  return summarize(samples);
+}
+
+function collectStreamSamples(protocol, stateJson, expectedCodeUnits, config) {
+  const invoke = (recordTiming) => {
+    let chunkCount = 0;
+    let codeUnits = 0;
+    let firstCallbackNs = null;
+    const start = process.hrtime.bigint();
+
+    protocol.renderStream(
+      stateJson,
+      (chunk) => {
+        if (recordTiming && firstCallbackNs === null) {
+          firstCallbackNs = Number(process.hrtime.bigint() - start);
+        }
+        chunkCount += 1;
+        codeUnits += chunk.length;
+      },
+      RENDER_OPTIONS,
+    );
+
+    const totalNs = Number(process.hrtime.bigint() - start);
+    assert.equal(codeUnits, expectedCodeUnits, "streamed output length changed");
+    assert.ok(chunkCount > 0, "renderStream emitted no chunks");
+    return { chunkCount, firstCallbackNs, totalNs };
+  };
+
+  for (let index = 0; index < config.warmupIterations; index += 1) {
+    invoke(false);
+  }
+
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+
+  const firstCallbackSamples = [];
+  const totalSamples = [];
+  let elapsedNs = 0;
+  let chunkCount = 0;
+  do {
+    const sample = invoke(true);
+    assert.notEqual(sample.firstCallbackNs, null);
+    firstCallbackSamples.push(sample.firstCallbackNs);
+    totalSamples.push(sample.totalNs);
+    elapsedNs += sample.totalNs;
+    chunkCount = sample.chunkCount;
+  } while (shouldContinue(totalSamples.length, elapsedNs, config));
+
+  return {
+    chunkCount,
+    firstCallback: summarize(firstCallbackSamples),
+    total: summarize(totalSamples),
+  };
+}
+
+function makeResult(name, metric, latency, details = {}) {
+  return {
+    name,
+    metric,
+    ...details,
+    latency,
+  };
+}
+
+// ── Baseline snapshots ────────────────────────────────────────────────
+
+function snapshotPath(name) {
+  return resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "target",
+    "bench-baselines",
+    `node-addon-${name}.json`,
+  );
+}
+
+function snapshotRows(report) {
+  return report.results.map((result) => ({
+    name: result.name,
+    metric: result.metric,
+    contacts: result.contacts ?? null,
+    inputBytes: result.inputBytes ?? null,
+    outputBytes: result.outputBytes ?? null,
+    chunkCount: result.chunkCount ?? null,
+    samples: result.latency.samples,
+    p50Ns: result.latency.p50Ns,
+    p95Ns: result.latency.p95Ns,
+    p99Ns: result.latency.p99Ns,
+    meanNs: result.latency.meanNs,
+  }));
+}
+
+function saveSnapshot(name, report) {
+  const path = snapshotPath(name);
+  mkdirSync(dirname(path), { recursive: true });
+  const snapshot = {
+    schema: SNAPSHOT_SCHEMA,
+    name,
+    timestampUnix: Math.floor(Date.now() / 1000),
+    environment: {
+      node: report.environment.node,
+      napi: report.environment.napi,
+      platform: report.environment.platform,
+      arch: report.environment.arch,
+    },
+    fixture: report.fixture,
+    rows: snapshotRows(report),
+  };
+  writeFileSync(path, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log(`\n✔ Baseline saved to ${path}`);
+}
+
+function loadSnapshot(name) {
+  const path = snapshotPath(name);
+  if (!existsSync(path)) {
+    throw new Error(
+      `Baseline '${name}' not found at ${path}. ` +
+        `Run with --save-baseline ${name} first.`,
+    );
+  }
+
+  let snapshot;
+  try {
+    snapshot = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse baseline ${path}: ${message}`);
+  }
+
+  if (snapshot.schema !== SNAPSHOT_SCHEMA) {
+    throw new Error(
+      `Baseline '${name}' has schema ${snapshot.schema}; ` +
+        `expected ${SNAPSHOT_SCHEMA}. Regenerate it.`,
+    );
+  }
+  if (snapshot.name !== name || !Array.isArray(snapshot.rows)) {
+    throw new Error(`Baseline '${name}' has invalid identity or result rows`);
+  }
+  if (
+    !Number.isFinite(snapshot.timestampUnix) ||
+    snapshot.environment === null ||
+    typeof snapshot.environment !== "object" ||
+    snapshot.fixture === null ||
+    typeof snapshot.fixture !== "object" ||
+    typeof snapshot.fixture.requestPath !== "string" ||
+    !Number.isFinite(snapshot.fixture.protocolBytes)
+  ) {
+    throw new Error(`Baseline '${name}' is missing required metadata`);
+  }
+  for (const row of snapshot.rows) {
+    const validIdentity =
+      typeof row.name === "string" && typeof row.metric === "string";
+    const validLatency = [row.p50Ns, row.p95Ns, row.p99Ns, row.meanNs].every(
+      (value) => Number.isFinite(value) && value >= 0,
+    );
+    const validOutputBytes =
+      row.outputBytes === null ||
+      (Number.isFinite(row.outputBytes) && row.outputBytes >= 0);
+    if (!validIdentity || !validLatency || !validOutputBytes) {
+      throw new Error(`Baseline '${name}' contains an invalid result row`);
+    }
+  }
+  return snapshot;
+}
+
+// ── Human-readable reporting ──────────────────────────────────────────
+
+function formatDuration(nanoseconds) {
+  if (nanoseconds < 1_000) return `${nanoseconds.toFixed(0)} ns`;
+  if (nanoseconds < 1_000_000) return `${(nanoseconds / 1_000).toFixed(2)} µs`;
+  return `${(nanoseconds / 1_000_000).toFixed(2)} ms`;
+}
+
+function pctChange(baseline, current) {
+  if (baseline === 0) return 0;
+  return ((current - baseline) / baseline) * 100;
+}
+
+function formatDelta(baseline, current) {
+  if (baseline === null || current === null) return "       —";
+  return `${pctChange(baseline, current).toFixed(1).padStart(8)}%`;
+}
+
+function formatChunkChange(baseline, current) {
+  if (baseline === null || current === null) return "       —";
+  const value = baseline === current ? String(current) : `${baseline}->${current}`;
+  return value.padStart(8);
+}
+
+function formatAge(timestampUnix) {
+  const seconds = Math.max(0, Math.floor(Date.now() / 1000) - timestampUnix);
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+function printEnvironmentWarnings(report, baseline) {
+  const current = report.environment;
+  const previous = baseline.environment ?? {};
+  const currentNodeMajor = current.node.split(".")[0];
+  const previousNodeMajor = String(previous.node ?? "").split(".")[0];
+
+  if (previous.platform !== current.platform || previous.arch !== current.arch) {
+    console.log(
+      `WARNING: baseline platform ${previous.platform}-${previous.arch} differs ` +
+        `from current ${current.platform}-${current.arch}.`,
+    );
+  }
+  if (previousNodeMajor && previousNodeMajor !== currentNodeMajor) {
+    console.log(
+      `WARNING: baseline Node ${previous.node} differs from current Node ${current.node}.`,
+    );
+  }
+  if (baseline.fixture?.protocolBytes !== report.fixture.protocolBytes) {
+    console.log(
+      `WARNING: protocol size changed from ${baseline.fixture?.protocolBytes} to ` +
+        `${report.fixture.protocolBytes} bytes; interpret latency deltas with care.`,
+    );
+  }
+  if (baseline.fixture?.requestPath !== report.fixture.requestPath) {
+    console.log(
+      `WARNING: baseline route ${baseline.fixture?.requestPath} differs from ` +
+        `current route ${report.fixture.requestPath}.`,
+    );
+  }
+}
+
+function printDiff(report, baseline) {
+  console.log(
+    `\nDiff vs baseline '${baseline.name}' (saved ${formatAge(baseline.timestampUnix)} ago):`,
+  );
+  printEnvironmentWarnings(report, baseline);
+  console.log(
+    "| case                                     | metric         |" +
+      "   P50 Δ% | bytes Δ% |   chunks |",
+  );
+  console.log(
+    "|------------------------------------------|----------------|" +
+      "----------|----------|----------|",
+  );
+
+  for (const current of snapshotRows(report)) {
+    const previous = baseline.rows.find(
+      (row) => row.name === current.name && row.metric === current.metric,
+    );
+    if (!previous) {
+      console.log(
+        `| ${current.name.padEnd(40)} | ${current.metric.padEnd(14)} |` +
+          "    (new) |        — |        — |",
+      );
+      continue;
+    }
+    const includeOutputShape = current.metric === "total";
+    const bytesDelta = includeOutputShape
+      ? formatDelta(previous.outputBytes, current.outputBytes)
+      : "       —";
+    const chunks = includeOutputShape
+      ? formatChunkChange(previous.chunkCount, current.chunkCount)
+      : "       —";
+    console.log(
+      `| ${current.name.padEnd(40)} | ${current.metric.padEnd(14)} | ` +
+        `${formatDelta(previous.p50Ns, current.p50Ns)} | ` +
+        `${bytesDelta} | ${chunks} |`,
+    );
+  }
+
+  console.log(
+    "\nNegative Δ% = improvement; positive = regression. " +
+      "Treat Node P50 changes below ±5% as noise.\n",
+  );
+}
+
+function printHumanReport(report) {
+  console.log("\nWebUI Node addon runtime benchmark");
+  console.log(`Addon:    ${report.environment.addonPath}`);
+  console.log(
+    `Runtime:  Node ${report.environment.node} ` +
+      `(${report.environment.platform}-${report.environment.arch})`,
+  );
+  console.log(
+    `Fixture:  contact-book-manager, route ${report.fixture.requestPath}, protocol ` +
+      `${report.fixture.protocolBytes.toLocaleString("en-US")} bytes`,
+  );
+  console.log(`Mode:     ${report.config.quick ? "quick smoke" : "full"}\n`);
+
+  console.log("Workloads:");
+  console.log("| contacts | state bytes | HTML bytes | stream chunks |");
+  console.log("|---------:|------------:|-----------:|--------------:|");
+  for (const workload of report.workloads) {
+    console.log(
+      `| ${String(workload.contacts).padStart(8)} ` +
+        `| ${workload.stateBytes.toLocaleString("en-US").padStart(11)} ` +
+        `| ${workload.htmlBytes.toLocaleString("en-US").padStart(10)} ` +
+        `| ${String(workload.streamChunks).padStart(13)} |`,
+    );
+  }
+
+  console.log("\nLatency:");
+  console.log(
+    "| case                               | metric         | samples |" +
+      "        P50 |        P95 |        P99 |      ops/s |",
+  );
+  console.log(
+    "|------------------------------------|----------------|--------:|" +
+      "-----------:|-----------:|-----------:|-----------:|",
+  );
+  for (const result of report.results) {
+    const meanSeconds = result.latency.meanNs / 1_000_000_000;
+    const throughput =
+      result.metric === "total" ? (1 / meanSeconds).toFixed(1) : "—";
+    console.log(
+      `| ${result.name.padEnd(34)} | ${result.metric.padEnd(14)} ` +
+        `| ${String(result.latency.samples).padStart(7)} ` +
+        `| ${formatDuration(result.latency.p50Ns).padStart(10)} ` +
+        `| ${formatDuration(result.latency.p95Ns).padStart(10)} ` +
+        `| ${formatDuration(result.latency.p99Ns).padStart(10)} ` +
+        `| ${throughput.padStart(10)} |`,
+    );
+  }
+  console.log("\nops/s is derived from mean total latency; first-callback is not completion.\n");
+}
+
+// ── Benchmark orchestration ───────────────────────────────────────────
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+  validateOptions(options);
+  const comparisonBaseline = options.compareBaseline
+    ? loadSnapshot(options.compareBaseline)
+    : null;
+
+  const config = options.quick
+    ? {
+        quick: true,
+        warmupIterations: 2,
+        minSamples: 3,
+        maxSamples: 3,
+        targetDurationNs: 0,
+      }
+    : {
+        quick: false,
+        warmupIterations: 10,
+        minSamples: 20,
+        maxSamples: 20_000,
+        targetDurationNs: 750_000_000,
+      };
+
+  // Resolve the native artifact before loading the public package.
+  const { resolve: resolveArtifact } = await import("@microsoft/webui/platform.js");
+  const addonPath = resolveArtifact("addon");
+  if (!addonPath) {
+    throw new Error(
+      "Node addon not found. Run: cargo build --release -p microsoft-webui-node",
+    );
+  }
+
+  const normalizedAddonPath = addonPath.replaceAll("\\", "/");
+  if (normalizedAddonPath.includes("/target/debug/") && !options.allowDebug) {
+    throw new Error(
+      `Refusing to benchmark debug addon ${addonPath}. ` +
+        "Build release or pass --allow-debug for a smoke run.",
+    );
+  }
+
+  // Lock the public package to the artifact reported above before it loads.
+  process.env.WEBUI_ADDON_PATH = addonPath;
+  const { build, Protocol } = await import("@microsoft/webui");
+
+  // Build and validate the live fixture outside every timed region.
+  const appDir = fileURLToPath(
+    new URL("../../app/contact-book-manager/src/", import.meta.url),
+  );
+  const statePath = fileURLToPath(
+    new URL("../../app/contact-book-manager/data/state.json", import.meta.url),
+  );
+  const seedState = JSON.parse(readFileSync(statePath, "utf8"));
+  if (!options.json) {
+    console.error("Preparing contact-book protocol and benchmark states...");
+  }
+  const buildResult = build({ appDir, css: "style" });
+  const protocolBytes = buildResult.protocol;
+  assert.ok(protocolBytes.length > 0, "build returned an empty protocol");
+  const protocol = new Protocol(protocolBytes);
+
+  const fixtures = CONTACT_COUNTS.map((contactCount) => {
+    const state = buildState(seedState, contactCount);
+    const stateJson = JSON.stringify(state);
+    const expected = protocol.render(stateJson, RENDER_OPTIONS);
+    assert.equal(
+      protocol.render(state, RENDER_OPTIONS),
+      expected,
+      `object and JSON-string render differ at ${contactCount} contacts`,
+    );
+    const chunks = [];
+    protocol.renderStream(
+      stateJson,
+      (chunk) => {
+        chunks.push(chunk);
+      },
+      RENDER_OPTIONS,
+    );
+    assert.equal(
+      chunks.join(""),
+      expected,
+      `renderStream output differs at ${contactCount} contacts`,
+    );
+    return {
+      contactCount,
+      state,
+      stateJson,
+      expected,
+      inputBytes: Buffer.byteLength(stateJson),
+      outputBytes: Buffer.byteLength(expected),
+      chunkCount: chunks.length,
+    };
+  });
+
+  // Measure construction once, then the reusable Protocol render paths.
+  const results = [];
+  results.push(
+    makeResult(
+      "protocol/new",
+      "total",
+      collectSyncSamples(() => new Protocol(protocolBytes), config),
+      { inputBytes: protocolBytes.length },
+    ),
+  );
+
+  for (const fixture of fixtures) {
+    const details = {
+      contacts: fixture.contactCount,
+      inputBytes: fixture.inputBytes,
+      outputBytes: fixture.outputBytes,
+    };
+
+    results.push(
+      makeResult(
+        `render/json-string/${fixture.contactCount}`,
+        "total",
+        collectSyncSamples(
+          () => protocol.render(fixture.stateJson, RENDER_OPTIONS),
+          config,
+        ),
+        details,
+      ),
+    );
+    results.push(
+      makeResult(
+        `render/object/${fixture.contactCount}`,
+        "total",
+        collectSyncSamples(
+          () => protocol.render(fixture.state, RENDER_OPTIONS),
+          config,
+        ),
+        details,
+      ),
+    );
+
+    const stream = collectStreamSamples(
+      protocol,
+      fixture.stateJson,
+      fixture.expected.length,
+      config,
+    );
+    assert.equal(
+      stream.chunkCount,
+      fixture.chunkCount,
+      `streaming chunk count changed at ${fixture.contactCount} contacts`,
+    );
+    results.push(
+      makeResult(
+        `render-stream/json-string/${fixture.contactCount}`,
+        "first-callback",
+        stream.firstCallback,
+        { ...details, chunkCount: stream.chunkCount },
+      ),
+    );
+    results.push(
+      makeResult(
+        `render-stream/json-string/${fixture.contactCount}`,
+        "total",
+        stream.total,
+        { ...details, chunkCount: stream.chunkCount },
+      ),
+    );
+  }
+
+  // Keep the raw report data-only so --json and snapshots stay machine-readable.
+  const report = {
+    schemaVersion: 1,
+    benchmark: "node-addon-runtime",
+    environment: {
+      addonPath,
+      node: process.versions.node,
+      napi: process.versions.napi,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    config,
+    fixture: {
+      name: "contact-book-manager",
+      requestPath: RENDER_OPTIONS.requestPath,
+      protocolBytes: protocolBytes.length,
+      contactCounts: CONTACT_COUNTS,
+    },
+    workloads: fixtures.map((fixture) => ({
+      contacts: fixture.contactCount,
+      stateBytes: fixture.inputBytes,
+      htmlBytes: fixture.outputBytes,
+      streamChunks: fixture.chunkCount,
+    })),
+    results,
+  };
+
+  // Human output, raw JSON, and baseline modes all consume the same report.
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  printHumanReport(report);
+  if (comparisonBaseline) {
+    printDiff(report, comparisonBaseline);
+  }
+  if (options.saveBaseline) {
+    saveSnapshot(options.saveBaseline, report);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/examples/integration/node-addon-bench/package.json
+++ b/examples/integration/node-addon-bench/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "node-addon-bench",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Runtime benchmark for the WebUI Node.js addon across the V8/N-API boundary.",
+  "type": "module",
+  "scripts": {
+    "test": "node --check bench.mjs",
+    "bench": "node --expose-gc bench.mjs",
+    "bench:quick": "node --expose-gc bench.mjs --quick",
+    "bench:json": "node --expose-gc bench.mjs --json"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@microsoft/webui": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/webui
 
+  examples/integration/node-addon-bench:
+    dependencies:
+      '@microsoft/webui':
+        specifier: workspace:*
+        version: link:../../../packages/webui
+
   examples/integration/streaming-browser-bench:
     devDependencies:
       '@playwright/test':

--- a/xtask/src/build_examples.rs
+++ b/xtask/src/build_examples.rs
@@ -36,6 +36,15 @@ pub const INTEGRATION_BUILDS: &[IntegrationBuild] = &[
         run_commands: &[],
     },
     IntegrationBuild {
+        name: "node-addon-bench",
+        commands: &[BuildCommand {
+            cmd: "node",
+            args: &["--check", "bench.mjs"],
+            cwd: Some("examples/integration/node-addon-bench"),
+        }],
+        run_commands: &[],
+    },
+    IntegrationBuild {
         name: "electron",
         commands: &[BuildCommand {
             cmd: "pnpm",

--- a/xtask/src/license_headers.rs
+++ b/xtask/src/license_headers.rs
@@ -18,7 +18,7 @@ const HEADER_LINE_1: &str = "// Copyright (c) Microsoft Corporation.";
 const HEADER_LINE_2: &str = "// Licensed under the MIT license.";
 
 /// Extensions that require the `//`-style license header.
-const CHECKED_EXTENSIONS: &[&str] = &["rs", "ts", "js", "cs", "h", "proto"];
+const CHECKED_EXTENSIONS: &[&str] = &["rs", "ts", "js", "mjs", "cs", "h", "proto"];
 
 /// Individual tracked files to skip (relative to workspace root).
 /// Generated files that are checked in but not hand-authored belong here.
@@ -242,6 +242,7 @@ mod tests {
         assert!(is_checked_file(Path::new("baz.cs")));
         assert!(is_checked_file(Path::new("qux.h")));
         assert!(is_checked_file(Path::new("quux.js")));
+        assert!(is_checked_file(Path::new("runner.mjs")));
         assert!(is_checked_file(Path::new("schema.proto")));
 
         assert!(!is_checked_file(Path::new("page.html")));

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,7 +16,8 @@ mod windows_local;
 use std::process::ExitCode;
 use std::time::Instant;
 use util::{
-    ensure_cargo_install, ensure_rustup_component, run_command, run_command_quiet, workspace_root,
+    build_command, ensure_cargo_install, ensure_rustup_component, run_command, run_command_quiet,
+    workspace_root,
 };
 
 fn main() -> ExitCode {
@@ -129,8 +130,9 @@ fn usage() -> ExitCode {
            build-wasm  Build WASM playground module\n  \
            docs    Build the documentation site\n  \
            bench <target> [-- <extra>] [--save-baseline NAME | --baseline NAME]\n  \
-                       Targets: parser, handler, protocol, expressions, state, contact-book, streaming, all\n  \
-                       Streaming-only: streaming-resource, streaming-e2e-ttfb, streaming-browser, streaming-all/full\n  \
+                       Criterion: parser, handler, protocol, expressions, state, contact-book, streaming, all\n  \
+                       Integration: node-addon, streaming-resource, streaming-e2e-ttfb, streaming-browser\n  \
+                       Streaming suite: streaming-all/full\n  \
                        Baselines: --save-baseline NAME records, --baseline NAME compares\n  \
            dev <app>  Run example app in dev mode (server + client watch concurrently)\n  \
            e2e [--update-snapshots]  Run Playwright E2E tests for all example apps\n  \
@@ -149,7 +151,7 @@ fn bench(target: Option<&str>, extra_args: &[&str]) -> ExitCode {
     // the extra args. These map to:
     //   * criterion benches: passed through as `--save-baseline`/`--baseline`
     //   * resource & e2e-ttfb examples: `--save NAME` / `--compare NAME`
-    //   * browser bench: `WEBUI_BENCH_SAVE` / `WEBUI_BENCH_COMPARE` env vars
+    //   * browser & Node benches: `WEBUI_BENCH_SAVE` / `WEBUI_BENCH_COMPARE` env vars
     let mut save_baseline: Option<String> = None;
     let mut compare_baseline: Option<String> = None;
     let mut criterion_args: Vec<&str> = Vec::with_capacity(extra_args.len());
@@ -180,6 +182,9 @@ fn bench(target: Option<&str>, extra_args: &[&str]) -> ExitCode {
         Some("streaming-resource") => bench_resource(save_baseline, compare_baseline),
         Some("streaming-e2e-ttfb") => bench_e2e_ttfb(save_baseline, compare_baseline),
         Some("streaming-browser") => bench_browser(save_baseline, compare_baseline),
+        Some("node-addon") | Some("webui-node") | Some("microsoft-webui-node") => {
+            bench_node_addon(save_baseline, compare_baseline)
+        }
         Some("streaming-all") | Some("full") => {
             // The full bench suite: criterion micro + resource + e2e + browser.
             // Each phase passes through the baseline flags.
@@ -255,8 +260,8 @@ fn bench(target: Option<&str>, extra_args: &[&str]) -> ExitCode {
                         "Unknown bench target '{other}'.\n\
                          Criterion targets: parser, handler, protocol, expressions, state, \
                          contact-book, streaming, all.\n\
-                         Non-criterion targets: streaming-resource, streaming-e2e-ttfb, \
-                         streaming-browser, streaming-all (= full)."
+                         Integration targets: node-addon, streaming-resource, \
+                         streaming-e2e-ttfb, streaming-browser, streaming-all (= full)."
                     );
                     return ExitCode::FAILURE;
                 }
@@ -406,6 +411,90 @@ fn bench_browser(save: Option<String>, compare: Option<String>) -> ExitCode {
         }
         Err(e) => {
             eprintln!("streaming-browser bench: failed to spawn pnpm: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn bench_node_addon(save: Option<String>, compare: Option<String>) -> ExitCode {
+    if save.is_some() && compare.is_some() {
+        eprintln!("node-addon bench: save and compare modes are mutually exclusive");
+        return ExitCode::FAILURE;
+    }
+
+    let bench_dir = std::path::PathBuf::from("examples")
+        .join("integration")
+        .join("node-addon-bench");
+    if !bench_dir.join("package.json").exists() {
+        eprintln!("node-addon bench: {} not found", bench_dir.display());
+        return ExitCode::FAILURE;
+    }
+
+    eprintln!(
+        "  {} building microsoft-webui-node (release)",
+        console::style("•").dim()
+    );
+    if let Err(message) = run_command(
+        "cargo",
+        &["build", "--release", "-p", "microsoft-webui-node"],
+        None,
+    ) {
+        eprintln!("node-addon bench: release addon build failed: {message}");
+        return ExitCode::FAILURE;
+    }
+
+    eprintln!(
+        "  {} building @microsoft/webui package",
+        console::style("•").dim()
+    );
+    if let Err(message) = run_command("pnpm", &["--filter", "@microsoft/webui", "build"], None) {
+        eprintln!("node-addon bench: package build failed: {message}");
+        return ExitCode::FAILURE;
+    }
+
+    let addon_file = if cfg!(target_os = "windows") {
+        "webui_node.dll"
+    } else if cfg!(target_os = "macos") {
+        "libwebui_node.dylib"
+    } else {
+        "libwebui_node.so"
+    };
+    let addon_path = match std::env::current_dir() {
+        Ok(root) => root.join("target").join("release").join(addon_file),
+        Err(error) => {
+            eprintln!("node-addon bench: failed to resolve workspace directory: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if !addon_path.is_file() {
+        eprintln!(
+            "node-addon bench: release addon not found at {}",
+            addon_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let mut cmd = build_command("pnpm", &["run", "bench"]);
+    cmd.current_dir(&bench_dir)
+        .env("WEBUI_ADDON_PATH", &addon_path)
+        .env_remove("WEBUI_BENCH_SAVE")
+        .env_remove("WEBUI_BENCH_COMPARE")
+        .env_remove("WEBUI_BENCH_QUICK");
+    if let Some(name) = save.as_ref() {
+        cmd.env("WEBUI_BENCH_SAVE", name);
+    }
+    if let Some(name) = compare.as_ref() {
+        cmd.env("WEBUI_BENCH_COMPARE", name);
+    }
+
+    match cmd.status() {
+        Ok(status) if status.success() => ExitCode::SUCCESS,
+        Ok(status) => {
+            eprintln!("node-addon bench exited with {status}");
+            ExitCode::FAILURE
+        }
+        Err(error) => {
+            eprintln!("node-addon bench: failed to spawn pnpm: {error}");
             ExitCode::FAILURE
         }
     }


### PR DESCRIPTION
## Summary

- Add a Node-process benchmark for `Protocol` construction, buffered rendering, and streaming callbacks across V8/N-API.
- Exercise the Contact Book `/contacts` route at 10, 100, and 1,000 contacts with output-equivalence checks.
- Integrate named baselines through `cargo xtask bench node-addon` and document the workflow.

## Local benchmark

`cargo xtask bench node-addon` on Linux x64, Node 24.18.0, release profile. Representative local run; not a cross-machine baseline.

`Protocol` construction P50: **43.90 µs**

| Contacts | State bytes | HTML bytes | Chunks |
|---:|---:|---:|---:|
| 10 | 8,725 | 33,130 | 2 |
| 100 | 71,039 | 245,464 | 15 |
| 1,000 | 696,189 | 2,370,550 | 144 |

| Contacts | JSON render P50 | Object render P50 | First callback P50 | Stream total P50 |
|---:|---:|---:|---:|---:|
| 10 | 78.88 µs | 88.96 µs | 51.28 µs | 78.90 µs |
| 100 | 795.90 µs | 927.45 µs | 274.20 µs | 686.62 µs |
| 1,000 | 9.23 ms | 11.29 ms | 2.51 ms | 7.57 ms |

## Validation

- `cargo xtask check`
- Named baseline save/compare workflow verified