### PR TITLE
chore: bump version to 0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "actix-web",
  "awc",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "cbindgen",
  "criterion",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "criterion",
  "microsoft-webui-expressions",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "clap",
  "criterion",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "criterion",
  "prost",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.19"
+version = "0.0.20"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.19", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.19" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.19" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.19" }
+microsoft-webui = { path = "../webui", version = "0.0.20", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.20" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.20" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.20" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -40,7 +40,7 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.20" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.19" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.20" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -30,7 +30,7 @@ cbindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
 
 [[bench]]
 name = "protocol_bench"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,16 +15,16 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.19" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.20" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.20" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.19" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.20" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.20" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.19" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
+microsoft-webui = { path = "../webui", version = "0.0.20" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.20", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,8 +26,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.20" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.19" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.20" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,10 +19,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.19", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.19" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.19" }
+microsoft-webui = { path = "../webui", version = "0.0.20", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.20" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.20" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.19" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.20" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.19" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.20" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.20", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,11 +18,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.19" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.19" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.20" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.20" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.20" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -44,8 +44,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.19" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.19", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.20" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.20", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.19</Version>
+    <Version>0.0.20</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration and compiled-template path mapping.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.19"
+  "version": "0.0.20"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.20`.

Previous release tag: `v0.0.19`

## Changes since `v0.0.19`

Features:

- Progressive streaming hydration boundaries allow streamed content to hydrate incrementally (feat: add progressive streaming hydration boundaries #409).

Fixes:

- Sibling repeat hydration now advances its cursor correctly across repeated DOM regions (fix: advance sibling repeat hydration cursor #406).
- Event bindings use direct listeners to preserve correct handler wiring (fix: wire event bindings with direct listeners instead of delegation #413).

Docs:

- The AI reference now follows template-first authoring and is published as an installable agent skill (docs: Restructure AI reference around template-first authoring #408, docs: Publish the AI reference as an installable agent skill #411).

Maintenance:

- NuGet publishing and artifact targeting are prepared for package releases (chore: prepare NuGet publishing for publishing #412, chore: target only the nuget package folder in artifacts directory as a pipeline artifact #414).
- Projection-manifest dependencies are feature-gated to reduce unnecessary build cost (perf: gate projection manifest dependencies #415).

## Validation

- `cargo xtask check`