### PR TITLE
chore: target only the nuget package folder in artifacts directory as a pipeline artifact

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -121,7 +121,7 @@ extends:
         templateContext:
           outputs:
             - output: pipelineArtifact
-              targetPath: '$(Build.ArtifactStagingDirectory)'
+              targetPath: '$(Build.ArtifactStagingDirectory)/publish_artifacts_nuget'
               artifactName: nuget_packages
               displayName: Publish signed NuGet packages
         steps:


### PR DESCRIPTION
# Description

Only the nuget/snuget packages need to be stored as a pipeline artifact, as a clean up this change targets only the nuget folder.