### PR TITLE
fix: make repeat reconciliation duplicate-safe

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1519,7 +1519,7 @@ update hot paths still call the function directly.
 | `a`   | `CompiledAttrMeta[]`              | Attribute binding metadata                         |
 | `ag`  | `[elementPath, start, count][]`   | Attribute-target groups for `a[]`                  |
 | `c`   | `[ConditionRef, blockIndex, slot][]` | Conditional blocks                              |
-| `r`   | `[collection, itemVar, blockIndex, slot][]` | Repeat blocks                            |
+| `r`   | `[collection, itemVar, blockIndex, slot, keyPath?][]` | Repeat blocks; `keyPath` is relative to the item variable |
 | `eg`  | `[event, [[handler, argSpecs, targetPath, usesEvent?]]][]` | Body events grouped by event name |
 | `b`   | `TemplateBlockMeta[]`             | Nested compiled block table referenced by `c` / `r` |
 | `sa`  | `string`                          | Optional module-mode adopted stylesheet specifier copied from `shadowrootadoptedstylesheets` |
@@ -1660,12 +1660,48 @@ The Rust compiler (`generate_compiled_template` in `webui-parser/src/plugin/webu
 | `:config="{{settings}}"`, `:value="{{searchQuery}}"` | `a[]` + `ag[]` | element kept marker-free |
 | `<if condition="expr">body</if>`     | `c[]` + `b[]`          | block removed; anchor slot stored |
 | `<for each="v in coll">body</for>`   | `r[]` + `b[]`          | block removed; anchor slot stored |
+| `<for each="v in coll"><x key="{{v.id}}">body</x></for>` | `r[]` + `b[]` | block removed; first-child key path stored |
 | `@event="{handler(item.id, e)}"`     | `eg[]`                 | element kept marker-free          |
 | `@event` on `<template>` wrapper     | `re[N]`                | *(stripped)*                      |
 | `w-ref="{name}"`                     | *(stays)*              | *(unchanged)*                     |
 | `<outlet />`                         | *(stays)*              | `<outlet></outlet>`               |
 
-**Authoring validation.** Build-time authoring mistakes are returned as a structured `ParserError::Template(Box<Diagnostic>)`, never panicked. This covers invalid `@event` handlers (e.g. `@click="e.preventDefault()"`, or a bare `@click="{closeMenu}"`), scriptless components that contain `@event` bindings, non-braced `w-ref` (`w-ref="name"` instead of `w-ref="{name}"`), core-parser mistakes — an invalid `<for each>` expression, a missing/invalid `<if condition>`, an unknown component tag, a recursive template reference — malformed CSS in a `<style>` block, and structural HTML well-formedness errors (unclosed/malformed tags, unterminated comments/declarations, unexpected closing tags, excessive nesting), so every build error renders identically. The `Diagnostic` is plain, actionable data — a **stable machine-readable `code`** (e.g. `invalid-for-each` or `scriptless-event-handler`; see `diagnostic::codes`), title, source location (rendered rustc-style as `--> owner:line:column` when the offending byte offset is known, otherwise `in component <c> · element <e>`), offending snippet, and a `help:` fix — and carries **no color**: `webui-cli` styles it with `console`, while Node/FFI/WASM forward the plain `Display` text through their native error channel. Where a fix is likely a typo, the `help:` offers a **"did you mean …?" suggestion** via an iterative Levenshtein match (`suggest::closest_match`): a misspelled directive attribute (`eahc` → `each`), or an unregistered custom-element tag that closely matches a registered component **in the same namespace** (`<mp-buton>` → `<mp-button>`; cross-namespace tags like `<md-button>` still pass through as genuine custom elements).
+Repeat identity is positional by default. At runtime, the existing block at
+index `i` receives the current collection item at index `i`; only tail growth
+or shrinkage creates or removes blocks. The runtime never infers identity from
+repeated-root attributes, so duplicate values and attributes are safe and
+attribute order has no reconciliation semantics.
+
+Authors may opt into logical identity by adding `key="{{item.id}}"` to the first
+child inside `<for>`. Primitive arrays use `key="{{item}}"`. Under the WebUI
+plugin, `key` is compiler-only structural metadata: the compiler validates this
+restricted item-rooted path grammar, removes the attribute from SSR and client
+HTML, and emits only the relative path as the optional fifth `r[]` tuple field
+(`""` for the item itself). It is not included in `a[]` or `ag[]`. Unkeyed
+repeats retain the four-field tuple. `data-key` remains an ordinary application
+attribute and has no identity semantics. Only `key` on the first repeated child
+is consumed as identity metadata. A `key` on another regular element produces
+an `invalid-for-key` build diagnostic; directive attributes remain governed by
+their own contracts. Keyed repeats accept unique
+strings and finite numbers, preserve number/string type identity, and use a
+stable-order positional fast path. A changed order uses a reusable key map to
+move existing block instances, preserving browser-owned and local component
+state with the logical item. Invalid or duplicate runtime key values clear
+established identity, warn once, and reconcile positionally for that update; a
+later valid update establishes identity again. Validation completes before DOM,
+scope, or instance mutation.
+
+SSR repeat markers do not serialize separate key values. When the bootstrap
+collection is present and its length matches the hydrated SSR instance count,
+the runtime derives typed keys by index from that collection and establishes
+identity immediately, so the first later reorder can move existing SSR blocks.
+Missing state, a count mismatch, or invalid keys leave identity unestablished
+and the next valid update reconciles positionally once. This relies on the
+existing hydration invariant that SSR HTML and bootstrap state represent the
+same render. FAST v2/v3 do not reserve `key` and do not emit WebUI key metadata
+into `<f-repeat>` markup.
+
+**Authoring validation.** Build-time authoring mistakes are returned as a structured `ParserError::Template(Box<Diagnostic>)`, never panicked. This covers invalid `@event` handlers (e.g. `@click="e.preventDefault()"`, or a bare `@click="{closeMenu}"`), scriptless components that contain `@event` bindings, non-braced `w-ref` (`w-ref="name"` instead of `w-ref="{name}"`), core-parser mistakes — an invalid `<for each>` expression, a malformed or misplaced first-child repeat key (`invalid-for-key`), a missing/invalid `<if condition>`, an unknown component tag, a recursive template reference — malformed CSS in a `<style>` block, and structural HTML well-formedness errors (unclosed/malformed tags, unterminated comments/declarations, unexpected closing tags, excessive nesting), so every build error renders identically. The `Diagnostic` is plain, actionable data — a **stable machine-readable `code`** (e.g. `invalid-for-each` or `scriptless-event-handler`; see `diagnostic::codes`), title, source location (rendered rustc-style as `--> owner:line:column` when the offending byte offset is known, otherwise `in component <c> · element <e>`), offending snippet, and a `help:` fix — and carries **no color**: `webui-cli` styles it with `console`, while Node/FFI/WASM forward the plain `Display` text through their native error channel. Where a fix is likely a typo, the `help:` offers a **"did you mean …?" suggestion** via an iterative Levenshtein match (`suggest::closest_match`): a misspelled directive attribute (`eahc` → `each`), or an unregistered custom-element tag that closely matches a registered component **in the same namespace** (`<mp-buton>` → `<mp-button>`; cross-namespace tags like `<md-button>` still pass through as genuine custom elements).
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1673,7 +1673,10 @@ repeated-root attributes, so duplicate values and attributes are safe and
 attribute order has no reconciliation semantics.
 
 Authors may opt into logical identity by adding `key="{{item.id}}"` to the first
-child inside `<for>`. Primitive arrays use `key="{{item}}"`. Under the WebUI
+concrete element inside `<for>`. Leading `<if>` wrappers are transparent, so the
+key belongs on the first concrete element inside the conditional, not on the
+directive. A nested `<for>` owns its own child key. `key` on `<if>`, `<for>`, or
+`<outlet>` is invalid. Primitive arrays use `key="{{item}}"`. Under the WebUI
 plugin, `key` is compiler-only structural metadata: the compiler validates this
 restricted item-rooted path grammar, removes the attribute from SSR and client
 HTML, and emits only the relative path as the optional fifth `r[]` tuple field

--- a/crates/webui-parser/src/diagnostic.rs
+++ b/crates/webui-parser/src/diagnostic.rs
@@ -67,6 +67,8 @@ pub mod codes {
     pub const INVALID_FOR_EACH: &str = "invalid-for-each";
     /// `<for each>` item or collection name uses disallowed characters.
     pub const INVALID_FOR_IDENTIFIER: &str = "invalid-for-identifier";
+    /// An explicit repeat key is malformed or used on a non-root element.
+    pub const INVALID_FOR_KEY: &str = "invalid-for-key";
     /// `<if>` element is missing its required `condition` attribute.
     pub const MISSING_IF_CONDITION: &str = "missing-if-condition";
     /// `<if condition>` value is not a parseable expression.

--- a/crates/webui-parser/src/diagnostic.rs
+++ b/crates/webui-parser/src/diagnostic.rs
@@ -67,7 +67,7 @@ pub mod codes {
     pub const INVALID_FOR_EACH: &str = "invalid-for-each";
     /// `<for each>` item or collection name uses disallowed characters.
     pub const INVALID_FOR_IDENTIFIER: &str = "invalid-for-identifier";
-    /// An explicit repeat key is malformed or used on a non-root element.
+    /// An explicit repeat key is malformed or used on an invalid element.
     pub const INVALID_FOR_KEY: &str = "invalid-for-key";
     /// `<if>` element is missing its required `condition` attribute.
     pub const MISSING_IF_CONDITION: &str = "missing-if-condition";

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -66,10 +66,11 @@ use super::{
 use crate::comment_policy;
 use crate::component_registry::Component;
 use crate::diagnostic::{codes, Diagnostic};
-use crate::html_parser::{find_tag_close, style_element_bounds};
+use crate::html_parser::{find_tag_close, parse_tag, style_element_bounds};
 use crate::{ConditionParser, DomStrategy, ParserOptions, Result};
 use std::cell::Cell;
 use std::fmt::Write;
+use std::ops::Range;
 use webui_protocol::{condition_expr, ConditionExpr, WebUIElementData};
 
 /// A component whose plugin-facing template HTML has been captured for compilation.
@@ -245,6 +246,9 @@ impl ParserPlugin for WebUIParserPlugin {
             self.element_events.set(self.element_events.get() + 1);
             return AttributeAction::Skip;
         }
+        if attr_name == "key" {
+            return AttributeAction::Skip;
+        }
         AttributeAction::Keep
     }
 
@@ -332,8 +336,8 @@ struct TemplateSectionMeta {
     conditionals: Vec<(ConditionExpr, usize)>,
     /// Client conditional anchor slots aligned to `conditionals`.
     condition_slots: Vec<SlotLocator>,
-    /// For-loop blocks: `(collection_path, item_variable, block_index)`.
-    repeats: Vec<(String, String, usize)>,
+    /// For-loop blocks and their optional first-child key paths.
+    repeats: Vec<CompiledRepeat>,
     /// Client repeat anchor slots aligned to `repeats`.
     repeat_slots: Vec<SlotLocator>,
     /// Body-level events: `(event_name, handler_method, argument_specs)`.
@@ -347,6 +351,26 @@ struct SlotLocator {
     parent_path: Vec<usize>,
     before_index: usize,
     order: usize,
+}
+
+struct CompiledRepeat {
+    collection: String,
+    item_var: String,
+    block_index: usize,
+    key_path: Option<String>,
+}
+
+struct ParsedForBlock {
+    collection: String,
+    item_var: String,
+    key_path: Option<String>,
+    body: String,
+    consumed: usize,
+}
+
+struct ParsedRepeatKey {
+    path: String,
+    attr_range: Range<usize>,
 }
 
 /// Collected metadata produced by [`compile_to_metadata`].
@@ -508,6 +532,7 @@ impl ConditionFunctionEmitter {
 /// | `:config="{{settings}}"`              | `a[]` + `ag[]`             | element kept marker-free          |
 /// | `<if condition="…">body</if>`         | `c[]` + `cl[]` + `b[]`     | block removed; anchor slot stored |
 /// | `<for each="v in coll">body</for>`    | `r[]` + `rl[]` + `b[]`     | block removed; anchor slot stored |
+/// | first-child `key="{{v.id}}"`          | optional fifth `r[]` field | relative repeat key path stored   |
 /// | `<link>` / `<style>` child nodes      | `h`                        | preserved in static HTML          |
 /// | module adopted stylesheet specifier   | `sa`                       | stored from `<template>` wrapper  |
 /// | `@event="{handler(e)}"`               | `eg[]`                     | element kept marker-free          |
@@ -517,7 +542,7 @@ impl ConditionFunctionEmitter {
 /// # Errors
 ///
 /// Returns [`crate::ParserError::Template`] if the template contains an invalid
-/// `@event` handler or a non-braced `w-ref` binding.
+/// `@event` handler, non-braced `w-ref`, or invalid first-child repeat key.
 pub fn generate_compiled_template(tag_name: &str, html_content: &str) -> Result<String> {
     Ok(generate_compiled_template_with_root_source(
         tag_name,
@@ -867,12 +892,12 @@ fn collect_template_build_metadata(meta: &TemplateMeta) -> TemplateBuildMetadata
             }
         }
 
-        for (collection, item_var, block_index) in &block.repeats {
-            add_root(&mut roots, collection, &scopes, visit.scope);
-            if let Some(child) = meta.blocks.get(*block_index) {
+        for repeat in &block.repeats {
+            add_root(&mut roots, &repeat.collection, &scopes, visit.scope);
+            if let Some(child) = meta.blocks.get(repeat.block_index) {
                 let scope = scopes.len();
                 scopes.push(RootScope {
-                    name: item_var,
+                    name: &repeat.item_var,
                     parent: visit.scope,
                 });
                 stack.push(RootVisit {
@@ -1256,7 +1281,7 @@ fn emit_json_template_section(
 
     if !meta.repeats.is_empty() {
         out.push_str(",\"r\":[");
-        for (i, ((collection, item_var, block_index), slot)) in meta
+        for (i, (repeat, slot)) in meta
             .repeats
             .iter()
             .zip(meta.repeat_slots.iter())
@@ -1266,13 +1291,17 @@ fn emit_json_template_section(
                 out.push(',');
             }
             out.push('[');
-            emit_js_string(collection, out);
+            emit_js_string(&repeat.collection, out);
             out.push(',');
-            emit_js_string(item_var, out);
+            emit_js_string(&repeat.item_var, out);
             out.push(',');
-            let _ = write!(out, "{}", block_index);
+            let _ = write!(out, "{}", repeat.block_index);
             out.push(',');
             emit_js_slot(slot, out);
+            if let Some(key_path) = &repeat.key_path {
+                out.push(',');
+                emit_js_string(key_path, out);
+            }
             out.push(']');
         }
         out.push(']');
@@ -1381,15 +1410,20 @@ fn compile_section(
 
             // <for each="item in collection">...</for> → marker + repeat
             if remaining.starts_with("<for ") || remaining.starts_with("<for\n") {
-                if let Some((collection, item_var, body, consumed)) = parse_for_block(remaining) {
+                if let Some(repeat) = parse_for_block(component, remaining)? {
                     let block_index = blocks.len();
                     blocks.push(TemplateSectionMeta::default());
-                    let block = compile_section(component, &body, blocks)?;
+                    let block = compile_section(component, &repeat.body, blocks)?;
                     blocks[block_index] = block;
                     let idx = meta.repeats.len();
-                    meta.repeats.push((collection, item_var, block_index));
+                    meta.repeats.push(CompiledRepeat {
+                        collection: repeat.collection,
+                        item_var: repeat.item_var,
+                        block_index,
+                        key_path: repeat.key_path,
+                    });
                     meta.html.push_str(&format!("<!--r:{idx}-->"));
-                    i += consumed;
+                    i += repeat.consumed;
                     continue;
                 }
             }
@@ -2373,33 +2407,153 @@ fn compile_condition_expr(input: &str) -> ConditionExpr {
     }
 }
 
-/// Parse `<for each="item in collection">BODY</for>` → `(collection, item_var, body, consumed)`.
+/// Parse a `<for>` block and the optional key on its first child.
 ///
 /// The `each` attribute must follow the `"item in collection"` pattern.
 /// The body template retains `{{expr}}` mustaches — they are resolved by the
 /// client runtime during reconciliation.
-fn parse_for_block(input: &str) -> Option<(String, String, String, usize)> {
+fn parse_for_block(component: &str, input: &str) -> Result<Option<ParsedForBlock>> {
     let close_tag = "</for>";
-    let end_pos = find_matching_block_end(input, "for")?;
-    let tag_content = &input[..end_pos];
+    let Some(end_pos) = find_matching_block_end(input, "for") else {
+        return Ok(None);
+    };
+    let Some(tag) = parse_tag(input) else {
+        return Ok(None);
+    };
+    let Some(each_val) = tag.attr("each") else {
+        return Ok(None);
+    };
 
-    // Extract each="item in collection"
-    let each_start = tag_content.find("each=\"")? + "each=\"".len();
-    let each_end = tag_content[each_start..].find('"')? + each_start;
-    let each_val = &tag_content[each_start..each_end];
+    let mut parts = each_val.split_whitespace();
+    let (Some(item_var), Some("in"), Some(collection), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return Ok(None);
+    };
+    let body_source = input[tag.close + 1..end_pos].trim();
+    let repeat_key = first_child_repeat_key(component, item_var, body_source)?;
+    let (key_path, body) = if let Some(repeat_key) = repeat_key {
+        let mut body = String::with_capacity(
+            body_source
+                .len()
+                .saturating_sub(repeat_key.attr_range.len()),
+        );
+        body.push_str(&body_source[..repeat_key.attr_range.start]);
+        body.push_str(&body_source[repeat_key.attr_range.end..]);
+        (Some(repeat_key.path), body)
+    } else {
+        (None, body_source.to_string())
+    };
 
-    let parts: Vec<&str> = each_val.splitn(3, ' ').collect();
-    if parts.len() != 3 || parts[1] != "in" {
-        return None;
+    Ok(Some(ParsedForBlock {
+        collection: collection.to_string(),
+        item_var: item_var.to_string(),
+        key_path,
+        body,
+        consumed: end_pos + close_tag.len(),
+    }))
+}
+
+fn relative_repeat_key<'a>(item_var: &str, key: &'a str) -> Option<&'a str> {
+    if key == item_var {
+        return Some("");
     }
-    let item_var = parts[0].to_string();
-    let collection = parts[2].to_string();
+    let relative = key.strip_prefix(item_var)?.strip_prefix('.')?;
+    (!relative.is_empty() && is_valid_event_path(relative)).then_some(relative)
+}
 
-    // Extract body
-    let body_start = find_tag_close(tag_content)? + 1;
-    let body = tag_content[body_start..].trim().to_string();
+fn first_child_repeat_key(
+    component: &str,
+    item_var: &str,
+    body: &str,
+) -> Result<Option<ParsedRepeatKey>> {
+    let mut remaining = body;
+    let mut offset = 0usize;
+    loop {
+        let trimmed = remaining.trim_start();
+        offset += remaining.len().saturating_sub(trimmed.len());
+        remaining = trimmed;
+        if remaining.starts_with("<!--") {
+            let Some(close) = remaining.find("-->") else {
+                return Ok(None);
+            };
+            offset += close + 3;
+            remaining = &remaining[close + 3..];
+            continue;
+        }
+        if remaining.starts_with("<!") {
+            let Some(close) = find_tag_close(remaining) else {
+                return Ok(None);
+            };
+            offset += close + 1;
+            remaining = &remaining[close + 1..];
+            continue;
+        }
+        break;
+    }
+    let Some(tag) = parse_tag(remaining) else {
+        return Ok(None);
+    };
+    if tag.closing {
+        return Ok(None);
+    }
+    let mut key_attr = None;
+    for attr in tag.attrs() {
+        if attr.name != "key" {
+            continue;
+        }
+        if key_attr.is_some() {
+            return Err(invalid_repeat_key_placement(component, tag.name).into());
+        }
+        key_attr = Some(attr);
+    }
+    let Some(attr) = key_attr else {
+        return Ok(None);
+    };
+    let path = parse_repeat_key(component, item_var, attr.value.unwrap_or_default())?;
+    Ok(Some(ParsedRepeatKey {
+        path,
+        attr_range: (offset + attr.raw_range.start)..(offset + attr.raw_range.end),
+    }))
+}
 
-    Some((collection, item_var, body, end_pos + close_tag.len()))
+fn parse_repeat_key(component: &str, item_var: &str, raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    let key = trimmed
+        .strip_prefix("{{")
+        .and_then(|value| value.strip_suffix("}}"))
+        .filter(|value| !value.starts_with('{') && !value.ends_with('}'))
+        .map(str::trim);
+    let Some(key) = key else {
+        return Err(invalid_repeat_key(component, item_var, raw).into());
+    };
+    let Some(relative) = relative_repeat_key(item_var, key) else {
+        return Err(invalid_repeat_key(component, item_var, raw).into());
+    };
+    Ok(relative.to_string())
+}
+
+#[cold]
+#[inline(never)]
+fn invalid_repeat_key(component: &str, item_var: &str, key: &str) -> Diagnostic {
+    Diagnostic::error("invalid repeat key expression")
+        .code(codes::INVALID_FOR_KEY)
+        .component(component)
+        .snippet(key)
+        .help(format!(
+            "use key=\"{{{{{item_var}}}}}\" or key=\"{{{{{item_var}.id}}}}\" on the first child of <for>"
+        ))
+}
+
+#[cold]
+#[inline(never)]
+fn invalid_repeat_key_placement(component: &str, element: &str) -> Diagnostic {
+    Diagnostic::error("invalid repeat key placement")
+        .code(codes::INVALID_FOR_KEY)
+        .component(component)
+        .element(element)
+        .snippet("key")
+        .help("use key=\"{{item.id}}\" only on the first child of <for>")
 }
 
 /// Build a [`Diagnostic`] for an invalid `@event` handler.
@@ -2606,6 +2760,10 @@ fn parse_regular_tag(
         let raw_attr = tag_body[attr_start..cursor].trim();
         if raw_attr.is_empty() {
             continue;
+        }
+
+        if name == "key" {
+            return Err(invalid_repeat_key_placement(component, tag_name).into());
         }
 
         if let Some(event_name) = name.strip_prefix('@') {
@@ -3094,6 +3252,8 @@ mod tests {
         let mut plugin = WebUIParserPlugin::new();
         assert_eq!(plugin.classify_attribute("@click"), AttributeAction::Skip);
         assert_eq!(plugin.classify_attribute("@keydown"), AttributeAction::Skip);
+        assert_eq!(plugin.classify_attribute("key"), AttributeAction::Skip);
+        assert_eq!(plugin.classify_attribute("data-key"), AttributeAction::Keep);
         assert_eq!(plugin.classify_attribute("w-ref"), AttributeAction::Keep);
         assert_eq!(plugin.classify_attribute("class"), AttributeAction::Keep);
     }
@@ -3274,20 +3434,122 @@ mod tests {
         assert_no_client_markers(&result);
         assert!(result.contains("\"items\""));
         assert!(result.contains("\"item\""));
+        assert!(result.contains(r#""r":[["items","item",0,[[],0]]]"#));
         assert!(!result.contains("<for"));
+    }
+
+    #[test]
+    fn test_metadata_emits_first_child_key_path() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p class="row" key="{{item.id}}">{{item.name}}</p></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0],"id"]]"#));
+        assert!(!result.contains("key="));
+        assert!(!result.contains(r#""a":[["key","#));
+    }
+
+    #[test]
+    fn test_metadata_treats_data_key_as_ordinary_attribute() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p data-key="{{item.id}}">{{item.name}}</p></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0]]]"#));
+        assert!(result.contains(r#""a":[["data-key",0,"item.id"]]"#));
+    }
+
+    #[test]
+    fn test_metadata_emits_empty_path_for_primitive_child_key() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p key="{{item}}">{{item}}</p></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0],""]]"#));
+    }
+
+    #[test]
+    fn test_metadata_rejects_invalid_first_child_key_path() {
+        let err = super::generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p key="{{item[0]}}">{{item}}</p></for>"#,
+        )
+        .expect_err("invalid explicit key must fail compilation");
+
+        let crate::ParserError::Template(diag) = err else {
+            panic!("expected template diagnostic");
+        };
+        assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+    }
+
+    #[test]
+    fn test_metadata_keeps_data_key_alongside_structural_key() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><p key="{{item.id}}" data-key="{{item.label}}">{{item}}</p></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0],"id"]]"#));
+        assert!(result.contains(r#""a":[["data-key",0,"item.label"]]"#));
+    }
+
+    #[test]
+    fn test_metadata_rejects_key_on_later_repeat_child() {
+        let err = super::generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><span>{{item.name}}</span><p key="{{item.id}}">{{item.name}}</p></for>"#,
+        )
+        .expect_err("key on a later child must fail compilation");
+
+        let crate::ParserError::Template(diag) = err else {
+            panic!("expected template diagnostic");
+        };
+        assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+    }
+
+    #[test]
+    fn test_metadata_rejects_key_outside_repeat() {
+        let err = super::generate_compiled_template(
+            "my-comp",
+            r#"<p key="{{item.id}}">{{item.name}}</p>"#,
+        )
+        .expect_err("key outside a repeat must fail compilation");
+
+        let crate::ParserError::Template(diag) = err else {
+            panic!("expected template diagnostic");
+        };
+        assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+    }
+
+    #[test]
+    fn test_metadata_finds_key_after_leading_comment() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><!-- row --><p key="{{item.id}}">{{item.name}}</p></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0],"id"]]"#));
+        assert!(!result.contains("key="));
     }
 
     #[test]
     fn test_parse_for_block_ignores_open_marker_inside_attr_value() {
         let input =
             r#"<for each="item in items"><div data-note="<for fake>">{{item.name}}</div></for>"#;
-        let (collection, item_var, body, consumed) =
-            parse_for_block(input).expect("for block should parse");
+        let parsed = parse_for_block("my-comp", input)
+            .expect("for block should be valid")
+            .expect("for block should parse");
 
-        assert_eq!(collection, "items");
-        assert_eq!(item_var, "item");
-        assert_eq!(body, r#"<div data-note="<for fake>">{{item.name}}</div>"#);
-        assert_eq!(consumed, input.len());
+        assert_eq!(parsed.collection, "items");
+        assert_eq!(parsed.item_var, "item");
+        assert_eq!(
+            parsed.body,
+            r#"<div data-note="<for fake>">{{item.name}}</div>"#
+        );
+        assert_eq!(parsed.consumed, input.len());
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -532,7 +532,7 @@ impl ConditionFunctionEmitter {
 /// | `:config="{{settings}}"`              | `a[]` + `ag[]`             | element kept marker-free          |
 /// | `<if condition="…">body</if>`         | `c[]` + `cl[]` + `b[]`     | block removed; anchor slot stored |
 /// | `<for each="v in coll">body</for>`    | `r[]` + `rl[]` + `b[]`     | block removed; anchor slot stored |
-/// | first-child `key="{{v.id}}"`          | optional fifth `r[]` field | relative repeat key path stored   |
+/// | first concrete `key="{{v.id}}"`       | optional fifth `r[]` field | relative repeat key path stored   |
 /// | `<link>` / `<style>` child nodes      | `h`                        | preserved in static HTML          |
 /// | module adopted stylesheet specifier   | `sa`                       | stored from `<template>` wrapper  |
 /// | `@event="{handler(e)}"`               | `eg[]`                     | element kept marker-free          |
@@ -542,7 +542,7 @@ impl ConditionFunctionEmitter {
 /// # Errors
 ///
 /// Returns [`crate::ParserError::Template`] if the template contains an invalid
-/// `@event` handler, non-braced `w-ref`, or invalid first-child repeat key.
+/// `@event` handler, non-braced `w-ref`, or invalid concrete-child repeat key.
 pub fn generate_compiled_template(tag_name: &str, html_content: &str) -> Result<String> {
     Ok(generate_compiled_template_with_root_source(
         tag_name,
@@ -2462,6 +2462,23 @@ fn relative_repeat_key<'a>(item_var: &str, key: &'a str) -> Option<&'a str> {
     (!relative.is_empty() && is_valid_event_path(relative)).then_some(relative)
 }
 
+fn skip_repeat_key_trivia<'a>(mut input: &'a str, offset: &mut usize) -> Option<&'a str> {
+    loop {
+        let trimmed = input.trim_start();
+        *offset += input.len().saturating_sub(trimmed.len());
+        input = trimmed;
+        let consumed = if input.starts_with("<!--") {
+            input.find("-->")? + 3
+        } else if input.starts_with("<!") {
+            find_tag_close(input)? + 1
+        } else {
+            return Some(input);
+        };
+        *offset += consumed;
+        input = &input[consumed..];
+    }
+}
+
 fn first_child_repeat_key(
     component: &str,
     item_var: &str,
@@ -2470,51 +2487,50 @@ fn first_child_repeat_key(
     let mut remaining = body;
     let mut offset = 0usize;
     loop {
-        let trimmed = remaining.trim_start();
-        offset += remaining.len().saturating_sub(trimmed.len());
+        let Some(trimmed) = skip_repeat_key_trivia(remaining, &mut offset) else {
+            return Ok(None);
+        };
         remaining = trimmed;
-        if remaining.starts_with("<!--") {
-            let Some(close) = remaining.find("-->") else {
-                return Ok(None);
-            };
-            offset += close + 3;
-            remaining = &remaining[close + 3..];
-            continue;
+        let Some(tag) = parse_tag(remaining) else {
+            return Ok(None);
+        };
+        if tag.closing {
+            return Ok(None);
         }
-        if remaining.starts_with("<!") {
-            let Some(close) = find_tag_close(remaining) else {
-                return Ok(None);
-            };
-            offset += close + 1;
-            remaining = &remaining[close + 1..];
-            continue;
+        let mut key_attr = None;
+        for attr in tag.attrs() {
+            if attr.name != "key" {
+                continue;
+            }
+            if key_attr.is_some() {
+                return Err(invalid_repeat_key_placement(component, tag.name).into());
+            }
+            key_attr = Some(attr);
         }
-        break;
-    }
-    let Some(tag) = parse_tag(remaining) else {
-        return Ok(None);
-    };
-    if tag.closing {
-        return Ok(None);
-    }
-    let mut key_attr = None;
-    for attr in tag.attrs() {
-        if attr.name != "key" {
-            continue;
-        }
-        if key_attr.is_some() {
+        if matches!(tag.name, "if" | "for" | "outlet") && key_attr.is_some() {
             return Err(invalid_repeat_key_placement(component, tag.name).into());
         }
-        key_attr = Some(attr);
+        if tag.name == "if" {
+            let body_start = tag.close + 1;
+            let Some(body_end) = find_matching_block_end(remaining, "if") else {
+                return Ok(None);
+            };
+            offset += body_start;
+            remaining = &remaining[body_start..body_end];
+            continue;
+        }
+        if matches!(tag.name, "for" | "outlet") {
+            return Ok(None);
+        }
+        let Some(attr) = key_attr else {
+            return Ok(None);
+        };
+        let path = parse_repeat_key(component, item_var, attr.value.unwrap_or_default())?;
+        return Ok(Some(ParsedRepeatKey {
+            path,
+            attr_range: (offset + attr.raw_range.start)..(offset + attr.raw_range.end),
+        }));
     }
-    let Some(attr) = key_attr else {
-        return Ok(None);
-    };
-    let path = parse_repeat_key(component, item_var, attr.value.unwrap_or_default())?;
-    Ok(Some(ParsedRepeatKey {
-        path,
-        attr_range: (offset + attr.raw_range.start)..(offset + attr.raw_range.end),
-    }))
 }
 
 fn parse_repeat_key(component: &str, item_var: &str, raw: &str) -> Result<String> {
@@ -2541,7 +2557,7 @@ fn invalid_repeat_key(component: &str, item_var: &str, key: &str) -> Diagnostic 
         .component(component)
         .snippet(key)
         .help(format!(
-            "use key=\"{{{{{item_var}}}}}\" or key=\"{{{{{item_var}.id}}}}\" on the first child of <for>"
+            "use key=\"{{{{{item_var}}}}}\" or key=\"{{{{{item_var}.id}}}}\" on the first concrete element inside <for>"
         ))
 }
 
@@ -2553,7 +2569,9 @@ fn invalid_repeat_key_placement(component: &str, element: &str) -> Diagnostic {
         .component(component)
         .element(element)
         .snippet("key")
-        .help("use key=\"{{item.id}}\" only on the first child of <for>")
+        .help(
+            "place key=\"{{item.id}}\" on the first concrete element rendered by <for>, not on <if>, <for>, or <outlet>",
+        )
 }
 
 /// Build a [`Diagnostic`] for an invalid `@event` handler.
@@ -3448,6 +3466,46 @@ mod tests {
         assert!(result.contains(r#""r":[["items","item",0,[[],0],"id"]]"#));
         assert!(!result.contains("key="));
         assert!(!result.contains(r#""a":[["key","#));
+    }
+
+    #[test]
+    fn test_metadata_emits_key_from_first_element_inside_if() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items"><if condition="item.visible"><span key="{{item.id}}">{{item.name}}</span></if></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["items","item",0,[[],0],"id"]]"#));
+        assert!(!result.contains("key="));
+    }
+
+    #[test]
+    fn test_metadata_rejects_key_on_repeat_child_directive() {
+        let templates = [
+            r#"<for each="item in items"><if key="{{item.id}}" condition="item.visible"><span>{{item.name}}</span></if></for>"#,
+            r#"<for each="item in items"><for key="{{item.id}}" each="child in item.children"><span>{{child}}</span></for></for>"#,
+            r#"<for each="item in items"><outlet key="{{item.id}}" /></for>"#,
+        ];
+
+        for template in templates {
+            let err = super::generate_compiled_template("my-comp", template)
+                .expect_err("key on a directive must fail compilation");
+            let crate::ParserError::Template(diag) = err else {
+                panic!("expected template diagnostic");
+            };
+            assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+        }
+    }
+
+    #[test]
+    fn test_metadata_leaves_nested_for_key_with_nested_repeat() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="group in groups"><for each="item in group.items"><span key="{{item.id}}">{{item.name}}</span></for></for>"#,
+        );
+
+        assert!(result.contains(r#""r":[["groups","group",0,[[],0]]]"#));
+        assert!(result.contains(r#""r":[["group.items","item",1,[[],0],"id"]]"#));
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -3509,6 +3509,19 @@ mod tests {
     }
 
     #[test]
+    fn test_metadata_scopes_key_through_nested_for_if_for_chain() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<for each="group in groups"><for each="section in group.sections"><if condition="section.visible"><for each="item in section.items"><span key="{{item.id}}">{{item.name}}</span></for></if></for></for>"#,
+        );
+
+        assert!(result.contains(r#"["groups","group",0,[[],0]]"#));
+        assert!(result.contains(r#"["group.sections","section",1,[[],0]]"#));
+        assert!(result.contains(r#"["section.items","item",3,[[],0],"id"]"#));
+        assert!(!result.contains("key="));
+    }
+
+    #[test]
     fn test_metadata_treats_data_key_as_ordinary_attribute() {
         let result = generate_compiled_template(
             "my-comp",

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -2420,6 +2420,9 @@ fn parse_for_block(component: &str, input: &str) -> Result<Option<ParsedForBlock
     let Some(tag) = parse_tag(input) else {
         return Ok(None);
     };
+    if tag.has_attr("key") {
+        return Err(invalid_repeat_key_placement(component, tag.name).into());
+    }
     let Some(each_val) = tag.attr("each") else {
         return Ok(None);
     };
@@ -2570,7 +2573,7 @@ fn invalid_repeat_key_placement(component: &str, element: &str) -> Diagnostic {
         .element(element)
         .snippet("key")
         .help(
-            "place key=\"{{item.id}}\" on the first concrete element rendered by <for>, not on <if>, <for>, or <outlet>",
+            "place the key attribute on the first concrete element rendered by <for>, not on <if>, <for>, or <outlet>",
         )
 }
 
@@ -3480,6 +3483,20 @@ mod tests {
     }
 
     #[test]
+    fn test_metadata_rejects_key_on_for_directive() {
+        let err = super::generate_compiled_template(
+            "my-comp",
+            r#"<for each="item in items" key="{{item.id}}"><span>{{item.name}}</span></for>"#,
+        )
+        .expect_err("key on <for> must fail compilation");
+
+        let crate::ParserError::Template(diag) = err else {
+            panic!("expected template diagnostic");
+        };
+        assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+    }
+
+    #[test]
     fn test_metadata_rejects_key_on_repeat_child_directive() {
         let templates = [
             r#"<for each="item in items"><if key="{{item.id}}" condition="item.visible"><span>{{item.name}}</span></if></for>"#,
@@ -3583,16 +3600,20 @@ mod tests {
 
     #[test]
     fn test_metadata_rejects_key_outside_repeat() {
-        let err = super::generate_compiled_template(
-            "my-comp",
-            r#"<p key="{{item.id}}">{{item.name}}</p>"#,
-        )
-        .expect_err("key outside a repeat must fail compilation");
+        let err =
+            super::generate_compiled_template("my-comp", r#"<p key="{{row.id}}">{{row.name}}</p>"#)
+                .expect_err("key outside a repeat must fail compilation");
 
         let crate::ParserError::Template(diag) = err else {
             panic!("expected template diagnostic");
         };
         assert_eq!(diag.error_code(), Some(codes::INVALID_FOR_KEY));
+        assert_eq!(
+            diag.help_text(),
+            Some(
+                "place the key attribute on the first concrete element rendered by <for>, not on <if>, <for>, or <outlet>"
+            )
+        );
     }
 
     #[test]

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -166,10 +166,21 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 <for each="item in items">
   <div>{{item.name}} - {{item.price}}</div>
 </for>
+
+<for each="item in reorderableItems">
+  <todo-row key="{{item.id}}" title="{{item.title}}"></todo-row>
+</for>
 ```
 
 - The collection must be a JSON array
 - Nested loops are supported; outer loop variables remain accessible
+- Repeats reconcile by array position by default; item attributes never act as keys
+- Duplicate item values and attributes do not create duplicate DOM
+- Add compiler-only `key="{{item.id}}"` to the first child to preserve logical DOM/component identity across reorder; it is not rendered
+- `data-key` is an ordinary application attribute and does not control repeat identity
+- `key="{{item}}"` supports arrays of unique string or finite-number primitives
+- Key paths must be rooted at the loop variable; invalid paths fail with `invalid-for-key`
+- Duplicate or invalid runtime keys warn once and safely fall back to positions
 - Components inside loops do NOT inherit loop variables. Pass data via attributes:
   ```html
   <for each="contact in contacts">

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -176,7 +176,7 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 - Nested loops are supported; outer loop variables remain accessible
 - Repeats reconcile by array position by default; item attributes never act as keys
 - Duplicate item values and attributes do not create duplicate DOM
-- Add compiler-only `key="{{item.id}}"` to the first child to preserve logical DOM/component identity across reorder; it is not rendered
+- Add compiler-only `key="{{item.id}}"` to the first concrete child to preserve logical DOM/component identity across reorder; leading `<if>` wrappers are transparent, while `key` directly on `<if>`, `<for>`, or `<outlet>` is invalid
 - `data-key` is an ordinary application attribute and does not control repeat identity
 - `key="{{item}}"` supports arrays of unique string or finite-number primitives
 - Key paths must be rooted at the loop variable; invalid paths fail with `invalid-for-key`

--- a/docs/guide/concepts/directives/for.md
+++ b/docs/guide/concepts/directives/for.md
@@ -64,39 +64,61 @@ Where:
 
 ## Repeat Reconciliation
 
-When an `@observable` array changes on the client, the `<for>` block uses
-cursor-based reconciliation (similar to Preact) that minimizes DOM mutations:
+When an `@observable` array changes on the client, the `<for>` block reconciles
+by array position by default. The existing block at index `i` receives the
+current item at index `i`; new tail items are appended and excess tail blocks
+are removed.
 
-| Operation | DOM Cost | Description |
-|-----------|----------|-------------|
-| Append | O(1) | Only the new node is inserted |
-| Prepend | O(1) | Only the new node is inserted; existing nodes untouched |
-| Remove | O(1) | Only the removed node is detached |
-| Reorder | O(moved) | Only nodes that changed position are moved |
+| Collection change | Runtime behavior |
+|-------------------|------------------|
+| Append | Reuse existing blocks and create the new tail |
+| Truncate | Reuse the shared prefix and remove the excess tail |
+| Replace or reorder | Rebind existing blocks at each position |
 
-### Keyed Reconciliation
-
-The first attribute in the repeat block template serves as the key:
+Duplicate values and duplicate attributes are safe. Dynamic attributes never
+act as hidden keys, so changing their order cannot change reconciliation.
 
 ```html
-<for each="item in items">
-  <todo-item id="{{item.id}}" title="{{item.title}}"></todo-item>
+<for each="tag in tags">
+  <span class="{{tag.className}}">{{tag.label}}</span>
 </for>
 ```
 
-Here, `item.id` (from the `id` attribute) is used as the key. Keyed
-reconciliation correctly handles reordering, insertion, and removal.
+Because identity is positional, reordering items does not move their existing
+subtrees by logical item. Browser-owned state such as focus or an uncontrolled
+input value remains associated with its position.
 
-### Unkeyed Reconciliation
+### Explicit keys
 
-Without a key attribute, items are matched by index. This is suitable for
-append-only lists but not for reordering or arbitrary insertion.
+Use an explicit key when reordered, prepended, or removed items must retain
+their existing DOM and component-local state:
 
-### Key Collision Warning
+```html
+<for each="item in items">
+  <todo-row key="{{item.id}}" title="{{item.title}}"></todo-row>
+</for>
+```
 
-Repeat item keys must be unique across the entire collection. If the server
-generates items 1–1000 and the client starts at id=1000, keys collide and
-the diff recreates all items - causing a visible flash.
+For an array of unique strings or finite numbers, key the item itself:
 
-**Best practice:** Use server-provided `nextId` in the state, UUIDs, or
-start client IDs at `max(server_ids) + 1`.
+```html
+<for each="tag in tags">
+  <span key="{{tag}}">{{tag}}</span>
+</for>
+```
+
+The `key` attribute must be on the first child inside `<for>`. Its value must
+be a single binding to the loop variable or a dot-separated property path
+rooted at it. Calls, brackets, operators, static values, empty paths, and
+unrelated variables fail the build with `invalid-for-key`. A `key` on another
+regular element produces the same diagnostic. Attributes on directives remain
+governed by each directive's own contract and do not provide repeat identity.
+
+`key` is compiler-only metadata: it does not render into SSR or browser-created
+HTML and does not become a reactive attribute binding. `data-key` remains a
+normal application-visible attribute and does not control repeat identity.
+
+Key values must be unique strings or finite numbers. If an update produces a
+duplicate or invalid value, WebUI warns once and safely uses positional
+reconciliation for that update. A later valid update re-establishes keyed
+identity.

--- a/docs/guide/concepts/directives/for.md
+++ b/docs/guide/concepts/directives/for.md
@@ -107,12 +107,16 @@ For an array of unique strings or finite numbers, key the item itself:
 </for>
 ```
 
-The `key` attribute must be on the first child inside `<for>`. Its value must
-be a single binding to the loop variable or a dot-separated property path
-rooted at it. Calls, brackets, operators, static values, empty paths, and
-unrelated variables fail the build with `invalid-for-key`. A `key` on another
-regular element produces the same diagnostic. Attributes on directives remain
-governed by each directive's own contract and do not provide repeat identity.
+The `key` attribute must be on the first concrete element inside `<for>`. If
+that element is wrapped by one or more leading `<if>` directives, put `key` on
+the concrete element inside the conditional. A nested `<for>` owns its own
+child key. Putting `key` directly on `<if>`, `<for>`, or `<outlet>` fails with
+`invalid-for-key`.
+
+The value must be a single binding to the loop variable or a dot-separated
+property path rooted at it. Calls, brackets, operators, static values, empty
+paths, unrelated variables, and `key` on another regular element fail with the
+same diagnostic.
 
 `key` is compiler-only metadata: it does not render into SSR or browser-created
 HTML and does not become a reactive attribute binding. `data-key` remains a

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -139,7 +139,7 @@ function TodoList({ items }) {
 ```html
 <ul>
   <for each="item in items">
-    <li>
+    <li key="{{item.id}}">
       <span>{{item.title}}</span>
       <span class="status {{item.state}}">{{item.state}}</span>
     </li>
@@ -150,7 +150,12 @@ function TodoList({ items }) {
 </div>
 </code-comparison>
 
-**What changed:** `Array.map()` with JSX becomes a declarative `<for>` directive. The `key` prop is replaced by the first attribute on the repeated element. This runs on the server and produces static HTML - no JavaScript array iteration in the browser.
+**What changed:** `Array.map()` with JSX becomes a declarative `<for>`
+directive. Like React, reorderable lists can declare stable identity by placing
+the compiler-only `key` attribute on the first repeated child. Simple loops may
+omit it and reconcile by position. `data-key` and other attributes never act as
+implicit keys. This runs on the server and produces static HTML - no JavaScript
+array iteration in the browser.
 
 ## Event Handling
 

--- a/docs/guide/concepts/react-comparison.md
+++ b/docs/guide/concepts/react-comparison.md
@@ -152,10 +152,11 @@ function TodoList({ items }) {
 
 **What changed:** `Array.map()` with JSX becomes a declarative `<for>`
 directive. Like React, reorderable lists can declare stable identity by placing
-the compiler-only `key` attribute on the first repeated child. Simple loops may
-omit it and reconcile by position. `data-key` and other attributes never act as
-implicit keys. This runs on the server and produces static HTML - no JavaScript
-array iteration in the browser.
+the compiler-only `key` attribute on the first concrete repeated child. Leading
+`<if>` wrappers are transparent, but directives cannot carry the key. Simple
+loops may omit it and reconcile by position. `data-key` and other attributes
+never act as implicit keys. This runs on the server and produces static HTML -
+no JavaScript array iteration in the browser.
 
 ## Event Handling
 

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -459,7 +459,7 @@ flowchart LR
 graph TD
     EL["element.ts (~850 lines)<br/><i>Orchestrator</i><br/>$mount, $wire, $hydrate,<br/>$resolveSSR, $applySSRState,<br/>$update, events, cleanup"]
 
-    DIFF["element/diff.ts (~130 lines)<br/><i>List Reconciliation</i><br/>keyed/sequential diffing<br/>for @for repeat blocks"]
+    DIFF["element/diff.ts<br/><i>List Reconciliation</i><br/>positional + explicit-key diffing<br/>for &lt;for&gt; repeat blocks"]
 
     COND["element/conditions.ts<br/><i>Condition Evaluation</i><br/>evaluateCondition (iterative),<br/>conditionUsesPath"]
 
@@ -687,38 +687,24 @@ conditions, and repeats.
 
 ## Repeat Reconciliation
 
-`@for(item of items)` blocks support two reconciliation strategies,
-implemented in `element/diff.ts` (~130 lines):
+`<for>` blocks reconcile by array position by default. The existing block at
+index `i` receives the current item at index `i`; only a new or removed tail
+creates or removes blocks.
 
-### Keyed Reconciliation
+Duplicate values and attributes are safe because dynamic attributes never act
+as hidden keys. Reordering rebinds existing blocks in place, so local
+browser-owned or component state remains associated with positions rather than
+logical items.
 
-When the repeat block's root element has attribute bindings (e.g.
-`<todo-item id="{{item.id}}">`), the framework uses the first attribute as a
-key.  This preserves DOM nodes across reorders:
-
-```mermaid
-flowchart TD
-    subgraph Before ["Before: items = [A, B, C]"]
-        A1["&lt;todo-item&gt; key=A"]
-        B1["&lt;todo-item&gt; key=B"]
-        C1["&lt;todo-item&gt; key=C"]
-    end
-
-    subgraph After ["After: items = [C, A]"]
-        C2["&lt;todo-item&gt; key=C ← reused"]
-        A2["&lt;todo-item&gt; key=A ← reused"]
-        B2["key=B ← removed"]
-    end
-
-    A1 -.->|"moved"| A2
-    C1 -.->|"moved"| C2
-    B1 -.->|"destroyed"| B2
-```
-
-### Sequential Reconciliation
-
-When no keying attributes exist, items are matched by position.  Excess items
-are removed; new items are appended.
+For reorderable or stateful lists, author `key="{{item.id}}"` on the first
+child inside `<for>` to move existing blocks with their logical items.
+`key="{{item}}"` supports arrays of unique string or finite-number primitives.
+`key` is compiler-only metadata and is removed from SSR and client HTML;
+`data-key` remains an ordinary attribute with no identity semantics. Key paths
+are compiler-validated and stored only for explicitly keyed repeats, so
+unkeyed bindings carry no key state or map allocation. Duplicate or invalid
+runtime keys warn once, clear identity, and use positional reconciliation until
+valid identity is re-established.
 
 ### SSR State Reading
 
@@ -792,7 +778,7 @@ This template-parallel traversal eliminates the need for any marker comments,
 | Initial hydration | O(bindings) | Single pass over compiled path mappings |
 | Reactive update | O(affected) | Per-path index skips unrelated bindings |
 | Conditional toggle | O(block size) | Create/destroy a block instance |
-| Repeat reconciliation | O(items) | Keyed map lookup or sequential scan |
+| Repeat reconciliation | O(items) | Positional scan; explicit keys use a reusable map only when order changes |
 | Event wiring | O(events) | One-time during hydration |
 
 ### What the framework does NOT do

--- a/packages/webui-framework/RENDERING.md
+++ b/packages/webui-framework/RENDERING.md
@@ -280,21 +280,38 @@ Synchronous escape hatch. Call it when you need the DOM to reflect pending write
 
 Implemented in `src/element/diff.ts`.
 
-### Keyed mode
+### Positional mode (default)
 
-When the repeat block's root element has at least one attribute binding (e.g. `<todo-item id="{{item.id}}">`), the **first attribute** is treated as the key. On collection change:
+Every repeat matches items by array index:
 
-1. Build a `Map<key, existingInstance>` from current items.
-2. Walk the new collection in order. For each new item:
-   - If a matching key exists, reuse the existing DOM and move it into position.
-   - Otherwise, create a new instance from the block template.
-3. Anything left in the map after the walk is destroyed.
+1. Rebind the shared prefix of existing instances to the current items.
+2. Append instances for any new tail.
+3. Destroy instances in any excess old tail.
 
-Reused instances keep their event listeners, computed state, and any focus/scroll/selection state in their DOM.
+Repeated-root attributes are never inferred as keys. Duplicate values and
+attributes are therefore safe, and attribute order has no effect on identity.
+On reorder, reused instances keep local browser and component state at their
+positions while bindings update to the new positional items.
 
-### Sequential mode
+### Explicit-key mode
 
-When the repeat root has no attribute bindings, items are matched by index. Excess items are destroyed; new items are appended. Cheaper but loses identity on reorder.
+`<for each="item in items"><x key="{{item.id}}"></x></for>` compiles the
+relative path `id` from the first child as an optional fifth repeat metadata
+field. `key="{{item}}"` compiles an empty path and keys primitive items
+directly. `key` is compiler-only: it is omitted from SSR HTML, client `h`, and
+attribute metadata. `data-key` is an ordinary application attribute and has no
+identity semantics. Unkeyed repeat bindings do not allocate key state.
+
+Explicit keys must resolve to unique strings or finite numbers. The runtime
+validates the complete next key set before changing DOM, scopes, or instances.
+Stable order, append, and truncate use the positional/prefix fast path. A real
+order change fills one reusable map from old keys to instances, reorders the
+instances, and then clears the map and scratch arrays.
+
+Duplicate, invalid, or throwing key reads clear established identity, warn
+once, and use positional reconciliation. A later valid update first reconciles
+positionally and establishes fresh identity; subsequent updates can move by
+key.
 
 ### SSR repeat reading
 
@@ -307,6 +324,14 @@ frame remains unknown and its SSR bindings are preserved during unrelated
 updates. A later explicit collection reconciles the repeat normally; an
 explicit empty collection removes the SSR items. The `<!--wi-->` markers are
 then collected for deletion.
+
+SSR item markers do not contain separate key values. When bootstrap collection
+state exists and its length matches the hydrated instance count, hydration
+derives typed keys by index from that collection. Missing state, a count
+mismatch, or invalid keys leave identity unestablished, so the next valid
+update reconciles positionally once before establishing fresh keys. This uses
+the same invariant as repeat scope hydration: SSR HTML and bootstrap state
+represent the same render.
 
 ---
 
@@ -393,8 +418,7 @@ The `webui:hydration-complete` event fires once after the last component on the 
 | Initial hydration | O(bindings) | Single pass over compiled paths |
 | Reactive update | O(affected) | Path index skips unrelated bindings |
 | Conditional toggle | O(block size) | Create or destroy a block instance |
-| Repeat reconciliation (keyed) | O(items) | Map lookup per item, in-place moves |
-| Repeat reconciliation (sequential) | O(items) | Linear scan, append/remove tail |
+| Repeat reconciliation | O(items) | Positional scan; keyed map only for changed explicit-key order |
 | Event wiring | O(events) | One-time during hydration |
 
 ### What the framework does NOT do
@@ -417,7 +441,7 @@ src/
 ├── element/
 │   ├── markers.ts              Marker constants, collectItemMarkers,
 │   │                           findByOrdinal (block-skipping ordinal walk)
-│   ├── diff.ts                 syncRepeat: keyed + sequential reconciliation
+│   ├── diff.ts                 syncRepeat: positional + explicit-key reconciliation
 │   ├── styles.ts               injectModuleStyle (adopted CSS modules)
 │   └── types.ts                AttrBinding, CondBinding, RepeatBinding,
 │                               TextBinding, ScopeFrame, TemplateInstance
@@ -454,6 +478,6 @@ Everything else is internal and may change without notice.
 ## Where to look next
 
 - `examples/app/todo-webui` — minimal SSR + interactivity example
-- `examples/app/contact-book-manager` — repeat blocks, keyed reconciliation
+- `examples/app/contact-book-manager` — repeat block reconciliation
 - `examples/app/commerce` — larger composition, multiple components per page
 - [Interactivity guide](https://microsoft.github.io/webui/guide/concepts/interactivity) — component-author view of the same machinery

--- a/packages/webui-framework/src/element/diff.test.ts
+++ b/packages/webui-framework/src/element/diff.test.ts
@@ -4,7 +4,18 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
 
-import { dotWalk } from './diff.js';
+import {
+  createRepeatKeyState,
+  dotWalk,
+  seedHydratedRepeatKeys,
+  syncRepeat,
+} from './diff.js';
+import type {
+  RepeatBinding,
+  RepeatHost,
+  ScopeFrame,
+  TemplateInstance,
+} from './types.js';
 
 describe('dotWalk (allocation-free dotted path)', () => {
   test('resolves a single-segment path', () => {
@@ -31,5 +42,336 @@ describe('dotWalk (allocation-free dotted path)', () => {
   test('walks from a start offset (skips the scope-var prefix)', () => {
     // Simulates resolving `item.name` against the `item` scope variable.
     assert.equal(dotWalk({ name: 'A' }, 'item.name', 5), 'A');
+  });
+});
+
+function emptyInstance(): TemplateInstance {
+  return {
+    container: null,
+    nodes: [],
+    texts: [],
+    attrs: [],
+    conds: [],
+    repeats: [],
+  };
+}
+
+function itemInstance(value: unknown): TemplateInstance {
+  const instance = emptyInstance();
+  instance.scope = { name: 'item', value, known: true };
+  return instance;
+}
+
+function repeatHost(
+  items: unknown[],
+  created: TemplateInstance[],
+  updated: TemplateInstance[],
+  removed: TemplateInstance[],
+  inserted: TemplateInstance[],
+): RepeatHost {
+  return {
+    $resolveValue: () => items,
+    $hasStateRoot: () => true,
+    $createBlockInstance: (
+      _blockIndex: number,
+      scope?: ScopeFrame,
+      parent?: TemplateInstance,
+      _container?: ParentNode & Node,
+    ) => {
+      const instance = emptyInstance();
+      instance.scope = scope;
+      instance.parent = parent;
+      created.push(instance);
+      return instance;
+    },
+    $updateInstance: (instance: TemplateInstance) => {
+      updated.push(instance);
+    },
+    $removeInstance: (instance: TemplateInstance) => {
+      removed.push(instance);
+    },
+    $compactInstanceNodes: () => {},
+    $invalidatePathIndex: () => {},
+    $insertInstanceAfter: (
+      cursor: Node | null,
+      _container: ParentNode & Node,
+      instance: TemplateInstance,
+    ) => {
+      inserted.push(instance);
+      return cursor;
+    },
+  };
+}
+
+function repeatBinding(
+  items: unknown[],
+  instances: TemplateInstance[],
+): RepeatBinding {
+  return {
+    markerId: 0,
+    collection: 'items',
+    itemVar: 'item',
+    blockIndex: 0,
+    container: { childNodes: [] } as unknown as ParentNode & Node,
+    start: null,
+    end: null,
+    owner: emptyInstance(),
+    instances: items.map((_value, index) => instances[index]),
+    synced: true,
+  };
+}
+
+function keyedRepeatBinding(
+  items: unknown[],
+  instances: TemplateInstance[],
+  path: string,
+  keys: Array<string | number>,
+): RepeatBinding {
+  const repeat = repeatBinding(items, instances);
+  const keyState = createRepeatKeyState(path);
+  keyState.established = true;
+  keyState.keys = keys;
+  repeat.keyState = keyState;
+  return repeat;
+}
+
+describe('syncRepeat', () => {
+  test('reuses entries by position when item attributes are duplicated', () => {
+    const oldItems = [
+      { label: 'one', className: 'same' },
+      { label: 'two', className: 'same' },
+      { label: 'three', className: 'same' },
+    ];
+    const newItems = [
+      { label: 'updated-one', className: 'same' },
+      { label: 'updated-two', className: 'same' },
+    ];
+    const oldInstances = oldItems.map(itemInstance);
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = repeatBinding(oldItems, oldInstances);
+    const host = repeatHost(
+      newItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+
+    syncRepeat(host, repeat);
+
+    assert.deepEqual(created, []);
+    assert.deepEqual(updated, oldInstances.slice(0, 2));
+    assert.deepEqual(removed, [oldInstances[2]]);
+    assert.deepEqual(inserted, oldInstances.slice(0, 2));
+    assert.equal(repeat.instances.length, 2);
+    assert.equal(repeat.instances[0], oldInstances[0]);
+    assert.equal(repeat.instances[1], oldInstances[1]);
+    assert.equal(oldInstances[0].scope?.value, newItems[0]);
+    assert.equal(oldInstances[1].scope?.value, newItems[1]);
+  });
+
+  test('appends only the new positional tail', () => {
+    const firstItem = { label: 'one' };
+    const firstInstance = itemInstance(firstItem);
+    const newItems = [firstItem, { label: 'two' }, { label: 'three' }];
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = repeatBinding([firstItem], [firstInstance]);
+    const host = repeatHost(
+      newItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+
+    syncRepeat(host, repeat);
+
+    assert.deepEqual(updated, [firstInstance]);
+    assert.deepEqual(removed, []);
+    assert.equal(repeat.instances.length, 3);
+    assert.equal(repeat.instances[0], firstInstance);
+    assert.deepEqual(repeat.instances.slice(1), created);
+    assert.deepEqual(inserted, repeat.instances);
+    assert.equal(created[0].scope?.value, newItems[1]);
+    assert.equal(created[1].scope?.value, newItems[2]);
+  });
+
+  test('moves established explicit keys with their instances', () => {
+    const oldItems = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const newItems = [{ id: 3 }, { id: 1 }, { id: 2 }];
+    const oldInstances = oldItems.map(itemInstance);
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = keyedRepeatBinding(oldItems, oldInstances, 'id', [1, 2, 3]);
+    const host = repeatHost(
+      newItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+
+    syncRepeat(host, repeat);
+
+    assert.deepEqual(repeat.instances, [
+      oldInstances[2],
+      oldInstances[0],
+      oldInstances[1],
+    ]);
+    assert.deepEqual(inserted, repeat.instances);
+    assert.deepEqual(updated, repeat.instances);
+    assert.deepEqual(created, []);
+    assert.deepEqual(removed, []);
+    assert.deepEqual(repeat.keyState?.keys, [3, 1, 2]);
+    assert.equal(oldInstances[2].scope?.value, newItems[0]);
+  });
+
+  test('uses the positional fast path when explicit key order is stable', () => {
+    const oldItems = [{ id: 'a', label: 'old' }, { id: 'b', label: 'old' }];
+    const newItems = [{ id: 'a', label: 'new' }, { id: 'b', label: 'new' }];
+    const oldInstances = oldItems.map(itemInstance);
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = keyedRepeatBinding(
+      oldItems,
+      oldInstances,
+      'id',
+      ['a', 'b'],
+    );
+    const scratch = repeat.keyState?.nextInstances;
+    const host = repeatHost(
+      newItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+
+    syncRepeat(host, repeat);
+
+    assert.deepEqual(repeat.instances, oldInstances);
+    assert.deepEqual(updated, oldInstances);
+    assert.deepEqual(created, []);
+    assert.deepEqual(removed, []);
+    assert.equal(repeat.keyState?.nextInstances, scratch);
+  });
+
+  test('reuses surviving keys and replaces removed keys', () => {
+    const oldItems = [{ id: 1 }, { id: 2 }];
+    const newItems = [{ id: 1 }, { id: 3 }];
+    const oldInstances = oldItems.map(itemInstance);
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = keyedRepeatBinding(oldItems, oldInstances, 'id', [1, 2]);
+    const host = repeatHost(
+      newItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+
+    syncRepeat(host, repeat);
+
+    assert.equal(repeat.instances[0], oldInstances[0]);
+    assert.equal(repeat.instances[1], created[0]);
+    assert.deepEqual(updated, [oldInstances[0]]);
+    assert.deepEqual(removed, [oldInstances[1]]);
+    assert.deepEqual(repeat.keyState?.keys, [1, 3]);
+  });
+
+  test('falls back safely on duplicate keys and re-establishes identity', () => {
+    const oldItems = [{ id: 1 }, { id: 2 }];
+    const duplicateItems = [{ id: 3 }, { id: 3 }];
+    const oldInstances = oldItems.map(itemInstance);
+    const created: TemplateInstance[] = [];
+    const updated: TemplateInstance[] = [];
+    const removed: TemplateInstance[] = [];
+    const inserted: TemplateInstance[] = [];
+    const repeat = keyedRepeatBinding(oldItems, oldInstances, 'id', [1, 2]);
+    let currentItems = duplicateItems;
+    const host = repeatHost(
+      currentItems,
+      created,
+      updated,
+      removed,
+      inserted,
+    );
+    host.$resolveValue = () => currentItems;
+    const originalWarn = console.warn;
+    let warningCount = 0;
+    console.warn = () => {
+      warningCount += 1;
+    };
+
+    try {
+      syncRepeat(host, repeat);
+      assert.deepEqual(repeat.instances, oldInstances);
+      assert.equal(repeat.keyState?.established, false);
+      assert.deepEqual(repeat.keyState?.keys, []);
+      assert.equal(warningCount, 1);
+
+      currentItems = [{ id: 4 }, { id: 5 }];
+      syncRepeat(host, repeat);
+      assert.equal(repeat.keyState?.established, true);
+      assert.deepEqual(repeat.keyState?.keys, [4, 5]);
+
+      currentItems = [{ id: 5 }, { id: 4 }];
+      updated.length = 0;
+      syncRepeat(host, repeat);
+      assert.deepEqual(repeat.instances, [oldInstances[1], oldInstances[0]]);
+      assert.equal(warningCount, 1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('supports primitive item keys without a property path', () => {
+    const oldItems = ['a', 'b'];
+    const newItems = ['b', 'a'];
+    const oldInstances = oldItems.map(itemInstance);
+    const repeat = keyedRepeatBinding(oldItems, oldInstances, '', oldItems);
+    const host = repeatHost(newItems, [], [], [], []);
+
+    syncRepeat(host, repeat);
+
+    assert.deepEqual(repeat.instances, [oldInstances[1], oldInstances[0]]);
+    assert.deepEqual(repeat.keyState?.keys, newItems);
+  });
+
+  test('seeds SSR identity from bootstrap collection order', () => {
+    const items = [{ id: 1 }, { id: 2 }];
+    const instances = items.map(itemInstance);
+    const repeat = repeatBinding(items, instances);
+    repeat.keyState = createRepeatKeyState('id');
+
+    seedHydratedRepeatKeys(repeat, items);
+
+    assert.equal(repeat.keyState.established, true);
+    assert.deepEqual(repeat.keyState.keys, [1, 2]);
+  });
+
+  test('does not seed SSR identity when marker and data counts disagree', () => {
+    const items = [{ id: 1 }, { id: 2 }];
+    const instances = [itemInstance(items[0])];
+    const repeat = repeatBinding(items.slice(0, 1), instances);
+    repeat.keyState = createRepeatKeyState('id');
+
+    seedHydratedRepeatKeys(repeat, items);
+
+    assert.equal(repeat.keyState.established, false);
+    assert.deepEqual(repeat.keyState.keys, []);
   });
 });

--- a/packages/webui-framework/src/element/diff.test.ts
+++ b/packages/webui-framework/src/element/diff.test.ts
@@ -90,8 +90,7 @@ function repeatHost(
     $removeInstance: (instance: TemplateInstance) => {
       removed.push(instance);
     },
-    $compactInstanceNodes: () => {},
-    $invalidatePathIndex: () => {},
+    $changeStructure: () => {},
     $insertInstanceAfter: (
       cursor: Node | null,
       _container: ParentNode & Node,
@@ -129,7 +128,6 @@ function keyedRepeatBinding(
 ): RepeatBinding {
   const repeat = repeatBinding(items, instances);
   const keyState = createRepeatKeyState(path);
-  keyState.established = true;
   keyState.keys = keys;
   repeat.keyState = keyState;
   return repeat;
@@ -248,7 +246,7 @@ describe('syncRepeat', () => {
       'id',
       ['a', 'b'],
     );
-    const scratch = repeat.keyState?.nextInstances;
+    const instances = repeat.instances;
     const host = repeatHost(
       newItems,
       created,
@@ -263,7 +261,7 @@ describe('syncRepeat', () => {
     assert.deepEqual(updated, oldInstances);
     assert.deepEqual(created, []);
     assert.deepEqual(removed, []);
-    assert.equal(repeat.keyState?.nextInstances, scratch);
+    assert.equal(repeat.instances, instances);
   });
 
   test('reuses surviving keys and replaces removed keys', () => {
@@ -319,13 +317,11 @@ describe('syncRepeat', () => {
     try {
       syncRepeat(host, repeat);
       assert.deepEqual(repeat.instances, oldInstances);
-      assert.equal(repeat.keyState?.established, false);
       assert.deepEqual(repeat.keyState?.keys, []);
       assert.equal(warningCount, 1);
 
       currentItems = [{ id: 4 }, { id: 5 }];
       syncRepeat(host, repeat);
-      assert.equal(repeat.keyState?.established, true);
       assert.deepEqual(repeat.keyState?.keys, [4, 5]);
 
       currentItems = [{ id: 5 }, { id: 4 }];
@@ -359,7 +355,6 @@ describe('syncRepeat', () => {
 
     seedHydratedRepeatKeys(repeat, items);
 
-    assert.equal(repeat.keyState.established, true);
     assert.deepEqual(repeat.keyState.keys, [1, 2]);
   });
 
@@ -371,7 +366,6 @@ describe('syncRepeat', () => {
 
     seedHydratedRepeatKeys(repeat, items);
 
-    assert.equal(repeat.keyState.established, false);
     assert.deepEqual(repeat.keyState.keys, []);
   });
 });

--- a/packages/webui-framework/src/element/diff.ts
+++ b/packages/webui-framework/src/element/diff.ts
@@ -1,18 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/**
- * Keyed child reconciliation for `@for(item of items)` repeat blocks.
- *
- * Diff that matches old instances by key, reuses what it
- * can, creates/removes the rest, then reorders DOM nodes in one forward pass.
- */
+/** Positional and explicit-key reconciliation for `<for>` repeat blocks. */
 
 import type {
   RepeatBinding,
   RepeatHost,
-  RepeatItemInstance,
+  RepeatKey,
+  RepeatKeyState,
   ScopeFrame,
+  TemplateInstance,
 } from './types.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -35,16 +32,279 @@ export function dotWalk(cursor: unknown, path: string, from: number): unknown {
   return cursor;
 }
 
-/** Compute a key for an item using the cached key path, or null. */
-function itemKey(item: unknown, keyPath: string | undefined): string | null {
-  if (keyPath === undefined || keyPath === '') return null;
-  const v = dotWalk(item, keyPath, 0);
-  return v != null ? String(v) : '';
-}
-
 /** Build a scope frame for a repeat item. */
 function itemScope(rep: RepeatBinding, item: unknown): ScopeFrame {
   return { name: rep.itemVar, value: item, parent: rep.scope, known: true };
+}
+
+/** Allocate keyed scratch state only for explicitly keyed repeats. */
+export function createRepeatKeyState(path: string): RepeatKeyState {
+  return {
+    path,
+    established: false,
+    warned: false,
+    keys: [],
+    nextKeys: [],
+    nextInstances: [],
+    map: new Map(),
+  };
+}
+
+/** Establish keyed identity from the bootstrap collection that produced SSR. */
+export function seedHydratedRepeatKeys(
+  rep: RepeatBinding,
+  items: unknown[],
+): void {
+  const state = rep.keyState;
+  if (!state || items.length !== rep.instances.length) return;
+  if (!collectRepeatKeys(items, state)) return;
+  commitKeyIdentity(state);
+}
+
+function setItemScope(instance: TemplateInstance, item: unknown): void {
+  if (!instance.scope) return;
+  instance.scope.value = item;
+  instance.scope.known = true;
+}
+
+function syncPositional(
+  host: RepeatHost,
+  rep: RepeatBinding,
+  items: unknown[],
+  container: ParentNode & Node,
+): void {
+  const instances = rep.instances;
+  const oldLength = instances.length;
+  const reuseCount = Math.min(oldLength, items.length);
+  let nextCount = reuseCount;
+  let created = false;
+
+  for (let i = 0; i < reuseCount; i += 1) {
+    setItemScope(instances[i], items[i]);
+  }
+  for (let i = reuseCount; i < items.length; i += 1) {
+    const instance = host.$createBlockInstance(
+      rep.blockIndex,
+      itemScope(rep, items[i]),
+      rep.owner,
+      container,
+    );
+    if (instance) {
+      instances[nextCount] = instance;
+      nextCount += 1;
+      created = true;
+    }
+  }
+  for (let i = reuseCount; i < oldLength; i += 1) {
+    host.$removeInstance(instances[i]);
+  }
+  instances.length = nextCount;
+  const removed = oldLength > reuseCount;
+  if (removed) host.$compactInstanceNodes(rep.owner);
+
+  let cursor: Node | null = rep.start;
+  for (let i = 0; i < instances.length; i += 1) {
+    cursor = host.$insertInstanceAfter(cursor, container, instances[i]);
+  }
+  for (let i = 0; i < reuseCount; i += 1) {
+    host.$updateInstance(instances[i]);
+  }
+  if (created || removed) host.$invalidatePathIndex();
+}
+
+function readRepeatKey(item: unknown, path: string): unknown {
+  if (path.length === 0) return item;
+  return dotWalk(item, path, 0);
+}
+
+function isRepeatKey(value: unknown): value is RepeatKey {
+  return (
+    typeof value === 'string' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  );
+}
+
+function collectRepeatKeys(items: unknown[], state: RepeatKeyState): boolean {
+  const keys = state.nextKeys;
+  const seen = state.map;
+  keys.length = items.length;
+  seen.clear();
+
+  for (let i = 0; i < items.length; i += 1) {
+    let value: unknown;
+    try {
+      value = readRepeatKey(items[i], state.path);
+    } catch {
+      keys.length = 0;
+      seen.clear();
+      return false;
+    }
+    if (!isRepeatKey(value) || seen.has(value)) {
+      keys.length = 0;
+      seen.clear();
+      return false;
+    }
+    keys[i] = value;
+    seen.set(value, undefined);
+  }
+  seen.clear();
+  return true;
+}
+
+function keysShareOrder(current: RepeatKey[], next: RepeatKey[]): boolean {
+  const sharedLength = Math.min(current.length, next.length);
+  for (let i = 0; i < sharedLength; i += 1) {
+    if (current[i] !== next[i]) return false;
+  }
+  return true;
+}
+
+function commitKeyIdentity(state: RepeatKeyState): void {
+  const oldKeys = state.keys;
+  state.keys = state.nextKeys;
+  state.nextKeys = oldKeys;
+  state.nextKeys.length = 0;
+  state.established = true;
+}
+
+function clearKeyIdentity(state: RepeatKeyState): void {
+  state.established = false;
+  state.keys.length = 0;
+  state.nextKeys.length = 0;
+  state.nextInstances.length = 0;
+  state.map.clear();
+}
+
+function warnKeyFallback(rep: RepeatBinding, state: RepeatKeyState): void {
+  if (state.warned) return;
+  state.warned = true;
+  const key = state.path.length === 0
+    ? rep.itemVar
+    : `${rep.itemVar}.${state.path}`;
+  console.warn(
+    `[webui] repeat "${rep.collection}" produced duplicate or invalid values for child key="${key}"; using positional reconciliation`,
+  );
+}
+
+function buildOldKeyMap(
+  state: RepeatKeyState,
+  instances: TemplateInstance[],
+): boolean {
+  const map = state.map;
+  map.clear();
+  for (let i = 0; i < state.keys.length; i += 1) {
+    const key = state.keys[i];
+    if (map.has(key)) {
+      map.clear();
+      return false;
+    }
+    map.set(key, instances[i]);
+  }
+  return true;
+}
+
+function reconcileByKey(
+  host: RepeatHost,
+  rep: RepeatBinding,
+  items: unknown[],
+  container: ParentNode & Node,
+  state: RepeatKeyState,
+): void {
+  const oldInstances = rep.instances;
+  const nextInstances = state.nextInstances;
+  const map = state.map;
+  let nextCount = 0;
+  let created = false;
+  let removed = false;
+  nextInstances.length = 0;
+
+  for (let i = 0; i < items.length; i += 1) {
+    const key = state.nextKeys[i];
+    let instance = map.get(key);
+    if (instance) {
+      map.set(key, undefined);
+      setItemScope(instance, items[i]);
+    } else {
+      instance = host.$createBlockInstance(
+        rep.blockIndex,
+        itemScope(rep, items[i]),
+        rep.owner,
+        container,
+      ) ?? undefined;
+      if (instance) created = true;
+    }
+    if (instance) {
+      nextInstances[nextCount] = instance;
+      state.nextKeys[nextCount] = key;
+      nextCount += 1;
+    }
+  }
+  state.nextKeys.length = nextCount;
+
+  for (const instance of map.values()) {
+    if (instance) {
+      host.$removeInstance(instance);
+      removed = true;
+    }
+  }
+  if (removed) host.$compactInstanceNodes(rep.owner);
+
+  let cursor: Node | null = rep.start;
+  for (let i = 0; i < nextCount; i += 1) {
+    cursor = host.$insertInstanceAfter(cursor, container, nextInstances[i]);
+  }
+  for (let i = 0; i < nextCount; i += 1) {
+    const key = state.nextKeys[i];
+    if (map.has(key) && map.get(key) === undefined) {
+      host.$updateInstance(nextInstances[i]);
+    }
+  }
+  map.clear();
+
+  rep.instances = nextInstances;
+  state.nextInstances = oldInstances;
+  state.nextInstances.length = 0;
+  commitKeyIdentity(state);
+  if (created || removed) host.$invalidatePathIndex();
+}
+
+function syncKeyed(
+  host: RepeatHost,
+  rep: RepeatBinding,
+  items: unknown[],
+  container: ParentNode & Node,
+  state: RepeatKeyState,
+): void {
+  if (!collectRepeatKeys(items, state)) {
+    warnKeyFallback(rep, state);
+    clearKeyIdentity(state);
+    syncPositional(host, rep, items, container);
+    return;
+  }
+
+  if (
+    !state.established ||
+    state.keys.length !== rep.instances.length ||
+    keysShareOrder(state.keys, state.nextKeys)
+  ) {
+    syncPositional(host, rep, items, container);
+    if (rep.instances.length === items.length) {
+      commitKeyIdentity(state);
+    } else {
+      clearKeyIdentity(state);
+    }
+    return;
+  }
+
+  if (!buildOldKeyMap(state, rep.instances)) {
+    warnKeyFallback(rep, state);
+    state.established = false;
+    state.keys.length = 0;
+    syncPositional(host, rep, items, container);
+    if (rep.instances.length === items.length) commitKeyIdentity(state);
+    return;
+  }
+  reconcileByKey(host, rep, items, container, state);
 }
 
 // ── Reconciliation ──────────────────────────────────────────────────
@@ -53,7 +313,7 @@ function itemScope(rep: RepeatBinding, item: unknown): ScopeFrame {
  * Reconcile a repeat binding against its current collection value.
  *
  * Called by `$updateInstance` on every reactive update.  Resolves the
- * collection path, diffs old vs. new items by key, and patches the DOM.
+ * collection path and applies either positional or explicit-key identity.
  */
 export function syncRepeat(
   host: RepeatHost,
@@ -81,114 +341,25 @@ export function syncRepeat(
 
   // If there are no items, just tear down everything.
   if (items.length === 0) {
+    const hadInstances = rep.instances.length !== 0;
     for (let i = 0; i < rep.instances.length; i += 1) {
-      host.$removeInstance(rep.instances[i].instance);
+      host.$removeInstance(rep.instances[i]);
     }
-    rep.instances = [];
-    return;
-  }
-
-  const keyPath = rep.keyPath;
-  const hasKeys = keyPath !== undefined && keyPath !== '';
-  const oldInstances = rep.instances;
-
-  // ── Fast path for unkeyed (index-based) repeats ────────────────
-  if (!hasKeys) {
-    const oldLength = oldInstances.length;
-    const reuseCount = Math.min(oldLength, items.length);
-    let nextCount = reuseCount;
-
-    // Reuse existing instances by index
-    for (let i = 0; i < reuseCount; i += 1) {
-      const entry = oldInstances[i];
-      entry.value = items[i];
-      if (entry.instance.scope) {
-        entry.instance.scope.value = items[i];
-        entry.instance.scope.known = true;
-      }
+    rep.instances.length = 0;
+    if (hadInstances) {
+      host.$compactInstanceNodes(rep.owner);
+      host.$invalidatePathIndex();
     }
-
-    // Create new instances for items beyond old length
-    for (let i = reuseCount; i < items.length; i += 1) {
-      const scope = itemScope(rep, items[i]);
-      const instance = host.$createBlockInstance(rep.blockIndex, scope);
-      if (instance) {
-        oldInstances[nextCount] = { key: null, value: items[i], instance };
-        nextCount += 1;
-      }
-    }
-
-    // Remove excess old instances
-    for (let i = reuseCount; i < oldLength; i += 1) {
-      host.$removeInstance(oldInstances[i].instance);
-    }
-
-    oldInstances.length = nextCount;
-
-    let cursor: Node | null = rep.start;
-    for (let i = 0; i < oldInstances.length; i += 1) {
-      cursor = host.$insertInstanceAfter(cursor, container, oldInstances[i].instance);
-    }
-    for (let i = 0; i < reuseCount; i += 1) {
-      host.$updateInstance(oldInstances[i].instance);
+    if (rep.keyState) {
+      clearKeyIdentity(rep.keyState);
+      rep.keyState.established = true;
     }
     return;
   }
 
-  // ── Keyed diff ─────────────────────────────────────────────────
-
-  // ── Build old-key → instance map ────────────────────────────────
-  const oldByKey = new Map<string, RepeatItemInstance | undefined>();
-  for (let i = 0; i < oldInstances.length; i += 1) {
-    const entry = oldInstances[i];
-    const k = entry.key;
-    if (k != null) oldByKey.set(k, entry);
-  }
-
-  // ── Match / create ──────────────────────────────────────────────
-  let nextCount = 0;
-  for (let i = 0; i < items.length; i += 1) {
-    const item = items[i];
-    const key = itemKey(item, keyPath);
-    const existing = key != null ? oldByKey.get(key) : undefined;
-
-    if (existing) {
-      oldByKey.set(key!, undefined);
-      existing.value = item;
-      existing.key = key;
-      if (existing.instance.scope) {
-        existing.instance.scope.value = item;
-        existing.instance.scope.known = true;
-      }
-      oldInstances[nextCount] = existing;
-      nextCount += 1;
-    } else {
-      const scope = itemScope(rep, item);
-      const instance = host.$createBlockInstance(rep.blockIndex, scope);
-      if (instance) {
-        oldInstances[nextCount] = { key: key ?? null, value: item, instance };
-        nextCount += 1;
-      }
-    }
-  }
-
-  // ── Remove unmatched old instances ──────────────────────────────
-  for (const leftover of oldByKey.values()) {
-    if (leftover) host.$removeInstance(leftover.instance);
-  }
-  oldInstances.length = nextCount;
-
-  // ── Reorder DOM (forward pass) ──────────────────────────────────
-  // Newly-created instances were patched while detached. Reused instances
-  // update after moving so nested structural nodes stay with the item.
-  let cursor: Node | null = rep.start;
-  for (let i = 0; i < oldInstances.length; i += 1) {
-    cursor = host.$insertInstanceAfter(cursor, container, oldInstances[i].instance);
-  }
-  for (let i = 0; i < oldInstances.length; i += 1) {
-    const entry = oldInstances[i];
-    if (entry.key != null && oldByKey.has(entry.key) && oldByKey.get(entry.key) === undefined) {
-      host.$updateInstance(entry.instance);
-    }
+  if (rep.keyState) {
+    syncKeyed(host, rep, items, container, rep.keyState);
+  } else {
+    syncPositional(host, rep, items, container);
   }
 }

--- a/packages/webui-framework/src/element/diff.ts
+++ b/packages/webui-framework/src/element/diff.ts
@@ -14,11 +14,6 @@ import type {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-function asParent(node: Node | null): (ParentNode & Node) | null {
-  if (!node) return null;
-  return 'childNodes' in node ? (node as ParentNode & Node) : null;
-}
-
 /** Resolve a dotted path from a start offset without allocating. */
 export function dotWalk(cursor: unknown, path: string, from: number): unknown {
   let start = from;
@@ -41,11 +36,9 @@ function itemScope(rep: RepeatBinding, item: unknown): ScopeFrame {
 export function createRepeatKeyState(path: string): RepeatKeyState {
   return {
     path,
-    established: false,
     warned: false,
     keys: [],
     nextKeys: [],
-    nextInstances: [],
     map: new Map(),
   };
 }
@@ -100,7 +93,6 @@ function syncPositional(
   }
   instances.length = nextCount;
   const removed = oldLength > reuseCount;
-  if (removed) host.$compactInstanceNodes(rep.owner);
 
   let cursor: Node | null = rep.start;
   for (let i = 0; i < instances.length; i += 1) {
@@ -109,7 +101,7 @@ function syncPositional(
   for (let i = 0; i < reuseCount; i += 1) {
     host.$updateInstance(instances[i]);
   }
-  if (created || removed) host.$invalidatePathIndex();
+  if (created || removed) host.$changeStructure(removed ? rep.owner : undefined);
 }
 
 function readRepeatKey(item: unknown, path: string): unknown {
@@ -145,17 +137,9 @@ function collectRepeatKeys(items: unknown[], state: RepeatKeyState): boolean {
       return false;
     }
     keys[i] = value;
-    seen.set(value, undefined);
+    seen.set(value, null);
   }
   seen.clear();
-  return true;
-}
-
-function keysShareOrder(current: RepeatKey[], next: RepeatKey[]): boolean {
-  const sharedLength = Math.min(current.length, next.length);
-  for (let i = 0; i < sharedLength; i += 1) {
-    if (current[i] !== next[i]) return false;
-  }
   return true;
 }
 
@@ -164,14 +148,11 @@ function commitKeyIdentity(state: RepeatKeyState): void {
   state.keys = state.nextKeys;
   state.nextKeys = oldKeys;
   state.nextKeys.length = 0;
-  state.established = true;
 }
 
 function clearKeyIdentity(state: RepeatKeyState): void {
-  state.established = false;
   state.keys.length = 0;
   state.nextKeys.length = 0;
-  state.nextInstances.length = 0;
   state.map.clear();
 }
 
@@ -186,23 +167,6 @@ function warnKeyFallback(rep: RepeatBinding, state: RepeatKeyState): void {
   );
 }
 
-function buildOldKeyMap(
-  state: RepeatKeyState,
-  instances: TemplateInstance[],
-): boolean {
-  const map = state.map;
-  map.clear();
-  for (let i = 0; i < state.keys.length; i += 1) {
-    const key = state.keys[i];
-    if (map.has(key)) {
-      map.clear();
-      return false;
-    }
-    map.set(key, instances[i]);
-  }
-  return true;
-}
-
 function reconcileByKey(
   host: RepeatHost,
   rep: RepeatBinding,
@@ -210,19 +174,17 @@ function reconcileByKey(
   container: ParentNode & Node,
   state: RepeatKeyState,
 ): void {
-  const oldInstances = rep.instances;
-  const nextInstances = state.nextInstances;
+  const instances = rep.instances;
   const map = state.map;
   let nextCount = 0;
   let created = false;
   let removed = false;
-  nextInstances.length = 0;
 
   for (let i = 0; i < items.length; i += 1) {
     const key = state.nextKeys[i];
     let instance = map.get(key);
     if (instance) {
-      map.set(key, undefined);
+      map.set(key, null);
       setItemScope(instance, items[i]);
     } else {
       instance = host.$createBlockInstance(
@@ -234,7 +196,7 @@ function reconcileByKey(
       if (instance) created = true;
     }
     if (instance) {
-      nextInstances[nextCount] = instance;
+      instances[nextCount] = instance;
       state.nextKeys[nextCount] = key;
       nextCount += 1;
     }
@@ -247,25 +209,20 @@ function reconcileByKey(
       removed = true;
     }
   }
-  if (removed) host.$compactInstanceNodes(rep.owner);
-
   let cursor: Node | null = rep.start;
   for (let i = 0; i < nextCount; i += 1) {
-    cursor = host.$insertInstanceAfter(cursor, container, nextInstances[i]);
+    cursor = host.$insertInstanceAfter(cursor, container, instances[i]);
   }
   for (let i = 0; i < nextCount; i += 1) {
-    const key = state.nextKeys[i];
-    if (map.has(key) && map.get(key) === undefined) {
-      host.$updateInstance(nextInstances[i]);
+    if (map.get(state.nextKeys[i]) === null) {
+      host.$updateInstance(instances[i]);
     }
   }
   map.clear();
 
-  rep.instances = nextInstances;
-  state.nextInstances = oldInstances;
-  state.nextInstances.length = 0;
+  instances.length = nextCount;
   commitKeyIdentity(state);
-  if (created || removed) host.$invalidatePathIndex();
+  if (created || removed) host.$changeStructure(removed ? rep.owner : undefined);
 }
 
 function syncKeyed(
@@ -282,11 +239,12 @@ function syncKeyed(
     return;
   }
 
-  if (
-    !state.established ||
-    state.keys.length !== rep.instances.length ||
-    keysShareOrder(state.keys, state.nextKeys)
-  ) {
+  let sharedOrder = true;
+  const sharedLength = Math.min(state.keys.length, state.nextKeys.length);
+  for (let i = 0; sharedOrder && i < sharedLength; i += 1) {
+    sharedOrder = state.keys[i] === state.nextKeys[i];
+  }
+  if (state.keys.length !== rep.instances.length || sharedOrder) {
     syncPositional(host, rep, items, container);
     if (rep.instances.length === items.length) {
       commitKeyIdentity(state);
@@ -296,13 +254,8 @@ function syncKeyed(
     return;
   }
 
-  if (!buildOldKeyMap(state, rep.instances)) {
-    warnKeyFallback(rep, state);
-    state.established = false;
-    state.keys.length = 0;
-    syncPositional(host, rep, items, container);
-    if (rep.instances.length === items.length) commitKeyIdentity(state);
-    return;
+  for (let i = 0; i < state.keys.length; i += 1) {
+    state.map.set(state.keys[i], rep.instances[i]);
   }
   reconcileByKey(host, rep, items, container, state);
 }
@@ -323,9 +276,9 @@ export function syncRepeat(
   const items = Array.isArray(resolved) ? resolved : [];
 
   // Locate the container once and cache it.
-  let container = rep.container
-    ?? (rep.start ? asParent(rep.start.parentNode) : null)
-    ?? (rep.owner.nodes[0] ? asParent(rep.owner.nodes[0].parentNode) : null);
+  const container = (rep.container
+    ?? rep.start?.parentNode
+    ?? rep.owner.nodes[0]?.parentNode) as (ParentNode & Node) | null;
   if (!container) return;
   rep.container = container;
 
@@ -346,13 +299,9 @@ export function syncRepeat(
       host.$removeInstance(rep.instances[i]);
     }
     rep.instances.length = 0;
-    if (hadInstances) {
-      host.$compactInstanceNodes(rep.owner);
-      host.$invalidatePathIndex();
-    }
+    if (hadInstances) host.$changeStructure(rep.owner);
     if (rep.keyState) {
       clearKeyIdentity(rep.keyState);
-      rep.keyState.established = true;
     }
     return;
   }

--- a/packages/webui-framework/src/element/markers.test.ts
+++ b/packages/webui-framework/src/element/markers.test.ts
@@ -69,6 +69,33 @@ describe('collectItemMarkers', () => {
     assert.strictEqual(end, null, 'end should be null when <!--/wr--> is missing');
   });
 
+  test('ignores item and end markers from nested repeats', () => {
+    const outerStart = { nodeType: COMMENT, data: 'wr', nextSibling: null } as MockNode;
+    const outerItem1 = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;
+    const innerStart1 = { nodeType: COMMENT, data: 'wr', nextSibling: null } as MockNode;
+    const innerItem1 = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;
+    const innerEnd1 = { nodeType: COMMENT, data: '/wr', nextSibling: null } as MockNode;
+    const outerItem2 = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;
+    const innerStart2 = { nodeType: COMMENT, data: 'wr', nextSibling: null } as MockNode;
+    const innerItem2 = { nodeType: COMMENT, data: 'wi', nextSibling: null } as MockNode;
+    const innerEnd2 = { nodeType: COMMENT, data: '/wr', nextSibling: null } as MockNode;
+    const outerEnd = { nodeType: COMMENT, data: '/wr', nextSibling: null } as MockNode;
+
+    outerStart.nextSibling = outerItem1;
+    outerItem1.nextSibling = innerStart1;
+    innerStart1.nextSibling = innerItem1;
+    innerItem1.nextSibling = innerEnd1;
+    innerEnd1.nextSibling = outerItem2;
+    outerItem2.nextSibling = innerStart2;
+    innerStart2.nextSibling = innerItem2;
+    innerItem2.nextSibling = innerEnd2;
+    innerEnd2.nextSibling = outerEnd;
+
+    const { items, end } = collectItemMarkers(outerStart as unknown as Comment);
+    assert.deepEqual(items, [outerItem1, outerItem2]);
+    assert.strictEqual(end, outerEnd);
+  });
+
   test('skips non-comment siblings', () => {
     // <!--wr--> text elem <!--wi--> text <!--/wr-->
     const wrStart = { nodeType: COMMENT, data: 'wr', nextSibling: null } as MockNode;

--- a/packages/webui-framework/src/element/markers.ts
+++ b/packages/webui-framework/src/element/markers.ts
@@ -34,12 +34,22 @@ const MARKER_REPEAT_ITEM = 'wi';
 export function collectItemMarkers(repeatStart: Comment): { items: Comment[]; end: Comment | null } {
   const items: Comment[] = [];
   let end: Comment | null = null;
+  let depth = 1;
   let node: Node | null = repeatStart.nextSibling;
   while (node) {
     if (node.nodeType === 8 /* COMMENT_NODE */) {
       const data = (node as Comment).data;
-      if (data === MARKER_REPEAT_END) { end = node as Comment; break; }
-      if (data === MARKER_REPEAT_ITEM) items.push(node as Comment);
+      if (data === MARKER_REPEAT_START) {
+        depth++;
+      } else if (data === MARKER_REPEAT_END) {
+        depth--;
+        if (depth === 0) {
+          end = node as Comment;
+          break;
+        }
+      } else if (data === MARKER_REPEAT_ITEM && depth === 1) {
+        items.push(node as Comment);
+      }
     }
     node = node.nextSibling;
   }

--- a/packages/webui-framework/src/element/types.ts
+++ b/packages/webui-framework/src/element/types.ts
@@ -66,6 +66,8 @@ export interface ScopeFrame {
 
 export interface TemplateInstance {
   scope?: ScopeFrame;
+  parent?: TemplateInstance;
+  container: (ParentNode & Node) | null;
   nodes: Node[];
   texts: TextBinding[];
   attrs: AttrBinding[];
@@ -86,7 +88,20 @@ export interface CondBinding {
   blockIndex: number;
   anchor: Comment;
   scope?: ScopeFrame;
+  owner: TemplateInstance;
   instance: TemplateInstance | null;
+}
+
+export type RepeatKey = string | number;
+
+export interface RepeatKeyState {
+  path: string;
+  established: boolean;
+  warned: boolean;
+  keys: RepeatKey[];
+  nextKeys: RepeatKey[];
+  nextInstances: TemplateInstance[];
+  map: Map<RepeatKey, TemplateInstance | undefined>;
 }
 
 /** Repeat block tracking. */
@@ -100,18 +115,10 @@ export interface RepeatBinding {
   end: Comment | null;
   scope?: ScopeFrame;
   owner: TemplateInstance;
-  instances: RepeatItemInstance[];
-  rootTag: string | null;
-  keyAttribute?: string;
-  keyPath?: string;
+  instances: TemplateInstance[];
+  keyState?: RepeatKeyState;
   /** Set to true once the collection has been explicitly set by client code. */
   synced?: boolean;
-}
-
-export interface RepeatItemInstance {
-  key: string | null;
-  value: unknown;
-  instance: TemplateInstance;
 }
 
 /**
@@ -125,8 +132,15 @@ export interface RepeatHost {
   $resolveValue(path: string, scope?: ScopeFrame): unknown;
   $hasStateRoot(path: string, scope?: ScopeFrame): boolean;
   /** Create, wire, and perform the first binding pass while detached. */
-  $createBlockInstance(blockIndex: number, scope?: ScopeFrame): TemplateInstance | null;
+  $createBlockInstance(
+    blockIndex: number,
+    scope?: ScopeFrame,
+    parent?: TemplateInstance,
+    container?: ParentNode & Node,
+  ): TemplateInstance | null;
   $updateInstance(instance: TemplateInstance): void;
   $removeInstance(instance: TemplateInstance): void;
+  $compactInstanceNodes(instance: TemplateInstance): void;
+  $invalidatePathIndex(): void;
   $insertInstanceAfter(cursor: Node | null, container: ParentNode & Node, instance: TemplateInstance): Node | null;
 }

--- a/packages/webui-framework/src/element/types.ts
+++ b/packages/webui-framework/src/element/types.ts
@@ -45,6 +45,16 @@ export const ATTR_KIND_COMPLEX = 1;
 export const ATTR_KIND_BOOLEAN = 2;
 export const ATTR_KIND_TEMPLATE = 3;
 
+/**
+ * Return whether an attribute binding must update a native live DOM property.
+ *
+ * Autonomous custom elements contain a hyphen and use attribute semantics
+ * unless the template explicitly opts into a `:property` binding.
+ */
+export function hasNativeLiveProperty(element: Element, name: string): boolean {
+  return element.localName.indexOf('-') === -1 && name in element;
+}
+
 /** Direct reference to an attribute binding. */
 export interface AttrBinding {
   element: Element;

--- a/packages/webui-framework/src/element/types.ts
+++ b/packages/webui-framework/src/element/types.ts
@@ -96,12 +96,10 @@ export type RepeatKey = string | number;
 
 export interface RepeatKeyState {
   path: string;
-  established: boolean;
   warned: boolean;
   keys: RepeatKey[];
   nextKeys: RepeatKey[];
-  nextInstances: TemplateInstance[];
-  map: Map<RepeatKey, TemplateInstance | undefined>;
+  map: Map<RepeatKey, TemplateInstance | null>;
 }
 
 /** Repeat block tracking. */
@@ -140,7 +138,6 @@ export interface RepeatHost {
   ): TemplateInstance | null;
   $updateInstance(instance: TemplateInstance): void;
   $removeInstance(instance: TemplateInstance): void;
-  $compactInstanceNodes(instance: TemplateInstance): void;
-  $invalidatePathIndex(): void;
+  $changeStructure(removedFrom?: TemplateInstance): void;
   $insertInstanceAfter(cursor: Node | null, container: ParentNode & Node, instance: TemplateInstance): Node | null;
 }

--- a/packages/webui-framework/src/hydration-mismatch.test.ts
+++ b/packages/webui-framework/src/hydration-mismatch.test.ts
@@ -159,22 +159,22 @@ describe('condDiffersFromDom', () => {
   const instance = {} as unknown as TemplateInstance;
 
   test('rendered block with a true condition does not differ', () => {
-    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, instance };
+    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, owner: instance, instance };
     assert.equal(condDiffersFromDom(c, makeCtx()), false);
   });
 
   test('absent block with a false condition does not differ', () => {
-    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, instance: null };
+    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, owner: instance, instance: null };
     assert.equal(condDiffersFromDom(c, makeCtx()), false);
   });
 
   test('absent block with a true condition differs (server dropped it)', () => {
-    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, instance: null };
+    const c: CondBinding = { condition: cond(() => true), blockIndex: 0, anchor: {} as Comment, owner: instance, instance: null };
     assert.equal(condDiffersFromDom(c, makeCtx()), true);
   });
 
   test('rendered block with a false condition differs', () => {
-    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, instance };
+    const c: CondBinding = { condition: cond(() => false), blockIndex: 0, anchor: {} as Comment, owner: instance, instance };
     assert.equal(condDiffersFromDom(c, makeCtx()), true);
   });
 
@@ -182,7 +182,7 @@ describe('condDiffersFromDom', () => {
     // count 5 -> 3 both satisfy `count > 0`; the block stays rendered, so a
     // value-only comparison would false-positive but a presence check must not.
     const gtZero = cond((r) => (r('count') as number) > 0);
-    const c: CondBinding = { condition: gtZero, blockIndex: 0, anchor: {} as Comment, instance };
+    const c: CondBinding = { condition: gtZero, blockIndex: 0, anchor: {} as Comment, owner: instance, instance };
     assert.equal(condDiffersFromDom(c, makeCtx({ count: 3 })), false);
   });
 });
@@ -195,7 +195,6 @@ function repeat(collection: string, instanceCount: number): RepeatBinding {
     container: null, start: null, end: null,
     owner: {} as unknown as TemplateInstance,
     instances: Array.from({ length: instanceCount }, () => ({})) as unknown as RepeatBinding['instances'],
-    rootTag: null,
   };
 }
 

--- a/packages/webui-framework/src/hydration-mismatch.test.ts
+++ b/packages/webui-framework/src/hydration-mismatch.test.ts
@@ -33,8 +33,15 @@ import {
 // The comparators only read getAttribute/hasAttribute, Text.data,
 // Element.innerHTML, and instance counts, so plain objects suffice — no DOM.
 
-function fakeEl(attrs: Record<string, string> = {}, innerHTML = ''): Element {
+function fakeEl(
+  attrs: Record<string, string> = {},
+  innerHTML = '',
+  localName = 'div',
+  properties: Record<string, unknown> = {},
+): Element {
   return {
+    localName,
+    ...properties,
     getAttribute: (n: string) => (n in attrs ? attrs[n] : null),
     hasAttribute: (n: string) => n in attrs,
     innerHTML,
@@ -143,13 +150,31 @@ describe('attrDiffersFromDom', () => {
     assert.equal(attrDiffersFromDom(differ, makeCtx({ value: '3' })), true);
   });
 
-  test('form-control value/checked/selected are skipped', () => {
-    for (const name of ['value', 'checked', 'selected']) {
+  test('native form-control value/checked/selected properties are skipped', () => {
+    const cases = [
+      ['value', 'input', ''],
+      ['checked', 'input', false],
+      ['selected', 'option', false],
+    ] as const;
+    for (const [name, localName, property] of cases) {
       const b: AttrBinding = {
-        element: fakeEl({}), name, kind: ATTR_KIND_ATTRIBUTE, path: 'v',
+        element: fakeEl({}, '', localName, { [name]: property }),
+        name,
+        kind: ATTR_KIND_ATTRIBUTE,
+        path: 'v',
       };
       assert.equal(attrDiffersFromDom(b, makeCtx({ v: 'x' })), false, name);
     }
+  });
+
+  test('custom-element value attributes are compared even when a property exists', () => {
+    const b: AttrBinding = {
+      element: fakeEl({ value: 'old' }, '', 'test-price', { value: 'new' }),
+      name: 'value',
+      kind: ATTR_KIND_ATTRIBUTE,
+      path: 'v',
+    };
+    assert.equal(attrDiffersFromDom(b, makeCtx({ v: 'new' })), true);
   });
 });
 

--- a/packages/webui-framework/src/hydration-mismatch.ts
+++ b/packages/webui-framework/src/hydration-mismatch.ts
@@ -31,6 +31,7 @@ import {
   ATTR_KIND_BOOLEAN,
   ATTR_KIND_COMPLEX,
   ATTR_KIND_TEMPLATE,
+  hasNativeLiveProperty,
   type AttrBinding,
   type CondBinding,
   type RepeatBinding,
@@ -132,7 +133,10 @@ export function attrDiffersFromDom(b: AttrBinding, ctx: MismatchContext): boolea
     default: {
       // Form-control properties diverge from their attribute after user
       // interaction, so an attribute comparison would be misleading.
-      if (b.name === 'value' || b.name === 'checked' || b.name === 'selected') return false;
+      if (
+        (b.name === 'value' || b.name === 'checked' || b.name === 'selected')
+        && hasNativeLiveProperty(el, b.name)
+      ) return false;
       const v = ctx.resolveValue(b.path!, b.scope);
       return (el.getAttribute(b.name) ?? '') !== (v == null ? '' : String(v));
     }

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -54,7 +54,12 @@ import type {
   TemplateNodePath,
 } from './template.js';
 import { hydrationStart, hydrationEnd } from './lifecycle.js';
-import { syncRepeat, dotWalk } from './element/diff.js';
+import {
+  createRepeatKeyState,
+  seedHydratedRepeatKeys,
+  syncRepeat,
+  dotWalk,
+} from './element/diff.js';
 import {
   collectItemMarkers,
   nextElement,
@@ -76,7 +81,6 @@ import type {
   AttrBinding,
   CondBinding,
   RepeatBinding,
-  RepeatItemInstance,
   ScopeFrame,
   TemplateInstance,
   TextBinding,
@@ -420,9 +424,14 @@ export class TemplateElement extends HTMLElement {
       this.$updateInstance(this.$root);
       if (this.$root.repeats.length !== 0 || this.$root.conds.length !== 0) {
         this.$root.nodes = childNodesArray(clientRoot);
-        this.$releaseStagingRepeatContainers(this.$root, clientRoot);
+        this.$releaseStagingRepeatContainers(
+          this.$root,
+          clientRoot,
+          root as ParentNode & Node,
+        );
       }
       this.$appendStagedChildren(root, clientRoot);
+      this.$root.container = root as ParentNode & Node;
     }
 
     hydrationEnd();
@@ -469,12 +478,30 @@ export class TemplateElement extends HTMLElement {
       c.instance = null;
     }
     for (const r of instance.repeats) {
-      for (const item of r.instances) this.$teardown(item.instance);
-      r.instances.length = 0;
-      r.container = null;
-      r.start = null;
-      r.end = null;
+      for (const item of r.instances) this.$teardown(item);
+      this.$clearRepeatBinding(r);
     }
+    this.$clearInstance(instance);
+  }
+
+  private $clearRepeatBinding(repeat: RepeatBinding): void {
+    repeat.instances.length = 0;
+    repeat.container = null;
+    repeat.start = null;
+    repeat.end = null;
+    const state = repeat.keyState;
+    if (state) {
+      state.keys.length = 0;
+      state.nextKeys.length = 0;
+      state.nextInstances.length = 0;
+      state.map.clear();
+    }
+  }
+
+  private $clearInstance(instance: TemplateInstance): void {
+    instance.scope = undefined;
+    instance.parent = undefined;
+    instance.container = null;
     instance.nodes.length = 0;
     instance.texts.length = 0;
     instance.attrs.length = 0;
@@ -712,11 +739,13 @@ export class TemplateElement extends HTMLElement {
 
   /** Flush all queued path updates. Handles re-entrant setter calls. */
   private $flush(): void {
-    if (!this.$ready || !this.$root || !this.$pathIndex) {
+    if (!this.$ready || !this.$root) {
       this.$dirtyPaths = null;
       this.$pendingFlush = false;
       return;
     }
+    if (!this.$pathIndex) this.$buildPathIndex();
+    if (!this.$pathIndex) return;
 
     while (this.$dirtyPaths && this.$dirtyPaths.size > 0) {
       // Snapshot and clear so re-entrant setters get a fresh set.
@@ -724,16 +753,19 @@ export class TemplateElement extends HTMLElement {
       this.$dirtyPaths = null;
 
       for (const path of dirty) {
-        const entry = this.$pathIndex.get(path);
+        if (!this.$pathIndex) this.$buildPathIndex();
+        const entry = this.$pathIndex?.get(path);
         if (entry) {
           this.$updateBindings(entry.texts, entry.attrs, entry.conds, entry.repeats);
         }
       }
       // Update wildcard bindings once per flush (not per dirty path)
+      if (!this.$pathIndex) this.$buildPathIndex();
       if (this.$wildcardBindings) {
         const wc = this.$wildcardBindings;
         this.$updateBindings(wc.texts, wc.attrs, wc.conds, wc.repeats);
       }
+      if (!this.$pathIndex) this.$buildPathIndex();
     }
 
     this.$pendingFlush = false;
@@ -911,23 +943,52 @@ export class TemplateElement extends HTMLElement {
     root.appendChild(fragment);
   }
 
-  private $releaseStagingRepeatContainers(instance: TemplateInstance | null, stagingRoot: Node | null): void {
+  private $releaseStagingRepeatContainers(
+    instance: TemplateInstance | null,
+    stagingRoot: Node | null,
+    target?: ParentNode & Node,
+  ): void {
     if (!instance || !stagingRoot) return;
     if (instance.repeats.length === 0 && instance.conds.length === 0) return;
     const stack: TemplateInstance[] = [instance];
     while (stack.length > 0) {
       const current = stack.pop();
       if (!current) continue;
+      if (target && current.container === stagingRoot) current.container = target;
       for (let i = 0; i < current.repeats.length; i++) {
         const repeat = current.repeats[i];
-        if (repeat.container === stagingRoot) repeat.container = null;
+        if (repeat.container === stagingRoot) repeat.container = target ?? null;
         for (let j = 0; j < repeat.instances.length; j++) {
-          stack.push(repeat.instances[j].instance);
+          stack.push(repeat.instances[j]);
         }
       }
       for (let i = 0; i < current.conds.length; i++) {
         const child = current.conds[i].instance;
         if (child) stack.push(child);
+      }
+    }
+  }
+
+  private $replaceInstanceContainer(
+    instance: TemplateInstance,
+    previous: (ParentNode & Node) | null,
+    next: ParentNode & Node,
+  ): void {
+    if (previous === next) return;
+    const stack: TemplateInstance[] = [instance];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) continue;
+      if (current.container === previous) current.container = next;
+      for (let i = 0; i < current.conds.length; i++) {
+        const child = current.conds[i].instance;
+        if (child) stack.push(child);
+      }
+      for (let i = 0; i < current.repeats.length; i++) {
+        const repeat = current.repeats[i];
+        if (repeat.container === previous) repeat.container = next;
+        const children = repeat.instances;
+        for (let j = 0; j < children.length; j++) stack.push(children[j]);
       }
     }
   }
@@ -938,7 +999,7 @@ export class TemplateElement extends HTMLElement {
 
   private $wire(root: Node, meta: TemplateBlockMeta, scope?: ScopeFrame): TemplateInstance {
     const instance: TemplateInstance = {
-      scope, nodes: childNodesArray(root),
+      scope, container: root as ParentNode & Node, nodes: childNodesArray(root),
       texts: [], attrs: [], conds: [], repeats: [],
     };
 
@@ -978,16 +1039,30 @@ export class TemplateElement extends HTMLElement {
     }
 
     // Pre-resolve repeat slots
-    type RepRef = { parent: Node; ref: Node | null; collection: string; itemVar: string; blockIndex: number };
+    type RepRef = {
+      parent: Node;
+      ref: Node | null;
+      collection: string;
+      itemVar: string;
+      blockIndex: number;
+      keyPath?: string;
+    };
     const repRefs = new Array<RepRef>(meta.r?.length ?? 0);
     let repRefCount = 0;
     if (meta.r) {
       for (let i = 0; i < meta.r.length; i++) {
-        const [collection, itemVar, blockIndex, slotMeta] = meta.r[i];
+        const [collection, itemVar, blockIndex, slotMeta, keyPath] = meta.r[i];
         const [parentPath, beforeIndex] = slotMeta;
         const parent = parentPath.length > 0 ? this.$resolve(root, parentPath) : root;
         if (!parent || (parent.nodeType !== 1 && parent.nodeType !== 11)) continue;
-        repRefs[repRefCount] = { parent, ref: parent.childNodes[beforeIndex] || null, collection, itemVar, blockIndex };
+        repRefs[repRefCount] = {
+          parent,
+          ref: parent.childNodes[beforeIndex] || null,
+          collection,
+          itemVar,
+          blockIndex,
+          keyPath,
+        };
         repRefCount += 1;
       }
     }
@@ -1025,7 +1100,14 @@ export class TemplateElement extends HTMLElement {
       const c = condRefs[i];
       const anchor = document.createComment('');
       c.parent.insertBefore(anchor, c.ref);
-      instance.conds.push({ condition: c.condition, blockIndex: c.blockIndex, anchor, scope, instance: null });
+      instance.conds.push({
+        condition: c.condition,
+        blockIndex: c.blockIndex,
+        anchor,
+        scope,
+        owner: instance,
+        instance: null,
+      });
     }
 
     // Repeat bindings
@@ -1033,13 +1115,15 @@ export class TemplateElement extends HTMLElement {
       const r = repRefs[i];
       const anchor = document.createComment('');
       r.parent.insertBefore(anchor, r.ref);
-      const { keyAttribute, keyPath } = this.$repeatMaps(r.blockIndex, r.itemVar);
-      instance.repeats.push({
+      const binding: RepeatBinding = {
         markerId: i, collection: r.collection, itemVar: r.itemVar, blockIndex: r.blockIndex,
         container: r.parent as ParentNode & Node, start: anchor, end: null,
-        scope, owner: instance, instances: [], rootTag: null,
-        keyAttribute, keyPath,
-      });
+        scope, owner: instance, instances: [],
+      };
+      if (r.keyPath !== undefined) {
+        binding.keyState = createRepeatKeyState(r.keyPath);
+      }
+      instance.repeats.push(binding);
     }
 
     // Evaluate conditionals and repeats inline so blocks are created
@@ -1072,6 +1156,7 @@ export class TemplateElement extends HTMLElement {
   ): TemplateInstance {
     const instance: TemplateInstance = {
       scope,
+      container: (pathStart > 0 ? ssrRoot.parentNode : ssrRoot) as (ParentNode & Node) | null,
       nodes: pathStart > 0 ? [ssrRoot] : childNodesArray(ssrRoot),
       texts: [], attrs: [], conds: [], repeats: [],
     };
@@ -1156,6 +1241,7 @@ export class TemplateElement extends HTMLElement {
         // than claiming the first static sibling after <!--/wc-->.
         if (marker && blockMeta) {
           condInstance = this.$hydrateCondContent(condAnchor, blockMeta, scope);
+          if (condInstance) condInstance.parent = instance;
         }
 
         // Collect <!--/wc--> end marker for deferred removal.
@@ -1172,7 +1258,7 @@ export class TemplateElement extends HTMLElement {
         instance.conds.push({
           condition: condition as CompiledCondition, blockIndex,
           anchor: condAnchor,
-          scope, instance: condInstance,
+          scope, owner: instance, instance: condInstance,
         });
       }
     }
@@ -1182,7 +1268,7 @@ export class TemplateElement extends HTMLElement {
       let lastRepMarker: Node | null = null;
       let lastRepParent: Node | null = null;
       for (let i = 0; i < meta.r.length; i++) {
-        const [collection, itemVar, blockIndex, slotMeta] = meta.r[i];
+        const [collection, itemVar, blockIndex, slotMeta, keyPath] = meta.r[i];
         const [parentPath] = slotMeta;
         const ssrParent = this.$resolveSSR(ssrRoot, tplDom, parentPath, pathStart) ?? ssrRoot;
 
@@ -1191,9 +1277,7 @@ export class TemplateElement extends HTMLElement {
           lastRepMarker = null;
           lastRepParent = ssrParent;
         }
-
         const blockMeta = this.$block(blockIndex);
-        const { keyAttribute, keyPath } = this.$repeatMaps(blockIndex, itemVar);
         const blockTplDom = blockMeta ? getTemplateDom(blockMeta) : null;
         const rootTag = blockMeta && blockTplDom?.childNodes.length === 1 && blockTplDom.children.length === 1
           ? this.$rootTag(blockMeta)
@@ -1215,7 +1299,7 @@ export class TemplateElement extends HTMLElement {
         }
         lastRepMarker = anchor;
 
-        const repeatInsts: RepeatItemInstance[] = [];
+        const repeatInsts: TemplateInstance[] = [];
         const hasCollectionState = this.$hasStateRoot(collection, scope);
         const itemsArr = this.$resolveValue(collection, scope);
         const items = Array.isArray(itemsArr) ? itemsArr as unknown[] : [];
@@ -1249,11 +1333,9 @@ export class TemplateElement extends HTMLElement {
             if (rootTag) {
               const itemEl = nextElement(itemMarkers[j]);
               if (itemEl) {
-                const key = keyAttribute !== undefined
-                  ? itemEl.getAttribute(keyAttribute)
-                  : String(j);
                 const childInstance = this.$hydrate(itemEl, blockMeta, blockTplDom, itemScope, 1);
-                repeatInsts.push({ key, value: itemValue, instance: childInstance });
+                childInstance.parent = instance;
+                repeatInsts.push(childInstance);
               }
             } else {
               const itemParent = itemMarkers[j].parentNode;
@@ -1266,6 +1348,7 @@ export class TemplateElement extends HTMLElement {
                 cursor = next;
               }
               const inst = this.$hydrate(wrapper, blockMeta, blockTplDom, itemScope);
+              inst.parent = instance;
               inst.nodes = childNodesArray(wrapper);
               let afterNode: Node = itemMarkers[j];
               for (let nodeIndex = 0; nodeIndex < inst.nodes.length; nodeIndex++) {
@@ -1273,12 +1356,14 @@ export class TemplateElement extends HTMLElement {
                 itemParent?.insertBefore(node, afterNode.nextSibling);
                 afterNode = node;
               }
-              const key = keyPath
-                ? (j < items.length
-                  ? String(dotWalk(itemValue, keyPath, 0) ?? '')
-                  : `\u0000ssr:${j}`)
-                : null;
-              repeatInsts.push({ key, value: itemValue, instance: inst });
+              if (itemParent) {
+                this.$replaceInstanceContainer(
+                  inst,
+                  wrapper,
+                  itemParent as ParentNode & Node,
+                );
+              }
+              repeatInsts.push(inst);
             }
           }
 
@@ -1292,15 +1377,20 @@ export class TemplateElement extends HTMLElement {
         // Defer <!--/wr--> end marker removal (including empty repeats).
         if (endMarker) staleMarkers.push(endMarker);
 
-        instance.repeats.push({
+        const binding: RepeatBinding = {
           markerId: i, collection, itemVar, blockIndex,
           container: (anchor.parentNode ?? ssrRoot) as ParentNode & Node,
           start: anchor, end: null,
-          scope, owner: instance, instances: repeatInsts, rootTag,
-          keyAttribute,
-          keyPath,
+          scope, owner: instance, instances: repeatInsts,
           synced: hasCollectionState,
-        });
+        };
+        if (keyPath !== undefined) {
+          binding.keyState = createRepeatKeyState(keyPath);
+          if (hasCollectionState) {
+            seedHydratedRepeatKeys(binding, items);
+          }
+        }
+        instance.repeats.push(binding);
       }
     }
 
@@ -1314,6 +1404,7 @@ export class TemplateElement extends HTMLElement {
     for (let i = 0; i < staleMarkers.length; i++) {
       staleMarkers[i].parentNode?.removeChild(staleMarkers[i]);
     }
+    this.$compactNodeArray(instance);
 
     return instance;
   }
@@ -1392,6 +1483,8 @@ export class TemplateElement extends HTMLElement {
       condAnchor.parentNode?.insertBefore(inst.nodes[cn], afterNode.nextSibling);
       afterNode = inst.nodes[cn];
     }
+    const container = condAnchor.parentNode as (ParentNode & Node) | null;
+    if (container) this.$replaceInstanceContainer(inst, wrapper, container);
     // Same as above — trust SSR DOM, skip binding evaluation.
     return inst;
   }
@@ -1522,45 +1615,6 @@ export class TemplateElement extends HTMLElement {
     return { element: el, name, kind: kind as number, path: (entry[2] as string) || '', scope };
   }
 
-  /** Build the first stable item-scoped key for a repeat block. */
-  private $repeatMaps(blockIndex: number, itemVar: string): {
-    keyAttribute?: string;
-    keyPath?: string;
-  } {
-    let keyAttribute: string | undefined;
-    let keyPath: string | undefined;
-    const bm = this.$block(blockIndex);
-    if (bm?.a && bm.ag) {
-      for (let g = 0; g < bm.ag.length; g++) {
-        const [tp, s, c] = bm.ag[g];
-        // tp.length === 0 means root of the block container;
-        // tp = [0] means the first (and typically only) child element,
-        // which IS the repeated root element in blocks like <todo-item>.
-        const isRoot = tp.length === 0 || (tp.length === 1 && tp[0] === 0);
-        if (isRoot) {
-          for (let j = 0; j < c; j++) {
-            const entry = bm.a[s + j];
-            if (entry) {
-              if (entry[1] === 0 || entry[1] === 3) {
-                const dp = this.$singleDynamic(
-                  entry[1] === 3 ? (entry[2] as CompiledAttrPart[]) : [[entry[2] as string]],
-                );
-                // Only use item-scoped paths as keys; outer-scope bindings
-                // (e.g. group.name inside <for each="opt in ...">) would
-                // resolve to the same value for every item and break keying.
-                if (dp && keyPath === undefined && dp.path.startsWith(itemVar + '.')) {
-                  keyAttribute = entry[0];
-                  keyPath = dp.path.slice(itemVar.length + 1);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    return { keyAttribute, keyPath };
-  }
-
   // ═══════════════════════════════════════════════════════════════
   //  Reactive update system
   // ═══════════════════════════════════════════════════════════════
@@ -1636,7 +1690,7 @@ export class TemplateElement extends HTMLElement {
           ensure(keyFor(rep.collection)).repeats.push(rep);
         }
         for (let i = 0; i < rep.instances.length; i++) {
-          visit(rep.instances[i].instance);
+          visit(rep.instances[i]);
         }
       }
     };
@@ -1760,19 +1814,28 @@ export class TemplateElement extends HTMLElement {
   private $toggleCond(c: CondBinding): void {
     const show = c.condition[0](this.$resolver, c.scope);
     if (show) {
+      let created = false;
+      const container = c.anchor.parentNode as (ParentNode & Node) | null;
       if (!c.instance) {
-        c.instance = this.$createBlockInstance(c.blockIndex, c.scope);
-        if (c.instance) {
-          const frag = document.createDocumentFragment();
-          for (const n of c.instance.nodes) frag.appendChild(n);
-          c.anchor.parentNode?.insertBefore(frag, c.anchor.nextSibling);
-        }
+        c.instance = this.$createBlockInstance(
+          c.blockIndex,
+          c.scope,
+          c.owner,
+          container ?? undefined,
+        );
+        created = c.instance !== null;
       } else {
         this.$updateInstance(c.instance);
+      }
+      if (c.instance && container) {
+        this.$insertInstanceAfter(c.anchor, container, c.instance);
+        if (created) this.$invalidatePathIndex();
       }
     } else if (c.instance) {
       this.$removeInstance(c.instance);
       c.instance = null;
+      this.$compactInstanceNodes(c.owner);
+      this.$invalidatePathIndex();
     }
   }
 
@@ -1844,32 +1907,76 @@ export class TemplateElement extends HTMLElement {
     return this.$meta?.b?.[blockIndex];
   }
 
-  $createBlockInstance(blockIndex: number, scope?: ScopeFrame): TemplateInstance | null {
+  $createBlockInstance(
+    blockIndex: number,
+    scope?: ScopeFrame,
+    parent?: TemplateInstance,
+    container?: ParentNode & Node,
+  ): TemplateInstance | null {
     const bm = this.$block(blockIndex);
     if (!bm) return null;
     const wrapper = this.$createStagingRoot(bm);
     const inst = this.$wire(wrapper, bm, scope);
+    inst.parent = parent;
     inst.nodes = childNodesArray(wrapper);
     this.$updateInstance(inst);
     if (inst.repeats.length !== 0 || inst.conds.length !== 0) {
       inst.nodes = childNodesArray(wrapper);
-      this.$releaseStagingRepeatContainers(inst, wrapper);
+      this.$releaseStagingRepeatContainers(inst, wrapper, container);
     }
+    if (container) inst.container = container;
     return inst;
   }
 
   $removeInstance(instance: TemplateInstance): void {
     this.$teardownInstanceCleanups(instance);
-    for (const n of instance.nodes) n.parentNode?.removeChild(n);
+    for (let i = 0; i < instance.nodes.length; i++) {
+      const node = instance.nodes[i];
+      node.parentNode?.removeChild(node);
+    }
     for (const c of instance.conds) {
-      if (c.instance) this.$removeInstance(c.instance);
+      if (c.instance) {
+        this.$removeInstance(c.instance);
+        c.instance = null;
+      }
     }
     for (const r of instance.repeats) {
-      for (const item of r.instances) this.$removeInstance(item.instance);
+      for (const item of r.instances) this.$removeInstance(item);
+      this.$clearRepeatBinding(r);
+    }
+    this.$clearInstance(instance);
+  }
+
+  private $compactNodeArray(instance: TemplateInstance): void {
+    const container = instance.container;
+    if (!container) return;
+    const nodes = instance.nodes;
+    let write = 0;
+    for (let read = 0; read < nodes.length; read++) {
+      const node = nodes[read];
+      if (node.parentNode === container) {
+        nodes[write] = node;
+        write++;
+      }
+    }
+    nodes.length = write;
+  }
+
+  $compactInstanceNodes(instance: TemplateInstance): void {
+    let current: TemplateInstance | undefined = instance;
+    while (current) {
+      this.$compactNodeArray(current);
+      current = current.parent;
     }
   }
 
+  $invalidatePathIndex(): void {
+    this.$pathIndex = undefined;
+    this.$wildcardBindings = undefined;
+  }
+
   $insertInstanceAfter(cursor: Node | null, container: ParentNode & Node, instance: TemplateInstance): Node | null {
+    this.$replaceInstanceContainer(instance, instance.container, container);
     const nodes = instance.nodes;
     if (nodes.length === 0) return cursor;
     const ref = cursor ? cursor.nextSibling : container.firstChild;
@@ -1880,14 +1987,4 @@ export class TemplateElement extends HTMLElement {
     return nodes[nodes.length - 1];
   }
 
-  /** Extract the single dynamic path from a compiled attr parts array. */
-  private $singleDynamic(parts: CompiledAttrPart[]): { path: string; prefix: string; suffix: string } | null {
-    let path = ''; let prefix = ''; let suffix = ''; let seen = false;
-    for (const p of parts) {
-      if (typeof p === 'string') { if (seen) suffix += p; else prefix += p; continue; }
-      if (seen) return null;
-      path = p[0]; seen = true;
-    }
-    return seen ? { path, prefix, suffix } : null;
-  }
 }

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -75,6 +75,7 @@ import {
   ATTR_KIND_BOOLEAN,
   ATTR_KIND_COMPLEX,
   ATTR_KIND_TEMPLATE,
+  hasNativeLiveProperty,
 } from './element/types.js';
 import { templateHasRoot, templateRootForAttribute } from './template-roots.js';
 import type {
@@ -1736,7 +1737,10 @@ export class TemplateElement extends HTMLElement {
         if (show) el.setAttribute(b.name, '');
         else el.removeAttribute(b.name);
         // Form control properties must be set via DOM property, not attribute
-        if (b.name === 'checked' || b.name === 'selected' || b.name === 'disabled') {
+        if (
+          (b.name === 'checked' || b.name === 'selected' || b.name === 'disabled')
+          && hasNativeLiveProperty(el, b.name)
+        ) {
           (el as unknown as Record<string, unknown>)[b.name] = show;
         }
         break;
@@ -1750,10 +1754,14 @@ export class TemplateElement extends HTMLElement {
         const v = this.$resolveValue(b.path!, b.scope);
         const s = v == null ? '' : String(v);
         // Form control properties diverge from attributes after user interaction
-        if (b.name === 'checked' || b.name === 'selected') {
+        if (
+          (b.name === 'checked' || b.name === 'selected')
+          && hasNativeLiveProperty(el, b.name)
+        ) {
           (el as unknown as Record<string, unknown>)[b.name] = !!v && v !== 'false' && v !== '0';
-        } else if (b.name === 'value') {
-          if ((el as HTMLInputElement).value !== s) (el as HTMLInputElement).value = s;
+        } else if (b.name === 'value' && hasNativeLiveProperty(el, b.name)) {
+          const target = el as Element & { value: unknown };
+          if (target.value !== s) target.value = s;
         } else {
           if (el.getAttribute(b.name) !== s) el.setAttribute(b.name, s);
         }

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -424,7 +424,7 @@ export class TemplateElement extends HTMLElement {
       this.$updateInstance(this.$root);
       if (this.$root.repeats.length !== 0 || this.$root.conds.length !== 0) {
         this.$root.nodes = childNodesArray(clientRoot);
-        this.$releaseStagingRepeatContainers(
+        this.$replaceInstanceContainer(
           this.$root,
           clientRoot,
           root as ParentNode & Node,
@@ -459,7 +459,7 @@ export class TemplateElement extends HTMLElement {
       this.$hasUnknownScopes = false;
       return;
     }
-    this.$teardown(this.$root);
+    this.$disposeInstance(this.$root, false);
     this.$root = null;
     this.$pathIndex = undefined;
     this.$wildcardBindings = undefined;
@@ -468,20 +468,6 @@ export class TemplateElement extends HTMLElement {
     this.$preReadyWrites = null;
     this.$ready = false;
     this.$hasUnknownScopes = false;
-  }
-
-  /** Break all DOM references held by a binding instance and its nested blocks. */
-  private $teardown(instance: TemplateInstance): void {
-    this.$teardownInstanceCleanups(instance);
-    for (const c of instance.conds) {
-      if (c.instance) this.$teardown(c.instance);
-      c.instance = null;
-    }
-    for (const r of instance.repeats) {
-      for (const item of r.instances) this.$teardown(item);
-      this.$clearRepeatBinding(r);
-    }
-    this.$clearInstance(instance);
   }
 
   private $clearRepeatBinding(repeat: RepeatBinding): void {
@@ -493,7 +479,6 @@ export class TemplateElement extends HTMLElement {
     if (state) {
       state.keys.length = 0;
       state.nextKeys.length = 0;
-      state.nextInstances.length = 0;
       state.map.clear();
     }
   }
@@ -507,14 +492,6 @@ export class TemplateElement extends HTMLElement {
     instance.attrs.length = 0;
     instance.conds.length = 0;
     instance.repeats.length = 0;
-  }
-
-  /** Run listener cleanup attached directly to one template instance. */
-  private $teardownInstanceCleanups(instance: TemplateInstance): void {
-    const cleanups = instance.cleanups;
-    if (!cleanups) return;
-    for (let i = 0; i < cleanups.length; i++) cleanups[i]();
-    cleanups.length = 0;
   }
 
   attributeChangedCallback(
@@ -943,36 +920,10 @@ export class TemplateElement extends HTMLElement {
     root.appendChild(fragment);
   }
 
-  private $releaseStagingRepeatContainers(
-    instance: TemplateInstance | null,
-    stagingRoot: Node | null,
-    target?: ParentNode & Node,
-  ): void {
-    if (!instance || !stagingRoot) return;
-    if (instance.repeats.length === 0 && instance.conds.length === 0) return;
-    const stack: TemplateInstance[] = [instance];
-    while (stack.length > 0) {
-      const current = stack.pop();
-      if (!current) continue;
-      if (target && current.container === stagingRoot) current.container = target;
-      for (let i = 0; i < current.repeats.length; i++) {
-        const repeat = current.repeats[i];
-        if (repeat.container === stagingRoot) repeat.container = target ?? null;
-        for (let j = 0; j < repeat.instances.length; j++) {
-          stack.push(repeat.instances[j]);
-        }
-      }
-      for (let i = 0; i < current.conds.length; i++) {
-        const child = current.conds[i].instance;
-        if (child) stack.push(child);
-      }
-    }
-  }
-
   private $replaceInstanceContainer(
     instance: TemplateInstance,
     previous: (ParentNode & Node) | null,
-    next: ParentNode & Node,
+    next: (ParentNode & Node) | null,
   ): void {
     if (previous === next) return;
     const stack: TemplateInstance[] = [instance];
@@ -1829,13 +1780,12 @@ export class TemplateElement extends HTMLElement {
       }
       if (c.instance && container) {
         this.$insertInstanceAfter(c.anchor, container, c.instance);
-        if (created) this.$invalidatePathIndex();
+        if (created) this.$changeStructure();
       }
     } else if (c.instance) {
       this.$removeInstance(c.instance);
       c.instance = null;
-      this.$compactInstanceNodes(c.owner);
-      this.$invalidatePathIndex();
+      this.$changeStructure(c.owner);
     }
   }
 
@@ -1922,29 +1872,40 @@ export class TemplateElement extends HTMLElement {
     this.$updateInstance(inst);
     if (inst.repeats.length !== 0 || inst.conds.length !== 0) {
       inst.nodes = childNodesArray(wrapper);
-      this.$releaseStagingRepeatContainers(inst, wrapper, container);
+      this.$replaceInstanceContainer(inst, wrapper, container ?? null);
+    } else if (container) {
+      inst.container = container;
     }
-    if (container) inst.container = container;
     return inst;
   }
 
   $removeInstance(instance: TemplateInstance): void {
-    this.$teardownInstanceCleanups(instance);
-    for (let i = 0; i < instance.nodes.length; i++) {
-      const node = instance.nodes[i];
-      node.parentNode?.removeChild(node);
-    }
-    for (const c of instance.conds) {
-      if (c.instance) {
-        this.$removeInstance(c.instance);
-        c.instance = null;
+    this.$disposeInstance(instance, true);
+  }
+
+  private $disposeInstance(root: TemplateInstance, removeNodes: boolean): void {
+    const stack: TemplateInstance[] = [root];
+    while (stack.length > 0) {
+      const instance = stack.pop();
+      if (!instance) continue;
+      const cleanups = instance.cleanups;
+      if (cleanups) {
+        for (const cleanup of cleanups) cleanup();
+        cleanups.length = 0;
       }
+      if (removeNodes) {
+        for (const node of instance.nodes) node.parentNode?.removeChild(node);
+      }
+      for (const binding of instance.conds) {
+        if (binding.instance) stack.push(binding.instance);
+        binding.instance = null;
+      }
+      for (const repeat of instance.repeats) {
+        for (const child of repeat.instances) stack.push(child);
+        this.$clearRepeatBinding(repeat);
+      }
+      this.$clearInstance(instance);
     }
-    for (const r of instance.repeats) {
-      for (const item of r.instances) this.$removeInstance(item);
-      this.$clearRepeatBinding(r);
-    }
-    this.$clearInstance(instance);
   }
 
   private $compactNodeArray(instance: TemplateInstance): void {
@@ -1962,15 +1923,14 @@ export class TemplateElement extends HTMLElement {
     nodes.length = write;
   }
 
-  $compactInstanceNodes(instance: TemplateInstance): void {
-    let current: TemplateInstance | undefined = instance;
-    while (current) {
-      this.$compactNodeArray(current);
-      current = current.parent;
+  $changeStructure(removedFrom?: TemplateInstance): void {
+    if (removedFrom) {
+      let current: TemplateInstance | undefined = removedFrom;
+      while (current) {
+        this.$compactNodeArray(current);
+        current = current.parent;
+      }
     }
-  }
-
-  $invalidatePathIndex(): void {
     this.$pathIndex = undefined;
     this.$wildcardBindings = undefined;
   }
@@ -1981,9 +1941,7 @@ export class TemplateElement extends HTMLElement {
     if (nodes.length === 0) return cursor;
     const ref = cursor ? cursor.nextSibling : container.firstChild;
     if (nodes[0] === ref) return nodes[nodes.length - 1];
-    const frag = document.createDocumentFragment();
-    for (let i = 0; i < nodes.length; i++) frag.appendChild(nodes[i]);
-    container.insertBefore(frag, ref);
+    for (let i = 0; i < nodes.length; i++) container.insertBefore(nodes[i], ref);
     return nodes[nodes.length - 1];
   }
 

--- a/packages/webui-framework/src/template-types.ts
+++ b/packages/webui-framework/src/template-types.ts
@@ -44,7 +44,13 @@ export type CompiledAttrMeta =
   | [name: string, kind: 2, condition: TemplateCondition]
   | [name: string, kind: 3, parts: CompiledAttrPart[]];
 
-export type CompiledRepeatMeta = [collection: string, itemVar: string, blockIndex: number, slot: TemplateSlotPath];
+export type CompiledRepeatMeta = [
+  collection: string,
+  itemVar: string,
+  blockIndex: number,
+  slot: TemplateSlotPath,
+  keyPath?: string,
+];
 export type CompiledEventArg =
   | ['e']
   | ['p', string]

--- a/packages/webui-framework/src/template.ts
+++ b/packages/webui-framework/src/template.ts
@@ -10,7 +10,7 @@
  * - `a`  — attribute binding metadata
  * - `ag` — attribute target groups `[path, startIndex, count]`
  * - `c`  — conditional blocks `[conditionRef, blockIndex, slot]`
- * - `r`  — repeat/for blocks `[collection, itemVar, blockIndex, slot]`
+ * - `r`  — repeat/for blocks `[collection, itemVar, blockIndex, slot, keyPath?]`
  * - `eg` — grouped element events `[eventName, [[handlerName, argSpecs, targetPath, usesEvent?]]]`
  * - `b`  — nested compiled block metadata
  * - `sa` — adopted stylesheet specifier for CSS module strategy

--- a/packages/webui-framework/tests/fixtures/bench/bench.spec.ts
+++ b/packages/webui-framework/tests/fixtures/bench/bench.spec.ts
@@ -12,6 +12,16 @@ interface BenchResult {
   allPropsPerUpdate: number;
 }
 
+interface RepeatBenchResult {
+  itemCount: number;
+  updateIterations: number;
+  createMs: number;
+  create2Ms: number;
+  updateMs: number;
+  updatePerIterationMs: number;
+  clearMs: number;
+}
+
 test.describe('bench fixture', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/bench/fixture.html');
@@ -51,5 +61,37 @@ test.describe('bench fixture', () => {
     // After Phase 5, single-prop should be ~10x faster.
     //
     // We don't assert this ratio yet — this test captures the baseline.
+  });
+
+  test('measures repeat reconciliation performance', async ({ page }) => {
+    await page.locator('test-bench-repeat .run-repeat').click();
+
+    await page.waitForFunction(
+      () =>
+        (window as unknown as Record<string, unknown>).__repeatBenchResult !=
+        null,
+    );
+
+    const result = await page.evaluate(
+      () =>
+        (window as unknown as Record<string, unknown>)
+          .__repeatBenchResult as RepeatBenchResult,
+    );
+
+    console.log('\n=== WebUI Framework Repeat Benchmark ===');
+    console.log(`Items: ${result.itemCount}`);
+    console.log(`Iterations: ${result.updateIterations}`);
+    console.log(`Create: ${result.createMs}ms`);
+    console.log(`Cached create: ${result.create2Ms}ms`);
+    console.log(
+      `Update: ${result.updateMs}ms total, ${result.updatePerIterationMs}ms/iteration`,
+    );
+    console.log(`Clear: ${result.clearMs}ms`);
+    console.log('=========================================\n');
+
+    expect(result.itemCount).toBe(200);
+    expect(result.updateIterations).toBe(200);
+    expect(result.updateMs).toBeGreaterThan(0);
+    expect(result.updatePerIterationMs).toBeGreaterThan(0);
   });
 });

--- a/packages/webui-framework/tests/fixtures/bench/element.ts
+++ b/packages/webui-framework/tests/fixtures/bench/element.ts
@@ -81,6 +81,7 @@ TestBench.define('test-bench');
 // ── Repeat instantiation benchmark ─────────────────────────────────
 
 interface BenchItem {
+  id: number;
   label: string;
   value: string;
 }
@@ -90,38 +91,44 @@ export class TestBenchRepeat extends WebUIElement {
   @observable benchResult = '';
 
   runRepeatBench(): void {
-    // Generate 200 items
+    const updateIterations = 200;
     const data: BenchItem[] = [];
+    const swapped: BenchItem[] = [];
     for (let i = 0; i < 200; i++) {
-      data.push({ label: `Item ${i}`, value: `val-${i}` });
+      data.push({ id: i, label: `Item ${i}`, value: `val-${i}` });
+      swapped.push({ id: i, label: `val-${i}`, value: `Item ${i}` });
     }
 
-    // Benchmark: create 200 items (measures template cloning vs parsing)
     const createStart = performance.now();
     this.items = data;
+    this.$flushUpdates();
     const createTime = performance.now() - createStart;
 
-    // Benchmark: update all items (swap values)
-    const swapped = data.map(d => ({ label: d.value, value: d.label }));
     const updateStart = performance.now();
-    this.items = swapped;
+    for (let i = 0; i < updateIterations; i++) {
+      this.items = i % 2 === 0 ? swapped : data;
+      this.$flushUpdates();
+    }
     const updateTime = performance.now() - updateStart;
 
-    // Benchmark: clear all
     const clearStart = performance.now();
     this.items = [];
+    this.$flushUpdates();
     const clearTime = performance.now() - clearStart;
 
-    // Second create to measure cached clone path
     const create2Start = performance.now();
     this.items = data;
+    this.$flushUpdates();
     const create2Time = performance.now() - create2Start;
 
     const result = {
       itemCount: 200,
+      updateIterations,
       createMs: Math.round(createTime * 100) / 100,
       create2Ms: Math.round(create2Time * 100) / 100,
       updateMs: Math.round(updateTime * 100) / 100,
+      updatePerIterationMs:
+        Math.round((updateTime / updateIterations) * 1000) / 1000,
       clearMs: Math.round(clearTime * 100) / 100,
     };
 

--- a/packages/webui-framework/tests/fixtures/bench/src/test-bench-repeat/test-bench-repeat.html
+++ b/packages/webui-framework/tests/fixtures/bench/src/test-bench-repeat/test-bench-repeat.html
@@ -1,1 +1,1 @@
-<button class="run-repeat" @click="{runRepeatBench()}"></button><ul class="list"><for each="item in items"><li class="bench-item"><span class="label">{{item.label}}</span> — <span class="value">{{item.value}}</span></li></for></ul>
+<button class="run-repeat" @click="{runRepeatBench()}"></button><ul class="list"><for each="item in items"><li class="bench-item" key="{{item.id}}"><span class="label">{{item.label}}</span> — <span class="value">{{item.value}}</span></li></for></ul>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/client-binding-lifecycle.spec.ts
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/client-binding-lifecycle.spec.ts
@@ -57,15 +57,17 @@ async function waitForConnectedValue(page: Page, selector: string, expected: str
   );
 }
 
-function readKeyedNestedSequence(page: Page, selector: string): Promise<string[]> {
+function readPositionalNestedSequence(page: Page, selector: string): Promise<string[]> {
   return page.evaluate((hostSelector) => {
     const host = document.querySelector(hostSelector);
     const children = host?.shadowRoot?.children ?? [];
     const sequence: string[] = [];
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
-      if (child.classList.contains('group-key')) {
+      if (child.classList.contains('group-label')) {
         sequence.push(`group:${child.textContent ?? ''}`);
+      } else if (child.classList.contains('section-label')) {
+        sequence.push(`section:${child.textContent ?? ''}`);
       } else if (child.localName === 'test-lifecycle-child') {
         sequence.push(`child:${(child as HTMLElement & { value?: string }).value ?? ''}`);
       }
@@ -230,7 +232,7 @@ test.describe('client binding lifecycle: CSR-created children', () => {
     });
   });
 
-  test('reused keyed repeat items move before nested repeats update', async ({ page }) => {
+  test('keyed groups move with their nested child instances', async ({ page }) => {
     await page.evaluate(() => {
       const parent = document.createElement('test-lifecycle-keyed-nested-repeat-parent') as HTMLElement & {
         setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
@@ -239,17 +241,292 @@ test.describe('client binding lifecycle: CSR-created children', () => {
       document.querySelector('#mount')?.appendChild(parent);
       parent.setGroups([
         { id: 'a', items: [{ id: 'a1', value: 'A1' }] },
-        { id: 'b', items: [{ id: 'b1', value: 'B1' }] },
+        {
+          id: 'b',
+          items: [
+            { id: 'b1', value: 'B1' },
+            { id: 'b2', value: 'B2' },
+          ],
+        },
       ]);
     });
 
     await page.waitForFunction(() => {
       const parent = document.querySelector('#dynamic-keyed-nested-repeat');
-      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 2;
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 3;
+    });
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-repeat');
+      const root = parent?.shadowRoot;
+      const win = window as unknown as {
+        __groupA?: Element;
+        __groupB?: Element;
+        __childA?: Element;
+        __childB1?: Element;
+        __childB2?: Element;
+      };
+      win.__groupA = root?.querySelector('[data-id="a"]') ?? undefined;
+      win.__groupB = root?.querySelector('[data-id="b"]') ?? undefined;
+      const children = root?.querySelectorAll('test-lifecycle-child');
+      win.__childA = children?.[0];
+      win.__childB1 = children?.[1];
+      win.__childB2 = children?.[2];
     });
 
     await page.evaluate(() => {
       const parent = document.querySelector('#dynamic-keyed-nested-repeat') as HTMLElement & {
+        setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
+      };
+      parent.setGroups([
+        {
+          id: 'b',
+          items: [
+            { id: 'b2', value: 'B2 updated' },
+            { id: 'b1', value: 'B1 updated' },
+          ],
+        },
+        { id: 'a', items: [{ id: 'a1', value: 'A1 updated' }] },
+      ]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-repeat');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 3;
+    });
+    const result = await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-repeat');
+      const root = parent?.shadowRoot;
+      const labels = root?.querySelectorAll('.group-label');
+      const children = root?.querySelectorAll('test-lifecycle-child');
+      const win = window as unknown as {
+        __groupA?: Element;
+        __groupB?: Element;
+        __childA?: Element;
+        __childB1?: Element;
+        __childB2?: Element;
+      };
+      return {
+        groupBPreserved: win.__groupB === labels?.[0],
+        groupAPreserved: win.__groupA === labels?.[1],
+        childB2Preserved: win.__childB2 === children?.[0],
+        childB1Preserved: win.__childB1 === children?.[1],
+        childAPreserved: win.__childA === children?.[2],
+      };
+    });
+
+    expect(result).toEqual({
+      groupBPreserved: true,
+      groupAPreserved: true,
+      childB2Preserved: true,
+      childB1Preserved: true,
+      childAPreserved: true,
+    });
+    const sequence = await readPositionalNestedSequence(
+      page,
+      '#dynamic-keyed-nested-repeat',
+    );
+    expect(sequence).toEqual([
+      'group:b',
+      'child:B2 updated',
+      'child:B1 updated',
+      'group:a',
+      'child:A1 updated',
+    ]);
+  });
+
+  test('removed nested items are not resurrected when a keyed parent moves', async ({ page }) => {
+    await page.evaluate(() => {
+      const parent = document.createElement('test-lifecycle-keyed-nested-repeat-parent') as HTMLElement & {
+        setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
+      };
+      parent.id = 'dynamic-keyed-nested-shrink';
+      document.querySelector('#mount')?.appendChild(parent);
+      parent.setGroups([
+        { id: 'a', items: [{ id: 'a1', value: 'A1' }] },
+        {
+          id: 'b',
+          items: [
+            { id: 'b1', value: 'B1' },
+            { id: 'b2', value: 'B2' },
+          ],
+        },
+      ]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-shrink');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 3;
+    });
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-shrink') as HTMLElement & {
+        setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
+      };
+      const children = parent.shadowRoot?.querySelectorAll('test-lifecycle-child');
+      (window as unknown as { __removedNestedChild?: Element }).__removedNestedChild = children?.[2];
+      parent.setGroups([
+        { id: 'a', items: [{ id: 'a1', value: 'A1' }] },
+        { id: 'b', items: [{ id: 'b1', value: 'B1' }] },
+      ]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-shrink');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 2;
+    });
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-shrink') as HTMLElement & {
+        setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
+      };
+      parent.setGroups([
+        { id: 'b', items: [{ id: 'b1', value: 'B1 updated' }] },
+        { id: 'a', items: [{ id: 'a1', value: 'A1 updated' }] },
+      ]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-keyed-nested-shrink');
+      const labels = parent?.shadowRoot?.querySelectorAll('.group-label');
+      return labels?.[0]?.textContent === 'b';
+    });
+    const sequence = await readPositionalNestedSequence(
+      page,
+      '#dynamic-keyed-nested-shrink',
+    );
+    const removedConnected = await page.evaluate(
+      () => (window as unknown as { __removedNestedChild?: Element })
+        .__removedNestedChild?.isConnected,
+    );
+
+    expect(sequence).toEqual([
+      'group:b',
+      'child:B1 updated',
+      'group:a',
+      'child:A1 updated',
+    ]);
+    expect(removedConnected).toBe(false);
+  });
+
+  test('deep nested removals survive keyed ancestor movement', async ({ page }) => {
+    await page.evaluate(() => {
+      const parent = document.createElement(
+        'test-lifecycle-deep-keyed-nested-repeat-parent',
+      ) as HTMLElement & {
+        setGroups(groups: Array<{
+          id: string;
+          sections: Array<{
+            id: string;
+            items: Array<{ id: string; value?: string }>;
+          }>;
+        }>): void;
+      };
+      parent.id = 'dynamic-deep-keyed-nested';
+      document.querySelector('#mount')?.appendChild(parent);
+      parent.setGroups([{
+        id: 'g',
+        sections: [
+          { id: 'a', items: [{ id: 'a1', value: 'A1' }] },
+          {
+            id: 'b',
+            items: [
+              { id: 'b1', value: 'B1' },
+              { id: 'b2', value: 'B2' },
+            ],
+          },
+        ],
+      }]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-deep-keyed-nested');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 3;
+    });
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-deep-keyed-nested') as HTMLElement & {
+        setGroups(groups: Array<{
+          id: string;
+          sections: Array<{
+            id: string;
+            items: Array<{ id: string; value?: string }>;
+          }>;
+        }>): void;
+      };
+      const children = parent.shadowRoot?.querySelectorAll('test-lifecycle-child');
+      (window as unknown as { __removedDeepChild?: Element }).__removedDeepChild = children?.[2];
+      parent.setGroups([{
+        id: 'g',
+        sections: [
+          { id: 'a', items: [{ id: 'a1', value: 'A1 updated' }] },
+          { id: 'b', items: [{ id: 'b1', value: 'B1 updated' }] },
+        ],
+      }]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-deep-keyed-nested');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 2;
+    });
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-deep-keyed-nested') as HTMLElement & {
+        setGroups(groups: Array<{
+          id: string;
+          sections: Array<{
+            id: string;
+            items: Array<{ id: string; value?: string }>;
+          }>;
+        }>): void;
+      };
+      parent.setGroups([{
+        id: 'g',
+        sections: [
+          { id: 'b', items: [{ id: 'b1', value: 'B1 moved' }] },
+          { id: 'a', items: [{ id: 'a1', value: 'A1 moved' }] },
+        ],
+      }]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-deep-keyed-nested');
+      return parent?.shadowRoot?.querySelector('.section-label')?.textContent === 'b';
+    });
+    const sequence = await readPositionalNestedSequence(
+      page,
+      '#dynamic-deep-keyed-nested',
+    );
+    const removedConnected = await page.evaluate(
+      () => (window as unknown as { __removedDeepChild?: Element })
+        .__removedDeepChild?.isConnected,
+    );
+
+    expect(sequence).toEqual([
+      'group:g',
+      'section:b',
+      'child:B1 moved',
+      'section:a',
+      'child:A1 moved',
+    ]);
+    expect(removedConnected).toBe(false);
+  });
+
+  test('reused positional items update nested repeats in place', async ({ page }) => {
+    await page.evaluate(() => {
+      const parent = document.createElement('test-lifecycle-positional-nested-repeat-parent') as HTMLElement & {
+        setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
+      };
+      parent.id = 'dynamic-positional-nested-repeat';
+      document.querySelector('#mount')?.appendChild(parent);
+      parent.setGroups([
+        { id: 'a', items: [{ id: 'a1', value: 'A1' }] },
+        { id: 'b', items: [{ id: 'b1', value: 'B1' }] },
+      ]);
+    });
+
+    await page.waitForFunction(() => {
+      const parent = document.querySelector('#dynamic-positional-nested-repeat');
+      return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 2;
+    });
+
+    await page.evaluate(() => {
+      const parent = document.querySelector('#dynamic-positional-nested-repeat') as HTMLElement & {
         setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void;
       };
       parent.setGroups([
@@ -259,11 +536,14 @@ test.describe('client binding lifecycle: CSR-created children', () => {
     });
 
     await page.waitForFunction(() => {
-      const parent = document.querySelector('#dynamic-keyed-nested-repeat');
+      const parent = document.querySelector('#dynamic-positional-nested-repeat');
       return parent?.shadowRoot?.querySelectorAll('test-lifecycle-child').length === 3;
     });
 
-    const sequence = await readKeyedNestedSequence(page, '#dynamic-keyed-nested-repeat');
+    const sequence = await readPositionalNestedSequence(
+      page,
+      '#dynamic-positional-nested-repeat',
+    );
     expect(sequence).toEqual(['group:b', 'child:B1', 'child:B2', 'group:a', 'child:A1']);
   });
 });

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/client-binding-lifecycle.spec.ts
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/client-binding-lifecycle.spec.ts
@@ -76,7 +76,7 @@ function readPositionalNestedSequence(page: Page, selector: string): Promise<str
   }, selector);
 }
 
-test.describe('client binding lifecycle: CSR-created children', () => {
+test.describe('client binding lifecycle', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/client-binding-lifecycle/fixture.html');
     await page.waitForFunction(() => {
@@ -188,6 +188,29 @@ test.describe('client binding lifecycle: CSR-created children', () => {
       fallbackApplied: 'yes',
       valueText: 'set-by-child',
     });
+  });
+
+  test('positional repeat updates value attributes on scriptless custom elements', async ({ page }) => {
+    const child = page.locator(
+      '#ssr-value-repeat-seed test-lifecycle-value-child',
+    );
+    await expect(child).toHaveAttribute('value', 'seed');
+    await expect(child.locator('.value')).toHaveText('seed');
+
+    await page.evaluate(() => {
+      const parent = document.querySelector('#ssr-value-repeat-seed') as HTMLElement & {
+        setValues(values: Array<{ value: string }>): void;
+      };
+      parent.setValues([{ value: 'updated' }]);
+    });
+
+    await expect(child).toHaveAttribute('value', 'updated');
+    await expect(child.locator('.value')).toHaveText('updated');
+    expect(
+      await child.evaluate((element) => (
+        Object.prototype.hasOwnProperty.call(element, 'value')
+      )),
+    ).toBe(false);
   });
 
   test('conditional-created nested repeat children are inserted after detached first update', async ({ page }) => {

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/element.ts
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/element.ts
@@ -63,10 +63,34 @@ export class TestLifecycleNestedRepeatParent extends WebUIElement {
   }
 }
 
+export class TestLifecyclePositionalNestedRepeatParent extends WebUIElement {
+  @observable groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }> = [];
+
+  setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void {
+    this.groups = groups;
+  }
+}
+
 export class TestLifecycleKeyedNestedRepeatParent extends WebUIElement {
   @observable groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }> = [];
 
   setGroups(groups: Array<{ id: string; items: Array<{ id: string; value?: string }> }>): void {
+    this.groups = groups;
+  }
+}
+
+type DeepGroup = {
+  id: string;
+  sections: Array<{
+    id: string;
+    items: Array<{ id: string; value?: string }>;
+  }>;
+};
+
+export class TestLifecycleDeepKeyedNestedRepeatParent extends WebUIElement {
+  @observable groups: DeepGroup[] = [];
+
+  setGroups(groups: DeepGroup[]): void {
     this.groups = groups;
   }
 }
@@ -77,4 +101,12 @@ TestLifecycleConditionalParent.define('test-lifecycle-conditional-parent');
 TestLifecycleRepeatParent.define('test-lifecycle-repeat-parent');
 TestLifecycleConditionalRepeatParent.define('test-lifecycle-conditional-repeat-parent');
 TestLifecycleNestedRepeatParent.define('test-lifecycle-nested-repeat-parent');
-TestLifecycleKeyedNestedRepeatParent.define('test-lifecycle-keyed-nested-repeat-parent');
+TestLifecyclePositionalNestedRepeatParent.define(
+  'test-lifecycle-positional-nested-repeat-parent',
+);
+TestLifecycleKeyedNestedRepeatParent.define(
+  'test-lifecycle-keyed-nested-repeat-parent',
+);
+TestLifecycleDeepKeyedNestedRepeatParent.define(
+  'test-lifecycle-deep-keyed-nested-repeat-parent',
+);

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/element.ts
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/element.ts
@@ -45,6 +45,14 @@ export class TestLifecycleRepeatParent extends WebUIElement {
   }
 }
 
+export class TestLifecycleValueRepeatParent extends WebUIElement {
+  @observable values: Array<{ value: string }> = [];
+
+  setValues(values: Array<{ value: string }>): void {
+    this.values = values;
+  }
+}
+
 export class TestLifecycleConditionalRepeatParent extends WebUIElement {
   @observable show = false;
   @observable items: Array<{ id: string; value?: string }> = [];
@@ -99,6 +107,7 @@ TestLifecycleChild.define('test-lifecycle-child');
 TestLifecycleParent.define('test-lifecycle-parent');
 TestLifecycleConditionalParent.define('test-lifecycle-conditional-parent');
 TestLifecycleRepeatParent.define('test-lifecycle-repeat-parent');
+TestLifecycleValueRepeatParent.define('test-lifecycle-value-repeat-parent');
 TestLifecycleConditionalRepeatParent.define('test-lifecycle-conditional-repeat-parent');
 TestLifecycleNestedRepeatParent.define('test-lifecycle-nested-repeat-parent');
 TestLifecyclePositionalNestedRepeatParent.define(

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/index.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/index.html
@@ -7,7 +7,9 @@
   <test-lifecycle-repeat-parent id="ssr-repeat-seed" style="display:none"></test-lifecycle-repeat-parent>
   <test-lifecycle-conditional-repeat-parent id="ssr-conditional-repeat-seed" style="display:none"></test-lifecycle-conditional-repeat-parent>
   <test-lifecycle-nested-repeat-parent id="ssr-nested-repeat-seed" style="display:none"></test-lifecycle-nested-repeat-parent>
+  <test-lifecycle-positional-nested-repeat-parent id="ssr-positional-nested-repeat-seed" style="display:none"></test-lifecycle-positional-nested-repeat-parent>
   <test-lifecycle-keyed-nested-repeat-parent id="ssr-keyed-nested-repeat-seed" style="display:none"></test-lifecycle-keyed-nested-repeat-parent>
+  <test-lifecycle-deep-keyed-nested-repeat-parent id="ssr-deep-keyed-nested-repeat-seed" style="display:none"></test-lifecycle-deep-keyed-nested-repeat-parent>
   <div id="mount"></div>
 </body>
 </html>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/index.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/index.html
@@ -5,6 +5,7 @@
   <test-lifecycle-parent id="ssr-parent-seed" style="display:none"></test-lifecycle-parent>
   <test-lifecycle-conditional-parent id="ssr-conditional-seed" style="display:none"></test-lifecycle-conditional-parent>
   <test-lifecycle-repeat-parent id="ssr-repeat-seed" style="display:none"></test-lifecycle-repeat-parent>
+  <test-lifecycle-value-repeat-parent id="ssr-value-repeat-seed" style="display:none"></test-lifecycle-value-repeat-parent>
   <test-lifecycle-conditional-repeat-parent id="ssr-conditional-repeat-seed" style="display:none"></test-lifecycle-conditional-repeat-parent>
   <test-lifecycle-nested-repeat-parent id="ssr-nested-repeat-seed" style="display:none"></test-lifecycle-nested-repeat-parent>
   <test-lifecycle-positional-nested-repeat-parent id="ssr-positional-nested-repeat-seed" style="display:none"></test-lifecycle-positional-nested-repeat-parent>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-deep-keyed-nested-repeat-parent/test-lifecycle-deep-keyed-nested-repeat-parent.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-deep-keyed-nested-repeat-parent/test-lifecycle-deep-keyed-nested-repeat-parent.html
@@ -1,0 +1,9 @@
+<for each="group in groups">
+  <span class="group-label" key="{{group.id}}">{{group.id}}</span>
+  <for each="section in group.sections">
+    <span class="section-label" key="{{section.id}}">{{section.id}}</span>
+    <for each="item in section.items">
+      <test-lifecycle-child key="{{item.id}}" :value="{{item.value}}"></test-lifecycle-child>
+    </for>
+  </for>
+</for>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-keyed-nested-repeat-parent/test-lifecycle-keyed-nested-repeat-parent.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-keyed-nested-repeat-parent/test-lifecycle-keyed-nested-repeat-parent.html
@@ -1,6 +1,6 @@
 <for each="group in groups">
-  <span class="group-key" data-id="{{group.id}}">{{group.id}}</span>
+  <span class="group-label" key="{{group.id}}" data-id="{{group.id}}">{{group.id}}</span>
   <for each="item in group.items">
-    <test-lifecycle-child :value="{{item.value}}"></test-lifecycle-child>
+    <test-lifecycle-child key="{{item.id}}" :value="{{item.value}}"></test-lifecycle-child>
   </for>
 </for>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-positional-nested-repeat-parent/test-lifecycle-positional-nested-repeat-parent.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-positional-nested-repeat-parent/test-lifecycle-positional-nested-repeat-parent.html
@@ -1,0 +1,6 @@
+<for each="group in groups">
+  <span class="group-label" data-id="{{group.id}}">{{group.id}}</span>
+  <for each="item in group.items">
+    <test-lifecycle-child :value="{{item.value}}"></test-lifecycle-child>
+  </for>
+</for>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-value-child/test-lifecycle-value-child.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-value-child/test-lifecycle-value-child.html
@@ -1,0 +1,1 @@
+<span class="value">{{value}}</span>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-value-repeat-parent/test-lifecycle-value-repeat-parent.html
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/src/test-lifecycle-value-repeat-parent/test-lifecycle-value-repeat-parent.html
@@ -1,0 +1,3 @@
+<for each="item in values">
+  <test-lifecycle-value-child value="{{item.value}}"></test-lifecycle-value-child>
+</for>

--- a/packages/webui-framework/tests/fixtures/client-binding-lifecycle/state.json
+++ b/packages/webui-framework/tests/fixtures/client-binding-lifecycle/state.json
@@ -1,5 +1,6 @@
 {
   "show": false,
   "items": [],
+  "values": [{ "value": "seed" }],
   "groups": []
 }

--- a/packages/webui-framework/tests/fixtures/list/list.spec.ts
+++ b/packages/webui-framework/tests/fixtures/list/list.spec.ts
@@ -22,6 +22,15 @@ test.describe('list fixture', () => {
     await expect(page.locator('test-list-item .done')).toHaveText(['Done']);
   });
 
+  test('keeps structural keys out of SSR and client-created DOM', async ({ page }) => {
+    await expect(page.locator('test-list-item[key]')).toHaveCount(0);
+
+    await page.locator('test-list .add').click();
+
+    await expect(page.locator('test-list-item')).toHaveCount(3);
+    await expect(page.locator('test-list-item[key]')).toHaveCount(0);
+  });
+
   test('boolean attr on repeat item root reflects item state', async ({ page }) => {
     // SSR: Beta (state=done) should have data-done, Alpha (pending) should not
     await expect(page.locator('test-list-item[data-done]')).toHaveCount(1);
@@ -50,23 +59,33 @@ test.describe('list fixture', () => {
     await expect(page.locator('test-list-item .done')).toHaveText(['Done', 'Done']);
   });
 
-  test('preserves keyed nodes when reversing the collection', async ({ page }) => {
+  test('moves keyed nodes with their items when reversing the collection', async ({ page }) => {
     const initial = await page.evaluate(() => {
       const host = document.querySelector('test-list');
-      const item = (host?.shadowRoot ?? host)?.querySelector('test-list-item[item-id="2"]');
-      const win = window as unknown as { __preservedNode?: Element | null };
-      win.__preservedNode = item;
-      return item instanceof HTMLElement;
+      const items = (host?.shadowRoot ?? host)?.querySelectorAll('test-list-item');
+      const win = window as unknown as {
+        __firstNode?: Element;
+        __secondNode?: Element;
+      };
+      win.__firstNode = items?.[0];
+      win.__secondNode = items?.[1];
+      return items?.length;
     });
 
-    expect(initial).toBe(true);
+    expect(initial).toBe(2);
 
     await page.locator('test-list .reverse').click();
 
     const preserved = await page.evaluate(() => {
       const host = document.querySelector('test-list');
-      const win = window as unknown as { __preservedNode?: Element | null };
-      return win.__preservedNode === (host?.shadowRoot ?? host)?.querySelector('test-list-item[item-id="2"]');
+      const items = (host?.shadowRoot ?? host)?.querySelectorAll('test-list-item');
+      const win = window as unknown as {
+        __firstNode?: Element;
+        __secondNode?: Element;
+      };
+      return (
+        win.__secondNode === items?.[0] && win.__firstNode === items?.[1]
+      );
     });
 
     expect(preserved).toBe(true);
@@ -78,34 +97,39 @@ test.describe('list fixture', () => {
     await expect(page.locator('test-list-item')).toHaveCount(0);
   });
 
-  test('prepend: inserts new item at top without recreating existing nodes', async ({ page }) => {
-    // Save references to existing nodes
+  test('prepend: preserves keyed item nodes after the inserted head', async ({ page }) => {
     const saved = await page.evaluate(() => {
       const host = document.querySelector('test-list');
       const root = host?.shadowRoot ?? host;
-      const win = window as unknown as { __item1?: Element | null; __item2?: Element | null };
-      win.__item1 = root?.querySelector('test-list-item[item-id="1"]');
-      win.__item2 = root?.querySelector('test-list-item[item-id="2"]');
-      return !!(win.__item1 && win.__item2);
+      const items = root?.querySelectorAll('test-list-item');
+      const win = window as unknown as {
+        __firstNode?: Element;
+        __secondNode?: Element;
+      };
+      win.__firstNode = items?.[0];
+      win.__secondNode = items?.[1];
+      return items?.length;
     });
-    expect(saved).toBe(true);
+    expect(saved).toBe(2);
 
     await page.locator('test-list .prepend').click();
 
-    // Existing nodes must be the same instances (not recreated)
     const preserved = await page.evaluate(() => {
       const host = document.querySelector('test-list');
       const root = host?.shadowRoot ?? host;
-      const win = window as unknown as { __item1?: Element | null; __item2?: Element | null };
+      const items = root?.querySelectorAll('test-list-item');
+      const win = window as unknown as {
+        __firstNode?: Element;
+        __secondNode?: Element;
+      };
       return {
-        item1Same: win.__item1 === root?.querySelector('test-list-item[item-id="1"]'),
-        item2Same: win.__item2 === root?.querySelector('test-list-item[item-id="2"]'),
+        firstSame: win.__firstNode === items?.[1],
+        secondSame: win.__secondNode === items?.[2],
       };
     });
-    expect(preserved.item1Same).toBe(true);
-    expect(preserved.item2Same).toBe(true);
+    expect(preserved.firstSame).toBe(true);
+    expect(preserved.secondSame).toBe(true);
 
-    // New item at top, existing items preserved in order
     await expect(page.locator('test-list-item').first().locator('.title')).toHaveText('Item 3');
     await expect(page.locator('test-list-item')).toHaveCount(3);
   });

--- a/packages/webui-framework/tests/fixtures/list/src/test-list/test-list.html
+++ b/packages/webui-framework/tests/fixtures/list/src/test-list/test-list.html
@@ -9,7 +9,7 @@
   </div>
   <div class="items">
     <for each="item in items">
-      <test-list-item item-id="{{item.id}}" title="{{item.title}}" state="{{item.state}}" ?data-done="{{item.state == 'done'}}" ?data-flagged="{{item.flagged}}"></test-list-item>
+      <test-list-item key="{{item.id}}" item-id="{{item.id}}" title="{{item.title}}" state="{{item.state}}" ?data-done="{{item.state == 'done'}}" ?data-flagged="{{item.flagged}}"></test-list-item>
       <button class="loop-arg" @click="{selectItem(item.id)}">{{item.title}}</button>
       <button class="loop-arg-event" @click="{selectItemWithEvent(item.id, e)}">{{item.title}}</button>
     </for>

--- a/packages/webui-framework/tests/fixtures/nested-repeat/element.ts
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/element.ts
@@ -13,6 +13,15 @@ interface NestedRepeatGroup {
   values: NestedRepeatValue[];
 }
 
+interface KeyedChainGroup {
+  id: string;
+  sections: Array<{
+    id: string;
+    visible: boolean;
+    items: Array<{ id: string; label: string }>;
+  }>;
+}
+
 export class TestNestedRepeat extends WebUIElement {
   @observable groups: NestedRepeatGroup[] = [];
 
@@ -82,5 +91,25 @@ export class TestNestedRepeat extends WebUIElement {
   }
 }
 
-TestNestedRepeat.define('test-nested-repeat');
+export class TestNestedRepeatKeyedChain extends WebUIElement {
+  @observable keyedGroups: KeyedChainGroup[] = [];
 
+  reverseItems(): void {
+    this.keyedGroups = this.keyedGroups.map((group) => ({
+      id: group.id,
+      sections: group.sections.map((section) => ({
+        id: section.id,
+        visible: section.visible,
+        items: section.items
+          .map((item) => ({
+            id: item.id,
+            label: `${item.label} updated`,
+          }))
+          .reverse(),
+      })),
+    }));
+  }
+}
+
+TestNestedRepeat.define('test-nested-repeat');
+TestNestedRepeatKeyedChain.define('test-nested-repeat-keyed-chain');

--- a/packages/webui-framework/tests/fixtures/nested-repeat/nested-repeat.spec.ts
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/nested-repeat.spec.ts
@@ -153,4 +153,53 @@ test.describe('nested repeat SSR hydration', () => {
   test('outer scope text bindings hydrate correctly', async ({ page }) => {
     await expect(page.locator('test-nested-repeat h2')).toHaveText(['Color', 'Size']);
   });
+
+  test('innermost keyed repeat hydrates and reorders through nested directives', async ({ page }) => {
+    await page.waitForFunction(() => {
+      const element = document.querySelector('test-nested-repeat-keyed-chain');
+      return element && (element as any).$ready === true;
+    });
+
+    const items = page.locator('test-nested-repeat-keyed-chain .keyed-chain-item');
+    await expect(items).toHaveCount(4);
+    await expect(items).toHaveText(['G1 A', 'G1 B', 'G2 A', 'G2 C']);
+
+    await page.evaluate(() => {
+      const parent = document.querySelector(
+        'test-nested-repeat-keyed-chain',
+      ) as HTMLElement & { reverseItems(): void };
+      const elements = parent.shadowRoot?.querySelectorAll('.keyed-chain-item');
+      const nodes = new Map<string, Element>();
+      elements?.forEach((element) => {
+        nodes.set(
+          `${element.getAttribute('data-group')}:${element.getAttribute('data-id')}`,
+          element,
+        );
+      });
+      (window as unknown as { __keyedChainNodes?: Map<string, Element> })
+        .__keyedChainNodes = nodes;
+      parent.reverseItems();
+    });
+
+    await expect(items).toHaveText([
+      'G1 B updated',
+      'G1 A updated',
+      'G2 C updated',
+      'G2 A updated',
+    ]);
+    const preserved = await page.evaluate(() => {
+      const parent = document.querySelector('test-nested-repeat-keyed-chain');
+      const elements = parent?.shadowRoot?.querySelectorAll('.keyed-chain-item');
+      const nodes = (window as unknown as {
+        __keyedChainNodes?: Map<string, Element>;
+      }).__keyedChainNodes;
+      return Array.from(elements ?? []).every((element) => (
+        nodes?.get(
+          `${element.getAttribute('data-group')}:${element.getAttribute('data-id')}`,
+        ) === element
+      ));
+    });
+
+    expect(preserved).toBe(true);
+  });
 });

--- a/packages/webui-framework/tests/fixtures/nested-repeat/src/index.html
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/src/index.html
@@ -6,5 +6,6 @@
 </head>
 <body>
   <test-nested-repeat></test-nested-repeat>
+  <test-nested-repeat-keyed-chain></test-nested-repeat-keyed-chain>
 </body>
 </html>

--- a/packages/webui-framework/tests/fixtures/nested-repeat/src/test-nested-repeat-keyed-chain/test-nested-repeat-keyed-chain.html
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/src/test-nested-repeat-keyed-chain/test-nested-repeat-keyed-chain.html
@@ -1,0 +1,15 @@
+<for each="group in keyedGroups">
+  <for each="section in group.sections">
+    <if condition="section.visible">
+      <for each="item in section.items">
+        <button
+          class="keyed-chain-item"
+          key="{{item.id}}"
+          data-group="{{group.id}}"
+          data-section="{{section.id}}"
+          data-id="{{item.id}}"
+        >{{item.label}}</button>
+      </for>
+    </if>
+  </for>
+</for>

--- a/packages/webui-framework/tests/fixtures/nested-repeat/state.json
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/state.json
@@ -14,5 +14,33 @@
         { "value": "M", "disabled": false }
       ]
     }
+  ],
+  "keyedGroups": [
+    {
+      "id": "g1",
+      "sections": [
+        {
+          "id": "s1",
+          "visible": true,
+          "items": [
+            { "id": "a", "label": "G1 A" },
+            { "id": "b", "label": "G1 B" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "g2",
+      "sections": [
+        {
+          "id": "s2",
+          "visible": true,
+          "items": [
+            { "id": "a", "label": "G2 A" },
+            { "id": "c", "label": "G2 C" }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/packages/webui-framework/tests/fixtures/sidebar-repeat/element.ts
+++ b/packages/webui-framework/tests/fixtures/sidebar-repeat/element.ts
@@ -3,13 +3,33 @@
 
 import { WebUIElement, attr, observable } from '../../../src/index.js';
 
+interface SidebarGroup {
+  className: string;
+  label: string;
+  slug: string;
+}
+
 export class TestSidebarRepeat extends WebUIElement {
   @attr page = 'dashboard';
   @attr activeGroup = '';
-  @observable groups: string[] = ['work', 'family', 'friends', 'other'];
+  @observable groups: SidebarGroup[] = [
+    { className: 'nav-item nav-item-group', label: 'work', slug: 'work' },
+    { className: 'nav-item nav-item-group', label: 'family', slug: 'family' },
+    { className: 'nav-item nav-item-group', label: 'friends', slug: 'friends' },
+    { className: 'nav-item nav-item-group', label: 'other', slug: 'other' },
+  ];
 
   syncGroups(): void {
-    this.groups = ['work', 'family', 'friends', 'other'];
+    this.groups = [
+      { className: 'nav-item nav-item-group', label: 'work', slug: 'work' },
+      { className: 'nav-item nav-item-group', label: 'family', slug: 'family' },
+      {
+        className: 'nav-item nav-item-group',
+        label: 'friends',
+        slug: 'friends',
+      },
+      { className: 'nav-item nav-item-group', label: 'other', slug: 'other' },
+    ];
   }
 }
 

--- a/packages/webui-framework/tests/fixtures/sidebar-repeat/sidebar-repeat.spec.ts
+++ b/packages/webui-framework/tests/fixtures/sidebar-repeat/sidebar-repeat.spec.ts
@@ -19,7 +19,7 @@ test.describe('sidebar repeat fixture', () => {
     await expect(active).toHaveAttribute('data-nav', nav);
   }
 
-  test('keeps SSR repeated anchors in the correct section when syncing groups', async ({ page }) => {
+  test('duplicate item attributes do not duplicate SSR entries', async ({ page }) => {
     const sections = page.locator('test-sidebar-repeat .nav-section');
 
     await expect(sections.nth(0).locator('.nav-item')).toHaveText([

--- a/packages/webui-framework/tests/fixtures/sidebar-repeat/src/test-sidebar-repeat/test-sidebar-repeat.html
+++ b/packages/webui-framework/tests/fixtures/sidebar-repeat/src/test-sidebar-repeat/test-sidebar-repeat.html
@@ -9,7 +9,7 @@
   <div class="nav-section">
     <h3 class="nav-heading">Groups</h3>
     <for each="group in groups">
-      <a class="nav-item nav-item-group" ?data-active="{{page == 'group' && activeGroup == group}}" data-nav="{{group}}" href="/groups/{{group}}">{{group}}</a>
+      <a class="{{group.className}}" ?data-active="{{page == 'group' && activeGroup == group.slug}}" data-nav="{{group.slug}}" href="/groups/{{group.slug}}">{{group.label}}</a>
     </for>
   </div>
 </nav>

--- a/packages/webui-framework/tests/fixtures/sidebar-repeat/state.json
+++ b/packages/webui-framework/tests/fixtures/sidebar-repeat/state.json
@@ -1,5 +1,26 @@
 {
   "page": "dashboard",
   "activeGroup": "",
-  "groups": ["work", "family", "friends", "other"]
+  "groups": [
+    {
+      "className": "nav-item nav-item-group",
+      "label": "work",
+      "slug": "work"
+    },
+    {
+      "className": "nav-item nav-item-group",
+      "label": "family",
+      "slug": "family"
+    },
+    {
+      "className": "nav-item nav-item-group",
+      "label": "friends",
+      "slug": "friends"
+    },
+    {
+      "className": "nav-item nav-item-group",
+      "label": "other",
+      "slug": "other"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- make unkeyed `<for>` blocks reconcile positionally so duplicate values and duplicate attributes cannot overwrite identity or duplicate DOM
- support optional compiler-only `key="{{item.id}}"` metadata on the first concrete repeated element under the WebUI plugin, including through leading `<if>` wrappers; reject keys on directive elements and leave nested `<for>` keys under the nested loop's ownership
- preserve keyed DOM and component instances across reorder, prepend, removal, hydration, and nested repeat updates with safe positional fallback for duplicate or invalid runtime keys
- hydrate root-level nested repeat chains with depth-aware marker ownership so nested item and end markers cannot contaminate parent repeats
- release removed nested DOM, scopes, bindings, listener cleanups, key scratch maps, and stale path-index entries so detached blocks cannot be retained or resurrected

## Performance and memory

- unkeyed repeats allocate no key state; keyed repeats lazily allocate and reuse only two key arrays and one map
- keyed reconciliation rewrites the existing instance array in place and performs one map lookup per reused-instance update
- stable-order keyed updates retain the positional fast path
- teardown is iterative for deep-template safety, and structural cleanup compacts ancestor snapshots once per removal batch
- staging-container propagation shares one iterative traversal; DOM moves no longer allocate a temporary `DocumentFragment`
- nested SSR marker collection remains a single iterative sibling pass without recursion or additional collections
- compiler-only keys are absent from SSR and browser-created DOM

### Client bundle size

Minified ESM bundled with esbuild for Chrome 133+ (the framework's existing minimum for multiple import maps):

| Build | Raw | gzip | Brotli |
|---|---:|---:|---:|
| Merge base | 33,579 B | 10,782 B | 9,686 B |
| Initial PR implementation | 36,063 B | 11,374 B | 10,246 B |
| Optimized PR | 34,670 B | 11,109 B | 9,975 B |
| Optimization savings | **-1,393 B** | **-265 B** | **-271 B** |
| Final PR delta | +1,091 B | +327 B | +289 B |

The depth-aware nested hydration fix adds 52 raw bytes, 13 gzip bytes, and 6 Brotli bytes. The remaining growth is isolated to explicit keyed reconciliation and nested lifecycle correctness; `template-element.ts` is 28 minified bytes smaller than the merge base despite the added ownership and cleanup guarantees.

## Validation

- `cargo xtask check`
- full framework unit, TypeScript, and Playwright suites
- exact `<for> > <for> > <if> > <for>` SSR hydration and keyed reorder regression
- 11 focused lifecycle Playwright regressions
- repeat benchmark: 200 items × 200 updates at 0.079 ms/update
- independent correctness, memory, and bundle review completed with no findings