### PR TITLE
fix: hydrate sibling repeats after nested repeats

### DIFF
--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -1249,8 +1249,6 @@ export class TemplateElement extends HTMLElement {
           const insertRef = ssrParent.childNodes[Math.min(beforeIndex ?? staticCount, ssrParent.childNodes.length)] ?? null;
           ssrParent.insertBefore(anchor, insertRef);
         }
-        lastRepMarker = anchor;
-
         const repeatInsts: TemplateInstance[] = [];
         const hasCollectionState = this.$hasStateRoot(collection, scope);
         const itemsArr = this.$resolveValue(collection, scope);
@@ -1260,6 +1258,7 @@ export class TemplateElement extends HTMLElement {
         const { items: itemMarkers, end: endMarker } = marker
           ? collectItemMarkers(anchor)
           : { items: [] as Comment[], end: null as Comment | null };
+        lastRepMarker = endMarker ?? anchor;
 
         if (blockMeta && blockTplDom && anchor.parentNode && itemMarkers.length > 0) {
           if (

--- a/packages/webui-framework/tests/fixtures/nested-repeat/element.ts
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/element.ts
@@ -111,5 +111,20 @@ export class TestNestedRepeatKeyedChain extends WebUIElement {
   }
 }
 
+export class TestRepeatSiblings extends WebUIElement {
+  @observable groups: NestedRepeatGroup[] = [];
+  @observable others: string[] = [];
+  @observable selected = 'none';
+
+  select(value: string): void {
+    this.selected = value;
+  }
+
+  replaceOthers(): void {
+    this.others = ['Three', 'Four'];
+  }
+}
+
 TestNestedRepeat.define('test-nested-repeat');
+TestRepeatSiblings.define('test-repeat-siblings');
 TestNestedRepeatKeyedChain.define('test-nested-repeat-keyed-chain');

--- a/packages/webui-framework/tests/fixtures/nested-repeat/nested-repeat.spec.ts
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/nested-repeat.spec.ts
@@ -203,3 +203,31 @@ test.describe('nested repeat SSR hydration', () => {
     expect(preserved).toBe(true);
   });
 });
+
+test.describe('sibling repeat after root-level nested repeat (#405)', () => {
+  test('hydrates the second repeat against its own marker', async ({ page }) => {
+    await page.goto('/nested-repeat/fixture.html');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('test-repeat-siblings');
+      return el && (el as unknown as { $ready?: boolean }).$ready === true;
+    });
+
+    const host = page.locator('test-repeat-siblings');
+    const others = host.locator('.other');
+
+    await expect(others).toHaveCount(2);
+    await expect(others).toHaveText(['One', 'Two']);
+
+    await others.first().click();
+    await expect(host.locator('.selected')).toHaveText('One');
+
+    await page.evaluate(() => {
+      (document.querySelector('test-repeat-siblings') as HTMLElement & {
+        replaceOthers(): void;
+      }).replaceOthers();
+    });
+
+    await expect(others).toHaveCount(2);
+    await expect(others).toHaveText(['Three', 'Four']);
+  });
+});

--- a/packages/webui-framework/tests/fixtures/nested-repeat/src/index.html
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/src/index.html
@@ -7,5 +7,6 @@
 <body>
   <test-nested-repeat></test-nested-repeat>
   <test-nested-repeat-keyed-chain></test-nested-repeat-keyed-chain>
+  <test-repeat-siblings></test-repeat-siblings>
 </body>
 </html>

--- a/packages/webui-framework/tests/fixtures/nested-repeat/src/test-repeat-siblings/test-repeat-siblings.html
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/src/test-repeat-siblings/test-repeat-siblings.html
@@ -1,0 +1,15 @@
+<div class="lists">
+  <for each="group in groups">
+    <span class="group-label">{{group.name}}</span>
+
+    <for each="item in group.values">
+      <span class="inner-value">{{item.value}}</span>
+    </for>
+  </for>
+
+  <for each="other in others">
+    <button class="other" @click="{select(other)}">{{other}}</button>
+  </for>
+
+  <output class="selected">{{selected}}</output>
+</div>

--- a/packages/webui-framework/tests/fixtures/nested-repeat/state.json
+++ b/packages/webui-framework/tests/fixtures/nested-repeat/state.json
@@ -1,4 +1,6 @@
 {
+  "others": ["One", "Two"],
+  "selected": "none",
   "groups": [
     {
       "name": "Color",


### PR DESCRIPTION
A sibling `<for>` following a root-level nested repeat could hydrate against the nested repeat's start marker instead of its own, leaving SSR content visible but non-interactive and causing later updates to reconcile at the wrong anchor.

Advance the sibling repeat cursor to the depth-matched outer end marker returned by `collectItemMarkers()`. This skips the entire hydrated repeat range before locating the next sibling marker. Add an SSR fixture that verifies event wiring and collection replacement for the affected layout.

Closes #405