### PR TITLE
docs: Restructure AI reference around template-first authoring

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -312,7 +312,7 @@ Every behavioral change must include corresponding documentation updates. Missin
 |-------|-----|
 | **DESIGN.md updated** | If the change modifies public APIs, protocol fields, behavioral contracts, error variants, or SSR markers, `DESIGN.md` must be updated in the same commit. |
 | **User-facing docs updated** | If the change affects CLI flags, template syntax, component authoring, routing, or integration behavior, `docs/` must be updated. |
-| **AI reference updated** | If the change affects anything a code-generation AI would need to know, `docs/guide/ai.md` must be updated. |
+| **AI reference updated** | If the change affects anything a code-generation AI would need to know, `docs/ai.md` must be updated. |
 | **README links to docs portal** | Package READMEs should defer to the docs portal, not duplicate content. |
 | **No stale examples** | Code examples in docs must use current API signatures, flag names, and marker formats. |
 | **docs build passes** | `cd docs && pnpm build` must succeed (catches broken links, unescaped `{{`, missing pages). |

--- a/.github/skills/docs-sync/SKILL.md
+++ b/.github/skills/docs-sync/SKILL.md
@@ -11,11 +11,11 @@ Use this skill whenever a change touches user-visible behavior, APIs, or contrac
 
 | What changed | Update |
 |-------------|--------|
-| CLI flags or commands | `docs/guide/cli/index.md` + `docs/guide/ai.md` (CLI section) |
-| Template syntax or directives | `docs/guide/concepts/directives/` + `docs/guide/ai.md` |
-| Component authoring model | `docs/guide/concepts/interactivity.md` + `docs/guide/ai.md` |
+| CLI flags or commands | `docs/guide/cli/index.md` + `docs/ai.md` (Build and run section) |
+| Template syntax or directives | `docs/guide/concepts/directives/` + `docs/ai.md` |
+| Component authoring model | `docs/guide/concepts/interactivity.md` + `docs/ai.md` |
 | Hydration markers or mechanism | `docs/guide/concepts/hydration.md` + `DESIGN.md` (WebUI Framework Plugin) |
-| Routing behavior | `docs/guide/concepts/routing.md` + `docs/guide/ai.md` |
+| Routing behavior | `docs/guide/concepts/routing.md` + `docs/ai.md` |
 | State management or path resolution | `docs/guide/concepts/state-management/index.md` |
 | Handler API (Rust, Node, FFI) | `docs/guide/concepts/handlers/` + `docs/guide/integrations.md` |
 | Protocol fields or fragment types | `DESIGN.md` (Protocol Specification) |
@@ -23,7 +23,7 @@ Use this skill whenever a change touches user-visible behavior, APIs, or contrac
 | Performance characteristics | `docs/guide/concepts/performance.md` |
 | Public API (Rust crate, npm package) | `DESIGN.md` + relevant handler/integration docs |
 | Error variants or error messages | `DESIGN.md` |
-| `@microsoft/webui-framework` decorators or API | `docs/guide/concepts/interactivity.md` + `docs/guide/ai.md` + `packages/webui-framework/README.md` |
+| `@microsoft/webui-framework` decorators or API | `docs/guide/concepts/interactivity.md` + `docs/ai.md` + `packages/webui-framework/README.md` |
 | `@microsoft/webui-router` behavior | `docs/guide/concepts/routing.md` + `packages/webui-router/README.md` |
 
 ## DESIGN.md rules
@@ -48,7 +48,9 @@ Update `docs/` in the same commit when the change is user-visible:
 - Integration behavior that external developers depend on
 - New features or removed features
 
-Keep protocol internals out of general user docs. The `docs/guide/ai.md` file is the single-page AI reference and should be kept in sync with all other docs.
+Keep protocol internals out of general user docs. The `docs/ai.md` file is the single-page AI reference and should be kept in sync with all other docs.
+
+`docs/ai.md` is authoring-first by design. Keep deep reference material (full CLI flag tables, error-code lists, per-language integration snippets) in its canonical page and link to it from `docs/ai.md` rather than duplicating it there.
 
 ## Validation
 

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when building or modifying WebUI applications.
 6. **HTML, CSS, TypeScript are separate files.** No JSX. No CSS-in-JS. No JS in templates.
 7. **The `<template>` tag is optional.** The build tool auto-injects it. Include it only for root host events (`@custom-event` on the shadow root).
 8. **Components inside `<for>` loops do NOT inherit loop variables.** Pass data via attributes.
-9. **Expressions in bindings: comparisons and logic OK; ternaries NOT.** `{{count > 0}}`, `?active="{{section == 'guide'}}"`, `<if condition="a && b">` all work. Operators: `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`. **Forbidden:** ternary (`? :`), function calls, mixing `&&` with `||`, more than 5 logical operators.
+9. **Text bindings are path lookups; comparisons belong in conditions.** `{{count}}` and `{{user.name}}` resolve a dotted state path - nothing else. `{{count > 0}}` is looked up as a key literally named `count > 0` and renders empty. Comparisons go in `<if condition="count > 0">` or `?active="{{section == 'guide'}}"`. Operators: `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`. **Forbidden everywhere:** ternary (`? :`), function calls, arithmetic (`items.length - 1` resolves as a path and silently fails - send a precomputed `lastIndex`), mixing `&&` with `||`, more than 5 logical operators.
 10. **`w-ref` requires braces.** `w-ref="{inputEl}"`, never `w-ref="inputEl"` - non-braced fails the build with `invalid-w-ref`. Use it only for imperative APIs (focus, scroll, `showModal`), never to read state.
 11. **`@attr({ mode: 'boolean' })` for true/false.** Present = true, absent = false. Never use string `"false"`.
 

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -9,26 +9,38 @@ Use this skill when building or modifying WebUI applications.
 
 ## Critical rules (memorize these)
 
-1. **Every template binding must exist in the server state JSON.** The server renders from JSON. Missing keys render empty.
-2. **HTML, CSS, TypeScript are separate files.** No JSX. No CSS-in-JS. No JS in templates.
-3. **The `<template>` tag is optional.** The build tool auto-injects it. Include it only for root host events (`@custom-event` on the shadow root).
-4. **Components inside `<for>` loops do NOT inherit loop variables.** Pass data via attributes.
-5. **Expressions in bindings: comparisons and logic OK; ternaries NOT.** `{{count > 0}}`, `?active="{{section == 'guide'}}"`, `<if condition="a && b">` all work. Operators: `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`. **Forbidden:** ternary (`? :`), function calls, mixing `&&` with `||`, more than 5 logical operators. See `docs/guide/ai.md` for full rules.
-6. **No `this.querySelector()` for reactive state.** Use `@observable` + template bindings.
-7. **Decorators: `@attr` (HTML attribute), `@observable` (reactive state).** Both work in SSR.
-8. **`@attr({ mode: 'boolean' })` for true/false.** Present = true, absent = false. Never use string `"false"`.
+1. **The template is the UI.** All structure lives in `.html`. Never `document.createElement`, `innerHTML`, `insertAdjacentHTML`, or `appendChild`. Show/hide with `<if>`, repeat with `<for>`. The only exception is mounting a lazily loaded component.
+2. **CSS owns all styling and animation.** Never `el.style.x =`, `classList.toggle`, or `adoptedStyleSheets`. Bind `?data-active="{{expr}}"` and select `[data-active]` in CSS. Animate with `transition`, `@keyframes`, `@starting-style` - never `element.animate()` or a JS animation library.
+3. **JavaScript is opt-in.** A component needs **no** `.ts` file unless it has an `@event`, a `w-ref` for an imperative API, a lifecycle hook, a fetch, or a public method API. `WebUIElement`, `@observable`, and `@attr` are optional - add them only when TypeScript reads/writes the value or it is public API. Otherwise the value belongs in the server state JSON.
+4. **Use the web platform.** `<dialog>` over a div modal, `popover` over a JS dropdown, `<details>` over a JS accordion. Prefer `:has()`, `@container`, `color-mix()`, `light-dark()`, `content-visibility`.
+5. **Every template binding must exist in the server state JSON.** Missing keys render empty, silently.
+6. **HTML, CSS, TypeScript are separate files.** No JSX. No CSS-in-JS. No JS in templates.
+7. **The `<template>` tag is optional.** The build tool auto-injects it. Include it only for root host events (`@custom-event` on the shadow root).
+8. **Components inside `<for>` loops do NOT inherit loop variables.** Pass data via attributes.
+9. **Expressions in bindings: comparisons and logic OK; ternaries NOT.** `{{count > 0}}`, `?active="{{section == 'guide'}}"`, `<if condition="a && b">` all work. Operators: `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`. **Forbidden:** ternary (`? :`), function calls, mixing `&&` with `||`, more than 5 logical operators.
+10. **`w-ref` requires braces.** `w-ref="{inputEl}"`, never `w-ref="inputEl"` - non-braced fails the build with `invalid-w-ref`. Use it only for imperative APIs (focus, scroll, `showModal`), never to read state.
+11. **`@attr({ mode: 'boolean' })` for true/false.** Present = true, absent = false. Never use string `"false"`.
 
 ## Quick reference
+
+Most components need only HTML and CSS:
+
+```html
+<!-- user-card.html - no .ts file -->
+<h2>{{user.name}}</h2>
+<if condition="user.isAdmin"><span class="badge">Admin</span></if>
+```
+
+Add a class only when something interactive happens:
 
 ```typescript
 import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
 
 export class MyComponent extends WebUIElement {
-  @attr label = '';
+  @attr label = '';                          // set by a parent template
   @attr({ mode: 'boolean' }) disabled = false;
-  @observable count = 0;
-  @observable items: Item[] = [];
-  inputEl!: HTMLInputElement;  // populated by w-ref="inputEl"
+  @observable count = 0;                     // mutated by increment()
+  inputEl!: HTMLInputElement;                // populated by w-ref="{inputEl}"
 
   increment(): void { this.count += 1; }
   onKeydown(e: KeyboardEvent): void { if (e.key === 'Enter') this.submit(); }
@@ -43,8 +55,8 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 ## Full reference
 
-The complete guide covering all template syntax, CLI flags, patterns, anti-patterns, routing, and language integrations:
+The complete guide covering all template syntax, styling and animation rules, anti-patterns, routing, and a pre-flight checklist:
 
-📖 **[docs/guide/ai.md](/docs/guide/ai.md)**
+**[docs/ai.md](/docs/ai.md)**
 
 Read that file before generating any WebUI code.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1539,6 +1539,13 @@ All arrays are optional and omitted from the output when empty to minimize paylo
 The closure itself has the shape `(resolve, scope) => boolean`; generated source calls
 `resolve(path, scope)` for identifier lookups and preserves the existing WebUI condition
 semantics for truthiness, comparison, negation, and `&&` / `||` compounds.
+
+> **Known divergence.** A bare identifier compiles to `!!resolve(path, scope)`, i.e.
+> host JavaScript truthiness, while the server evaluator in `webui-expressions`
+> reports `Value::Array` and `Value::Object` as truthy only when non-empty. An
+> empty array or object therefore evaluates falsy during SSR and truthy on the
+> client. Scalars agree. Templates must test `items.length` rather than `items`
+> until the two evaluators are reconciled.
 - `5` = `GREATER_THAN_OR_EQUAL`
 - `6` = `LESS_THAN_OR_EQUAL`
 

--- a/crates/webui-press/template/docs-search/docs-search.test.ts
+++ b/crates/webui-press/template/docs-search/docs-search.test.ts
@@ -91,18 +91,32 @@ test('heading search results use CSS spacing for breadcrumb separators', async (
     el.openSearch();
     await new Promise((resolve) => setTimeout(resolve, 300));
     const input = el.shadowRoot.querySelector('input');
-    input.value = 'webassembly';
+    input.value = 'wasm bundles';
     el.onInput();
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   const separator = await page.locator('docs-search').evaluate((el) => {
-    const item = [...el.shadowRoot.querySelectorAll('.result')].find((result) =>
-      result.getAttribute('href').includes('#webassembly'),
+    const results = [...el.shadowRoot.querySelectorAll('.result')];
+    const hrefs = results.map((result) => result.getAttribute('href'));
+    const item = results.find((result) =>
+      result.getAttribute('href').includes('#building-the-wasm-bundles'),
     );
+    if (!item) {
+      return {
+        found: false,
+        hrefs,
+        text: '',
+        marginLeft: 0,
+        marginRight: 0,
+        normalizedTitle: '',
+      };
+    }
     const sep = item.querySelector('.result-separator');
     const style = getComputedStyle(sep);
     return {
+      found: true,
+      hrefs,
       text: sep.textContent,
       marginLeft: Number.parseFloat(style.marginLeft),
       marginRight: Number.parseFloat(style.marginRight),
@@ -112,10 +126,14 @@ test('heading search results use CSS spacing for breadcrumb separators', async (
     };
   });
 
+  assert.ok(
+    separator.found,
+    `no heading result linking to #building-the-wasm-bundles; got [${separator.hrefs.join(', ')}]`,
+  );
   assert.equal(separator.text, '>');
   assert.equal(
     separator.normalizedTitle,
-    'WebUIFramework-AIReference>WebAssembly',
+    'WebUIWebAssembly>BuildingtheWASMbundles',
   );
   assert.ok(separator.marginLeft > 0, `marginLeft=${separator.marginLeft}`);
   assert.ok(separator.marginRight > 0, `marginRight=${separator.marginRight}`);

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -4,127 +4,145 @@ layout: page
 
 # WebUI Framework - AI Reference
 
-> **Single-page reference for LLMs.** This page contains everything an AI coding
-> assistant needs to generate correct WebUI Framework code. It covers the SSR
-> model, template syntax, component authoring, CLI commands, and known
-> constraints. Bookmark this page and feed it to your AI when working with
-> WebUI.
+> **Single-page reference for LLMs.** Everything an AI coding assistant needs to
+> generate correct WebUI code. Read the Rules first - they are the constraints
+> that most often get violated. Deep-dive links are indexed at the bottom.
 
-## What is WebUI Framework?
+## Rules
 
-WebUI is a **language-agnostic server-side rendering framework**. Templates
-are compiled to a binary Protocol Buffer at build time. At runtime, any
-backend (Rust, Node, Go, C#, Python) fills in JSON state and produces HTML.
-On the client, interactive Web Components hydrate as islands.
+These four rules decide almost every authoring question. When in doubt, re-read
+them before writing code.
 
-**Key facts an AI must know:**
+### 1. The template is the UI
 
-- The server renders HTML from a compiled binary + JSON state. No JavaScript
-  runs on the server.
-- Only interactive components ship JavaScript to the browser.
-- Templates are declarative: HTML for structure, CSS for styling, TypeScript
-  for behavior. They are always in **separate files**.
-- There is no JSX, no CSS-in-JS, no template literals, no virtual DOM.
+All UI structure lives in `.html` template files. There is no other way to
+create UI.
 
-## The SSR Mental Model
+- Never `document.createElement()`, `innerHTML`, `insertAdjacentHTML`,
+  `appendChild`, `cloneNode`, or `new DOMParser()` to build UI.
+- Show and hide with `<if>`. Repeat with `<for>`. Swap regions with `<outlet>`.
+- If the markup you need does not exist yet, add it to the template and gate it
+  with `<if>` - do not build it from JavaScript.
+- **The single exception** is mounting a lazily loaded component, which has no
+  template representation until it is fetched. See
+  [Lazy component mounting](#lazy-component-mounting).
+
+### 2. CSS owns all styling and animation
+
+All styling lives in `.css` files. All animation is declarative CSS.
+
+- Never `el.style.color = ...`, `classList.add/remove/toggle`,
+  `setAttribute('style', ...)`, `adoptedStyleSheets`, or injected `<style>` tags.
+- To style from state, bind an attribute in the template and select on it in CSS:
+  `?data-active="{{isActive}}"` plus `[data-active] { ... }`.
+- Animate with `transition`, `@keyframes`, `@starting-style`, and view
+  transitions. Never `element.animate()`, `requestAnimationFrame` tweening,
+  `setInterval` timers, or a JavaScript animation library.
+
+### 3. JavaScript is opt-in, and only for interactivity
+
+A component needs **no** `.ts` file at all unless something interactive happens
+in it. Scriptless components still render bindings, `<if>`, and `<for>` on the
+server, and still activate for browser state and soft navigation.
+
+- `WebUIElement`, `@observable`, and `@attr` are **optional**. Add them only
+  when JavaScript actually reads or writes the value, or when the value is part
+  of the component's public API that another module sets.
+- A value that only appears in the template belongs in the server state JSON,
+  not in an `@observable`.
+- JavaScript is for event handlers, network calls, focus management, and
+  imperative browser APIs. Nothing else.
+
+### 4. Use the web platform
+
+Prefer a built-in HTML element or modern CSS feature over a hand-built one.
+
+- `<dialog>` over a div-based modal. `popover` over a JS dropdown.
+  `<details>` over a JS accordion.
+- `:has()`, `@container`, `@starting-style`, `field-sizing`, `color-mix()`,
+  `light-dark()`, `content-visibility`, `inert`, `@layer`.
+- Native form validation, `<input type="...">` variants, `loading="lazy"`.
+- No UI libraries, no CSS frameworks, no polyfills for baseline features.
+
+## What to reach for
+
+| You need | Use this | Not this |
+|---|---|---|
+| Show / hide a region | `<if condition="...">` | `el.hidden`, `style.display` |
+| Render a list | `<for each="x in xs">` | `createElement` in a loop |
+| Style from state | `?data-x="{{expr}}"` + CSS attribute selector | `classList.toggle` |
+| Toggle a class-like variant | `?data-variant="{{mode == 'compact'}}"` | `className = ...` |
+| Modal | `<dialog>` + `showModal()` | div overlay + z-index juggling |
+| Dropdown / tooltip / menu | `popover` + `:popover-open` | JS positioning library |
+| Accordion / disclosure | `<details><summary>` | click handler + height math |
+| Tabs | radio inputs or `?data-selected` + CSS | JS show/hide of panels |
+| Enter / exit animation | `@starting-style` + `transition-behavior: allow-discrete` | `element.animate()` |
+| Looping animation | `@keyframes` | `requestAnimationFrame` loop |
+| Page transition | `view-transition-name` + `::view-transition-*` | manual fade with JS |
+| Responsive to container | `@container` | `ResizeObserver` + inline styles |
+| Style a parent from a child | `:has()` | JS class propagation |
+| Theme values | CSS custom properties + `--theme` | JS theme objects |
+| Derived boolean | `<if condition="items.length">` | `@observable hasItems` |
+| Text that never changes on the client | server state JSON | `@observable` |
+| Focus / scroll / measure | `w-ref="{el}"` + a `.ts` file | `querySelector` |
+
+## Mental model
 
 ```
 BUILD TIME          SERVER RENDER         CLIENT HYDRATION
-─────────────       ──────────────        ─────────────────
-HTML + CSS + TS →   protocol.bin    →     Web Components
+---------------     ---------------       -----------------
+HTML + CSS + TS ->  protocol.bin    ->    Web Components
 webui build         + JSON state          hydrate as islands
-                    → rendered HTML
+                    -> rendered HTML
 ```
 
-### Rules
+WebUI is a **language-agnostic server-side rendering framework**. Templates
+compile to a binary Protocol Buffer at build time. At runtime any backend
+(Rust, Node, Go, C#, Python) supplies JSON state and produces HTML. On the
+client, interactive components hydrate as islands.
 
-1. **Every template binding must exist in the server state JSON.**
-   If your template uses `{{title}}`, the server must provide
-   `{ "title": "..." }`.
-
-2. **Derived state belongs in the server or the template.** Use template
-   expressions like `items.length` or `status == 'active'` for simple
-   derivations. For complex values, compute on the server.
-
+1. **Every template binding must exist in the server state JSON.** If the
+   template uses `{{title}}`, the server must provide `{ "title": "..." }`.
+   Missing paths render empty and `<if>` evaluates false. No error is raised.
+2. **Derived state belongs in the template or the server.** Use expressions like
+   `items.length` or `status == 'active'`. Compute complex values server-side.
 3. **The server is the source of truth for the initial render.** The client
    takes over after hydration for user interactions.
-
 4. **Scriptless components are dormant, not dead.** Their bindings render on the
-   server and contribute no initial bootstrap state. When the framework is
-   loaded, compiler-owned hosts can activate for browser-applied state, parent
-   property writes, or soft navigation. Events, lifecycle code, decorators, and
-   imperative APIs need a same-named `.ts` or `.js` module.
+   server and contribute no initial bootstrap state. Compiler-owned hosts can
+   still activate for browser-applied state, parent property writes, or soft
+   navigation. Events and lifecycle code need a same-named `.ts` or `.js`.
+5. **Hydration state is client-facing.** It reduces CPU and bytes but is not a
+   secrecy boundary. Never put credentials or private tokens in render state.
 
-5. **Hydration state is client-facing.** Initial `#webui-data.state` is
-   projected to hydration keys for components reachable on the active route.
-   This reduces CPU and bytes, but it is not a secrecy boundary. Never put
-   credentials or private tokens in browser render state.
-
-## Project Structure
+## Project structure
 
 ```
 my-app/
-├── src/
-│   ├── index.html              ← Entry template
-│   ├── index.ts                ← Hydration entry point
-│   ├── my-component/
-│   │   ├── my-component.html   ← Component template
-│   │   ├── my-component.css    ← Component styles (scoped)
-│   │   └── my-component.ts     ← Component behavior
-│   └── other-widget/
-│       ├── other-widget.html
-│       ├── other-widget.css
-│       └── other-widget.ts
-├── build-client.mjs           ← Application-owned browser bundle + manifest
-├── data/
-│   └── state.json              ← Server state for dev
-├── dist/
-│   ├── index.js                ← Browser entry/chunks
-│   └── webui-projection.json   ← Build-time state projection sidecar
-└── package.json
+|- src/
+|  |- index.html              <- Entry template
+|  |- index.ts                <- Hydration entry point
+|  |- my-component/
+|  |  |- my-component.html    <- Component template
+|  |  |- my-component.css     <- Component styles (scoped)
+|  |  \- my-component.ts      <- Optional: only if interactive
+|  \- static-widget/
+|     |- static-widget.html   <- Scriptless: no .ts needed
+|     \- static-widget.css
+|- data/state.json            <- Server state for dev
+\- dist/
 ```
 
-**Component discovery rules:**
-- HTML files with a hyphen in the name are components (`my-card.html` → `<my-card>`)
-- CSS files with the same name are auto-paired (`my-card.css`)
-- A same-named TypeScript or JavaScript file opts the component into authored
-  behavior (`my-card.ts`)
-- With a validated projection manifest, only exact `@observable` / `@attr`
-  fields opt into initial state hydration; without a manifest, state remains
-  full
-- Scriptless components retain compiler-owned browser templates but contribute
-  no keys to initial bootstrap state
-- Discovery is recursive through subdirectories
+**Component discovery:**
 
-## The `<template>` Tag
+- HTML files with a hyphen in the name are components
+  (`my-card.html` -> `<my-card>`).
+- CSS files with the same name are auto-paired.
+- A same-named `.ts` or `.js` file opts the component into authored behavior.
+  Most components should not have one.
+- Discovery is recursive through subdirectories.
 
-The `<template shadowrootmode="open">` wrapper is **optional** in component
-HTML files. The build tool auto-injects it when absent.
-
-**Omit it** for most components (the framework wraps your content automatically):
-```html
-<!-- my-card.html -->
-<h2>{{title}}</h2>
-<p>{{description}}</p>
-```
-
-**Include it** when you need root host events on the shadow root itself:
-```html
-<!-- todo-app.html -->
-<template shadowrootmode="open"
-  @toggle-item="{onToggleItem(e)}"
-  @delete-item="{onDeleteItem(e)}"
->
-  <for each="item in items">
-    <todo-item id="{{item.id}}"></todo-item>
-  </for>
-</template>
-```
-
-Root host events catch custom events bubbling up from child components.
-This is the delegated event pattern for parent-child communication.
-
-## Template Syntax
+## Template syntax
 
 ### Text binding
 
@@ -135,6 +153,8 @@ This is the delegated event pattern for parent-child communication.
 
 - `{{expr}}` - HTML-escaped output (safe for user input)
 - `{{{expr}}}` - raw/unescaped output (only for trusted content)
+
+Text bindings do path lookups only. They cannot do arithmetic or call functions.
 
 ### Conditionals
 
@@ -152,13 +172,10 @@ This is the delegated event pattern for parent-child communication.
 </if>
 ```
 
-Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
+Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 
-**Constraints:**
-- Maximum 5 logical operators per expression
-- Cannot mix `&&` and `||` in the same expression
-- No parentheses for grouping
-- No ternary operator (`? :`)
+**Constraints:** max 5 logical operators per expression; cannot mix `&&` and
+`||` in one expression; no parentheses for grouping; no ternary.
 
 ### Loops
 
@@ -172,16 +189,20 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 </for>
 ```
 
-- The collection must be a JSON array
-- Nested loops are supported; outer loop variables remain accessible
-- Repeats reconcile by array position by default; item attributes never act as keys
-- Duplicate item values and attributes do not create duplicate DOM
-- Add compiler-only `key="{{item.id}}"` to the first concrete child to preserve logical DOM/component identity across reorder; leading `<if>` wrappers are transparent, while `key` directly on `<if>`, `<for>`, or `<outlet>` is invalid
-- `data-key` is an ordinary application attribute and does not control repeat identity
-- `key="{{item}}"` supports arrays of unique string or finite-number primitives
-- Key paths must be rooted at the loop variable; invalid paths fail with `invalid-for-key`
-- Duplicate or invalid runtime keys warn once and safely fall back to positions
-- Components inside loops do NOT inherit loop variables. Pass data via attributes:
+- The collection must be a JSON array.
+- Nested loops are supported; outer loop variables remain accessible.
+- Repeats reconcile by array position by default; item attributes never act as
+  keys, and `data-key` is an ordinary application attribute.
+- Add compiler-only `key="{{item.id}}"` to the first concrete child to preserve
+  identity across reorder. Leading `<if>` wrappers are transparent; `key`
+  directly on `<if>`, `<for>`, or `<outlet>` is invalid.
+- `key="{{item}}"` supports arrays of unique string or finite-number primitives.
+  Key paths must be rooted at the loop variable or the build fails with
+  `invalid-for-key`. Duplicate or invalid runtime keys warn once and fall back
+  to positions.
+- **Components inside loops do NOT inherit loop variables.** Pass data via
+  attributes:
+
   ```html
   <for each="contact in contacts">
     <contact-card name="{{contact.name}}" email="{{contact.email}}"></contact-card>
@@ -199,7 +220,7 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 <input type="checkbox" ?checked="{{isSelected}}" />
 
 <!-- Boolean attributes accept the same expressions as <if condition="...">.
-     Use comparisons against existing state instead of creating mirror observables. -->
+     Compare against existing state instead of creating mirror observables. -->
 <button ?disabled="{{currentIndex == 0}}">Prev</button>
 <button ?disabled="{{currentIndex == items.length - 1}}">Next</button>
 <option ?selected="{{item.id == selectedId}}">{{item.name}}</option>
@@ -211,13 +232,15 @@ Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 <my-widget :config="{{settings}}"></my-widget>
 ```
 
-Property bindings use `:` to write directly to DOM properties. For
-client-created component trees, initial property bindings are applied before a
-child component's `connectedCallback` runs. Children can read parent-provided
-values during setup, initialize their own fallback when a value is missing, and
-still receive later parent updates through the live binding.
+`?attr` is also the styling hook. Bind a `data-*` attribute and select on it in
+CSS rather than touching `classList` from JavaScript.
 
-### Events (client-side only)
+Property bindings use `:` to write directly to DOM properties. For
+client-created trees, initial property bindings are applied before a child's
+`connectedCallback` runs, so children can read parent-provided values during
+setup and still receive later updates through the live binding.
+
+### Events
 
 ```html
 <button @click="{handleClick()}">Click me</button>
@@ -226,67 +249,53 @@ still receive later parent updates through the live binding.
 <div @mouseenter="{onHover()}" @mouseleave="{onLeave()}">Hover</div>
 ```
 
-Event handler arguments can be `e`, dotted component or repeat-scope paths,
-string/number/boolean/null literals, or a mix of those. Nested JavaScript
-expressions are not parsed in templates.
+Handler arguments can be `e`, dotted component or repeat-scope paths, or
+string/number/boolean/null literals. Nested JavaScript expressions are not
+parsed in templates. An `@event` requires a `.ts` file on that component.
 
 ### DOM references
 
 ```html
-<input w-ref="searchInput" type="text" />
+<input w-ref="{searchInput}" type="text" />
 ```
 
-In the TypeScript class: `searchInput!: HTMLInputElement;`
+The braces are **required**. A non-braced `w-ref="searchInput"` fails the build
+with `invalid-w-ref`. Declare the property in the class:
+`searchInput!: HTMLInputElement;`
 
-### Routes
+Use `w-ref` only for imperative browser APIs - `focus()`, `scrollIntoView()`,
+`showModal()`, `showPopover()`, measurement. Never use it to read or write
+state that a template binding could express.
+
+### The `<template>` tag
+
+The `<template shadowrootmode="open">` wrapper is **optional**. The build tool
+auto-injects it when absent.
+
+Omit it for most components:
 
 ```html
-<route path="/" component="app-shell">
-  <route path="" component="home-page" exact />
-  <route path="users" component="user-list" exact />
-  <route path="users/:id" component="user-detail" exact />
-</route>
+<!-- my-card.html -->
+<h2>{{title}}</h2>
+<p>{{description}}</p>
 ```
 
-**Path & matching:**
-- Child paths are relative to parent (no leading `/`)
-- Use `exact` on leaf routes (no children)
-- Omit `exact` on parent routes that have `<outlet />`
-- Path params: `:id` (required), `:query?` (optional), `*path` (catch-all)
+Include it only when you need root host events on the shadow root itself:
 
-**Attributes on `<route>`:**
+```html
+<!-- todo-app.html -->
+<template shadowrootmode="open"
+  @toggle-item="{onToggleItem(e)}"
+  @delete-item="{onDeleteItem(e)}"
+>
+  <for each="item in items">
+    <todo-item id="{{item.id}}"></todo-item>
+  </for>
+</template>
+```
 
-| Attribute | Example | Description |
-|-----------|---------|-------------|
-| `path` | `"users/:id"` | URL path template (relative to parent) |
-| `component` | `"user-detail"` | Component tag to mount |
-| `exact` | (boolean) | Require exact path match (use on leaf routes) |
-| `query` | `"action,to,subject"` | Allowlist of query params set as component attributes (deny-by-default) |
-| `keep-alive` | (boolean) | Preserve DOM and local state across navigations |
-| `cache-tags` | `"thread:{threadId},inbox"` | Cache tag templates - `{param}` resolved at render time |
-| `invalidates` | `"inbox,sent,counts"` | Tags to auto-invalidate after mutation actions |
-| `pending` | `"loading-skeleton"` | Component for loading UI during slow navigations (>150ms) |
-| `error` | `"error-display"` | Component for error boundary on fetch failure |
-
-All attributes are validated at build time. Referencing a non-existent `pending` or `error` component is a compile error.
-
-**State flow:**
-- Scriptless route components use compiler-owned hosts when the framework is
-  loaded, so partial navigation applies only their template-root state
-- `keep-alive` preserves DOM and local state. On reactivation, only param/query attrs are updated
-- Route loaders: `static loader({ params, query, signal })` on component class - fetches custom data instead of server state. Runs pre-commit. Falls back to server state on failure
-- Keep-alive + loader: DOM preserved, loader refreshes data on reactivation
-- Route actions: `Router.start({ actions: true })` enables `static action({ formData, params, signal })` on component class - handles `<form method="post">`. Returns `{ invalidateTags?, state? }`. Auto-invalidates cache with merged tags
-
-**Cache & preload:**
-- Preload on hover: `Router.start({ preload: true })` - speculatively fetches on link hover
-- Tagged cache: `Router.start({ cache: { staleTime, gcTime, maxEntries } })` - responses cached by path, tagged with `cacheTags`
-- Cache/preload are optional runtime tiers; default `Router.start()` does not load the cache module
-- `Router.invalidateTags(tags)` - evict cache entries by tag
-- `Router.invalidate(path?)` - evict by path or all
-
-**Server headers:**
-- `X-WebUI-Inventory` header: hex bitmask of loaded templates - server skips re-sending
+Root host events catch custom events bubbling up from child components. This is
+the delegated event pattern for parent-child communication.
 
 ### Outlet
 
@@ -296,210 +305,27 @@ All attributes are validated at build time. Referencing a non-existent `pending`
 <main><outlet /></main>
 ```
 
-## Component Class
-
-Every interactive component extends `WebUIElement`:
-
-```typescript
-import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
-
-export class MyComponent extends WebUIElement {
-  // --- Decorators ---
-
-  // @attr: reflects to/from HTML attribute (kebab-case)
-  // String mode (default):
-  @attr label = 'Default';
-
-  // Boolean mode (present = true, absent = false):
-  @attr({ mode: 'boolean' }) disabled = false;
-
-  // @observable: reactive state, changes trigger DOM updates
-  @observable count = 0;
-  @observable items: Item[] = [];
-
-  // Derived state: computed in event handlers, not as a getter
-  @observable totalPrice = 0;
-
-  private recalcTotal(): void {
-    this.totalPrice = this.items.reduce((sum, i) => sum + i.price, 0);
-  }
-
-  // --- DOM refs (populated by w-ref="name" in template) ---
-  inputEl!: HTMLInputElement;
-
-  // --- Event handlers (referenced by @event in template) ---
-  onSubmit(): void {
-    const text = this.inputEl.value.trim();
-    if (!text) return;
-    this.items = [...this.items, { text, price: 0 }];
-    this.inputEl.value = '';
-  }
-
-  onKeydown(e: KeyboardEvent): void {
-    if (e.key === 'Enter') this.onSubmit();
-  }
-
-  // --- Custom events (child-to-parent communication) ---
-  onItemDelete(e: CustomEvent<{ id: string }>): void {
-    this.items = this.items.filter(i => i.id !== e.detail.id);
-  }
-}
-
-// Register as custom element
-MyComponent.define('my-component');
-```
-
-Components can omit the `.ts` file when server-rendered output is final. The
-sibling module is the authored behavior boundary: without it, WebUI emits no
-bootstrap state for that component, but retains its compiled template for later
-browser rendering. Create a custom element for events, custom lifecycle code,
-imperative methods, or JavaScript-owned state.
-
-`@observable` and `@attr` are optional. Use them when TypeScript code reads or
-mutates the value directly, or when the value is part of the component's public
-API.
-
-### Decorator reference
-
-| Decorator | Purpose | SSR? | Triggers DOM update? |
-|-----------|---------|------|---------------------|
-| `@attr` | HTML attribute reflection | Yes; an existing SSR host attribute wins | Yes |
-| `@attr({ mode: 'boolean' })` | Boolean attribute (present/absent) | Yes; host presence wins | Yes |
-| `@observable` | Reactive state used by TypeScript code | Yes (from JSON state) | Yes |
-
-
-### Component API
-
-| Method/Property | Description |
-|----------------|-------------|
-| `this.$emit(name, detail?)` | Dispatch a CustomEvent that bubbles up |
-| `this.$update()` | Force a reactive update cycle |
-| `this.$flushUpdates()` | Synchronously flush pending updates |
-| `static define(tagName)` | Register as a custom element |
-| `defineComponentAssets(manifest)` | Define lazy component assets with `preload(tag)` and `create(tag)` |
-
-### Emitting custom events
-
-```typescript
-// Child component
-this.$emit('item-selected', { id: this.id, name: this.name });
-```
+### Entry template
 
 ```html
-<!-- Parent template catches it -->
-<child-component @item-selected="{onItemSelected(e)}"></child-component>
+<!DOCTYPE html>
+<html lang="en" dir="{{textdirection}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+</head>
+<body>
+  <app-shell></app-shell>
+  <script type="module" src="/index.js"></script>
+</body>
+</html>
 ```
 
-```typescript
-// Parent handler
-onItemSelected(e: CustomEvent): void {
-  this.selectedId = e.detail.id;
-}
-```
+## Styling
 
-### Dynamic Component Loading
-
-Components like dialogs, overlays, and drawers are declared as routes but loaded
-on demand, not during initial navigation. Declare them in the route tree so they
-can be loaded dynamically:
-
-```html
-<route path="/" component="app-shell">
-  <route path="" component="home-page" exact />
-  <route path="users/:id" component="user-detail" exact />
-  <!-- Available for dynamic loading, but only loaded when needed -->
-  <route path="settings" component="settings-dialog" exact />
-</route>
-```
-
-Then load on demand with `Router.ensureLoaded` before creating the element:
-
-```typescript
-// Fetches template + CSS from /_webui/templates before showing UI.
-await Router.ensureLoaded('settings-dialog');
-this.showSettings = true;
-
-// Batch multiple in one request
-await Router.ensureLoaded('modal-a', 'modal-b', 'drawer-c');
-```
-
-The component's template is **not** sent during initial SSR or partial
-navigation. It has zero client cost until requested.
-
-If a user navigates directly to `/settings` (deep link), the component
-renders normally in the outlet. It works both ways.
-
-Configure a custom endpoint if needed:
-
-```typescript
-Router.start({
-  templateEndpoint: '/api/templates', // default: '/_webui/templates'
-  loaders: { ... },
-});
-```
-
-Every route intended for partial navigation must register a custom element.
-Authored routes register eagerly or through `loaders`. Scriptless templates are
-registered by the framework's compiler-owned host runtime. If a route remains
-unregistered after template publication and loader resolution, the router
-navigates the document to let the server render the component.
-
-Without `@microsoft/webui-router`, prebuild static assets and load them from a
-CDN or the app's static folder:
-
-```bash
-webui build ./src --out ./dist --plugin=webui \
-  --emit-component-assets settings-dialog
-```
-
-Rust callers can set `BuildOptions::component_asset_roots`; rendered ESM files
-are returned in `BuildResult::component_asset_files` and written by
-`build_to_disk()`. Node callers use `componentAssetRoots` and receive flattened
-`componentAssetFiles` (`[filename, content, ...]`) from `build()`.
-
-`webui serve` accepts the same `--emit-component-assets` flag and validates each
-root on every dev build. HTML and theme-token errors in lazily loaded components
-fail the build instead of being missed because the component is outside the
-initial route tree. The dev server serves `<tag>.webui.js` from memory and
-rebuilds it on change under `--watch`. No separate `webui build`/`--out` step is
-needed during development.
-
-```typescript
-import { settingsAssets } from './lazy-assets.js';
-
-async onOpenSettings(): Promise<void> {
-  settingsAssets.preload('settings-dialog');
-  this.panelSlot.replaceChildren(await settingsAssets.create('settings-dialog'));
-}
-```
-
-```typescript
-// lazy-assets.ts
-import { defineComponentAssets } from '@microsoft/webui-framework/component-asset.js';
-
-export const settingsAssets = defineComponentAssets({
-  'settings-dialog': {
-    asset: '/settings-dialog.webui.js',
-    module: () => import('./settings-dialog/settings-dialog.js'),
-    data: async () => await (await fetch('/settings-dialog-data.json')).json(),
-  },
-});
-```
-
-`defineComponentAssets()` uses the current page CSP nonce when it needs to append
-CSS module importmaps. The `.webui.js` asset is a browser-native ESM module that
-carries the component template and style payload in one request. Concurrent calls
-for the same URL share one in-flight request, and CSS module styles are deduped.
-The manifest helper lets the shell start the template asset, JS chunk, and data
-fetch in parallel as soon as the user expresses intent via `preload(tag)`;
-`create(tag)` waits for only the template asset and JS module by default, then
-creates the element. Use
-`create(tag, { awaitData: true, dataTimeoutMs: 150 })` only when a component
-must wait briefly for state before mounting.
-
-## Component CSS
-
-CSS is scoped per component via Shadow DOM. No CSS-in-JS.
+CSS is scoped per component via Shadow DOM. No CSS-in-JS, no inline styles
+written from script, no runtime style injection.
 
 ```css
 /* my-component.css */
@@ -517,493 +343,394 @@ CSS is scoped per component via Shadow DOM. No CSS-in-JS.
   background: var(--colorBrandBackground);
 }
 
-/* Internal elements */
 .header { font-weight: bold; }
-.content { padding: 0.5rem; }
 ```
 
-**Rules:**
-- `:host` styles the component root element
-- `:host([attr])` styles based on attribute presence/value
-- Internal selectors are scoped to the shadow root
-- Use CSS custom properties (`var(--name)`) for theming. Nested fallbacks like
+- `:host` styles the component root; `:host([attr])` styles by attribute.
+- Internal selectors are scoped to the shadow root. No styles leak in or out.
+- Use CSS custom properties for theming. Nested fallbacks like
   `var(--primary, var(--fallback))` are also discovered as tokens.
-- Malformed CSS fails the build, including unterminated `var()` calls, comments,
-  strings, and unmatched delimiters.
-- No styles leak in or out
+- Malformed CSS fails the build, including unterminated `var()` calls,
+  comments, strings, and unmatched delimiters.
 
-## Entry Template
+### Reactive styling
+
+State drives styling through bound attributes, never through script.
 
 ```html
-<!DOCTYPE html>
-<html lang="en" dir="{{textdirection}}">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{title}}</title>
-</head>
-<body>
-  <app-shell></app-shell>
-  <script type="module" src="/index.js"></script>
-</body>
-</html>
+<button ?data-active="{{isActive}}" @click="{toggle()}">{{label}}</button>
+<article ?data-compact="{{density == 'compact'}}">...</article>
 ```
 
-## Hydration Entry Point
+```css
+button[data-active] { background: var(--accent); color: white; }
+button:not([data-active]) { background: transparent; }
+article[data-compact] { --row-height: 1.5rem; }
+```
+
+This works during SSR, needs no synchronization code, and stays correct when the
+server re-renders.
+
+### Modern CSS to prefer
+
+| Feature | Use for |
+|---|---|
+| `:has()` | Parent/sibling state without a JS class |
+| `@container` / `cqi` units | Component-level responsiveness |
+| `@starting-style` + `transition-behavior: allow-discrete` | Animating in/out of `display: none`, `popover`, `<dialog>` |
+| `color-mix()` / `light-dark()` / `oklch()` | Derived colors, dual themes without JS |
+| `@layer` | Predictable cascade ordering |
+| `content-visibility: auto` | Long lists without virtualization code |
+| `text-wrap: balance` | Headline typography |
+| `:user-valid` / `:user-invalid` | Form feedback without validation JS |
+
+### Modern HTML to prefer
+
+| Element / attribute | Replaces |
+|---|---|
+| `<dialog>` + `showModal()` | Custom modal with overlay and focus trap |
+| `popover` / `popovertarget` | JS dropdown, menu, tooltip, toast |
+| `<details><summary>` | JS accordion or disclosure |
+| `<datalist>` | JS autocomplete |
+| `inert` | Manual `tabindex` juggling |
+| `loading="lazy"` / `decoding="async"` | IntersectionObserver image loaders |
+| `<progress>` / `<meter>` | Div-based bars |
+| Native constraint validation | Hand-rolled validators |
+
+### Progressive enhancement only
+
+These are not Baseline across all engines. Use them as an enhancement layer that
+degrades cleanly, never as load-bearing layout or behavior.
+
+| Feature | Guard with |
+|---|---|
+| `anchor-name` / `position-area` | `@supports (anchor-name: --x)`, fall back to static placement |
+| Scroll-driven animations | `@supports (animation-timeline: view())` |
+| `field-sizing: content` | A sensible fixed `width` / `rows` default |
+| `text-wrap: pretty` | Harmless when ignored |
+| Customizable `<select>` / `<selectedcontent>` | The native `<select>` rendering |
+
+Never polyfill these in JavaScript. If the fallback is unacceptable, use a
+Baseline approach instead.
+
+### Animation
+
+Animation is CSS. There is no supported JavaScript animation path.
+
+```css
+/* Enter and exit for a popover or dialog */
+.menu-panel {
+  transition: transform 200ms ease, overlay 200ms allow-discrete,
+              display 200ms allow-discrete;
+  transform: translateX(-100%);
+}
+
+.menu-panel:popover-open {
+  transform: translateX(0);
+}
+
+@starting-style {
+  .menu-panel:popover-open {
+    transform: translateX(-100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .menu-panel { transition: none; }
+}
+```
+
+Always honor `prefers-reduced-motion`.
+
+### View transitions
+
+The router wraps every client-side navigation in `document.startViewTransition()`
+automatically. **Do not** wrap `Router.navigate()` in your own
+`startViewTransition()` - that would double-transition.
+
+Name the transitioning element in **component CSS**:
+
+```css
+/* mp-app.css */
+.route-surface {
+  view-transition-name: page-content;
+}
+```
+
+Declare the animations in the **entry template's document-level `<style>`**.
+`::view-transition-*` pseudo-elements live on the document root and cannot be
+reached from inside a shadow root:
+
+```html
+<!-- index.html -->
+<style>
+  ::view-transition-old(page-content) {
+    animation: 200ms ease-out both fade-out;
+  }
+  ::view-transition-new(page-content) {
+    animation: 300ms ease-in both fade-in;
+  }
+  @keyframes fade-in  { from { opacity: 0; } }
+  @keyframes fade-out { to   { opacity: 0; } }
+</style>
+```
+
+While the router is active it installs a nonce-bearing
+`@view-transition { navigation: none; }` override, because automatic
+cross-document transitions conflict with intercepted routes that fall back to
+SSR document requests. `Router.destroy()` removes the override. The router
+awaits `updateCallbackDone` (not `.finished`) so rapid navigations supersede
+each other without queuing.
+
+## Interactivity
+
+### Start scriptless
+
+Most components should have only `.html` and `.css`. A scriptless component
+renders bindings, `<if>`, and `<for>` on the server and contributes no bootstrap
+state to the client.
+
+```html
+<!-- user-card.html - no .ts file, nothing to add -->
+<h2>{{user.name}}</h2>
+<p>{{user.title}}</p>
+<if condition="user.isAdmin">
+  <span class="badge">Admin</span>
+</if>
+```
+
+### When to add a `.ts` file
+
+Add one only when at least one of these is true:
+
+1. The template has an `@event` handler.
+2. The template has a `w-ref` you need for an imperative browser API.
+3. You need `connectedCallback` / `disconnectedCallback` lifecycle work.
+4. You need to fetch data or call a browser API.
+5. The component exposes imperative methods or a public property API.
+
+If none apply, do not create the file.
+
+### When to add `@observable` or `@attr`
+
+Same test, one level down. These decorators exist to connect a value to
+JavaScript - not to make it render.
+
+- **`@observable`** - only when TypeScript in this component reads or writes the
+  value after hydration. A value that is rendered once and never changed on the
+  client belongs in the server state JSON.
+- **`@attr`** - only when the value is part of the component's public API:
+  another component, a parent template, or the router sets it as an HTML
+  attribute.
+
+```typescript
+// Justified: the click handler mutates it, the template renders it.
+@observable count = 0;
+increment(): void { this.count += 1; }
+
+// Justified: a parent template sets label="..." on this element.
+@attr label = '';
+
+// NOT justified: nothing in TypeScript touches it - put it in state JSON.
+@observable heading = 'Welcome';
+
+// NOT justified: mirrors an expression the template can evaluate.
+@observable hasItems = false;   // use <if condition="items.length">
+@observable prevDisabled = true; // use ?disabled="{{currentIndex == 0}}"
+```
+
+### The component class
+
+```typescript
+import { WebUIElement, attr, observable } from '@microsoft/webui-framework';
+
+export class MyComponent extends WebUIElement {
+  @attr label = 'Default';
+  @attr({ mode: 'boolean' }) disabled = false;
+
+  @observable count = 0;
+  @observable items: Item[] = [];
+
+  // Populated by w-ref="{inputEl}" in the template
+  inputEl!: HTMLInputElement;
+
+  onSubmit(): void {
+    const text = this.inputEl.value.trim();
+    if (!text) return;
+    this.items = [...this.items, { text, price: 0 }];
+    this.inputEl.value = '';
+  }
+
+  onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') this.onSubmit();
+  }
+
+  onItemDelete(e: CustomEvent<{ id: string }>): void {
+    this.items = this.items.filter(i => i.id !== e.detail.id);
+  }
+}
+
+MyComponent.define('my-component');
+```
+
+| Decorator | Purpose | SSR? | Triggers DOM update? |
+|---|---|---|---|
+| `@attr` | HTML attribute reflection | Yes; an existing SSR host attribute wins | Yes |
+| `@attr({ mode: 'boolean' })` | Boolean attribute (present/absent) | Yes; host presence wins | Yes |
+| `@observable` | Reactive state used by TypeScript | Yes (from JSON state) | Yes |
+
+| Method / property | Description |
+|---|---|
+| `this.$emit(name, detail?)` | Dispatch a bubbling CustomEvent |
+| `this.$update()` | Force a reactive update cycle |
+| `this.$flushUpdates()` | Synchronously flush pending updates |
+| `static define(tagName)` | Register as a custom element |
+| `defineComponentAssets(manifest)` | Lazy component assets with `preload(tag)` / `create(tag)` |
+
+### Custom events
+
+```typescript
+// Child
+this.$emit('item-selected', { id: this.id, name: this.name });
+```
+
+```html
+<!-- Parent template -->
+<child-component @item-selected="{onItemSelected(e)}"></child-component>
+```
+
+```typescript
+// Parent
+onItemSelected(e: CustomEvent): void {
+  this.selectedId = e.detail.id;
+}
+```
+
+### Hydration entry point
 
 ```typescript
 // index.ts
-import { WebUIElement } from '@microsoft/webui-framework';
-
-// Import components to register them as custom elements.
-// Registration triggers hydration automatically.
 import './app-shell/app-shell.js';
 import './user-card/user-card.js';
-
-// Optional: listen for hydration completion
-window.addEventListener('webui:hydration-complete', () => {
-  const total = performance.getEntriesByName('webui:hydrate:total', 'measure')[0];
-  console.log(`Hydration: ${total?.duration.toFixed(1)}ms`);
-});
 ```
 
-## Build-Time State Projection
+Importing a component module registers it as a custom element, which triggers
+hydration. Nothing else is required.
 
-Rust never analyzes JavaScript or TypeScript. Bundle browser code first and emit
-projection metadata from the same resolved graph:
+### The `super.connectedCallback()` boundary
 
-```bash
-npm install -D esbuild typescript
-```
+Never write `@observable` values before `super.connectedCallback()`. During SSR
+hydration the server-rendered DOM is trusted and not re-rendered, so a value set
+in a field initializer, the constructor, or before that call cannot reach the
+DOM. The write is dropped and the runtime logs a `[WebUI] Hydration mismatch`
+warning (development-only; stripped from production via `__WEBUI_DEV__`).
 
-```javascript
-// build-client.mjs
-import * as esbuild from 'esbuild';
-import { esbuildProjection } from '@microsoft/webui/projection.js';
+If the value must appear in the first render, put it in the SSR state JSON.
+Otherwise assign it after `super.connectedCallback()`, which is a synchronous
+hydration boundary: when it returns, the component's bindings, events, and
+`w-ref` references are wired.
 
-await esbuild.build({
-  entryPoints: ['src/index.ts'],
-  outdir: 'dist',
-  bundle: true,
-  splitting: true,
-  format: 'esm',
-  plugins: [esbuildProjection()],
-});
-```
+Load definitions through a parser-inserted, non-async ES module script or a
+classic `defer` script. Descendants must not structurally mutate a containing
+WebUI component's SSR subtree before it hydrates - insertion, removal, or
+reordering shifts compiled paths.
 
-```bash
-node build-client.mjs
-webui build ./src --out ./dist --plugin=webui \
-  --projection-manifest ./dist/webui-projection.json
-```
+### Lazy component mounting
 
-Rules:
+This is the **only** sanctioned place to insert an element from JavaScript,
+because a lazily loaded component has no template representation until fetched.
 
-- `@microsoft/webui/projection.js` is build-only. `esbuild` and `typescript` are
-  optional peers and are not imported by the root `@microsoft/webui` runtime.
-- The compiler contract is bundler-neutral; the package currently includes the
-  supported esbuild adapter.
-- esbuild runs once. The adapter observes that run and writes
-  `webui-projection.json` atomically after successful output.
-- No manifest means full state and no JavaScript inference.
-- Any supplied manifest enables strict coverage. Every scripted component in
-  the protocol, including components discovered through `--components`, must
-  have exactly one entry or the build fails with `PROJ-B001`.
-- Code-split and external bundles remain application-owned. Build external
-  shared controls separately and repeat `--projection-manifest` for each
-  fragment.
-- The manifest uses JavaScript property names for `@observable` and `@attr`.
-  Existing SSR host attributes take precedence over projected `@attr` values.
-- WebUI validates input/output hashes and embeds compact metadata in
-  `protocol.bin`. Runtime handlers never open the manifest.
-
-## Hydration with Router
+Prefer the template-driven form, which needs no DOM insertion at all:
 
 ```typescript
-// index.ts
-import { WebUIElement } from '@microsoft/webui-framework';
-import { Router } from '@microsoft/webui-router';
-import './app-shell/app-shell.js';
+await Router.ensureLoaded('settings-dialog');
+this.showSettings = true;
+```
 
-// Start router after components are registered
+```html
+<if condition="showSettings">
+  <settings-dialog @close="{onCloseSettings()}"></settings-dialog>
+</if>
+```
+
+Without `@microsoft/webui-router`, prebuild the asset and mount it into a
+`w-ref` slot:
+
+```bash
+webui build ./src --out ./dist --plugin=webui \
+  --emit-component-assets settings-dialog
+```
+
+```typescript
+import { defineComponentAssets } from '@microsoft/webui-framework/component-asset.js';
+
+export const settingsAssets = defineComponentAssets({
+  'settings-dialog': {
+    asset: '/settings-dialog.webui.js',
+    module: () => import('./settings-dialog/settings-dialog.js'),
+  },
+});
+
+async onOpenSettings(): Promise<void> {
+  settingsAssets.preload('settings-dialog');
+  this.panelSlot.replaceChildren(await settingsAssets.create('settings-dialog'));
+}
+```
+
+`preload(tag)` starts the template asset, JS chunk, and data fetch in parallel
+as soon as the user expresses intent. `create(tag)` waits for the template asset
+and module, then creates the element.
+
+## Routing
+
+```html
+<route path="/" component="app-shell">
+  <route path="" component="home-page" exact />
+  <route path="users" component="user-list" exact />
+  <route path="users/:id" component="user-detail" exact />
+</route>
+```
+
+- Child paths are relative to the parent (no leading `/`).
+- Use `exact` on leaf routes; omit it on parents that have `<outlet />`.
+- Path params: `:id` (required), `:query?` (optional), `*path` (catch-all).
+
+| Attribute | Example | Description |
+|---|---|---|
+| `path` | `"users/:id"` | URL path template (relative to parent) |
+| `component` | `"user-detail"` | Component tag to mount |
+| `exact` | (boolean) | Require exact path match |
+| `query` | `"action,to,subject"` | Allowlist of query params set as attributes (deny-by-default) |
+| `keep-alive` | (boolean) | Preserve DOM and local state across navigations |
+| `cache-tags` | `"thread:{threadId},inbox"` | Cache tag templates resolved at render time |
+| `invalidates` | `"inbox,sent,counts"` | Tags auto-invalidated after mutation actions |
+| `pending` | `"loading-skeleton"` | Loading UI for slow navigations (>150ms) |
+| `error` | `"error-display"` | Error boundary on fetch failure |
+
+All attributes are validated at build time. Referencing a non-existent `pending`
+or `error` component is a compile error.
+
+```typescript
 Router.start({
   loaders: {
     'home-page': () => import('./pages/home-page.js'),
-    'user-list': () => import('./pages/user-list.js'),
     'user-detail': () => import('./pages/user-detail.js'),
   },
 });
 ```
 
-### View Transitions
-
-The router wraps every client-side navigation in `document.startViewTransition()`
-automatically. **Do not** wrap `Router.navigate()` in your own `startViewTransition()`
-— that would double-transition.
-
-While active, the router installs a nonce-bearing
-`@view-transition { navigation: none; }` override. Automatic cross-document
-transitions would conflict with intercepted routes that fall back to SSR
-document requests. Explicit client-side transitions still use
-`document.startViewTransition()`, and `Router.destroy()` removes the override.
-
-To customize the animation, assign `view-transition-name` to elements in your CSS
-and target them with `::view-transition-old()` / `::view-transition-new()`:
-
-```css
-.content-area { view-transition-name: content; }
-
-::view-transition-old(content) { animation: fade-out 100ms ease-out; }
-::view-transition-new(content) { animation: fade-in 150ms ease-in; }
-```
-
-The router awaits `updateCallbackDone` (not `.finished`) so rapid navigations
-supersede each other without queuing.
-
-## CLI Commands
-
-### Build
-
-```bash
-webui build ./src --out ./dist --plugin=webui
-```
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `APP` (positional) | `.` | App source directory |
-| `--out <DIR>` | *required* | Output directory |
-| `--entry <FILE>` | `index.html` | Entry HTML file |
-| `--css <MODE>` | `link` | `link`, `style`, or `module` |
-| `--dom <MODE>` | `shadow` | `shadow` or `light` |
-| `--plugin <NAME>` | none | Plugin identifier (e.g. `webui`) |
-| `--components <PACKAGE>` | none | Extra component sources (repeatable) |
-| `--projection-manifest <PATH>` | none | Bundler projection fragment (repeatable); requires `--plugin=webui` |
-| `--emit-component-assets <TAGS>` | none | Comma-separated root component tags emitted as static `.webui.js` ESM assets in `--out` |
-| `--theme <PACKAGE>` | none | Design token theme to validate against (see below) |
-| `--asset-file-name-template <TEMPLATE>` | `[name].[ext]` | Emitted asset filename template for Link-mode CSS files and static component assets. Tokens: `[name]`, `[hash]`, `[ext]` |
-| `--css-public-base <BASE>` | none | Public URL/path prefix for Link-mode CSS hrefs |
-| `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
-| `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
-
-With `--css module`, WebUI appends
-`shadowrootadoptedstylesheets="<component-name>"` to component `<template>`
-wrappers when needed. If you author the wrapper yourself for root events, keep
-your attributes there; WebUI preserves them for client/plugin templates.
-
-For framework apps that bundle browser code, bundle your source browser entry
-directly. Import `@microsoft/webui-framework` from authored component modules.
-An app that stays static after SSR needs no framework browser runtime. Import
-the framework once when scriptless components need browser state or soft
-navigation.
-
-For exact state projection, run the browser bundler first and pass its completed
-manifest to `webui build`. Repeat `--projection-manifest` for separately built
-external component bundles. Omitting the flag preserves full state.
-
-For CDN/browser caching in `link` mode, prefer:
-
-```bash
-webui build ./src --out ./dist \
-  --asset-file-name-template "[name]-[hash].[ext]" \
-  --css-public-base "https://cdn.example.com/assets"
-```
-
-`[hash]` is the component CSS file's SHA-256 content hash truncated to 8 hex
-characters. The CSS files are still written to `--out`; `--css-public-base`
-changes only the href compiled into `protocol.bin` and emitted in stylesheet
-`<link>` tags.
-
-For lazy components without `@microsoft/webui-router`, emit static component
-assets:
-
-```bash
-webui build ./src --out ./dist --plugin=webui \
-  --emit-component-assets mail-thread,compose-page
-```
-
-This writes `mail-thread.webui.js`. Requested roots stay outside initial SSR
-unless the entry template also references them. The asset is standard ESM that
-carries the component template and styles. Load it with
-`defineComponentAssets()` before mounting the component. Use
-`--asset-file-name-template "[name]-[hash].[ext]"` for CDN-cacheable filenames.
-Do not reference the lazy component tag from an SSR-reachable template unless you
-intentionally want it eligible for initial SSR.
-
-HTML comments are stripped at build time and bindings inside them are ignored.
-CSS comments are stripped except legal comments and `<style>` signal fragments.
-Legal CSS comments containing `@license` or `@preserve`, or starting with `/*!`
-or `//!`, are preserved only when `--legal-comments inline` is active.
-Malformed HTML or CSS fails `webui build`; escape literal `<` as `&lt;` and
-close all tags, comments, declarations, `var()` calls, and CSS delimiters.
-
-### Serve (dev server)
-
-```bash
-webui serve ./src --state ./data/state.json --plugin=webui --watch
-```
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `APP` (positional) | `.` | App source directory |
-| `--state <FILE>` | *required* | JSON state file |
-| `--port <PORT>` | `3000` | Server port |
-| `--watch` | false | Enable live reload |
-| `--servedir <DIR>` | none | Static asset directory |
-| `--entry <FILE>` | `index.html` | Entry HTML file |
-| `--css <MODE>` | `link` | `link`, `style`, or `module` |
-| `--dom <MODE>` | `shadow` | `shadow` or `light` |
-| `--plugin <NAME>` | none | Plugin identifier (e.g. `webui`) |
-| `--components <PACKAGE>` | none | Extra component sources (repeatable) |
-| `--projection-manifest <PATH>` | none | Bundler projection fragment (repeatable); watched explicitly with `--watch` |
-| `--api-port <PORT>` | none | Proxy route requests with encoded paths and queries preserved |
-| `--theme <PACKAGE>` | none | Design token theme; missing unresolved tokens fail the build (see below) |
-| `--asset-file-name-template <TEMPLATE>` | `[name].[ext]` | Emitted asset filename template |
-| `--css-public-base <BASE>` | none | Public URL/path prefix for Link-mode CSS hrefs |
-| `--legal-comments <MODE>` | `inline` | `inline` preserves legal CSS comments, `none` strips all comments |
-| `--format <FORMAT>` | `human` | `human` (colorized) or `json` (machine-readable diagnostics on stdout) |
-
-With `--api-port`, backend state requests and `/api/*` forwarding preserve the
-incoming encoded path and query except for the entry route alias. `/` and
-`/index.html` both resolve backend state at `/` (the entry path is normalized),
-while still preserving the query string. All other request paths forward their
-encoded path and query unchanged. Applications must not double-encode route
-parameters for development; `%2F` remains within one route segment.
-
-After generated assets and `--servedir` files miss, route fallback is based on
-the `Accept` header. Requests that explicitly accept `text/html` or
-`application/xhtml+xml` receive the SSR document, and requests that explicitly
-accept `application/json` receive the JSON partial response. `q=0` disables
-that media type, while a malformed or out-of-range `q` value falls back to
-`q=1.0`; when HTML and JSON are both acceptable, the higher `q` wins and exact
-ties prefer JSON. Missing or wildcard-only `Accept` headers return 404, as do JS,
-CSS, image, and other
-non-HTML/non-JSON asset requests. Dots are valid in route segments, so paths
-such as `/docs/v2.1` can still fall back to the route renderer.
-
-### Inspect
-
-```bash
-webui inspect ./dist/protocol.bin
-webui inspect ./dist/protocol.bin | jq '.fragments | keys'
-```
-
-## Build Diagnostics & Error Output
-
-Authoring mistakes fail `webui build` with a structured, actionable diagnostic
-(never a stack trace). Each one has a **stable error code**, the source
-location, the offending snippet, and a `help:` fix:
-
-```
-✘ error: invalid <for> each expression [invalid-for-each]
-  --> index.html:67:5
-    each="person inpeople"
-  help: use the form each="item in collection", e.g. each="todo in todos"
-```
-
-When a mistake looks like a typo, `help:` suggests the intended name — a
-misspelled directive attribute (`eahc` → `each`) or an unregistered
-custom-element tag that closely matches a registered component **in the same
-namespace** (`<mp-buton>` → `<mp-button>`). A different-namespace tag (e.g. a
-third-party `<md-button>`) passes through as a genuine custom element.
-
-### Machine-readable output (`--format json`)
-
-For editors, CI, and AI tooling, pass the global `--format json` flag. Each
-error is emitted as a single JSON object on **stdout** (no ANSI), so it can be
-parsed directly instead of scraping terminal text:
-
-```bash
-webui build ./src --out ./dist --format json
-```
-
-```json
-{
-  "severity": "error",
-  "code": "invalid-for-each",
-  "message": "invalid <for> each expression",
-  "file": "index.html",
-  "line": 67,
-  "column": 5,
-  "snippet": "each=\"person inpeople\"",
-  "help": "use the form each=\"item in collection\", e.g. each=\"todo in todos\"",
-  "chain": ["Build failed", "Failed to parse index.html", "..."]
-}
-```
-
-Branch on the stable `code`, not the human-readable `message`. Fields that don't
-apply to a given error are `null`.
-
-### Error codes
-
-`invalid-for-each`, `invalid-for-identifier`, `missing-for-each`,
-`invalid-if-condition`, `missing-if-condition`, `unknown-component`,
-`invalid-event-handler`, `invalid-w-ref`, `missing-theme-token`,
-`unclosed-html-tag`,
-`malformed-html-tag`, `unexpected-closing-tag`, `unterminated-html-comment`,
-`unterminated-html-declaration`, `excessive-nesting`, `recursive-template`,
-`invalid-css`, `PROJ-P001`, `PROJ-P002`, `PROJ-B001`, `PROJ-B002`,
-`PROJ-M001`, `PROJ-M003`, `PROJ-M004`, `PROJ-M006`, `PROJ-M007`,
-`PROJ-M009`, `PROJ-S001`, `PROJ-S003`, `PROJ-S004`.
-
-### Exit codes
-
-Following `sysexits.h`: `0` success, `2` argument/usage error, `65`
-template/authoring error, `66` missing input (app folder, `--state`,
-`--servedir`, or entry file), `69` port already in use, `74` I/O error, `1`
-otherwise.
-
-## `--components` - External Component Sources
-
-The `--components` flag discovers components from npm packages or local
-directories outside your app folder. Repeatable.
-
-**What it accepts:**
-
-- **npm package name** - `@scope/my-widgets` or `my-widget`
-- **Scoped prefix** - `@scope` (discovers ALL sub-packages under `node_modules/@scope/`)
-- **Local path** - `./shared/components` or `/libs/ui-kit`
-
-Values starting with `.`, `/`, `\`, or a drive letter are treated as local
-paths. Everything else is treated as an npm package name.
-
-**npm package requirements:**
-
-The package's `package.json` must have:
-
-```json
-{
-  "name": "@scope/my-button",
-  "customElements": "./custom-elements.json",
-  "exports": {
-    "./template-webui.html": "./dist/template-webui.html",
-    "./styles.css": "./dist/styles.css"
-  }
-}
-```
-
-| Field | Required | Purpose |
-|-------|----------|---------|
-| `exports["./template-webui.html"]` | Yes | Component HTML template |
-| `exports["./styles.css"]` | No | Component CSS |
-| `customElements` | Yes | Path to Custom Elements Manifest (provides tag name) |
-
-Packages with a root JavaScript entry (`exports["."]`, `main`, `module`, or
-`browser`) are authored custom-element packages. Packages with only WebUI
-template/style exports are compiler-owned template libraries. Their dynamic
-templates render on the server and can activate in the browser when the
-framework runtime is loaded.
-
-**Local path scanning** works like app directory scanning: HTML files with
-hyphenated names are registered as components, matching CSS files are
-auto-paired. A sibling `.ts` or `.js` file marks the component as authored and
-interactive.
-
-**Caching:** npm results are cached at `~/.webui/cache/components/` and
-invalidated when `package.json` changes. Local paths are always re-scanned.
-
-```bash
-# Single scoped package
-webui build ./src --out ./dist --components @reactive-ui/button
-
-# All packages under a scope
-webui build ./src --out ./dist --components @reactive-ui
-
-# Local shared library
-webui build ./src --out ./dist --components ./shared/components
-
-# Multiple sources
-webui build ./src --out ./dist \
-  --components @reactive-ui \
-  --components ./shared/components
-```
-
-## `--theme` - Design Token Themes
-
-The `--theme` flag loads a token JSON file. On `webui build`, it validates that
-each unresolved CSS token discovered by the parser exists in every theme. On
-`webui serve`, it performs the same validation and injects resolved CSS custom
-property declarations into the render state.
-
-**What it accepts:**
-
-- **Local JSON file** - `./themes/dark.json`
-- **npm package** - `@my-org/brand-tokens` (looks for `tokens.json` inside the package)
-- **npm package with subpath** - `@my-org/brand-tokens/custom.json`
-
-**How it works:**
-
-1. Loads the JSON file (multi-theme or flat single-theme format)
-2. Filters tokens to only those actually used in your CSS (`var(--name)`,
-   including nested `var()` fallbacks)
-3. Expands present transitive `var()` references; theme internals are trusted, so
-   missing/cyclic references inside theme values are left to browser CSS
-   semantics
-4. Fails with `missing-theme-token` when any required token is absent from a
-   theme. `var(--a, var(--b, var(--c)))` requires `a`, `b`, and `c` unless a
-   token is defined by local/ancestor CSS. A `var()` usage with a literal
-   fallback (e.g. `var(--brand, #000)`) is exempt — the token is still hoisted
-   for runtime resolution but its absence does not fail the build, unless the
-   same token is also used without a fallback.
-5. Generates CSS declaration strings per theme
-6. Injects into SSR state as `state.tokens.light`, `state.tokens.dark`, etc.
-   These render-only token strings are omitted from the emitted client state.
-
-A token used only with a literal `var()` fallback and absent from every theme
-(e.g. a misspelled `var(--colr-brand, #000)`) is reported as a non-fatal
-`unthemed-token` **warning** on `BuildResult.warnings` (a `Vec<Diagnostic>`,
-also printed by `webui build` and `webui serve`) instead of failing the build —
-a typo safety net. Warnings are warning-severity `Diagnostic`s, so they render
-with the same layout as `missing-theme-token` errors: both carry the source
-location (`my-card.css:2:10` + the CSS line) and a `did you mean --…?`
-suggestion computed by Levenshtein edit distance against the theme's tokens. The
-dev server frames each error/warning with blank lines so consecutive advisories
-stay readable.
-
-In `webui serve --watch`, rebuild failures are retained in dev-server state:
-the terminal and live-reload SSE report the error, and a browser refresh returns
-the latest rebuild error instead of stale HTML while keeping the live-reload
-connection active until the next clean rebuild.
-
-**Multi-theme format:**
-```json
-{
-  "themes": {
-    "light": {
-      "surface-page": "#ffffff",
-      "text-primary": "#111827"
-    },
-    "dark": {
-      "surface-page": "#171717",
-      "text-primary": "#fafafa"
-    }
-  }
-}
-```
-
-**Flat format** (single theme, treated as `"default"`):
-```json
-{
-  "surface-page": "#ffffff",
-  "text-primary": "#111827"
-}
-```
-
-**Template usage** - wrap dynamic CSS fragments in a CSS block comment:
-```html
-<style>
-  :root {
-    /*{{{tokens.light}}}*/
-  }
-</style>
-```
-
-The handler resolves `tokens.light` from the state, outputting:
-```css
-:root {
-  --surface-page: #ffffff;
-  --text-primary: #111827;
-}
-```
+Route loaders (`static loader({ params, query, signal })`) and actions
+(`static action({ formData, params, signal })`, enabled by
+`Router.start({ actions: true })`) live on the component class. Cache and
+preload are optional runtime tiers; a default `Router.start()` does not load the
+cache module.
+
+Every route intended for partial navigation must register a custom element.
+Scriptless templates are registered by the compiler-owned host runtime. If a
+route remains unregistered after template publication and loader resolution, the
+router navigates the document so the server can render it.
+
+Full detail: [Routing](/guide/concepts/routing).
 
 ## State JSON
 
@@ -1022,199 +749,209 @@ The handler resolves `tokens.light` from the state, outputting:
 
 **Path resolution:** `title`, `user.name`, `items.0.label`, `items.length`
 
-**Missing paths:** text bindings render empty, `<if>` evaluates to false. No error.
+**Missing paths:** text bindings render empty, `<if>` evaluates false. No error.
 
-## Truthiness in Conditions
+**Route-scoped state.** Each route handler should return only the keys that
+route's template binds to. Sending full app state on every route wastes
+bandwidth and render time.
+
+### Truthiness
 
 | Value | Truthy? |
-|-------|---------|
+|---|---|
 | `true` | Yes |
 | `false` | No |
 | `0` | No |
 | Non-zero number | Yes |
 | `""` (empty string) | No |
 | `"false"` (string!) | **Yes** (non-empty string) |
+| `[]` (empty array) | **Yes** (use `.length`) |
 | `null` / missing key | No |
 
-**Never use string `"false"` for boolean state. Use real booleans.**
+**Never use the string `"false"` for boolean state. Use real booleans.**
 
-## Things You CANNOT Do
+## Anti-patterns
 
-1. **No ternary in templates.** `{{x ? 'yes' : 'no'}}` does not work.
-   Use `<if>` blocks or boolean attributes instead.
-
-2. **No function calls in bindings.** `{{formatDate(item.date)}}` does not
-   work. Compute the value on the server or in an event handler.
-
-3. **No mixed `&&` and `||`.** `<if condition="a && b || c">` is invalid.
-   Split into nested `<if>` blocks.
-
-4. **No parentheses in conditions.** `<if condition="(a && b) || c">` is
-   invalid.
-
-5. **No JavaScript in HTML templates.** Templates are compiled to binary.
-   Logic goes in the TypeScript class file, not the template.
-
-6. **No JavaScript in CSS.** CSS is plain CSS in `.css` files. Use CSS
-   custom properties for dynamic values.
-
-7. **No computed getters for SSR state.** If a value appears in the
-   template, it must be in the server state JSON. Use `@observable`
-   only when event handlers or other TypeScript code read or change it.
-
-8. **Components inside `<for>` loops do NOT inherit loop variables.**
-   Pass data explicitly via attributes.
-
-9. **No `import` or `require` in templates.** Components are discovered
-   by file naming convention, not imports.
-
-10. **No `this.querySelector()` for reactive state.** Use `@observable` for
-    state your TypeScript changes, and use template bindings for DOM output.
-    Use `w-ref` only for imperative DOM access (focus, scroll, etc.).
-
-11. **No `@observable` writes before `super.connectedCallback()`.** During SSR
-    hydration the server-rendered DOM is trusted and not re-rendered, so a value
-    set in a field initializer, the `constructor`, or before
-    `super.connectedCallback()` cannot reach the DOM — the write is dropped and
-    the runtime logs a `[WebUI] Hydration mismatch` warning. If the value must
-    appear in the first render, put it in the SSR state JSON; otherwise assign it
-    after `super.connectedCallback()`. The call is a synchronous hydration
-    boundary: when it returns, that component's bindings, events, and `w-ref`
-    references are wired. Load definitions through a parser-inserted, non-async
-    ES module script or a classic `defer` script. A blocking classic script must
-    follow every SSR instance it may upgrade. Descendants must not structurally
-    mutate a containing WebUI component's SSR subtree before it hydrates, because
-    node insertion, removal, or reordering shifts compiled paths. The warning is
-    development-only — it is
-    stripped from production bundles via the `__WEBUI_DEV__` compile-time flag
-    (`webui-press build` sets `__WEBUI_DEV__=false` automatically; self-bundled
-    apps add the define for production).
-
-## Common Patterns
-
-### Toggle visibility
-
-```html
-<button @click="{togglePanel()}">Toggle</button>
-<if condition="isPanelOpen">
-  <div class="panel">Panel content</div>
-</if>
-```
+### Building UI from JavaScript
 
 ```typescript
-@observable isPanelOpen = false;
-togglePanel(): void { this.isPanelOpen = !this.isPanelOpen; }
+// WRONG
+const row = document.createElement('div');
+row.textContent = item.name;
+this.list.appendChild(row);
+
+// WRONG
+this.list.innerHTML = items.map(i => `<div>${i.name}</div>`).join('');
 ```
 
-### List with add/remove
-
 ```html
-<input w-ref="input" @keydown="{onKey(e)}" />
+<!-- RIGHT -->
 <for each="item in items">
-  <div>
-    {{item.text}}
-    <button @click="{remove(item.id)}">×</button>
-  </div>
+  <div>{{item.name}}</div>
 </for>
 ```
 
-`remove(item.id)` receives the current loop item's id. The framework captures
-the active repeat scope during hydration and resolves the path when the click
-event fires.
+### Styling from JavaScript
 
-### Boolean attribute styling
+```typescript
+// WRONG
+this.panel.style.background = this.isActive ? 'blue' : 'transparent';
+this.panel.classList.toggle('active', this.isActive);
+this.shadowRoot.adoptedStyleSheets = [sheet];
+```
 
 ```html
-<button ?data-active="{{isActive}}" @click="{toggle()}">
-  {{label}}
-</button>
+<!-- RIGHT -->
+<div class="panel" ?data-active="{{isActive}}">...</div>
 ```
 
 ```css
-button[data-active] { background: blue; color: white; }
-button:not([data-active]) { background: transparent; }
+.panel[data-active] { background: var(--accent); }
 ```
 
-### Lazy-loaded dialog
-
-Declare the component as a route (so it's compiled), then load dynamically:
-
-```html
-<!-- index.html - settings-dialog is available but not navigated to -->
-<route path="/" component="app-shell">
-  <route path="" component="home-page" exact />
-  <route path="settings" component="settings-dialog" exact />
-</route>
-```
+### Animating from JavaScript
 
 ```typescript
-// Shell component - load template + CSS on demand
-async onOpenSettings(): Promise<void> {
-  await Router.ensureLoaded('settings-dialog');
-  await import('./settings-dialog/settings-dialog.js');
-  this.showSettings = true;
-}
+// WRONG
+el.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 200 });
+// WRONG
+let o = 0; setInterval(() => { el.style.opacity = String(o += 0.05); }, 16);
 ```
 
-```html
-<!-- Shell template - create the element dynamically -->
-<if condition="showSettings">
-  <settings-dialog @close="{onCloseSettings()}"></settings-dialog>
-</if>
+```css
+/* RIGHT */
+.toast { transition: opacity 200ms ease; opacity: 1; }
+@starting-style { .toast { opacity: 0; } }
 ```
 
-### Derived state (prefer template expressions over shadow observables)
+### Unnecessary framework surface
 
-Anywhere an expression works (`<if condition="...">`, `?boolAttr="{{...}}"`, text
-bindings via path lookups), compare existing state directly. Do not introduce
-extra observables that just mirror a comparison or sentinel of other state, and
-do not bake per-item flags like `isCurrent` / `isDisabled` into the SSR JSON
-when a single comparison can derive them.
-
-```html
-<!-- DO: derive in the template -->
-<if condition="items.length">
-  <span>{{items.length}} items</span>
-</if>
-
-<button ?disabled="{{currentIndex == 0}}">Prev</button>
-<button ?disabled="{{currentIndex == totalItems}}">Next</button>
-
-<for each="app in apps">
-  <option ?selected="{{app.slug == currentApp.slug}}">{{app.name}}</option>
-</for>
-
-<!-- DON'T: shadow observables that mirror a comparison -->
-<!-- @observable hasItems = false;     // mirrors items.length > 0 -->
-<!-- @observable prevDisabled = true;  // mirrors currentIndex == 0 -->
-<!-- @observable nextDisabled = false; // mirrors currentIndex == totalItems -->
-
-<!-- DON'T: per-item flags in JSON state that mirror a comparison -->
-<!-- { "apps": [{ "slug": "...", "isCurrent": true }, ...] }
-     Just compare against the selected slug/id in the template. -->
+```typescript
+// WRONG - nothing in TypeScript touches these
+@observable heading = 'Welcome';
+@observable subtitle = 'Get started below';
 ```
-
-Loop variables (e.g. `app`) compose with outer component state (e.g.
-`currentApp`) inside the same expression, so per-iteration flags are almost
-never needed.
-
-Text bindings only do path lookups — they can't do arithmetic. If you need
-`{{currentIndex + 1}}` for a 1-based display, that's a legitimate `@observable`
-(or precomputed in the SSR state).
-
-### Route-scoped state
-
-Each route handler should return only the state that route's component needs:
 
 ```json
-// GET /inbox -> only inbox data
-{ "threads": [...], "selectedFolder": "inbox" }
-
-// GET /settings -> only settings data
-{ "theme": "dark", "language": "en" }
+// RIGHT - server state JSON
+{ "heading": "Welcome", "subtitle": "Get started below" }
 ```
 
-## package.json
+### Shadow observables that mirror an expression
+
+```typescript
+// WRONG
+@observable items: Item[] = [];
+@observable hasItems = false;
+onItemsChanged(): void { this.hasItems = this.items.length > 0; }
+```
+
+```html
+<!-- RIGHT -->
+<if condition="items.length">...</if>
+<button ?disabled="{{currentIndex == 0}}">Prev</button>
+<option ?selected="{{app.slug == currentApp.slug}}">{{app.name}}</option>
+```
+
+Loop variables compose with outer component state in the same expression, so
+per-item flags like `isCurrent` in the SSR JSON are almost never needed.
+
+Text bindings do path lookups only. If you need `{{currentIndex + 1}}` for a
+1-based display, that is a legitimate `@observable` or a precomputed state key.
+
+### Reading DOM instead of state
+
+```typescript
+// WRONG
+const value = this.shadowRoot.querySelector('.count').textContent;
+```
+
+Use `@observable` for state TypeScript changes, template bindings for output,
+and `w-ref` only for imperative APIs.
+
+### Hand-built platform primitives
+
+```html
+<!-- WRONG -->
+<div class="modal-backdrop" @click="{close()}">
+  <div class="modal" role="dialog">...</div>
+</div>
+
+<!-- RIGHT -->
+<dialog w-ref="{dialogEl}" @close="{onClose()}">...</dialog>
+```
+
+`showModal()` gives focus trapping, `inert` backdrop, Escape handling, and
+top-layer stacking for free.
+
+### Also not supported
+
+1. **No ternary in templates.** `{{x ? 'yes' : 'no'}}` does not work.
+2. **No function calls in bindings.** `{{formatDate(item.date)}}` does not work.
+   Compute on the server or in an event handler.
+3. **No mixed `&&` and `||`** in one condition. Split into nested `<if>` blocks.
+4. **No parentheses in conditions.**
+5. **No JavaScript in HTML templates.** Templates compile to binary.
+6. **No JavaScript in CSS.** Use custom properties for dynamic values.
+7. **No computed getters for SSR state.**
+8. **Components inside `<for>` do NOT inherit loop variables.**
+9. **No `import` or `require` in templates.** Components are discovered by file
+   naming convention.
+10. **Non-braced `w-ref`** fails the build. Use `w-ref="{name}"`.
+
+## Pre-flight checklist
+
+Before emitting WebUI code, confirm:
+
+- [ ] No `createElement`, `innerHTML`, `appendChild`, or `insertAdjacentHTML`,
+      except mounting a lazily loaded component.
+- [ ] No `.style.x =`, `classList`, `setAttribute('style')`, or
+      `adoptedStyleSheets`.
+- [ ] No `element.animate()`, `requestAnimationFrame` tweening, or animation
+      library. Animation is in `.css`.
+- [ ] Every `.ts` file exists because of an event, `w-ref`, lifecycle hook,
+      fetch, or public API - not by default.
+- [ ] Every `@observable` / `@attr` is read or written by TypeScript, or is
+      public API. Otherwise it moved to the state JSON.
+- [ ] No observable mirrors an expression the template can evaluate.
+- [ ] Every `{{binding}}`, `<if>`, and `<for>` path exists in the state JSON.
+- [ ] Every `w-ref` uses braces.
+- [ ] A built-in element was considered before a hand-built one
+      (`<dialog>`, `popover`, `<details>`).
+- [ ] `::view-transition-*` rules are in the entry template, not component CSS.
+- [ ] `prefers-reduced-motion` is honored wherever motion is used.
+- [ ] No conditions mix `&&` with `||`, use parentheses, or use a ternary.
+
+## Build and run
+
+```bash
+# Dev server with live reload
+webui serve ./src --state ./data/state.json --plugin=webui --watch
+
+# Production build
+webui build ./src --out ./dist --plugin=webui
+
+# Inspect the compiled protocol
+webui inspect ./dist/protocol.bin
+```
+
+Common flags on both commands: `--entry`, `--css <link|style|module>`,
+`--dom <shadow|light>`, `--components`, `--theme`,
+`--projection-manifest`, `--emit-component-assets`, `--format json`.
+
+Authoring mistakes fail the build with a structured diagnostic carrying a stable
+code, source location, snippet, and a `help:` fix. Branch on the `code`, never
+the message. `--format json` emits one JSON object per error on stdout.
+
+```
+x error: invalid <for> each expression [invalid-for-each]
+  --> index.html:67:5
+    each="person inpeople"
+  help: use the form each="item in collection", e.g. each="todo in todos"
+```
+
+Full flag tables, exit codes, and the error-code list:
+[CLI Reference](/guide/cli/).
 
 ```json
 {
@@ -1231,134 +968,41 @@ Each route handler should return only the state that route's component needs:
 }
 ```
 
-Add `@microsoft/webui-router` if using client-side navigation.
-Run the client bundler in watch mode alongside `dev:server`; the dev server
-rebuilds when the adapter atomically replaces the manifest.
+Add `@microsoft/webui-router` for client-side navigation. Passing
+`--projection-manifest` narrows hydration state to exactly the `@observable` and
+`@attr` fields your bundle uses; omitting it keeps full state.
 
-## Language Integration (Server Side)
+## Server integration
 
-WebUI renders from **any** backend. The server loads `protocol.bin` into one
-`Protocol`, then renders with JSON state per request. Projection
-manifests are consumed only while producing `protocol.bin`; runtime rendering
-does not load projection tooling. In Node, `Protocol.render()` returns a UTF-8
-`Buffer`; call `.toString('utf8')` only when string operations are required.
-
-### Rust
+Any backend loads `protocol.bin` once and renders with JSON state per request.
 
 ```rust
 let protocol = Protocol::from_protobuf(&fs::read("dist/protocol.bin")?)?;
-let state = json!({ "title": "Home", "items": items_vec });
 let handler = WebUIHandler::new();
 handler.render(&protocol, &state, &options, &mut writer)?;
 ```
 
-**Streaming SSR (production).** Use `webui::streaming::StreamingWriter::new_pooled(tx, chunk_pool)` with a process-wide `ChunkPool` for bounded backpressure + zero per-flush allocation. Configure `.with_flush_timeout(Duration::from_secs(30))` to bound slow-loris DoS. Use `RenderOptions::with_head_inject(html)` / `with_body_inject(html)` for per-request HTML splicing at parser-synthesized `head_end` / `body_end` boundaries (no byte-scanner, cannot mis-fire on literals in comments / srcdoc). `HandlerError::ClientDisconnected` and `StreamTimeout` are returned from both `write()` and `end()` for telemetry. Pre-escape untrusted inject content with `webui_handler::encode_safe`.
-
-### Node.js
-
 ```javascript
-import { build, Protocol } from '@microsoft/webui';
-
-const result = build({
-  appDir: './src',
-  plugin: 'webui',
-  projectionManifests: ['./dist/webui-projection.json'],
-});
-
 const protocol = new Protocol(result.protocol, { plugin: 'webui' });
-const html = protocol.render(state, {
-  entry: 'index.html',
-  requestPath: req.url,
-});
+const html = protocol.render(state, { entry: 'index.html', requestPath: req.url });
 ```
 
-### WebAssembly
+Equivalent APIs exist for WebAssembly, Python (FFI), Go (cgo), and C#. For
+`Router.ensureLoaded()`, expose `GET /_webui/templates?t=tag1,tag2` backed by
+`render_component_templates(&tags, &inv)`.
 
-Use the split WASM bundles when rendering or parsing in the browser:
+Full detail: [Integrations](/guide/integrations/).
 
-```javascript
-import initHandler, { Protocol } from './wasm/handler/webui_wasm_handler.js';
-await initHandler();
-const protocolBytes = new Uint8Array(await (await fetch('/protocol.bin')).arrayBuffer());
-const protocol = new Protocol(protocolBytes, 'webui');
-const html = protocol.render(
-  JSON.stringify(state),
-  { entry: 'index.html', requestPath: '/' },
-);
-```
+## Where to read more
 
-```javascript
-import initParser, { build_protocol } from './wasm/parser/webui_wasm_parser.js';
-await initParser();
-const protocolBytes = build_protocol(
-  { 'index.html': '<h1>{{title}}</h1>' },
-  'index.html',
-  [projectionManifest],
-);
-```
-
-Use `wasm/all/webui_wasm_all.js` when both parser and handler exports are needed in one module, such as a playground.
-
-### Python (FFI)
-
-```python
-protocol_bytes = Path("dist/protocol.bin").read_bytes()
-buffer = (ctypes.c_uint8 * len(protocol_bytes)).from_buffer_copy(protocol_bytes)
-protocol = lib.webui_protocol_create(buffer, len(protocol_bytes))
-handler = lib.webui_handler_create()
-ptr = lib.webui_handler_render(
-    handler, protocol, data_json, b"index.html", request_path
-)
-result = ctypes.cast(ptr, c_char_p).value.decode("utf-8")
-lib.webui_free(ptr)
-lib.webui_protocol_destroy(protocol)
-lib.webui_handler_destroy(handler)
-```
-
-Create the protocol and handler once at startup, then pass both handles to
-`webui_handler_render` on every request.
-
-### Go (cgo)
-
-```go
-protocol := C.webui_protocol_create(
-    (*C.uint8_t)(unsafe.Pointer(&protocolBytes[0])),
-    C.uintptr_t(len(protocolBytes)),
-)
-handler := C.webui_handler_create()
-ptr := C.webui_handler_render(handler, protocol, cJSON, cEntry, cPath)
-defer C.webui_free(ptr)
-result := C.GoString(ptr)
-```
-
-### C# (.NET package)
-
-```csharp
-using var protocol = new Protocol(File.ReadAllBytes("dist/protocol.bin"));
-using var handler = new WebUIHandler("webui");
-string result = handler.Render(protocol, dataJson, "index.html", requestPath);
-string partial = protocol.RenderPartial(dataJson, "index.html", requestPath, invHex);
-string templates = protocol.RenderComponentTemplates(["settings-dialog"], invHex);
-string[] tokens = protocol.Tokens();
-```
-
-### Server Template Endpoint
-
-For `Router.ensureLoaded()`, expose `GET /_webui/templates?t=tag1,tag2`:
-
-```rust
-let result = protocol.render_component_templates(&tags, &inv);
-```
-
-```javascript
-// @microsoft/webui npm package
-const result = protocol.renderComponentTemplates(['settings-dialog'], invHex);
-```
-
-```csharp
-string result = protocol.RenderComponentTemplates(["settings-dialog"], invHex);
-```
-
-The JSON response contains component-tag-keyed `templates`, matching
-`templateFunctions`, `templateStyles` for CSS module importmaps, and `inventory`
-with the updated component bitmask.
+| Topic | Page |
+|---|---|
+| Directives (`if`, `for`, attributes, `route`) | [/guide/concepts/directives/](/guide/concepts/directives/) |
+| Component authoring and hydration | [/guide/concepts/interactivity](/guide/concepts/interactivity) |
+| Best practices and React-habit pitfalls | [/guide/concepts/best-practices](/guide/concepts/best-practices) |
+| Routing, loaders, actions, caching | [/guide/concepts/routing](/guide/concepts/routing) |
+| Design tokens and theming | [/guide/concepts/css-tokens](/guide/concepts/css-tokens) |
+| CLI flags, diagnostics, exit codes | [/guide/cli/](/guide/cli/) |
+| Rust, Node, WASM, FFI, Electron | [/guide/integrations/](/guide/integrations/) |
+| Performance characteristics | [/guide/concepts/performance](/guide/concepts/performance) |
+| Build a first app | [/tutorials/hello-world/](/tutorials/hello-world/) |

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -175,7 +175,15 @@ Text bindings do path lookups only. They cannot do arithmetic or call functions.
 Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 
 **Constraints:** max 5 logical operators per expression; cannot mix `&&` and
-`||` in one expression; no parentheses for grouping; no ternary.
+`||` in one expression; no parentheses for grouping; no ternary; **no
+arithmetic**.
+
+Each side of a comparison is either a literal (number, quoted string, `true`,
+`false`) or a dotted state path. Anything else is read as a path, so
+`{{currentIndex == items.length - 1}}` looks up a key literally named
+`items.length - 1`, finds nothing, and the condition is silently false. Have the
+server send a precomputed `lastIndex` (or `isLast`) instead. Bare `.length` on an
+array or string does work: `<if condition="items.length > 3">`.
 
 ### Loops
 
@@ -222,7 +230,7 @@ Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `!`
 <!-- Boolean attributes accept the same expressions as <if condition="...">.
      Compare against existing state instead of creating mirror observables. -->
 <button ?disabled="{{currentIndex == 0}}">Prev</button>
-<button ?disabled="{{currentIndex == items.length - 1}}">Next</button>
+<button ?disabled="{{currentIndex == lastIndex}}">Next</button>
 <option ?selected="{{item.id == selectedId}}">{{item.name}}</option>
 
 <!-- Mixed static + dynamic -->
@@ -765,10 +773,17 @@ bandwidth and render time.
 | Non-zero number | Yes |
 | `""` (empty string) | No |
 | `"false"` (string!) | **Yes** (non-empty string) |
-| `[]` (empty array) | **Yes** (use `.length`) |
+| `[]` (empty array) | No (server) / **Yes** (client) - always use `.length` |
+| `{}` (empty object) | No (server) / **Yes** (client) - test a real field |
 | `null` / missing key | No |
 
 **Never use the string `"false"` for boolean state. Use real booleans.**
+
+**Never test a bare array or object for truthiness.** The server evaluator treats
+empty collections as falsy; the compiled client condition is plain JS `!!value`,
+where `[]` and `{}` are truthy. Writing `<if condition="items">` means SSR and
+hydration can disagree. Write `<if condition="items.length">` instead - that
+agrees on both sides.
 
 ## Anti-patterns
 

--- a/docs/guide/concepts/best-practices.md
+++ b/docs/guide/concepts/best-practices.md
@@ -124,7 +124,7 @@ In your server state JSON, use actual booleans:
 
 ## Observable Truthiness in `<if>` Conditions
 
-The `<if>` directive evaluates conditions using standard JavaScript truthiness rules. Understanding these rules prevents subtle rendering bugs.
+The `<if>` directive evaluates conditions with JavaScript-like truthiness, with one important exception: empty collections. The server evaluator treats an empty array or object as falsy, while the compiled client condition is plain `!!value`, where both are truthy. Understanding these rules prevents subtle rendering bugs.
 
 | Value | Truthy? | Notes |
 |-------|---------|-------|
@@ -136,7 +136,8 @@ The `<if>` directive evaluates conditions using standard JavaScript truthiness r
 | `""` | ❌ No | Empty string |
 | `"false"` | ✅ Yes ⚠️ | Non-empty string - this is truthy! |
 | `"0"` | ✅ Yes ⚠️ | Non-empty string - this is truthy! |
-| `[]` (empty array) | ✅ Yes ⚠️ | Arrays are objects - always truthy |
+| `[]` (empty array) | ⚠️ Differs | Falsy on the server, truthy on the client - never test it directly |
+| `{}` (empty object) | ⚠️ Differs | Falsy on the server, truthy on the client - never test it directly |
 | `[].length` → `0` | ❌ No | Use `.length` to check for empty arrays |
 
 ### Common patterns
@@ -160,7 +161,7 @@ The `<if>` directive evaluates conditions using standard JavaScript truthiness r
 
 <webui-blockquote appearance="tip" title="Tip" icon="💡">
 
-Always use `.length` to check whether an array is empty. An empty array `[]` is truthy - only its `.length` (which is `0`) is falsy.
+Always use `.length` to check whether an array is empty. Never write `<if condition="items">`: the server treats `[]` as falsy while the client treats it as truthy, so server-rendered output and hydration can disagree. `items.length` is `0` for an empty array, which is falsy on both sides.
 
 </webui-blockquote>
 
@@ -412,7 +413,7 @@ Start with Shadow DOM (the default). Switch individual components or pages to Li
 | Provide all bound keys in server state | Missing keys silently render empty |
 | Use template expressions over shadow observables | Fewer properties, no sync bugs, no extra server state |
 | Use `@attr({ mode: 'boolean' })` for true/false | Follows HTML spec, avoids string `"false"` trap |
-| Check `.length` for empty arrays | Empty arrays are truthy; `.length` of `0` is falsy |
+| Check `.length` for empty arrays | Server and client disagree on bare `[]`; `.length` of `0` is falsy on both |
 | Return route-scoped state | Smaller payloads, faster rendering |
 | Prefer declarative bindings over imperative DOM manipulation | Template bindings are reactive and SSR-compatible |
 | Use Light DOM for performance-critical pages | Measurably faster FCP and fewer layout operations |

--- a/docs/guide/concepts/directives/attributes.md
+++ b/docs/guide/concepts/directives/attributes.md
@@ -44,7 +44,7 @@ Boolean attributes accept the same expression syntax as `<if>`, so **derive bool
 ```html
 <!-- ✅ Good: derive from existing state -->
 <button ?disabled="{{currentIndex == 0}}">Prev</button>
-<button ?disabled="{{currentIndex == items.length - 1}}">Next</button>
+<button ?disabled="{{currentIndex == lastIndex}}">Next</button>
 <option ?selected="{{item.id == selectedId}}">{{item.name}}</option>
 
 <!-- ❌ Avoid: mirror observables that duplicate derivable state -->
@@ -54,6 +54,8 @@ Boolean attributes accept the same expression syntax as `<if>`, so **derive bool
 ```
 
 Mirror observables are a common source of UI desync bugs: any code path that mutates `currentIndex` but forgets to update `isPrevDisabled` produces incorrect rendering. Expressions are evaluated automatically whenever any signal they reference changes.
+
+Expressions compare a dotted path against a literal or another dotted path. There is **no arithmetic**: `{{currentIndex == items.length - 1}}` is read as a comparison against a state key literally named `items.length - 1`, which never resolves, so the attribute is silently never rendered. Supply a precomputed `lastIndex` instead. A bare `.length` is fine on its own (`{{items.length > 0}}`).
 
 ### Dotted Paths
 

--- a/docs/guide/concepts/directives/if.md
+++ b/docs/guide/concepts/directives/if.md
@@ -69,8 +69,9 @@ Supported logical operators:
 
 ## Truthiness Rules
 
-The `<if>` condition evaluator follows JavaScript truthiness semantics on both
-server (Rust `serde_json::Value`) and client (`!!value`):
+The `<if>` condition evaluator follows JavaScript truthiness semantics for
+scalars on both server (Rust `serde_json::Value`) and client (`!!value`). Empty
+collections are the exception - see the note below the table:
 
 | Value | Truthy? | Example |
 |-------|---------|---------|
@@ -81,7 +82,8 @@ server (Rust `serde_json::Value`) and client (`!!value`):
 | `""` (empty string) | ❌ No | `@observable name = ''` |
 | `"hello"` (non-empty string) | ✅ Yes | `@observable name = 'Alice'` |
 | `"false"` (string) | ⚠️ **Yes** | Non-empty string is truthy! |
-| `[]` (empty array) | - | Use `items.length` instead |
+| `[]` (empty array) | ⚠️ Differs | Use `items.length` instead |
+| `{}` (empty object) | ⚠️ Differs | Test a real field instead |
 | `null` / missing | ❌ No | Missing state key |
 
 <webui-blockquote appearance="warning" title="Warning" icon="⚠️">
@@ -89,6 +91,16 @@ server (Rust `serde_json::Value`) and client (`!!value`):
 The string `"false"` is truthy because it is a non-empty string. Never use
 `@observable show = 'false'` with `<if condition="show">`. Use a real boolean:
 `@observable show = false`.
+
+</webui-blockquote>
+
+<webui-blockquote appearance="warning" title="Warning" icon="⚠️">
+
+Never test a bare array or object. The server evaluator treats `[]` and `{}` as
+falsy, while the compiled client condition is plain `!!value`, where both are
+truthy - so `<if condition="items">` can render differently after hydration than
+it did on the server. Write `<if condition="items.length">`, which is falsy on
+both sides when the array is empty.
 
 </webui-blockquote>
 
@@ -102,3 +114,9 @@ The string `"false"` is truthy because it is a non-empty string. Never use
 | Comparisons | `<if condition="status == 'active'">` |
 | Compound AND | `<if condition="isAdmin && isActive">` |
 | Compound OR | `<if condition="hasEmail \|\| hasPhone">` |
+
+Each side of a comparison is a literal (number, quoted string, `true`, `false`)
+or a dotted state path. There is no arithmetic and there are no function calls -
+`<if condition="currentIndex == items.length - 1">` compares against a state key
+literally named `items.length - 1`, never resolves, and is silently false. Send a
+precomputed `lastIndex` from the server instead.


### PR DESCRIPTION
## Why

`docs/ai.md` is the page we point AI assistants at before they generate WebUI code, but it had drifted into a near-mirror of the CLI and integration docs. Two problems came out of a read-through:

**Ordering.** The constraints an AI must not violate ("Things You CANNOT Do") sat at line 1041 of 1365, roughly 76% into the page. Models weight the head of a document most, so the rules were in the worst possible position.

**Weighting.** About 570 lines duplicated pages that already own that material (`guide/cli/index.md`, `guide/integrations/*`, `routing.md`, `interactivity.md`). Meanwhile the disciplines that most often get violated in generated code were absent or actively undermined by example.

Concretely, a grep of the old file found zero mentions of `createElement`, `innerHTML`, `appendChild`, `.style.x =`, `classList`, or `adoptedStyleSheets`, and zero mentions of `<dialog>`, `popover`, `<details>`, `:has()`, `@container`, `@starting-style`, or `@keyframes`. The optionality of `@observable` / `@attr` was stated five times in prose, but the largest section in the file (201 lines) opened with a fully decorated `WebUIElement`, teaching the opposite by example.

## Approach

Re-weight the page around template-first authoring rather than trimming uniformly.

A **Rules** block now sits immediately after the title, covering the four disciplines that decide most authoring questions: the template is the UI, CSS owns styling and animation, JavaScript is opt-in, use the web platform. Everything else in the page is downstream of those four.

Two new devices do most of the work of steering generated code:

- A **"What to reach for"** decision table maps each common UI need to a template/CSS answer and names the JS anti-pattern beside it (`show/hide -> <if>`, `class swap -> ?data-* + CSS`, `modal -> <dialog>`, `fade -> @starting-style`).
- A **pre-flight checklist** an assistant runs before emitting code.

The interactivity section now leads scriptless and adds an explicit threshold test for when a `.ts` file is justified, then a second test for `@observable` / `@attr`. Lazy component mounting is called out as the single sanctioned place to insert an element from JavaScript, since it genuinely has no template representation until fetched.

The duplicated CLI, `--theme`, `--components`, diagnostics, projection, and per-language integration sections are replaced by a pointer index to the canonical pages.

Net: 1365 -> 791 lines, with authoring guidance going from roughly 35% to 75% of the page.

## Correctness fixes found during the review

These are the reason this is worth reviewing carefully rather than skimming as a docs reshuffle:

1. **`w-ref` was documented without braces.** The page showed `w-ref="searchInput"`, but a non-braced `w-ref` fails the build with `invalid-w-ref` (`crates/webui-parser/src/plugin/webui.rs:2809`). This was actively causing generated code that does not compile. Corrected to `w-ref="{searchInput}"` here and in `webui-dev/SKILL.md`, which had the same mistake in its quick reference.

2. **`::view-transition-*` was shown as component CSS.** Those pseudo-elements live on the document root and cannot be reached from inside a shadow root. Corrected to match how `examples/app/routes/src/index.html` actually does it: name the element via `view-transition-name` in component CSS, declare the animations in the entry template's document-level `<style>`.

3. **Eight skill pointers referenced `docs/guide/ai.md`**, which does not exist. The file is at `docs/ai.md`. Fixed across `webui-dev`, `docs-sync`, and `code-review`.

## Notes for reviewers

The modern-platform guidance is split into two tables on purpose. Baseline features (`<dialog>`, `popover`, `:has()`, `@container`, `@starting-style`, `color-mix()`) are recommended outright. Features that are not yet Baseline across engines (`anchor-name`, scroll-driven animations, `field-sizing`, customizable `<select>`) are in a separate progressive-enhancement table with a required guard and an instruction never to polyfill them. This is the part most worth a second opinion, since the line moves over time.

`docs-sync/SKILL.md` also gains a short note that `docs/ai.md` is authoring-first by design, so deep reference material should be linked rather than copied into it. That is what should keep this from drifting back.

## Validation

`cd docs && pnpm build` passes. Verified in the built output that all nine cross-page links resolve, the `#lazy-component-mounting` anchor resolves, all fourteen sections render, and template samples in fenced blocks are still entity-escaped correctly rather than being interpolated.