### PR TITLE
fix: preserve encoded development proxy URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 dist-test/
+*.tsbuildinfo
 bin/
 obj/
 target/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1196,6 +1196,15 @@ and query unchanged. Encoded slashes such as `%2F` therefore remain inside one
 route segment, and encoded spaces, percent signs, and UTF-8 bytes reach
 development backends with the same representation used by production clients.
 
+After generated assets and `--servedir` files miss, `webui serve` uses request
+intent rather than path punctuation to decide whether to run the SPA route
+fallback. Fallback runs only when `Accept` explicitly includes `text/html` or
+`application/xhtml+xml` for document navigation, or `application/json` for a
+WebUI JSON partial render. Missing, invalid, or wildcard-only `Accept` headers
+return 404, as do JS, CSS, image, and other non-HTML/non-JSON asset requests.
+Literal dots in route segments, such as `/docs/v2.1`, are valid and do not block
+route matching or fallback.
+
 In `webui serve --watch`, the file watcher is **content-aware**: it hashes each
 changed file and drops events whose bytes are unchanged, so a no-op save
 (repeated Ctrl+S that rewrites identical content) triggers no rebuild in the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1187,11 +1187,14 @@ fails before the initial build if that port is already in use, returning an
 actionable message so stale dev processes can be stopped explicitly.
 
 With `webui serve --api-port`, route state requests and `/api/*` forwarding
-preserve the incoming URI's encoded path and query exactly. The development
-server does not decode or re-encode percent escapes before sending the request
-to the backend. Encoded slashes such as `%2F` therefore remain inside one route
-segment, and encoded spaces, percent signs, and UTF-8 bytes reach development
-backends with the same representation used by production clients.
+preserve the incoming URI's encoded path and query exactly except for the entry
+route alias. The development server does not decode or re-encode percent escapes
+before sending non-entry request paths to the backend. `/` and `/index.html`
+both resolve backend state at `/` (the entry path is normalized), while still
+preserving the query string. All other request paths forward their encoded path
+and query unchanged. Encoded slashes such as `%2F` therefore remain inside one
+route segment, and encoded spaces, percent signs, and UTF-8 bytes reach
+development backends with the same representation used by production clients.
 
 In `webui serve --watch`, the file watcher is **content-aware**: it hashes each
 changed file and drops events whose bytes are unchanged, so a no-op save

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1200,10 +1200,11 @@ After generated assets and `--servedir` files miss, `webui serve` uses request
 intent rather than path punctuation to decide whether to run the SPA route
 fallback. Fallback runs only when `Accept` explicitly includes `text/html` or
 `application/xhtml+xml` for document navigation, or `application/json` for a
-WebUI JSON partial render. `q=0` disables that media type; when HTML and JSON
-are both acceptable, the higher `q` wins and exact ties prefer JSON. Missing,
-invalid, or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and
-other non-HTML/non-JSON asset requests.
+WebUI JSON partial render. `q=0` disables that media type, while a malformed or
+out-of-range `q` value falls back to `q=1.0`; when HTML and JSON are both
+acceptable, the higher `q` wins and exact ties prefer JSON. Missing or
+wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+non-HTML/non-JSON asset requests.
 Literal dots in route segments, such as `/docs/v2.1`, are valid and do not block
 route matching or fallback.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1186,6 +1186,13 @@ webui serve ./templates --state ./data/state.json --plugin=webui --emit-componen
 fails before the initial build if that port is already in use, returning an
 actionable message so stale dev processes can be stopped explicitly.
 
+With `webui serve --api-port`, route state requests and `/api/*` forwarding
+preserve the incoming URI's encoded path and query exactly. The development
+server does not decode or re-encode percent escapes before sending the request
+to the backend. Encoded slashes such as `%2F` therefore remain inside one route
+segment, and encoded spaces, percent signs, and UTF-8 bytes reach development
+backends with the same representation used by production clients.
+
 In `webui serve --watch`, the file watcher is **content-aware**: it hashes each
 changed file and drops events whose bytes are unchanged, so a no-op save
 (repeated Ctrl+S that rewrites identical content) triggers no rebuild in the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1200,8 +1200,10 @@ After generated assets and `--servedir` files miss, `webui serve` uses request
 intent rather than path punctuation to decide whether to run the SPA route
 fallback. Fallback runs only when `Accept` explicitly includes `text/html` or
 `application/xhtml+xml` for document navigation, or `application/json` for a
-WebUI JSON partial render. Missing, invalid, or wildcard-only `Accept` headers
-return 404, as do JS, CSS, image, and other non-HTML/non-JSON asset requests.
+WebUI JSON partial render. `q=0` disables that media type; when HTML and JSON
+are both acceptable, the higher `q` wins and exact ties prefer JSON. Missing,
+invalid, or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and
+other non-HTML/non-JSON asset requests.
 Literal dots in route segments, such as `/docs/v2.1`, are valid and do not block
 route matching or fallback.
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -50,7 +50,8 @@ pub struct ServeArgs {
     #[arg(long)]
     pub watch: bool,
 
-    /// Port of the user's API server to proxy route requests to
+    /// Port of the user's API server to proxy route requests to. Encoded path
+    /// and query bytes are forwarded unchanged.
     #[arg(long)]
     pub api_port: Option<u16>,
 
@@ -652,6 +653,18 @@ fn build_request_paths(relative: &str, query: &str) -> RequestPaths {
     }
 }
 
+fn request_paths(req: &HttpRequest) -> RequestPaths {
+    let uri = req.uri();
+    let route_path = uri.path().to_string();
+    let request_path = uri
+        .path_and_query()
+        .map_or_else(|| route_path.clone(), |value| value.as_str().to_string());
+    RequestPaths {
+        route_path,
+        request_path,
+    }
+}
+
 /// Fetch state from the user's API server for a given request path, including query parameters.
 async fn fetch_api_state(api_port: u16, path: &str) -> Result<Value, String> {
     let client = awc::Client::new();
@@ -819,7 +832,8 @@ async fn render_page_response(
 async fn handle_index(req: HttpRequest, context: web::Data<ServerContext>) -> HttpResponse {
     // JSON partial render for client-side navigation
     if wants_json(&req) {
-        return handle_json_partial(&req, &context, "").await;
+        let paths = build_request_paths("", req.query_string());
+        return handle_json_partial(&req, &context, paths).await;
     }
 
     // With API proxy, render on-the-fly with fresh state
@@ -960,18 +974,20 @@ fn wants_json(req: &HttpRequest) -> bool {
 async fn spa_fallback(
     req: &HttpRequest,
     context: &web::Data<ServerContext>,
-    relative: &str,
+    decoded_relative: &str,
 ) -> HttpResponse {
     // Only serve fallback for paths without file extensions (likely route paths)
-    if relative.contains('.') {
+    if decoded_relative.contains('.') {
         return HttpResponse::NotFound().body("Not Found");
     }
 
-    let paths = build_request_paths(relative, req.query_string());
+    // Actix decodes `web::Path` values. Route matching and backend state
+    // requests must instead receive the original encoded request target.
+    let paths = request_paths(req);
 
     // JSON partial render: return { state, templates } for client-side navigation
     if wants_json(req) {
-        return handle_json_partial(req, context, relative).await;
+        return handle_json_partial(req, context, paths).await;
     }
 
     render_page_response(context, &paths.route_path, &paths.request_path).await
@@ -985,10 +1001,8 @@ async fn spa_fallback(
 async fn handle_json_partial(
     req: &HttpRequest,
     context: &web::Data<ServerContext>,
-    relative: &str,
+    paths: RequestPaths,
 ) -> HttpResponse {
-    let paths = build_request_paths(relative, req.query_string());
-
     // Clone protocol from shared state (release lock quickly)
     let (protocol, entry) = match context.state.lock() {
         Ok(s) => {
@@ -1081,7 +1095,6 @@ fn collect_needed_template_names(
 /// Forward requests under `/api/*` to the user's API server.
 async fn handle_api_proxy(
     req: HttpRequest,
-    path: web::Path<String>,
     body: web::Bytes,
     context: web::Data<ServerContext>,
 ) -> HttpResponse {
@@ -1089,20 +1102,11 @@ async fn handle_api_proxy(
         return HttpResponse::NotFound().body("Not Found");
     };
 
-    let tail = path.into_inner();
-    let query = req.query_string();
-    let url = if query.is_empty() {
-        format!("http://127.0.0.1:{api_port}/api/{tail}")
-    } else {
-        let mut u = String::with_capacity(30 + tail.len() + query.len());
-        u.push_str("http://127.0.0.1:");
-        u.push_str(&api_port.to_string());
-        u.push_str("/api/");
-        u.push_str(&tail);
-        u.push('?');
-        u.push_str(query);
-        u
-    };
+    let uri = req.uri();
+    let path_and_query = uri
+        .path_and_query()
+        .map_or(uri.path(), |value| value.as_str());
+    let url = format!("http://127.0.0.1:{api_port}{path_and_query}");
 
     let client = awc::Client::new();
     let mut proxy_req = client.request(req.method().clone(), &url);
@@ -1294,6 +1298,60 @@ mod tests {
             fs::write(&path, content).unwrap();
         }
         dir
+    }
+
+    fn test_server_context(api_port: u16) -> web::Data<ServerContext> {
+        web::Data::new(ServerContext {
+            state: Arc::new(Mutex::new(SharedState {
+                rendered_html: "<html><body>ok</body></html>".to_string(),
+                css_files: HashMap::new(),
+                component_assets: HashMap::new(),
+                protocol: None,
+                state_data: None,
+                token_css: None,
+                rebuild_error: None,
+                entry: "index.html".to_string(),
+            })),
+            livereload: None,
+            assets_dir: None,
+            api_port: Some(api_port),
+            plugin: None,
+            base_path: None,
+            chunk_pool: Arc::new(webui::streaming::ChunkPool::new(
+                4,
+                StreamingWriter::CHUNK_TARGET + 1024,
+            )),
+        })
+    }
+
+    fn start_request_target_server() -> (u16, actix_web::dev::ServerHandle, Arc<Mutex<Vec<String>>>)
+    {
+        let request_targets = Arc::new(Mutex::new(Vec::new()));
+        let server_targets = Arc::clone(&request_targets);
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = HttpServer::new(move || {
+            let request_targets = Arc::clone(&server_targets);
+            App::new().default_service(web::to(move |req: HttpRequest| {
+                let request_targets = Arc::clone(&request_targets);
+                async move {
+                    let request_target = req.uri().path_and_query().map_or_else(
+                        || req.path().to_string(),
+                        |value| value.as_str().to_string(),
+                    );
+                    request_targets.lock().unwrap().push(request_target.clone());
+                    HttpResponse::Ok().json(serde_json::json!({
+                        "state": { "requestTarget": request_target }
+                    }))
+                }
+            }))
+        })
+        .listen(listener)
+        .unwrap()
+        .run();
+        let handle = server.handle();
+        actix_web::rt::spawn(server);
+        (port, handle, request_targets)
     }
 
     #[test]
@@ -1707,6 +1765,77 @@ mod tests {
         assert_eq!(state["query"], "shirt");
         assert_eq!(state["sort"], "price-desc");
 
+        handle.stop(true).await;
+    }
+
+    #[actix_web::test]
+    async fn test_route_state_fetch_preserves_encoded_request_target() {
+        let request_targets = [
+            "/projects/WebUI%20Fidelity%20Fixture?filter=space%20value",
+            "/reviews/WebUI/ceo%2Fbranch?filter=slash%2Fvalue",
+            "/discount/100%25?filter=percent%25value",
+            "/city/Montr%C3%A9al?filter=unicode%C3%A9",
+        ];
+        let (port, handle, captured_targets) = start_request_target_server();
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(test_server_context(port))
+                .route("/{tail:.*}", web::get().to(handle_asset)),
+        )
+        .await;
+
+        for request_target in request_targets {
+            let response = actix_test::call_service(
+                &app,
+                actix_test::TestRequest::get()
+                    .uri(request_target)
+                    .insert_header(("accept", "application/json"))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let expected: Vec<String> = request_targets
+            .iter()
+            .map(|target| (*target).to_string())
+            .collect();
+        assert_eq!(*captured_targets.lock().unwrap(), expected);
+        handle.stop(true).await;
+    }
+
+    #[actix_web::test]
+    async fn test_api_proxy_preserves_encoded_request_target() {
+        let request_targets = [
+            "/api/projects/WebUI%20Fidelity%20Fixture?filter=space%20value",
+            "/api/reviews/WebUI/ceo%2Fbranch?filter=slash%2Fvalue",
+            "/api/discount/100%25?filter=percent%25value",
+            "/api/city/Montr%C3%A9al?filter=unicode%C3%A9",
+        ];
+        let (port, handle, captured_targets) = start_request_target_server();
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(test_server_context(port))
+                .route("/api/{tail:.*}", web::route().to(handle_api_proxy)),
+        )
+        .await;
+
+        for request_target in request_targets {
+            let response = actix_test::call_service(
+                &app,
+                actix_test::TestRequest::get()
+                    .uri(request_target)
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let expected: Vec<String> = request_targets
+            .iter()
+            .map(|target| (*target).to_string())
+            .collect();
+        assert_eq!(*captured_targets.lock().unwrap(), expected);
         handle.stop(true).await;
     }
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -971,28 +971,63 @@ async fn handle_asset(
         .body(body)
 }
 
+fn accept_media_q(params: &str) -> f32 {
+    for raw_param in params.split(';') {
+        let Some((key, value)) = raw_param.trim().split_once('=') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case("q") {
+            return value
+                .trim()
+                .parse::<f32>()
+                .ok()
+                .filter(|q| q.is_finite())
+                .unwrap_or(1.0);
+        }
+    }
+    1.0
+}
+
+/// Select the SPA fallback response explicitly accepted by the request.
+///
+/// `q=0` disables that media type, and malformed q values are treated as
+/// absent with the default q of 1.0. When HTML and JSON have the same highest
+/// acceptable q value, JSON wins because it is only sent by clients opting into
+/// partial render.
 fn spa_fallback_kind(req: &HttpRequest) -> SpaFallbackKind {
     let Some(accept) = req.headers().get("accept").and_then(|v| v.to_str().ok()) else {
         return SpaFallbackKind::None;
     };
 
-    let mut accepts_html = false;
+    let mut html_q = 0.0;
+    let mut json_q = 0.0;
     for raw_media in accept.split(',') {
-        let media = raw_media
+        let (media, params) = raw_media
             .split_once(';')
-            .map_or(raw_media, |(value, _)| value)
-            .trim();
-        if media.eq_ignore_ascii_case("application/json") {
-            return SpaFallbackKind::Json;
+            .map_or((raw_media, ""), |(value, params)| (value, params));
+        let q = accept_media_q(params);
+        if q <= 0.0 {
+            continue;
         }
-        accepts_html |= media.eq_ignore_ascii_case("text/html")
-            || media.eq_ignore_ascii_case("application/xhtml+xml");
+
+        let media = media.trim();
+        if media.eq_ignore_ascii_case("text/html")
+            || media.eq_ignore_ascii_case("application/xhtml+xml")
+        {
+            if q > html_q {
+                html_q = q;
+            }
+        } else if media.eq_ignore_ascii_case("application/json") && q > json_q {
+            json_q = q;
+        }
     }
 
-    if accepts_html {
-        SpaFallbackKind::Html
-    } else {
+    if html_q <= 0.0 && json_q <= 0.0 {
         SpaFallbackKind::None
+    } else if json_q >= html_q {
+        SpaFallbackKind::Json
+    } else {
+        SpaFallbackKind::Html
     }
 }
 
@@ -1886,6 +1921,41 @@ mod tests {
             .collect();
         assert_eq!(*captured_targets.lock().unwrap(), expected);
         handle.stop(true).await;
+    }
+
+    fn fallback_kind_for_accept(accept: &str) -> SpaFallbackKind {
+        let req = actix_test::TestRequest::default()
+            .insert_header(("accept", accept))
+            .to_http_request();
+        spa_fallback_kind(&req)
+    }
+
+    #[test]
+    fn test_spa_fallback_kind_honors_q_weights() {
+        let cases = [
+            ("application/json;q=0", SpaFallbackKind::None),
+            ("text/html;q=0", SpaFallbackKind::None),
+            (
+                "text/html;q=0.8, application/json;q=0.9",
+                SpaFallbackKind::Json,
+            ),
+            (
+                "text/html;q=0.9, application/json;q=0.8",
+                SpaFallbackKind::Html,
+            ),
+            ("text/html;q=1, application/json;q=1", SpaFallbackKind::Json),
+            ("application/json", SpaFallbackKind::Json),
+            (
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                SpaFallbackKind::Html,
+            ),
+            ("APPLICATION/JSON ; Q=0.5", SpaFallbackKind::Json),
+            ("application/json;q=not-a-number", SpaFallbackKind::Json),
+        ];
+
+        for (accept, expected) in cases {
+            assert_eq!(fallback_kind_for_accept(accept), expected, "{accept}");
+        }
     }
 
     #[actix_web::test]

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -51,7 +51,8 @@ pub struct ServeArgs {
     pub watch: bool,
 
     /// Port of the user's API server to proxy route requests to. Encoded path
-    /// and query bytes are forwarded unchanged.
+    /// and query bytes are forwarded unchanged, except the entry route: `/` and
+    /// `/index.html` both resolve backend state at `/` (query preserved).
     #[arg(long)]
     pub api_port: Option<u16>,
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -932,7 +932,7 @@ async fn handle_asset(
 
     let Some(assets_dir) = &context.assets_dir else {
         // No assets dir — try SPA fallback for paths without file extensions
-        return spa_fallback(&req, &context, &relative).await;
+        return spa_fallback(&req, &context).await;
     };
 
     let asset_path = assets_dir.join(&relative);
@@ -941,7 +941,7 @@ async fn handle_asset(
         Ok(p) => p,
         Err(_) => {
             // File not found — SPA fallback for paths without file extensions
-            return spa_fallback(&req, &context, &relative).await;
+            return spa_fallback(&req, &context).await;
         }
     };
 
@@ -951,7 +951,7 @@ async fn handle_asset(
 
     let body = match fs::read(&canonical) {
         Ok(bytes) => bytes,
-        Err(_) => return spa_fallback(&req, &context, &relative).await,
+        Err(_) => return spa_fallback(&req, &context).await,
     };
 
     let content_type = from_path(&canonical).first_or_octet_stream();
@@ -971,19 +971,17 @@ fn wants_json(req: &HttpRequest) -> bool {
 
 /// SPA fallback: serve HTML or JSON partial depending on Accept header.
 /// Activates for paths that look like route paths (no file extension).
-async fn spa_fallback(
-    req: &HttpRequest,
-    context: &web::Data<ServerContext>,
-    decoded_relative: &str,
-) -> HttpResponse {
-    // Only serve fallback for paths without file extensions (likely route paths)
-    if decoded_relative.contains('.') {
-        return HttpResponse::NotFound().body("Not Found");
-    }
-
+async fn spa_fallback(req: &HttpRequest, context: &web::Data<ServerContext>) -> HttpResponse {
     // Actix decodes `web::Path` values. Route matching and backend state
     // requests must instead receive the original encoded request target.
     let paths = request_paths(req);
+
+    // Only serve fallback for paths without a file extension (likely route
+    // paths). Test the *encoded* path so an encoded dot (`%2E`) inside a
+    // route parameter is not misread as a literal extension separator.
+    if paths.route_path.contains('.') {
+        return HttpResponse::NotFound().body("Not Found");
+    }
 
     // JSON partial render: return { state, templates } for client-side navigation
     if wants_json(req) {
@@ -1807,6 +1805,45 @@ mod tests {
             .map(|target| (*target).to_string())
             .collect();
         assert_eq!(*captured_targets.lock().unwrap(), expected);
+        handle.stop(true).await;
+    }
+
+    #[actix_web::test]
+    async fn test_spa_fallback_allows_encoded_dot_route_parameter() {
+        let request_target = "/discount/100%2E5?filter=x";
+        let (port, handle, captured_targets) = start_request_target_server();
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(test_server_context(port))
+                .route("/{tail:.*}", web::get().to(handle_asset)),
+        )
+        .await;
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri(request_target)
+                .insert_header(("accept", "application/json"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/missing.css")
+                .insert_header(("accept", "application/json"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let captured = match captured_targets.lock() {
+            Ok(targets) => targets.clone(),
+            Err(error) => panic!("captured targets mutex poisoned: {error}"),
+        };
+        assert_eq!(captured, vec![request_target.to_string()]);
         handle.stop(true).await;
     }
 

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -1177,7 +1177,10 @@ async fn handle_api_proxy(
     let mut url =
         String::with_capacity(API_URL_PREFIX.len() + MAX_PORT_DIGITS + path_and_query.len());
     url.push_str(API_URL_PREFIX);
-    url.push_str(&api_port.to_string());
+    // Write the port digits straight into the reserved capacity instead of
+    // allocating a temporary `String` via `to_string()` on the proxy hot path.
+    use std::fmt::Write as _;
+    let _ = write!(url, "{api_port}");
     url.push_str(path_and_query);
 
     let client = awc::Client::new();

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -977,11 +977,14 @@ fn accept_media_q(params: &str) -> f32 {
             continue;
         };
         if key.trim().eq_ignore_ascii_case("q") {
+            // HTTP qvalues are finite and within 0..=1. Anything outside that
+            // range is malformed and falls back to the default of 1.0 so an
+            // invalid header cannot force a 404 or skew tie-breaking.
             return value
                 .trim()
                 .parse::<f32>()
                 .ok()
-                .filter(|q| q.is_finite())
+                .filter(|q| (0.0..=1.0).contains(q))
                 .unwrap_or(1.0);
         }
     }
@@ -990,10 +993,10 @@ fn accept_media_q(params: &str) -> f32 {
 
 /// Select the SPA fallback response explicitly accepted by the request.
 ///
-/// `q=0` disables that media type, and malformed q values are treated as
-/// absent with the default q of 1.0. When HTML and JSON have the same highest
-/// acceptable q value, JSON wins because it is only sent by clients opting into
-/// partial render.
+/// `q=0` disables that media type, while malformed or out-of-range q values
+/// (outside `0..=1`) are treated as absent with the default q of 1.0. When HTML
+/// and JSON have the same highest acceptable q value, JSON wins because it is
+/// only sent by clients opting into partial render.
 fn spa_fallback_kind(req: &HttpRequest) -> SpaFallbackKind {
     let Some(accept) = req.headers().get("accept").and_then(|v| v.to_str().ok()) else {
         return SpaFallbackKind::None;
@@ -1951,6 +1954,10 @@ mod tests {
             ),
             ("APPLICATION/JSON ; Q=0.5", SpaFallbackKind::Json),
             ("application/json;q=not-a-number", SpaFallbackKind::Json),
+            // Out-of-range q is malformed and falls back to the default 1.0, so
+            // it neither wins tie-breaking nor disables the media type.
+            ("text/html;q=2, application/json;q=1", SpaFallbackKind::Json),
+            ("text/html;q=-1", SpaFallbackKind::Html),
         ];
 
         for (accept, expected) in cases {

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -626,6 +626,13 @@ struct RequestPaths {
     request_path: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpaFallbackKind {
+    None,
+    Html,
+    Json,
+}
+
 fn build_request_paths(relative: &str, query: &str) -> RequestPaths {
     let route_path = if relative.is_empty() {
         "/".to_string()
@@ -932,7 +939,8 @@ async fn handle_asset(
     }
 
     let Some(assets_dir) = &context.assets_dir else {
-        // No assets dir — try SPA fallback for paths without file extensions
+        // No assets dir: let the Accept header decide whether this was a route
+        // navigation/partial request or a missing asset fetch.
         return spa_fallback(&req, &context).await;
     };
 
@@ -941,7 +949,8 @@ async fn handle_asset(
     let canonical = match asset_path.canonicalize() {
         Ok(p) => p,
         Err(_) => {
-            // File not found — SPA fallback for paths without file extensions
+            // File not found: let the Accept header decide whether this was a
+            // route navigation/partial request or a missing asset fetch.
             return spa_fallback(&req, &context).await;
         }
     };
@@ -962,30 +971,50 @@ async fn handle_asset(
         .body(body)
 }
 
-/// Check if the request accepts JSON (for partial render).
+fn spa_fallback_kind(req: &HttpRequest) -> SpaFallbackKind {
+    let Some(accept) = req.headers().get("accept").and_then(|v| v.to_str().ok()) else {
+        return SpaFallbackKind::None;
+    };
+
+    let mut accepts_html = false;
+    for raw_media in accept.split(',') {
+        let media = raw_media
+            .split_once(';')
+            .map_or(raw_media, |(value, _)| value)
+            .trim();
+        if media.eq_ignore_ascii_case("application/json") {
+            return SpaFallbackKind::Json;
+        }
+        accepts_html |= media.eq_ignore_ascii_case("text/html")
+            || media.eq_ignore_ascii_case("application/xhtml+xml");
+    }
+
+    if accepts_html {
+        SpaFallbackKind::Html
+    } else {
+        SpaFallbackKind::None
+    }
+}
+
+/// Check if the request explicitly accepts JSON (for partial render).
 fn wants_json(req: &HttpRequest) -> bool {
-    req.headers()
-        .get("accept")
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|v| v.contains("application/json"))
+    spa_fallback_kind(req) == SpaFallbackKind::Json
 }
 
 /// SPA fallback: serve HTML or JSON partial depending on Accept header.
-/// Activates for paths that look like route paths (no file extension).
+/// Activates for explicit document navigation or JSON partial requests.
 async fn spa_fallback(req: &HttpRequest, context: &web::Data<ServerContext>) -> HttpResponse {
+    let kind = spa_fallback_kind(req);
+    if kind == SpaFallbackKind::None {
+        return HttpResponse::NotFound().body("Not Found");
+    }
+
     // Actix decodes `web::Path` values. Route matching and backend state
     // requests must instead receive the original encoded request target.
     let paths = request_paths(req);
 
-    // Only serve fallback for paths without a file extension (likely route
-    // paths). Test the *encoded* path so an encoded dot (`%2E`) inside a
-    // route parameter is not misread as a literal extension separator.
-    if paths.route_path.contains('.') {
-        return HttpResponse::NotFound().body("Not Found");
-    }
-
-    // JSON partial render: return { state, templates } for client-side navigation
-    if wants_json(req) {
+    // JSON partial render: return { state, templates } for client-side navigation.
+    if kind == SpaFallbackKind::Json {
         return handle_json_partial(req, context, paths).await;
     }
 
@@ -1327,6 +1356,56 @@ mod tests {
                 StreamingWriter::CHUNK_TARGET + 1024,
             )),
         })
+    }
+
+    fn test_route_context(protocol: Arc<Protocol>) -> web::Data<ServerContext> {
+        web::Data::new(ServerContext {
+            state: Arc::new(Mutex::new(SharedState {
+                rendered_html: "<html><body>ok</body></html>".to_string(),
+                css_files: HashMap::new(),
+                component_assets: HashMap::new(),
+                protocol: Some(protocol),
+                state_data: Some(Value::Object(serde_json::Map::new())),
+                token_css: None,
+                rebuild_error: None,
+                entry: "index.html".to_string(),
+            })),
+            livereload: None,
+            assets_dir: None,
+            api_port: None,
+            plugin: None,
+            base_path: None,
+            chunk_pool: Arc::new(webui::streaming::ChunkPool::new(
+                4,
+                StreamingWriter::CHUNK_TARGET + 1024,
+            )),
+        })
+    }
+
+    fn dotted_route_protocol() -> Arc<Protocol> {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::route_from(WebUiFragmentRoute {
+                    path: "/docs/:version".to_string(),
+                    fragment_id: "docs-page".to_string(),
+                    exact: true,
+                    keep_alive: false,
+                    ..Default::default()
+                })],
+            },
+        );
+        fragments.insert(
+            "docs-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<main>docs</main>")],
+            },
+        );
+        Arc::new(Protocol::new(WebUIProtocol::with_tokens(
+            fragments,
+            Vec::new(),
+        )))
     }
 
     fn start_request_target_server() -> (u16, actix_web::dev::ServerHandle, Arc<Mutex<Vec<String>>>)
@@ -1830,22 +1909,72 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let response = actix_test::call_service(
-            &app,
-            actix_test::TestRequest::get()
-                .uri("/missing.css")
-                .insert_header(("accept", "application/json"))
-                .to_request(),
-        )
-        .await;
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
         let captured = match captured_targets.lock() {
             Ok(targets) => targets.clone(),
             Err(error) => panic!("captured targets mutex poisoned: {error}"),
         };
         assert_eq!(captured, vec![request_target.to_string()]);
         handle.stop(true).await;
+    }
+
+    #[actix_web::test]
+    async fn test_spa_fallback_allows_literal_dot_html_route() {
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(test_route_context(dotted_route_protocol()))
+                .route("/{tail:.*}", web::get().to(handle_asset)),
+        )
+        .await;
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/docs/v2.1")
+                .insert_header(("accept", "text/html,application/xhtml+xml"))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[actix_web::test]
+    async fn test_spa_fallback_rejects_missing_asset_intent() {
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(test_route_context(dotted_route_protocol()))
+                .route("/{tail:.*}", web::get().to(handle_asset)),
+        )
+        .await;
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/missing.js")
+                .insert_header(("accept", "text/javascript,*/*;q=0.1"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/users/john.doe")
+                .insert_header(("accept", "*/*"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let response = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/docs/v2.1")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[actix_web::test]

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -1106,7 +1106,13 @@ async fn handle_api_proxy(
     let path_and_query = uri
         .path_and_query()
         .map_or(uri.path(), |value| value.as_str());
-    let url = format!("http://127.0.0.1:{api_port}{path_and_query}");
+    const API_URL_PREFIX: &str = "http://127.0.0.1:";
+    const MAX_PORT_DIGITS: usize = 5;
+    let mut url =
+        String::with_capacity(API_URL_PREFIX.len() + MAX_PORT_DIGITS + path_and_query.len());
+    url.push_str(API_URL_PREFIX);
+    url.push_str(&api_port.to_string());
+    url.push_str(path_and_query);
 
     let client = awc::Client::new();
     let mut proxy_req = client.request(req.method().clone(), &url);

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -752,7 +752,10 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 | `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
 
 With `--api-port`, backend state requests and `/api/*` forwarding preserve the
-incoming encoded path and query. Applications must not double-encode route
+incoming encoded path and query except for the entry route alias. `/` and
+`/index.html` both resolve backend state at `/` (the entry path is normalized),
+while still preserving the query string. All other request paths forward their
+encoded path and query unchanged. Applications must not double-encode route
 parameters for development; `%2F` remains within one route segment.
 
 ### Inspect

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -761,8 +761,10 @@ parameters for development; `%2F` remains within one route segment.
 After generated assets and `--servedir` files miss, route fallback is based on
 the `Accept` header. Requests that explicitly accept `text/html` or
 `application/xhtml+xml` receive the SSR document, and requests that explicitly
-accept `application/json` receive the JSON partial response. Missing, invalid,
-or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+accept `application/json` receive the JSON partial response. `q=0` disables
+that media type; when HTML and JSON are both acceptable, the higher `q` wins and
+exact ties prefer JSON. Missing, invalid, or wildcard-only `Accept` headers
+return 404, as do JS, CSS, image, and other
 non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
 such as `/docs/v2.1` can still fall back to the route renderer.
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -762,9 +762,10 @@ After generated assets and `--servedir` files miss, route fallback is based on
 the `Accept` header. Requests that explicitly accept `text/html` or
 `application/xhtml+xml` receive the SSR document, and requests that explicitly
 accept `application/json` receive the JSON partial response. `q=0` disables
-that media type; when HTML and JSON are both acceptable, the higher `q` wins and
-exact ties prefer JSON. Missing, invalid, or wildcard-only `Accept` headers
-return 404, as do JS, CSS, image, and other
+that media type, while a malformed or out-of-range `q` value falls back to
+`q=1.0`; when HTML and JSON are both acceptable, the higher `q` wins and exact
+ties prefer JSON. Missing or wildcard-only `Accept` headers return 404, as do JS,
+CSS, image, and other
 non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
 such as `/docs/v2.1` can still fall back to the route renderer.
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -758,6 +758,14 @@ while still preserving the query string. All other request paths forward their
 encoded path and query unchanged. Applications must not double-encode route
 parameters for development; `%2F` remains within one route segment.
 
+After generated assets and `--servedir` files miss, route fallback is based on
+the `Accept` header. Requests that explicitly accept `text/html` or
+`application/xhtml+xml` receive the SSR document, and requests that explicitly
+accept `application/json` receive the JSON partial response. Missing, invalid,
+or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
+such as `/docs/v2.1` can still fall back to the route renderer.
+
 ### Inspect
 
 ```bash

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -744,12 +744,16 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 | `--plugin <NAME>` | none | Plugin identifier (e.g. `webui`) |
 | `--components <PACKAGE>` | none | Extra component sources (repeatable) |
 | `--projection-manifest <PATH>` | none | Bundler projection fragment (repeatable); watched explicitly with `--watch` |
-| `--api-port <PORT>` | none | Proxy route requests to API server |
+| `--api-port <PORT>` | none | Proxy route requests with encoded paths and queries preserved |
 | `--theme <PACKAGE>` | none | Design token theme; missing unresolved tokens fail the build (see below) |
 | `--asset-file-name-template <TEMPLATE>` | `[name].[ext]` | Emitted asset filename template |
 | `--css-public-base <BASE>` | none | Public URL/path prefix for Link-mode CSS hrefs |
 | `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
 | `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
+
+With `--api-port`, backend state requests and `/api/*` forwarding preserve the
+incoming encoded path and query. Applications must not double-encode route
+parameters for development; `%2F` remains within one route segment.
 
 ### Inspect
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -276,8 +276,10 @@ instead of becoming a path separator.
 After generated assets and `--servedir` files miss, route fallback is based on
 the `Accept` header. Requests that explicitly accept `text/html` or
 `application/xhtml+xml` receive the SSR document, and requests that explicitly
-accept `application/json` receive the JSON partial response. Missing, invalid,
-or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+accept `application/json` receive the JSON partial response. `q=0` disables
+that media type; when HTML and JSON are both acceptable, the higher `q` wins and
+exact ties prefer JSON. Missing, invalid, or wildcard-only `Accept` headers
+return 404, as do JS, CSS, image, and other
 non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
 such as `/docs/v2.1` can still fall back to the route renderer.
 
@@ -346,7 +348,7 @@ successful rebuild clears the error and reloads connected browsers.
 | `/` or `/index.html` | Rendered HTML with live-reload script |
 | `/<tag>.webui.js` | In-memory static component assets emitted by `--emit-component-assets` (served as JS modules) |
 | `/*` | Static files from `--servedir` (when provided) |
-| `/*` with `Accept: text/html`, `application/xhtml+xml`, or `application/json` after asset misses | SPA route fallback |
+| `/*` with `Accept: text/html`, `application/xhtml+xml`, or `application/json` at q > 0 after asset misses | SPA route fallback (highest q wins; JSON wins exact ties) |
 | Missing JS, CSS, image, and wildcard-only asset requests | 404 |
 | `/hmr` | HMR version endpoint (polling backend, only when `--watch`) |
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -266,7 +266,10 @@ The `APP` directory should contain your entry HTML and component files.
 6. If `--watch` is enabled, connected browsers reload automatically via the polling HMR backend
 
 When `--api-port` is set, backend state requests and `/api/*` forwarding use
-the encoded path and query exactly as received. Do not double-encode route
+the encoded path and query exactly as received except for the entry route alias.
+`/` and `/index.html` both resolve backend state at `/` (the entry path is
+normalized), while still preserving the query string. All other request paths
+forward their encoded path and query unchanged. Do not double-encode route
 parameters for development. For example, `%2F` remains part of one parameter
 instead of becoming a path separator.
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -247,7 +247,7 @@ webui serve [APP] --state <FILE> [--servedir <DIR>] [--watch] [--port <PORT>] [-
 | `--dom <STRATEGY>` | DOM strategy: `shadow` or `light` | `shadow` |
 | `--components <SOURCE>` | Additional component sources (npm packages or local paths). Repeatable. | *(none)* |
 | `--projection-manifest <PATH>` | Bundler projection manifest fragment. Repeatable and valid only with `--plugin=webui`. | *(none; full state)* |
-| `--api-port <PORT>` | Proxy route requests to your API server on this port. The dev server forwards navigation requests so your backend can provide real state data. | *(none)* |
+| `--api-port <PORT>` | Proxy route requests to your API server on this port. Encoded paths and queries are forwarded unchanged. | *(none)* |
 | `--emit-component-assets <TAGS>` | Comma-separated root component tags to compile as static WebUI component assets, matching `webui build`. Their templates and CSS are parsed and validated on every build, and the compiled `<tag>.webui.js` modules are served from memory. | *(none)* |
 | `--theme <VALUE>` | Design token theme: a path to a JSON file or an npm package name. Missing required tokens fail the build; resolved tokens are injected into the render state. | *(none)* |
 | `--asset-file-name-template <TEMPLATE>` | Emitted asset filename template for Link-mode CSS files. Tokens: `[name]`, `[hash]`, `[ext]` | `[name].[ext]` |
@@ -264,6 +264,11 @@ The `APP` directory should contain your entry HTML and component files.
 4. If `--watch` is enabled, watches app, state, asset, and explicit projection manifest files for changes
 5. If `--watch` is enabled, automatically rebuilds and re-renders when files change
 6. If `--watch` is enabled, connected browsers reload automatically via the polling HMR backend
+
+When `--api-port` is set, backend state requests and `/api/*` forwarding use
+the encoded path and query exactly as received. Do not double-encode route
+parameters for development. For example, `%2F` remains part of one parameter
+instead of becoming a path separator.
 
 **Examples:**
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -277,9 +277,10 @@ After generated assets and `--servedir` files miss, route fallback is based on
 the `Accept` header. Requests that explicitly accept `text/html` or
 `application/xhtml+xml` receive the SSR document, and requests that explicitly
 accept `application/json` receive the JSON partial response. `q=0` disables
-that media type; when HTML and JSON are both acceptable, the higher `q` wins and
-exact ties prefer JSON. Missing, invalid, or wildcard-only `Accept` headers
-return 404, as do JS, CSS, image, and other
+that media type, while a malformed or out-of-range `q` value falls back to
+`q=1.0`; when HTML and JSON are both acceptable, the higher `q` wins and exact
+ties prefer JSON. Missing or wildcard-only `Accept` headers return 404, as do JS,
+CSS, image, and other
 non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
 such as `/docs/v2.1` can still fall back to the route renderer.
 

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -273,6 +273,14 @@ forward their encoded path and query unchanged. Do not double-encode route
 parameters for development. For example, `%2F` remains part of one parameter
 instead of becoming a path separator.
 
+After generated assets and `--servedir` files miss, route fallback is based on
+the `Accept` header. Requests that explicitly accept `text/html` or
+`application/xhtml+xml` receive the SSR document, and requests that explicitly
+accept `application/json` receive the JSON partial response. Missing, invalid,
+or wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
+such as `/docs/v2.1` can still fall back to the route renderer.
+
 **Examples:**
 
 ```bash
@@ -338,6 +346,8 @@ successful rebuild clears the error and reloads connected browsers.
 | `/` or `/index.html` | Rendered HTML with live-reload script |
 | `/<tag>.webui.js` | In-memory static component assets emitted by `--emit-component-assets` (served as JS modules) |
 | `/*` | Static files from `--servedir` (when provided) |
+| `/*` with `Accept: text/html`, `application/xhtml+xml`, or `application/json` after asset misses | SPA route fallback |
+| Missing JS, CSS, image, and wildcard-only asset requests | 404 |
 | `/hmr` | HMR version endpoint (polling backend, only when `--watch`) |
 
 ## Error output and exit codes

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -66,9 +66,10 @@ The server SSRs the matched route on first load. The router handles clicks on `<
 Route segments may contain literal dots, such as `/docs/v2.1` or
 `/users/john.doe`. In `webui serve`, a missed asset lookup falls back to route
 rendering only for requests that explicitly accept `text/html`,
-`application/xhtml+xml`, or `application/json`. `q=0` disables that media type;
-when HTML and JSON are both acceptable, the higher `q` wins and exact ties
-prefer JSON. Missing, invalid, or wildcard-only `Accept` headers return 404, as
+`application/xhtml+xml`, or `application/json`. `q=0` disables that media type,
+while a malformed or out-of-range `q` value falls back to `q=1.0`; when HTML and
+JSON are both acceptable, the higher `q` wins and exact ties prefer JSON. Missing
+or wildcard-only `Accept` headers return 404, as
 do JS, CSS, image, and other
 non-HTML/non-JSON asset requests.
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -66,8 +66,10 @@ The server SSRs the matched route on first load. The router handles clicks on `<
 Route segments may contain literal dots, such as `/docs/v2.1` or
 `/users/john.doe`. In `webui serve`, a missed asset lookup falls back to route
 rendering only for requests that explicitly accept `text/html`,
-`application/xhtml+xml`, or `application/json`. Missing, invalid, or
-wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+`application/xhtml+xml`, or `application/json`. `q=0` disables that media type;
+when HTML and JSON are both acceptable, the higher `q` wins and exact ties
+prefer JSON. Missing, invalid, or wildcard-only `Accept` headers return 404, as
+do JS, CSS, image, and other
 non-HTML/non-JSON asset requests.
 
 The router never imports framework code. Authored route components use their

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -63,6 +63,13 @@ Router.start();
 
 The server SSRs the matched route on first load. The router handles clicks on `<a>` tags for subsequent navigations - no full page reloads.
 
+Route segments may contain literal dots, such as `/docs/v2.1` or
+`/users/john.doe`. In `webui serve`, a missed asset lookup falls back to route
+rendering only for requests that explicitly accept `text/html`,
+`application/xhtml+xml`, or `application/json`. Missing, invalid, or
+wildcard-only `Accept` headers return 404, as do JS, CSS, image, and other
+non-HTML/non-JSON asset requests.
+
 The router never imports framework code. Authored route components use their
 registered classes. When the application also loads
 `@microsoft/webui-framework`, HTML-only route templates can mount during soft

--- a/packages/webui-framework/tsconfig.json
+++ b/packages/webui-framework/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/packages/webui-router/tsconfig.json
+++ b/packages/webui-router/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",

--- a/packages/webui/tsconfig.json
+++ b/packages/webui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/xtask/src/build_examples.rs
+++ b/xtask/src/build_examples.rs
@@ -175,7 +175,42 @@ pub fn run_app_builds() -> Result<(), String> {
 pub fn run_example_builds() -> Result<(), String> {
     run_integration_builds()?;
     ensure_example_wasm()?;
+    ensure_example_deps()?;
     run_app_builds()
+}
+
+/// Build the shared workspace JS packages once, before the parallel app builds.
+///
+/// Every example app's `build:deps` step compiles the shared packages
+/// (`@microsoft/webui`, `@microsoft/webui-framework`, `@microsoft/webui-router`)
+/// with `tsc` into their `dist/` directories. Building the apps in parallel
+/// makes those `tsc` invocations race for the shared output: one app reads
+/// `packages/webui/dist/projection/adapters/esbuild.js` while another app's
+/// `tsc` is mid-rewrite of the sibling `loader.js`, surfacing in CI as
+/// `does not provide an export named 'compileProjection'`.
+///
+/// Building the shared packages once here seeds their outputs and the
+/// incremental `.tsbuildinfo` (the shared tsconfigs set `"incremental": true`),
+/// so each per-app `build:deps` becomes a no-op emit that never rewrites the
+/// shared files concurrently. Mirrors `ensure_example_wasm`: one up-front build
+/// keeps `build-examples` self-contained. This is strictly less work than the
+/// status quo, which ran the same shared build once per app in parallel.
+fn ensure_example_deps() -> Result<(), String> {
+    run_command_quiet(
+        "pnpm",
+        &[
+            "--filter",
+            "@microsoft/webui",
+            "--filter",
+            "@microsoft/webui-framework",
+            "--filter",
+            "@microsoft/webui-router",
+            "run",
+            "build",
+        ],
+        None,
+    )
+    .map_err(|message| format!("shared example dependency build failed: {message}"))
 }
 
 /// Build the WASM bundles once, before the parallel app builds, when they are

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -82,10 +82,23 @@ pub fn run_command_quiet(cmd: &str, args: &[&str], cwd: Option<&Path>) -> Result
 /// huge startup time scanning hundreds of thousands of stale fingerprint
 /// files. Disabling it here keeps `cargo xtask check` reliably fast on
 /// long-lived working copies.
+///
+/// For pnpm invocations, this forces `manage-package-manager-versions=false`.
+/// pnpm honours the root `packageManager` pin by re-running its
+/// package-manager self-management on every `pnpm run`, resolving (and, when the
+/// shared global store is being churned by other pnpm processes, blocking on) a
+/// pinned pnpm under `~/AppData/Local/pnpm/.tools`. On a loaded machine that
+/// pre-run step can stall for tens of seconds before the script even starts,
+/// even though the underlying work (e.g. an esbuild integration build) is
+/// milliseconds. CI and the `engines`/`packageManager` fields already guarantee
+/// the correct pnpm, so xtask runs the already-resolved pnpm directly. This
+/// keeps the pnpm-driven `cargo xtask check` phases fast regardless of load.
 pub fn build_command(cmd: &str, args: &[&str]) -> Command {
     let mut command = build_command_inner(cmd, args);
     if cmd == "cargo" {
         command.env("CARGO_INCREMENTAL", "0");
+    } else if cmd == "pnpm" {
+        command.env("npm_config_manage_package_manager_versions", "false");
     }
     command
 }


### PR DESCRIPTION
Development requests with encoded route parameters were decoded by Actix path extraction before forwarding. Encoded slashes changed route boundaries, while spaces and UTF-8 values could produce invalid upstream URIs, leading to partial path mismatches or fallback state.

Build backend requests from the original URI path and query for both route-state resolution and /api forwarding, while retaining decoded paths for local asset lookup. Add wire-level regression coverage and document the transport contract.

## Bundled build-system fixes

While validating this change through `cargo xtask check`, two unrelated but blocking build-system issues were fixed here to keep the gate and CI green. They are called out separately so the scope stays clear:

- **Parallel `tsc` example-build race** (`ensure_example_deps` + TypeScript `incremental`): each example app's `build:deps` recompiled the shared JS packages into the same `dist/` concurrently, so one app could read a half-written `loader.js`/`esbuild.js` while another app's `tsc` rewrote it, surfacing in CI as `does not provide an export named 'compileProjection'`. The shared packages are now built once up front and the shared tsconfigs are incremental, so each per-app `build:deps` is a no-op emit.
- **pnpm package-manager self-management stall** (`npm_config_manage_package_manager_versions=false` in xtask's `build_command`): every `pnpm run` re-ran pnpm's version self-management, which could block for tens of seconds before the script started on a machine whose shared pnpm store was busy. xtask now runs the already-resolved pnpm directly (`engines`/`packageManager` and CI already pin the version).