### PR TITLE
perf: gate projection manifest dependencies

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2389,9 +2389,11 @@ pub projection_manifests: Vec<ProjectionManifestSource>,
 ```
 
 Schema parsing, canonical ordering/reference validation, and build-ID
-recomputation live in `webui-protocol::projection_manifest` so native and WASM
-hosts share one contract. `webui` adds filesystem root, symlink, and stale
-input/output validation for path and inline native sources.
+recomputation live in `webui-protocol::projection_manifest` behind the
+opt-in `projection-manifest` feature so native and WASM build-time hosts share
+one contract without adding SHA-256 dependencies to handler-only consumers.
+`webui` adds filesystem root, symlink, and stale input/output validation for
+path and inline native sources.
 
 The handler runtime never reads manifest files. Protocol fields are the sole
 runtime source of projection metadata.

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -20,7 +20,7 @@ napi = { workspace = true }
 napi-derive = { workspace = true }
 microsoft-webui = { path = "../webui", version = "0.0.19" }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/webui-protocol/Cargo.toml
+++ b/crates/webui-protocol/Cargo.toml
@@ -16,6 +16,8 @@ exclude = ["build.rs"]
 name = "webui_protocol"
 
 [features]
+# Enable the build-time state-projection manifest contract and validation.
+projection-manifest = ["dep:sha2"]
 # Enable to regenerate src/gen_webui.rs from proto/webui.proto via prost-build.
 # Off by default so crates.io consumers don't pull in prost-build.
 regenerate-proto = ["dep:prost-build"]
@@ -25,7 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 prost = { workspace = true }
-sha2 = { workspace = true }
+sha2 = { workspace = true, optional = true }
 
 [build-dependencies]
 prost-build = { workspace = true, optional = true }

--- a/crates/webui-protocol/README.md
+++ b/crates/webui-protocol/README.md
@@ -6,6 +6,11 @@ Protobuf protocol definitions and serialization for the [WebUI](https://github.c
 
 `microsoft-webui-protocol` uses `prost` for zero-copy protobuf encoding and decoding. It defines the `WebUIProtocol` message and all fragment types that flow between the parser and handler.
 
+## Features
+
+- `projection-manifest` - Enables the build-time state-projection manifest schema and validation APIs. This is disabled by default so handler-only consumers do not compile the SHA-256 implementation.
+- `regenerate-proto` - Regenerates the checked-in Rust protocol types from `proto/webui.proto`.
+
 ## Documentation
 
 See the [WebUI repository](https://github.com/microsoft/webui) for full usage guides and examples.

--- a/crates/webui-protocol/src/lib.rs
+++ b/crates/webui-protocol/src/lib.rs
@@ -18,6 +18,7 @@ use thiserror::Error;
 pub mod plugin;
 
 /// Bundler-neutral state-projection manifest contract.
+#[cfg(feature = "projection-manifest")]
 pub mod projection_manifest;
 
 /// Attribute-name ↔ property-name mapping for irregular HTML attributes.

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["all"]
 all = ["handler", "parser"]
 handler = ["dep:microsoft-webui-handler"]
-parser = ["dep:microsoft-webui-parser"]
+parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19", default-features = false, optional = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -19,7 +19,7 @@ cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
 microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
 microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.19" }
 microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.19" }
@@ -45,7 +45,7 @@ awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
 microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }


### PR DESCRIPTION
Handler-only consumers of `microsoft-webui-protocol` currently compile `sha2` and seven transitive crates even though runtime rendering never reads projection manifests.

This makes projection-manifest support opt-in at the protocol boundary and enables it only for build-time consumers that validate manifests. The standard `webui` build API and WASM parser retain the existing behavior, while handler-only integrations avoid the SHA-256 dependency path.

The protocol README and technical specification document the feature contract.

## Validation

- `cargo xtask check`
- Protocol tests with and without `projection-manifest`
- Handler dependency tree excludes `sha2` and its seven transitive crates