### PR TITLE
docs: Publish the AI reference as an installable agent skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "webui",
+  "description": "WebUI framework agent skills.",
+  "skills": ["./docs/ai"]
+}

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -312,7 +312,7 @@ Every behavioral change must include corresponding documentation updates. Missin
 |-------|-----|
 | **DESIGN.md updated** | If the change modifies public APIs, protocol fields, behavioral contracts, error variants, or SSR markers, `DESIGN.md` must be updated in the same commit. |
 | **User-facing docs updated** | If the change affects CLI flags, template syntax, component authoring, routing, or integration behavior, `docs/` must be updated. |
-| **AI reference updated** | If the change affects anything a code-generation AI would need to know, `docs/ai.md` must be updated. |
+| **AI reference updated** | If the change affects anything a code-generation AI would need to know, `docs/ai/SKILL.md` must be updated. |
 | **README links to docs portal** | Package READMEs should defer to the docs portal, not duplicate content. |
 | **No stale examples** | Code examples in docs must use current API signatures, flag names, and marker formats. |
 | **docs build passes** | `cd docs && pnpm build` must succeed (catches broken links, unescaped `{{`, missing pages). |

--- a/.github/skills/diagnostics/SKILL.md
+++ b/.github/skills/diagnostics/SKILL.md
@@ -144,5 +144,5 @@ with **no** added hot-path work).
       (confirm with a benchmark if it sits near a hot loop).
 - [ ] Tests: a regression test that fails without the error, asserting on the
       `code` (not the prose); JSON stays plain (no `\x1b`).
-- [ ] `DESIGN.md` and `docs/` (incl. `docs/ai.md`) updated if the contract or
+- [ ] `DESIGN.md` and `docs/` (incl. `docs/ai/SKILL.md`) updated if the contract or
       a user-visible code/flag changed.

--- a/.github/skills/docs-sync/SKILL.md
+++ b/.github/skills/docs-sync/SKILL.md
@@ -11,11 +11,11 @@ Use this skill whenever a change touches user-visible behavior, APIs, or contrac
 
 | What changed | Update |
 |-------------|--------|
-| CLI flags or commands | `docs/guide/cli/index.md` + `docs/ai.md` (Build and run section) |
-| Template syntax or directives | `docs/guide/concepts/directives/` + `docs/ai.md` |
-| Component authoring model | `docs/guide/concepts/interactivity.md` + `docs/ai.md` |
+| CLI flags or commands | `docs/guide/cli/index.md` + `docs/ai/SKILL.md` (Build and run section) |
+| Template syntax or directives | `docs/guide/concepts/directives/` + `docs/ai/SKILL.md` |
+| Component authoring model | `docs/guide/concepts/interactivity.md` + `docs/ai/SKILL.md` |
 | Hydration markers or mechanism | `docs/guide/concepts/hydration.md` + `DESIGN.md` (WebUI Framework Plugin) |
-| Routing behavior | `docs/guide/concepts/routing.md` + `docs/ai.md` |
+| Routing behavior | `docs/guide/concepts/routing.md` + `docs/ai/SKILL.md` |
 | State management or path resolution | `docs/guide/concepts/state-management/index.md` |
 | Handler API (Rust, Node, FFI) | `docs/guide/concepts/handlers/` + `docs/guide/integrations.md` |
 | Protocol fields or fragment types | `DESIGN.md` (Protocol Specification) |
@@ -23,7 +23,7 @@ Use this skill whenever a change touches user-visible behavior, APIs, or contrac
 | Performance characteristics | `docs/guide/concepts/performance.md` |
 | Public API (Rust crate, npm package) | `DESIGN.md` + relevant handler/integration docs |
 | Error variants or error messages | `DESIGN.md` |
-| `@microsoft/webui-framework` decorators or API | `docs/guide/concepts/interactivity.md` + `docs/ai.md` + `packages/webui-framework/README.md` |
+| `@microsoft/webui-framework` decorators or API | `docs/guide/concepts/interactivity.md` + `docs/ai/SKILL.md` + `packages/webui-framework/README.md` |
 | `@microsoft/webui-router` behavior | `docs/guide/concepts/routing.md` + `packages/webui-router/README.md` |
 
 ## DESIGN.md rules
@@ -48,9 +48,9 @@ Update `docs/` in the same commit when the change is user-visible:
 - Integration behavior that external developers depend on
 - New features or removed features
 
-Keep protocol internals out of general user docs. The `docs/ai.md` file is the single-page AI reference and should be kept in sync with all other docs.
+Keep protocol internals out of general user docs. The `docs/ai/SKILL.md` file is the single-page AI reference and should be kept in sync with all other docs.
 
-`docs/ai.md` is authoring-first by design. Keep deep reference material (full CLI flag tables, error-code lists, per-language integration snippets) in its canonical page and link to it from `docs/ai.md` rather than duplicating it there.
+`docs/ai/SKILL.md` is authoring-first by design. Keep deep reference material (full CLI flag tables, error-code lists, per-language integration snippets) in its canonical page and link to it from `docs/ai/SKILL.md` rather than duplicating it there.
 
 ## Validation
 

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -57,6 +57,6 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 The complete guide covering all template syntax, styling and animation rules, anti-patterns, routing, and a pre-flight checklist:
 
-**[docs/ai/SKILL.md](../../../docs/ai/SKILL.md)**
+**[docs/ai/SKILL.md](/docs/ai/SKILL.md)**
 
 Read that file before generating any WebUI code.

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -57,6 +57,6 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 The complete guide covering all template syntax, styling and animation rules, anti-patterns, routing, and a pre-flight checklist:
 
-**[docs/ai.md](/docs/ai.md)**
+**[docs/ai/SKILL.md](/docs/ai/SKILL.md)**
 
 Read that file before generating any WebUI code.

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -57,6 +57,6 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 The complete guide covering all template syntax, styling and animation rules, anti-patterns, routing, and a pre-flight checklist:
 
-**[docs/ai/SKILL.md](https://github.com/microsoft/webui/blob/main/docs/ai/SKILL.md)**
+**[docs/ai/SKILL.md](../../../docs/ai/SKILL.md)**
 
 Read that file before generating any WebUI code.

--- a/.github/skills/webui-dev/SKILL.md
+++ b/.github/skills/webui-dev/SKILL.md
@@ -57,6 +57,6 @@ webui serve ./src --state ./data/state.json --plugin=webui --watch
 
 The complete guide covering all template syntax, styling and animation rules, anti-patterns, routing, and a pre-flight checklist:
 
-**[docs/ai/SKILL.md](/docs/ai/SKILL.md)**
+**[docs/ai/SKILL.md](https://github.com/microsoft/webui/blob/main/docs/ai/SKILL.md)**
 
 Read that file before generating any WebUI code.

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -211,6 +211,7 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
   "nav": [
     { "text": "Guide",      "link": "/guide/" },
     { "text": "Tutorials",  "link": "/tutorials/" },
+    { "text": "AI",         "link": "/ai", "source": "ai/SKILL.md" },
     { "text": "GitHub",     "link": "https://github.com/me/proj" }
   ],
 
@@ -270,6 +271,34 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
 - **`sidebar`** is the default sidebar shown on pages that don't match a `sidebarGroups` prefix.
 - **`sidebarGroups`** maps URL prefixes to sidebar definitions. The longest matching prefix wins. A page at `/guide/concepts/` uses the `/guide/` sidebar.
 - **`prev`/`next`** links at the bottom of a page are derived from the active sidebar's flat link order.
+
+### Routing
+
+URLs are derived from the filesystem. Every `.md` file under `contentDir` becomes
+a page; `nav` and `sidebar` control navigation, not discovery.
+
+| Source file | URL |
+| ----------- | --- |
+| `index.md` | `/` |
+| `guide/install.md` | `/guide/install` |
+| `guide/index.md` | `/guide` |
+| `components/my-button/my-button.md` | `/components/my-button` |
+
+A trailing `index`, or a filename that repeats its parent folder, collapses to
+the folder.
+
+When a filename is dictated by an outside convention and should not leak into
+the URL, point a `nav` entry at the file with `source` (a path relative to
+`contentDir`, using forward slashes):
+
+```json
+{ "text": "AI", "link": "/ai", "source": "ai/SKILL.md" }
+```
+
+That serves `ai/SKILL.md` at `/ai` instead of `/ai/SKILL`. This is what keeps a
+page installable as an agent skill — the [agent-skill
+spec](https://agentskills.io) requires the file be named `SKILL.md` — while
+keeping its published docs URL stable.
 
 ### Shared state
 

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -166,14 +166,21 @@ fn normalize_path_as_index(path: &str) -> &str {
 /// `rel_path` is the file's path relative to the content directory, using
 /// forward slashes (e.g. `guide/install.md`). A nav entry that claims this
 /// file via its `source` field wins outright, which lets a page keep a stable
-/// URL when its filename is dictated by an outside convention. Otherwise the
-/// URL is derived from the filesystem: `.md` is dropped, then a trailing
-/// `index` — or a filename that repeats its parent folder — collapses to the
-/// folder.
+/// URL when its filename is dictated by an outside convention. Any fragment
+/// (`#`) or query string (`?`) in the override link is stripped before the
+/// route is formed — they are navigation-only markers that cannot appear in a
+/// filesystem path and would break prev/next matching against normalized
+/// sidebar links. Otherwise the URL is derived from the filesystem: `.md` is
+/// dropped, then a trailing `index` — or a filename that repeats its parent
+/// folder — collapses to the folder.
 fn page_url_path(rel_path: &str, base_path: &str, sources: &HashMap<&str, &str>) -> String {
     let prefix = base_path.trim_end_matches('/');
 
-    if let Some(link) = sources.get(rel_path) {
+    if let Some(&link) = sources.get(rel_path) {
+        // Strip any fragment (#) or query (?) — they are navigation-only and
+        // cannot appear in a filesystem-derived route or match sidebar links.
+        let end = link.find(['#', '?']).unwrap_or(link.len());
+        let link = &link[..end];
         let cleaned = link.trim_matches('/');
         return if cleaned.is_empty() {
             format!("{prefix}/")
@@ -196,9 +203,18 @@ fn page_url_path(rel_path: &str, base_path: &str, sources: &HashMap<&str, &str>)
 /// Map each nav entry that declares a `source` file to its configured link.
 ///
 /// Keys are content-relative markdown paths; values are raw config links.
+/// Entries whose `link` starts with `http` are excluded because `source` is
+/// only meaningful for internal routes; pairing it with an external URL would
+/// produce an invalid route in `page_url_path`.
 fn nav_source_overrides(nav: &[NavLink]) -> HashMap<&str, &str> {
     nav.iter()
-        .filter_map(|item| Some((item.source.as_deref()?, item.link.as_str())))
+        .filter_map(|item| {
+            let source = item.source.as_deref()?;
+            if item.link.starts_with("http") {
+                return None;
+            }
+            Some((source, item.link.as_str()))
+        })
         .collect()
 }
 
@@ -813,6 +829,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn page_url_path_nav_source_strips_fragment_from_override() {
+        // A nav link like "/ai#rules" must route to "/ai", not "/ai#rules".
+        let map = sources(&[("ai/SKILL.md", "/ai#rules")]);
+        assert_eq!(page_url_path("ai/SKILL.md", "/webui/", &map), "/webui/ai");
+    }
+
+    #[test]
+    fn page_url_path_nav_source_strips_query_from_override() {
+        // A nav link like "/ai?v=2" must route to "/ai", not "/ai?v=2".
+        let map = sources(&[("ai/SKILL.md", "/ai?v=2")]);
+        assert_eq!(page_url_path("ai/SKILL.md", "/webui/", &map), "/webui/ai");
+    }
+
     // --- nav_source_overrides ---------------------------------------------
 
     fn nav_link(text: &str, link: &str, source: Option<&str>) -> NavLink {
@@ -838,6 +868,24 @@ mod tests {
     #[test]
     fn nav_source_overrides_empty_nav_yields_no_overrides() {
         assert!(nav_source_overrides(&[]).is_empty());
+    }
+
+    #[test]
+    fn nav_source_overrides_excludes_external_link_with_source() {
+        // Accidentally pairing `source` with an external URL must be silently
+        // dropped so it never reaches `page_url_path` as a broken route.
+        let nav = vec![
+            nav_link("AI", "/ai", Some("ai/SKILL.md")),
+            nav_link(
+                "GitHub",
+                "https://github.com/microsoft/webui",
+                Some("github.md"),
+            ),
+        ];
+        let map = nav_source_overrides(&nav);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("ai/SKILL.md"), Some(&"/ai"));
+        assert!(!map.contains_key("github.md"));
     }
 
     #[test]

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -12,7 +12,7 @@ use serde_json::{Map, Value};
 use crate::error::{Error, Result};
 use crate::markdown::{render_markdown, Highlighter};
 use crate::state::{load_render_states, merge_page_state, LoadedStates};
-use crate::types::{DocsConfig, PageDescriptor, SidebarItem, SidebarSection};
+use crate::types::{DocsConfig, NavLink, PageDescriptor, SidebarItem, SidebarSection};
 
 /// Normalize a config link (e.g. `/guide/intro/` or `/guide/intro`) to a
 /// canonical URL path that includes the site's `base_path` prefix and
@@ -137,13 +137,10 @@ fn collect_sidebar_links(items: &[SidebarItem]) -> Vec<&str> {
     links
 }
 
-/// Build the page registry by walking content_dir for every `.md` file.
+/// Strip a redundant filename when it should resolve to its parent folder.
 ///
-/// Discovery is filesystem-driven: any markdown file under content_dir becomes
-/// a page. The sidebar/nav config controls navigation, not discovery.
-/// Strip redundant filename if it matches the parent folder name.
 /// E.g., "my-button/my-button" → "my-button"
-///      "my-button/usage" → "my-button/usage" (unchanged)
+///       "my-button/usage" → "my-button/usage" (unchanged)
 fn normalize_path_as_index(path: &str) -> &str {
     // Find the last slash to split parent/filename
     let Some(slash_pos) = path.rfind('/') else {
@@ -164,7 +161,56 @@ fn normalize_path_as_index(path: &str) -> &str {
     }
 }
 
-fn build_page_registry(content_dir: &Path, base_path: &str) -> Vec<(String, std::path::PathBuf)> {
+/// Resolve the public URL path for a markdown file.
+///
+/// `rel_path` is the file's path relative to the content directory, using
+/// forward slashes (e.g. `guide/install.md`). A nav entry that claims this
+/// file via its `source` field wins outright, which lets a page keep a stable
+/// URL when its filename is dictated by an outside convention. Otherwise the
+/// URL is derived from the filesystem: `.md` is dropped, then a trailing
+/// `index` — or a filename that repeats its parent folder — collapses to the
+/// folder.
+fn page_url_path(rel_path: &str, base_path: &str, sources: &HashMap<&str, &str>) -> String {
+    let prefix = base_path.trim_end_matches('/');
+
+    if let Some(link) = sources.get(rel_path) {
+        let cleaned = link.trim_matches('/');
+        return if cleaned.is_empty() {
+            format!("{prefix}/")
+        } else {
+            format!("{prefix}/{cleaned}")
+        };
+    }
+
+    let trimmed = rel_path.trim_end_matches(".md");
+    let trimmed = trimmed.strip_suffix("/index").unwrap_or(trimmed);
+    let trimmed = normalize_path_as_index(trimmed);
+
+    if trimmed.is_empty() || trimmed == "index" {
+        format!("{prefix}/")
+    } else {
+        format!("{prefix}/{trimmed}")
+    }
+}
+
+/// Map each nav entry that declares a `source` file to its configured link.
+///
+/// Keys are content-relative markdown paths; values are raw config links.
+fn nav_source_overrides(nav: &[NavLink]) -> HashMap<&str, &str> {
+    nav.iter()
+        .filter_map(|item| Some((item.source.as_deref()?, item.link.as_str())))
+        .collect()
+}
+
+/// Build the page registry by walking content_dir for every `.md` file.
+///
+/// Discovery is filesystem-driven: any markdown file under content_dir becomes
+/// a page. The sidebar/nav config controls navigation, not discovery.
+fn build_page_registry(
+    content_dir: &Path,
+    base_path: &str,
+    sources: &HashMap<&str, &str>,
+) -> Vec<(String, std::path::PathBuf)> {
     let mut pages = Vec::new();
     let mut stack: Vec<std::path::PathBuf> = vec![content_dir.to_path_buf()];
 
@@ -188,34 +234,12 @@ fn build_page_registry(content_dir: &Path, base_path: &str) -> Vec<(String, std:
                 continue;
             }
 
-            // Compute URL: relative path from content_dir, drop trailing /index.md,
-            // drop .md, prefix with base_path.
             let rel = match path.strip_prefix(content_dir) {
                 Ok(r) => r,
                 Err(_) => continue,
             };
             let rel_str = rel.to_string_lossy().replace('\\', "/");
-            let trimmed = rel_str.trim_end_matches(".md");
-
-            // Strip /index suffix
-            let trimmed = trimmed.strip_suffix("/index").unwrap_or(trimmed);
-
-            // Strip redundant filename if it matches parent folder
-            // e.g., "webui-button/webui-button" → "webui-button"
-            let trimmed = normalize_path_as_index(trimmed);
-
-            // Root index.md => "/"
-            let url_path = if trimmed.is_empty() || trimmed == "index" {
-                if base_path.is_empty() {
-                    "/".to_string()
-                } else {
-                    base_path.trim_end_matches('/').to_string() + "/"
-                }
-            } else {
-                let prefix = base_path.trim_end_matches('/');
-                format!("{prefix}/{trimmed}")
-            };
-            pages.push((url_path, path));
+            pages.push((page_url_path(&rel_str, base_path, sources), path));
         }
     }
 
@@ -364,7 +388,8 @@ pub(crate) fn process_content_with_states(
         })
         .collect();
 
-    let mut registry = build_page_registry(content_dir, base_path);
+    let mut registry =
+        build_page_registry(content_dir, base_path, &nav_source_overrides(&config.nav));
 
     // Register custom pages
     for page_link in config.custom_pages.keys() {
@@ -721,6 +746,98 @@ mod tests {
     #[test]
     fn normalize_path_as_index_no_slash_returns_unchanged() {
         assert_eq!(normalize_path_as_index("webui-button"), "webui-button");
+    }
+
+    // --- page_url_path ----------------------------------------------------
+
+    fn sources(pairs: &[(&'static str, &'static str)]) -> HashMap<&'static str, &'static str> {
+        pairs.iter().copied().collect()
+    }
+
+    #[test]
+    fn page_url_path_derives_url_from_filesystem() {
+        let none = sources(&[]);
+        assert_eq!(
+            page_url_path("guide/install.md", "/webui/", &none),
+            "/webui/guide/install"
+        );
+    }
+
+    #[test]
+    fn page_url_path_collapses_index_and_root() {
+        let none = sources(&[]);
+        assert_eq!(
+            page_url_path("guide/index.md", "/webui/", &none),
+            "/webui/guide"
+        );
+        assert_eq!(page_url_path("index.md", "/webui/", &none), "/webui/");
+        assert_eq!(page_url_path("index.md", "", &none), "/");
+    }
+
+    #[test]
+    fn page_url_path_collapses_filename_repeating_its_folder() {
+        let none = sources(&[]);
+        assert_eq!(
+            page_url_path("components/webui-button/webui-button.md", "/webui/", &none),
+            "/webui/components/webui-button"
+        );
+    }
+
+    #[test]
+    fn page_url_path_nav_source_overrides_derived_url() {
+        // `SKILL.md` is a filename fixed by the agent-skill spec; the nav entry
+        // keeps the page on `/ai` instead of leaking it as `/ai/SKILL`.
+        let map = sources(&[("ai/SKILL.md", "/ai")]);
+        assert_eq!(page_url_path("ai/SKILL.md", "/webui/", &map), "/webui/ai");
+    }
+
+    #[test]
+    fn page_url_path_nav_source_tolerates_surrounding_slashes() {
+        let map = sources(&[("ai/SKILL.md", "ai/"), ("b/SKILL.md", "/b")]);
+        assert_eq!(page_url_path("ai/SKILL.md", "/webui/", &map), "/webui/ai");
+        assert_eq!(page_url_path("b/SKILL.md", "", &map), "/b");
+    }
+
+    #[test]
+    fn page_url_path_nav_source_can_target_site_root() {
+        let map = sources(&[("home/landing.md", "/")]);
+        assert_eq!(page_url_path("home/landing.md", "/webui/", &map), "/webui/");
+    }
+
+    #[test]
+    fn page_url_path_ignores_nav_source_for_other_files() {
+        let map = sources(&[("ai/SKILL.md", "/ai")]);
+        assert_eq!(
+            page_url_path("guide/SKILL.md", "/webui/", &map),
+            "/webui/guide/SKILL"
+        );
+    }
+
+    // --- nav_source_overrides ---------------------------------------------
+
+    fn nav_link(text: &str, link: &str, source: Option<&str>) -> NavLink {
+        NavLink {
+            text: text.to_string(),
+            link: link.to_string(),
+            source: source.map(String::from),
+        }
+    }
+
+    #[test]
+    fn nav_source_overrides_collects_only_entries_declaring_a_source() {
+        let nav = vec![
+            nav_link("Guide", "/guide/", None),
+            nav_link("AI", "/ai", Some("ai/SKILL.md")),
+            nav_link("GitHub", "https://github.com/microsoft/webui", None),
+        ];
+        let map = nav_source_overrides(&nav);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("ai/SKILL.md"), Some(&"/ai"));
+    }
+
+    #[test]
+    fn nav_source_overrides_empty_nav_yields_no_overrides() {
+        assert!(nav_source_overrides(&[]).is_empty());
     }
 
     #[test]

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -55,6 +55,12 @@ pub struct SiteConfig {
 pub struct NavLink {
     pub text: String,
     pub link: String,
+    /// Markdown file backing this link, relative to `contentDir` with forward
+    /// slashes (e.g. `ai/SKILL.md`). Pages are normally routed by filename, so
+    /// this is only needed when a file's name is dictated by an outside
+    /// convention and should not leak into the URL.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/docs/.webui-press/config.json
+++ b/docs/.webui-press/config.json
@@ -42,7 +42,8 @@
     },
     {
       "text": "AI",
-      "link": "/ai"
+      "link": "/ai",
+      "source": "ai/SKILL.md"
     },
     {
       "text": "GitHub",

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1,5 +1,7 @@
 ---
 layout: page
+name: webui-ai-reference
+description: Authoritative WebUI framework reference for generating correct application code - template-first authoring rules, template syntax, styling, interactivity, routing, state JSON, and anti-patterns.
 ---
 
 # WebUI Framework - AI Reference

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -9,6 +9,10 @@ description: Authoritative WebUI framework reference for generating correct appl
 > **Single-page reference for LLMs.** Everything an AI coding assistant needs to
 > generate correct WebUI code. Read the Rules first - they are the constraints
 > that most often get violated. Deep-dive links are indexed at the bottom.
+>
+> Install this reference into your agent with
+> `npx skills add microsoft/webui --skill webui-ai-reference` - see
+> [AI Coding Agents](/guide/installation#ai-coding-agents).
 
 ## Rules
 

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-name: webui-ai-reference
+name: webui-reference
 description: Authoritative WebUI framework reference for generating correct application code - template-first authoring rules, template syntax, styling, interactivity, routing, state JSON, and anti-patterns.
 ---
 
@@ -11,7 +11,7 @@ description: Authoritative WebUI framework reference for generating correct appl
 > that most often get violated. Deep-dive links are indexed at the bottom.
 >
 > Install this reference into your agent with
-> `npx skills add microsoft/webui --skill webui-ai-reference` - see
+> `npx skills add microsoft/webui --skill webui-reference` - see
 > [AI Coding Agents](/guide/installation#ai-coding-agents).
 
 ## Rules

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -200,27 +200,27 @@ WebUI publishes its framework reference as an installable [agent skill](https://
 <webui-press-tab-panel active>
 
 ```bash
-npx skills add microsoft/webui --skill webui-ai-reference
+npx skills add microsoft/webui --skill webui-reference
 ```
 
 </webui-press-tab-panel>
 <webui-press-tab-panel>
 
 ```bash
-yarn dlx skills add microsoft/webui --skill webui-ai-reference
+yarn dlx skills add microsoft/webui --skill webui-reference
 ```
 
 </webui-press-tab-panel>
 <webui-press-tab-panel>
 
 ```bash
-pnpm dlx skills add microsoft/webui --skill webui-ai-reference
+pnpm dlx skills add microsoft/webui --skill webui-reference
 ```
 
 </webui-press-tab-panel>
 </webui-press-tabs>
 
-The skill lands in `.agents/skills/webui-ai-reference/`, which GitHub Copilot reads directly. Agents that keep their own folder, such as Claude Code, also get a copy in theirs. Useful flags:
+The skill lands in `.agents/skills/webui-reference/`, which GitHub Copilot reads directly. Agents that keep their own folder, such as Claude Code, also get a copy in theirs. Useful flags:
 
 | Flag | Effect |
 | ---- | ------ |
@@ -231,7 +231,7 @@ The skill lands in `.agents/skills/webui-ai-reference/`, which GitHub Copilot re
 To try the reference in a single session without installing it:
 
 ```bash
-npx skills use microsoft/webui@webui-ai-reference | copilot
+npx skills use microsoft/webui@webui-reference | copilot
 ```
 
 <webui-blockquote appearance="tip" title="Read it yourself" icon="💡">

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -191,7 +191,7 @@ See the [Routing guide](/guide/concepts/routing) for setup and usage.
 
 ## AI Coding Agents
 
-WebUI publishes its framework reference as an installable [agent skill](https://agentskills.io). Installing it gives Claude Code, GitHub Copilot, Cursor, Codex, and other supported agents the authoring rules WebUI expects — template-first structure, CSS-owned styling, opt-in JavaScript — so generated code follows them instead of falling back to React habits.
+WebUI publishes its framework reference as an installable [agent skill](https://agentskills.io). Installing it gives GitHub Copilot, Claude Code, Cursor, Codex, and other supported agents the authoring rules WebUI expects — template-first structure, CSS-owned styling, opt-in JavaScript — so generated code follows them instead of falling back to React habits.
 
 <webui-press-tabs>
 <webui-press-tab slot="tab" active>npm</webui-press-tab>
@@ -220,18 +220,18 @@ pnpm dlx skills add microsoft/webui --skill webui-ai-reference
 </webui-press-tab-panel>
 </webui-press-tabs>
 
-The skill is written to `.agents/skills/webui-ai-reference/` and linked into each selected agent's own directory, such as `.claude/skills/`. Useful flags:
+The skill lands in `.agents/skills/webui-ai-reference/`, which GitHub Copilot reads directly. Agents that keep their own folder, such as Claude Code, also get a copy in theirs. Useful flags:
 
 | Flag | Effect |
 | ---- | ------ |
-| `-g` | Install once for every project on your machine instead of the current one |
-| `-a <agent>` | Target specific agents, for example `-a claude-code`. Defaults to prompting |
+| `-g` | Install once for every project on your machine, into the agent's user directory (`~/.copilot/skills/` for Copilot) |
+| `-a <agent>` | Target specific agents, for example `-a github-copilot`. Defaults to prompting |
 | `-l` | List what the repository publishes without installing anything |
 
 To try the reference in a single session without installing it:
 
 ```bash
-npx skills use microsoft/webui@webui-ai-reference | claude
+npx skills use microsoft/webui@webui-ai-reference | copilot
 ```
 
 <webui-blockquote appearance="tip" title="Read it yourself" icon="💡">

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -188,3 +188,54 @@ pnpm add @microsoft/webui-router
 The router works with both WebUI Framework (`@microsoft/webui-framework`) and `@microsoft/fast-element` 3.x components. It's a separate package because it's only needed for apps with client-side navigation.
 
 See the [Routing guide](/guide/concepts/routing) for setup and usage.
+
+## AI Coding Agents
+
+WebUI publishes its framework reference as an installable [agent skill](https://agentskills.io). Installing it gives Claude Code, GitHub Copilot, Cursor, Codex, and other supported agents the authoring rules WebUI expects — template-first structure, CSS-owned styling, opt-in JavaScript — so generated code follows them instead of falling back to React habits.
+
+<webui-press-tabs>
+<webui-press-tab slot="tab" active>npm</webui-press-tab>
+<webui-press-tab slot="tab">yarn</webui-press-tab>
+<webui-press-tab slot="tab">pnpm</webui-press-tab>
+<webui-press-tab-panel active>
+
+```bash
+npx skills add microsoft/webui --skill webui-ai-reference
+```
+
+</webui-press-tab-panel>
+<webui-press-tab-panel>
+
+```bash
+yarn dlx skills add microsoft/webui --skill webui-ai-reference
+```
+
+</webui-press-tab-panel>
+<webui-press-tab-panel>
+
+```bash
+pnpm dlx skills add microsoft/webui --skill webui-ai-reference
+```
+
+</webui-press-tab-panel>
+</webui-press-tabs>
+
+The skill is written to `.agents/skills/webui-ai-reference/` and linked into each selected agent's own directory, such as `.claude/skills/`. Useful flags:
+
+| Flag | Effect |
+| ---- | ------ |
+| `-g` | Install once for every project on your machine instead of the current one |
+| `-a <agent>` | Target specific agents, for example `-a claude-code`. Defaults to prompting |
+| `-l` | List what the repository publishes without installing anything |
+
+To try the reference in a single session without installing it:
+
+```bash
+npx skills use microsoft/webui@webui-ai-reference | claude
+```
+
+<webui-blockquote appearance="tip" title="Read it yourself" icon="💡">
+
+The skill is the same document served at [AI Reference](/ai). Read it directly when you want the rules and the anti-patterns without wiring up an agent.
+
+</webui-blockquote>


### PR DESCRIPTION
WebUI ships a thorough framework reference at `docs/ai.md`, but there was no way for a developer to load it into their coding agent. This publishes it as an installable agent skill, so `npx skills add microsoft/webui --skill webui-reference` wires it into Copilot, Claude Code, Cursor, Codex, and the other agents the `skills` CLI supports.

## Why the file moved

Skill discovery is filename-locked: the CLI's `hasSkillMd()` only ever opens a file literally named `SKILL.md` inside a directory. I tested the alternatives before moving anything:

- `/tree/main/docs/ai` returns 404, since `ai.md` is a file and not a directory.
- `/blob/main/docs/ai.md` is silently stripped back to the repo root, so the whole repo gets cloned and `ai.md` is never opened.
- `raw.githubusercontent.com` URLs are treated as git clone URLs and fail outright.

So `docs/ai.md` becomes `docs/ai/SKILL.md` (via `git mv`, history preserved) plus the `name` and `description` frontmatter the parser requires.

The skill is named `webui-reference`. Every skill in this ecosystem is consumed by an agent, so an `ai` qualifier would carry no matching signal; the name instead distinguishes the consumer-facing framework reference from the contributor-facing `webui-dev` skill.

## Keeping /ai stable

The move would have changed the published URL to `/ai/SKILL`. Rather than teach the generator about a magic `SKILL` stem, `webui-press` now accepts an optional `source` on an existing `nav` entry:

```json
{ "text": "AI", "link": "/ai", "source": "ai/SKILL.md" }
```

The override sits next to the link that already declares the URL, so a filename convention imposed from outside stays a property of the one page that needs it. URL computation moved into a pure `page_url_path()` taking a borrowed override map, which made it unit-testable without touching the filesystem.

Worth flagging: this only covers pages that appear in `nav`. `SidebarItem` has no equivalent field. That felt acceptable, since the point of the override is to protect a published URL and published URLs live in `nav`.

## Why .claude-plugin exists

A full-repo scan walks the root only one level deep, and its recursive fallback fires only when zero skills are found. `.github/skills` already yields 10, so the fallback never runs and `docs/ai/SKILL.md` would be invisible without a manifest.

The directory name is historical rather than Claude-specific. It is read during discovery before any agent is selected, so the one manifest covers every supported agent. There is no Codex or Copilot equivalent to add.

## Docs

New "AI Coding Agents" section in the installation guide, plus a two line pointer at the top of the reference itself.

`--skill webui-reference` in the documented command is deliberate. A bare `npx skills add microsoft/webui` also pulls the ten contributor skills under `.github/skills` (`pr`, `quality-gate`, `bump-version`, and friends), which exist to build and release this repo and are noise in a consumer project.

## Verification

- `cargo xtask check` passes.
- 98 `webui-press` tests pass, including 12 new ones covering `page_url_path` and `nav_source_overrides`.
- `npx skills add . --list` reports 11 skills, including `webui-reference`.
- Installed into a temp directory against both `--agent github-copilot` and `--agent claude-code` to confirm the install paths quoted in the docs.
- Docs build emits 33 pages with `dist/ai/index.html` present and no `SKILL` route leaked.
- Confirmed `npx skills use ... | copilot` runs non-interactively and exits 0.