### PR TITLE
fix: recover streamed updates and refused streams

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1197,6 +1197,16 @@ and query unchanged. Encoded slashes such as `%2F` therefore remain inside one
 route segment, and encoded spaces, percent signs, and UTF-8 bytes reach
 development backends with the same representation used by production clients.
 
+Backend failures degrade uniformly. Whether the API is unreachable, returns a
+body that is not parseable state, or answers a stream request with a non-success
+status, `webui serve` logs one warning and renders the page from fallback state.
+A refused stream request is an *acquisition* failure — no record has been written
+and no boundary has reached the browser — so it is handled like any other
+pre-stream failure rather than surfacing the upstream error body in place of the
+application. This is distinct from rule 19: once a stream is live, a mid-stream
+transport failure still fails the response, because already-committed boundaries
+cannot be rewound into a buffered render.
+
 After generated assets and `--servedir` files miss, `webui serve` uses request
 intent rather than path punctuation to decide whether to run the SPA route
 fallback. Fallback runs only when `Accept` explicitly includes `text/html` or
@@ -1819,7 +1829,19 @@ contract rather than introduce a parallel one.
     and root references immediately. An updatable checkpoint retains only its
     bounded root array until the terminal record or fatal cleanup, when all
     update targets and queued state are released together. Final boundaries pay
-    no target-map or root-retention cost.
+    no target-map or root-retention cost. That array holds **live roots only**:
+    a root joins when it activates successfully, so one that was ignored,
+    failed, or was abandoned is never an update target and its element is not
+    kept alive by the boundary. Liveness is never inferred from `data-ws`,
+    which rule 9 strips on rejection and abandonment as well as on activation,
+    and which would therefore mark an inert root as ready to receive. The
+    retention budget is charged separately, at scan time, against every marked
+    root the checkpoint saw, so activating a root after its boundary was
+    retained can never grow that boundary past its bound. Delivering an update
+    to a live root is consequently an array walk with no DOM access. Because
+    `setState()` is defined on `TemplateElement` itself, a live root missing it
+    is a framework invariant violation and halts the stream rather than
+    reporting the same failure on every later update.
 13. **Bounded terminal failure.** On malformed, truncated, or overflow input
     the coordinator releases every discoverable scaffold and pending reference
     within its configured bounds, balances the pending-boundary count, and
@@ -1836,12 +1858,20 @@ contract rather than introduce a parallel one.
     `setState()` path on each target root. It does not rerun
     `$activateDeferredSSR()`, template wiring, or `hydratedCallback()`. If the
     target class is not defined or its boundary is still activating, one
-    bounded shallow patch is queued per target and applied immediately after
-    activation. A state update may reference only an earlier updatable
+    bounded shallow patch is queued per target and replayed through that same
+    `setState()` path immediately after the root activates - never merged into
+    the state the root hydrates from. Hydration wires bindings against the
+    server's bytes without evaluating them, so seeding a post-render value
+    first would bind the branch the DOM actually shows while the element
+    believed it held the new one, and the next equal-valued write would skip
+    the patch entirely. A root retained behind an undefined ancestor is
+    patched after its own activation, parent first.
+    A state update may reference only an earlier updatable
     checkpoint; forward references and updates to final checkpoints are fatal
     protocol errors. An application component whose `setState()` or change
     handler throws degrades that root alone: the failure is reported and the
-    walk continues to the remaining targets, matching activation, because one
+    walk continues to the remaining targets, including the retained
+    descendants of a throwing root, because one
     component's bug must never strand later boundaries.
 
 **Compile time**

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -785,32 +785,36 @@ async fn render_page_response(
             .send()
             .await
         {
-            Ok(mut response) if streaming_api::is_stream(response.headers()) => {
+            Ok(response) if streaming_api::is_stream(response.headers()) => {
                 let status = response.status();
                 if !status.is_success() {
-                    return match response.body().await {
-                        Ok(body) => HttpResponse::build(status)
-                            .content_type("text/plain; charset=utf-8")
-                            .body(body),
-                        Err(error) => HttpResponse::BadGateway()
-                            .body(format!("API stream body error: {error}")),
-                    };
+                    // The upstream refused before writing a single record, so no
+                    // boundary has reached the browser and rule 19's "never
+                    // degrade a live stream to buffering" does not apply. Treat
+                    // it like any other pre-stream acquisition failure and
+                    // render the page from fallback state, rather than handing
+                    // the browser a raw upstream error body in place of the app.
+                    log_api_state_warning(&format!(
+                        "API stream unavailable (HTTP {status}); rendering with fallback state"
+                    ));
+                    fallback_state(context)
+                } else {
+                    let backend = response.map(|chunk| chunk.map_err(|error| error.to_string()));
+                    let defaults = streaming_state_defaults(context, route_params);
+                    return streaming_api::render(
+                        backend,
+                        streaming_api::RenderConfig {
+                            protocol: proto,
+                            entry,
+                            route_path: route_path.to_owned(),
+                            plugin,
+                            body_inject: livereload_script,
+                            chunk_pool: Arc::clone(&context.chunk_pool),
+                        },
+                        defaults,
+                    )
+                    .await;
                 }
-                let backend = response.map(|chunk| chunk.map_err(|error| error.to_string()));
-                let defaults = streaming_state_defaults(context, route_params);
-                return streaming_api::render(
-                    backend,
-                    streaming_api::RenderConfig {
-                        protocol: proto,
-                        entry,
-                        route_path: route_path.to_owned(),
-                        plugin,
-                        body_inject: livereload_script,
-                        chunk_pool: Arc::clone(&context.chunk_pool),
-                    },
-                    defaults,
-                )
-                .await;
             }
             Ok(mut response) => match response.body().await {
                 Ok(body) => match parse_api_state(&body) {
@@ -1464,6 +1468,7 @@ fn rebuild_and_update_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::body::to_bytes;
     use actix_web::http::StatusCode;
     use actix_web::test as actix_test;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2034,6 +2039,91 @@ mod tests {
             .collect();
         assert_eq!(*captured_targets.lock().unwrap(), expected);
         handle.stop(true).await;
+    }
+
+    fn start_stream_status_server(status: StatusCode) -> (u16, actix_web::dev::ServerHandle) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = HttpServer::new(move || {
+            App::new().default_service(web::to(move || async move {
+                HttpResponse::build(status)
+                    .content_type("application/x-webui-stream")
+                    .body("streaming render capacity is temporarily exhausted")
+            }))
+        })
+        .listen(listener)
+        .unwrap()
+        .run();
+        let handle = server.handle();
+        actix_web::rt::spawn(server);
+        (port, handle)
+    }
+
+    fn streaming_fallback_context(api_port: u16) -> web::Data<ServerContext> {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw(
+                    "<html><body><main>fallback rendered</main></body></html>",
+                )],
+            },
+        );
+        let protocol = Arc::new(Protocol::new(WebUIProtocol::with_tokens(
+            fragments,
+            Vec::new(),
+        )));
+        web::Data::new(ServerContext {
+            state: Arc::new(Mutex::new(SharedState {
+                rendered_html: String::new(),
+                css_files: HashMap::new(),
+                component_assets: HashMap::new(),
+                protocol: Some(protocol),
+                state_data: Some(Value::Object(serde_json::Map::new())),
+                token_css: None,
+                rebuild_error: None,
+                entry: "index.html".to_string(),
+            })),
+            livereload: None,
+            assets_dir: None,
+            api_port: Some(api_port),
+            plugin: None,
+            base_path: None,
+            chunk_pool: Arc::new(webui::streaming::ChunkPool::new(
+                4,
+                StreamingWriter::CHUNK_TARGET + 1024,
+            )),
+        })
+    }
+
+    /// A streaming API that refuses the request never produced a stream, so the
+    /// dev server must degrade to a buffered render exactly like it does for a
+    /// connection error — not hand the browser a raw upstream error body.
+    #[actix_web::test]
+    async fn test_streaming_api_error_status_degrades_to_a_rendered_page() {
+        for status in [
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+        ] {
+            let (port, handle) = start_stream_status_server(status);
+            let context = streaming_fallback_context(port);
+
+            let response = render_page_response(&context, "/", "/").await;
+
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "upstream {status} must not surface as the page status",
+            );
+            let body = to_bytes(response.into_body()).await.unwrap();
+            let body = String::from_utf8_lossy(&body);
+            assert!(
+                body.contains("fallback rendered"),
+                "upstream {status} must still render the page, got: {body}",
+            );
+            handle.stop(true).await;
+        }
     }
 
     fn fallback_kind_for_accept(accept: &str) -> SpaFallbackKind {

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1118,6 +1118,12 @@ capacity-one command channel, resolves boundary names once, and keeps the
 compiled protocol plus browser-facing bytes in Rust. Returning JSON keeps the
 buffered state path.
 
+If the backend refuses a stream request (non-success status such as a `503`
+from its own concurrency cap), no boundary was ever sent, so `webui serve` logs
+one warning and renders the page from fallback state rather than replacing the
+app with the upstream error body. A failure *after* the stream is live still
+fails the response, because boundaries already flushed cannot be rewound.
+
 Equivalent APIs exist for WebAssembly, Python (FFI), Go (cgo), and C#. For
 `Router.ensureLoaded()`, expose `GET /_webui/templates?t=tag1,tag2` backed by
 `render_component_templates(&tags, &inv)`.

--- a/docs/guide/cli/index.md
+++ b/docs/guide/cli/index.md
@@ -296,6 +296,14 @@ Returning JSON retains the ordinary buffered behavior. See
 [`<boundary>`](/guide/concepts/directives/boundary) and
 `examples/app/streaming`.
 
+If the backend is unreachable, returns state the server cannot parse, or answers
+a stream request with a non-success status such as `503` from its concurrency
+cap, `webui serve` logs one warning and still renders the page from fallback
+state. A refused request never started a stream, so it degrades the same way an
+unreachable backend does instead of replacing your app with the upstream error
+body. A failure that occurs *after* the stream is live still fails the response,
+because boundaries already sent to the browser cannot be rewound.
+
 After generated assets and `--servedir` files miss, route fallback is based on
 the `Accept` header. Requests that explicitly accept `text/html` or
 `application/xhtml+xml` receive the SSR document, and requests that explicitly

--- a/docs/guide/concepts/directives/boundary.md
+++ b/docs/guide/concepts/directives/boundary.md
@@ -1,15 +1,25 @@
 # Streaming Boundaries
 
-`<boundary>` marks a complete part of an entry page that can be flushed
-and hydrated before the rest of the response arrives. It is available with the
-WebUI parser plugin and the opt-in Rust streaming render path.
+`<boundary>` splits an entry page into complete regions that WebUI can flush
+and hydrate before the full response arrives.
+
+A boundary is a compile-time directive, not a DOM element. WebUI removes it
+from the rendered HTML and streams its children in normal document order.
+
+## 1. Author the checkpoints
+
+Put boundaries around independently useful page regions, ordered by priority:
 
 ```html
 <head>
   <script type="module" async src="/index.js"></script>
 </head>
 <body>
-  <boundary name="composer">
+  <boundary name="weather-shell">
+    <weather-panel status="loading"></weather-panel>
+  </boundary>
+
+  <boundary name="composer-ready">
     <message-composer></message-composer>
   </boundary>
 
@@ -19,315 +29,143 @@ WebUI parser plugin and the opt-in Rust streaming render path.
 </body>
 ```
 
-The directive is removed at compile time. It does not add an element to the
-application DOM. A normal `WebUIHandler::render` call renders its children as
-usual without enabling progressive hydration. Use
-`WebUIHandler::render_streaming` with a `FlushWriter` to commit every checkpoint
-as final, or use `WebUIHandler::stream_response` when the host controls boundary
-timing and later state updates. Node and other HTTP backends can instead return
-the versioned `application/x-webui-stream` control format to
-`webui serve --api-port`; the CLI retains the Rust response session and bounded
-browser transport.
-
-The async browser entry must install the streaming coordinator before importing
-component registration modules:
+Import the streaming coordinator before component registration modules:
 
 ```typescript
 import '@microsoft/webui-framework/streaming.js';
+import './weather-panel/weather-panel.js';
 import './message-composer/message-composer.js';
 import './activity-feed/activity-feed.js';
 ```
 
-The normal `@microsoft/webui-framework` entry deliberately excludes coordinator
-code.
+The application module must be `async` and appear in `<head>` before boundary
+content so early checkpoints can hydrate while the document is still parsing.
 
-## Authoring Rules
+## 2. Choose how the server drives the response
 
-In the current implementation:
+| Need | Use |
+|---|---|
+| Render all boundaries immediately with one state value | Rust `WebUIHandler::render_streaming` |
+| Control when each boundary commits or send later state | Rust `WebUIHandler::stream_response` |
+| Let an API backend control readiness while `webui serve` owns rendering | `webui serve --api-port` |
+| Stream directly from Node, WASM, .NET, or C | That handler's streaming session API |
 
-- `name` is required, non-empty, static, and unique within the entry template.
-  It cannot contain a <code v-pre>{{binding}}</code>.
-- A boundary can appear only in the outermost entry template. Boundaries in
-  reusable components and route-shell component templates are not supported.
-- A boundary cannot appear inside another boundary, `<if>`, `<for>`, or
-  `<route>`. Put it in the entry template so it fully wraps any such scope.
-- A boundary cannot appear inside a registered component's host content or
-  inside native raw/inert content such as `<textarea>`, `<script>`, or
-  `<template>`. The browser treats the generated sentinel as text or inert DOM
-  there, so wrap the whole host or native element instead.
-- A boundary cannot appear inside `<table>`, `<thead>`, `<tbody>`, `<tfoot>`,
-  `<tr>`, `<colgroup>`, `<select>`, or `<optgroup>`. In those contexts the
-  browser's HTML parser foster-parents the generated `<webui-hydrate>` sentinel
-  out of the table while the payload script stays inside, which permanently
-  breaks hydration. Wrap the whole table in a boundary instead, or place the
-  boundary inside a `<td>`, `<th>`, or `<caption>` — those return to normal
-  insertion rules and are allowed.
-- During `render_streaming`, every registered WebUI component host must be
-  inside an explicit boundary. The handler rejects an outside host because it
-  cannot safely activate that component after parser-time upgrade. Native HTML
-  and unregistered static tail markup may remain outside boundaries.
-- `<webui-hydrate>` is reserved for generated runtime output and must never be
-  authored.
+All paths produce the same ordered browser protocol.
 
-Invalid markup fails the build with a structured diagnostic such as
-`missing-boundary-name`, `invalid-boundary-name`,
-`duplicate-boundary-name`, `nested-boundary`, `boundary-crosses-scope`,
-`boundary-in-foster-context`, or `authored-webui-hydrate`.
+## 3. Drive a host-controlled response
 
-## Send Boundary-Local State
+Resolve authored names once to integer boundary handles. Then use these four
+operations:
 
-Pass the client build's `webui-projection.json` to `BuildOptions` whenever an
-entry declares boundaries:
+| Operation | Purpose |
+|---|---|
+| `write_shell(state)` | Flush everything before the first boundary |
+| `write_boundary(id, state, mode)` | Render and flush the next boundary |
+| `update(id, state)` | Patch an earlier boundary committed as `Updatable` |
+| `finish(state)` | Render the tail, emit the terminal record, and end the response |
 
-```rust
-let mut options = BuildOptions::new(app_root, "index.html");
-options.plugin = Some(Plugin::WebUI);
-options.projection_manifests = vec![app_root.join("dist/webui-projection.json").into()];
+The required order is:
+
+```text
+write_shell -> write_boundary* -> finish
 ```
 
-Without a manifest the build falls back to full-state hydration, so **every**
-checkpoint serializes the entire application state instead of just its own
-components' keys. That turns the wire cost into `O(boundaries × full state)`.
-The build reports this as a `streaming-without-projection` warning.
-
-On the streaming example this single option cut the response from 19,403 to
-12,228 bytes, and steady-state feed checkpoints from 1,470 bytes to 35.
-
-Boundary HTML is committed only in document order. Server work can run
-concurrently, and projected state-update records can arrive between boundary
-checkpoints. State updates target already committed updatable boundaries; they
-do not relocate server markup.
-
-### Slow surfaces: stream the shell, then its state
-
-Give a slow region a complete component shell in an early boundary. Commit it as
-updatable so later boundaries are not blocked, then send its projected state
-when backend work finishes:
-
-```html
-<header>
-  <boundary name="weather-shell">
-    <weather-panel status="loading"></weather-panel>
-  </boundary>
-</header>
-```
+`update` may run between boundary writes, but only after its target has
+committed as updatable.
 
 ```rust
-let mut response = handler.stream_response(&protocol, &options, &mut writer)?;
+use webui::{BoundaryMode, RenderOptions, WebUIHandler};
+
+let options = RenderOptions::new("index.html", "/");
+let mut response =
+    handler.stream_response(&protocol, &options, &mut writer)?;
+
 let weather = response.boundary("weather-shell")?;
-let composer = response.boundary("composer")?;
+let composer = response.boundary("composer-ready")?;
+let feed = response.boundary("feed")?;
 
 response.write_shell(&page_state)?;
-response.write_boundary(weather, &loading_state, BoundaryMode::Updatable)?;
-response.write_boundary(composer, &composer_state, BoundaryMode::Final)?;
+response.write_boundary(
+    weather,
+    &loading_weather,
+    BoundaryMode::Updatable,
+)?;
+response.write_boundary(
+    composer,
+    &composer_state,
+    BoundaryMode::Final,
+)?;
 
-// This can run after any amount of backend work. The record uses the
-// checkpoint's compiled projection and the same open HTML response.
-response.update(weather, &forecast_state)?;
+response.update(weather, &ready_weather)?;
+response.write_boundary(feed, &feed_state, BoundaryMode::Final)?;
+response.finish(&tail_state)?;
 ```
 
-The browser applies the patch through the component's `setState()` path. It does
-not rerun hydration or `hydratedCallback()`. If the island module has not defined
-the element yet, WebUI merges updates into the pending activation state and
-activates once with the newest values. `examples/app/streaming` demonstrates a
-forecast update arriving between feed batches with no browser fetch.
+Boundary HTML always commits once in declaration order. Backend work may run
+concurrently, but a later boundary cannot overtake an earlier one.
 
-### Load an island's code with the island
+### Final or updatable?
 
-A boundary can carry its own `<script>`. Put the island's module inside it and
-the browser fetches that code when the chunk reaches the parser, so your
-critical entry never carries bytes the first interaction does not need:
+| Mode | Use it when | Browser retention |
+|---|---|---|
+| `Final` | The boundary needs no later server state | Releases boundary roots after hydration |
+| `Updatable` | A complete shell should hydrate now and receive state later | Retains only successfully activated roots until `finish` |
 
-```html
-<boundary name="weather-shell">
-  <script type="module" async src="./weather-panel.js"></script>
-  <weather-panel status="loading"></weather-panel>
-</boundary>
+Use `Final` by default. An update calls the component's normal `setState()`
+path and never re-runs hydration or `hydratedCallback()`. If the component
+module is still loading, WebUI hydrates the server-rendered DOM first, then
+replays the latest queued patch through `setState()`.
+
+## 4. Drive streaming through `webui serve`
+
+With `webui serve --api-port`, the API backend can return newline-delimited
+control records:
+
+```text
+{"type":"shell","version":1,"state":{"feed":[]}}
+{"type":"boundary","name":"weather-shell","mode":"updatable"}
+{"type":"boundary","name":"composer-ready"}
+{"type":"update","name":"weather-shell","state":{"status":"ready"}}
+{"type":"boundary","name":"feed"}
+{"type":"finish"}
 ```
 
-This is safe by construction. The boundary commits before the class exists, so
-the coordinator retains that boundary's state with the root and waits on one
-`customElements.whenDefined()` reaction per tag, activating it when the module
-registers. An undefined outer component is a barrier for its descendants, so
-parent-first hydration remains intact. `webui:hydration-complete` stays open
-until all definitions activate, and the script is authored content, so boundary
-teardown leaves it alone.
+These records go from the backend to the CLI, not to the browser. The CLI
+resolves names, renders the compiled template in Rust, and streams the resulting
+HTML. See [`webui serve --api-port`](/guide/cli/) for limits and fallback
+behavior.
 
-**WebUI preloads the shared chunks for you.** Splitting an island into its own bundle entry makes your bundler hoist the
-framework runtime into a chunk your critical entry statically imports. The
-preload scanner cannot see that chunk behind your `<script>` tag, so without
-help the browser would only discover it after downloading and parsing the
-entry — a full round trip on the critical path.
+## Authoring rules
 
-That round trip cancels out what splitting saves. On `examples/app/streaming`
-over a throttled link, splitting alone was a wash: 1074 ms composer
-time-to-interactive bundled versus 1061 ms split. Adding
-`<link rel="modulepreload">` for the shared chunk recovers it — a 7-11% win,
-measured back to back against one binary — but only in the right order.
-Preloads are issued in document order and share the connection, so listing a
-284-byte chunk ahead of a 35 KB one delays the long pole behind it and gives
-the whole win back (1076 ms). Getting the order wrong is worse than emitting
-nothing, which is exactly why it is not yours to hand-write.
+- `name` is required, static, non-empty, and unique in the entry template.
+- Author boundaries only in the outermost entry template.
+- Boundaries cannot nest or appear inside `<if>`, `<for>`, or `<route>`.
+  They may wrap a complete directive scope.
+- Do not place a boundary inside registered component host content, raw or
+  inert elements such as `<script>` or `<template>`, or table/select parser
+  contexts. Wrap the complete host, element, or table instead.
+- Every registered WebUI component rendered in streaming mode must be inside
+  an explicit boundary. Native static HTML may remain outside.
+- Never author `<webui-hydrate>`; it is generated runtime output.
 
-You do not write those hints, and you could not: your bundler content-hashes
-the filenames. Pass your bundler's projection manifest to the build and WebUI
-emits them into `<head>` for you, ordered largest first. Islands are excluded
-automatically — a module loaded by a `<script>` **inside** a boundary is
-deferred on purpose, and preloading it would undo the split. A chunk your
-island shares with the critical entry still gets preloaded, because it is
-genuinely critical.
+Invalid placement fails the build with an actionable diagnostic.
 
-When esbuild uses a non-empty `publicPath`, WebUI suppresses these generated
-hints rather than guessing how local metafile paths map to served or
-cross-origin URLs. The browser still discovers the imports normally.
+## Production checklist
 
-For a sub-kilobyte component the extra request may still not be worth it;
-split for the architectural benefit first.
+- Pass the generated `webui-projection.json` to `BuildOptions` in custom Rust
+  builds. Without it, every checkpoint falls back to serializing full state.
+- Preserve HTTP backpressure and cap concurrent streaming renders.
+- Disable reverse-proxy response buffering for the streaming route, for example
+  with `X-Accel-Buffering: no` in nginx.
+- Use an updatable boundary for slow data instead of blocking later
+  checkpoints.
+- Use `examples/app/streaming` as the complete reference application.
 
-Each checkpoint includes projected state and first-use metadata for the
-component graph reachable from roots rendered in that boundary. This includes
-initially hidden conditional/repeat descendants so they can appear after a
-client state change without a page-global bootstrap. Inventory remains limited
-to roots that actually rendered, and unrelated later boundaries remain
-excluded.
+## More detail
 
-## Drive the Response from Your Host
-
-Streaming is not Rust-only. Node, WASM, C, and C# open a **streaming session**
-whose methods *return* the bytes they produced instead of writing them, so your
-server keeps the socket and applies its own backpressure policy.
-
-**Node**
-
-```js
-import { once } from 'node:events';
-
-const session = protocol.streamResponse({ entry: 'index.html', requestPath: '/' });
-const weather = session.boundary('weather-shell');   // resolve names once
-const composer = session.boundary('composer');
-
-res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-await write(res, session.writeShell(pageState));
-await write(res, session.writeBoundary(weather, loadingState, 'updatable'));
-await write(res, session.writeBoundary(composer, composerState));
-
-await write(res, session.update(weather, await forecast));
-res.end(session.finish({}));
-
-async function write(res, chunk) {
-  if (res.write(chunk)) return;
-  // An aborted client never emits 'drain', and surfaces as 'close', not
-  // 'error' — so waiting on 'drain' alone would hang forever.
-  await new Promise((ok, fail) => {
-    const done = (error) => {
-      res.off('drain', onDrain);
-      res.off('close', onClose);
-      if (error) fail(error);
-      else ok();
-    };
-    const onDrain = () => done();
-    const onClose = () => done(new Error('client disconnected'));
-    res.once('drain', onDrain);
-    res.once('close', onClose);
-  });
-}
-```
-
-**C#**
-
-```csharp
-using var session = handler.StreamResponse(protocol, "index.html", "/");
-var weather = session.Boundary("weather-shell");
-var composer = session.Boundary("composer");
-
-Response.ContentType = "text/html; charset=utf-8";
-await Response.Body.WriteAsync(session.WriteShell(pageState));
-await Response.Body.WriteAsync(
-    session.WriteBoundary(weather, loadingState, BoundaryMode.Updatable));
-await Response.Body.WriteAsync(session.WriteBoundary(composer, composerState));
-await Response.Body.FlushAsync();
-
-await Response.Body.WriteAsync(session.Update(weather, await forecast));
-await Response.Body.WriteAsync(session.Finish("{}"));
-```
-
-**C**
-
-```c
-size_t len = 0;
-uint8_t *chunk = webui_streaming_session_write_shell(session, page_state, &len);
-if (!chunk) { /* webui_last_error() */ }
-send_all(socket, chunk, len);   /* the length is authoritative: not NUL-terminated */
-webui_free(chunk);
-```
-
-The rules are identical everywhere: resolve boundary names once, write the shell
-first, write boundaries in declaration order, `update` only boundaries committed
-as `updatable`, and `finish` last. A rejected call leaves the session usable, so
-bad input does not cost you the response.
-
-Rust servers can use the same session, or keep `stream_response`, which writes
-directly into a borrowed `ResponseWriter` and avoids the per-chunk buffer.
-
-**Two ways to run this.** Use a **session** when your server already terminates
-HTTP and wants WebUI as a library — see
-`examples/integration/node/streaming-server.js`. Use
-**`webui serve --api-port`** when you want your backend to own readiness and
-ordering while the CLI owns rendering, static assets, and the browser transport
-— see `examples/app/streaming`. Both are thin adapters over the same session, so
-ordering, projection, the wire format, and every diagnostic are shared.
-
-Whichever you pick, disable proxy buffering for the route
-(`X-Accel-Buffering: no` for nginx). A flush that a proxy coalesces is not a
-flush the browser sees.
-
-## Pick a CSS Strategy for Streaming
-
-Component CSS is delivered by [`BuildOptions.css`](/guide/integrations/rust), and the
-choice matters more when streaming than it does for a buffered response.
-`style` inlines each component's stylesheet into **every** rendered shadow root,
-so a repeated component pays for its CSS once per instance. A four-item feed
-already emits `feed-item`'s rules five times — four instances plus the template
-metadata.
-
-Measured on the streaming example (two components, four feed items), with a
-cold browser context, six runs, 100 ms RTT and 1.6 Mbps down:
-
-| Strategy | Response | Composer styled | Delivery |
-| --- | --- | --- | --- |
-| `style` | 12,228 B | 147 ms | Inline `<style>`, repeated per instance |
-| `module` | 10,061 B (−17.8%) | 158 ms (+11 ms) | One `data:` import map per component |
-| `link` | 8,368 B (−31.6%) | 268 ms (+121 ms) | One cacheable request per component |
-
-Time to interactive was unchanged (615–617 ms) — it is gated by the application
-bundle, not by CSS. What changes is when the critical island stops being
-unstyled.
-
-- **`style`** costs the most bytes but is the only strategy with **zero extra
-  round trips**: a boundary's CSS arrives in the same chunk as its markup. Use
-  it when a critical boundary must paint styled immediately.
-- **`module`** removes per-instance duplication while keeping CSS in the
-  response, so it recovers most of the byte savings for only ~11 ms. This is
-  usually the best default for pages that stream many repeated components.
-- **`link`** is the smallest response and the only cacheable-across-navigations
-  option, but each stylesheet is a separate request. WebUI emits
-  `<link rel="preload">` in `<head>` so that request starts as early as
-  possible; under real latency it still costs a round trip before the shadow
-  root is styled. Prefer it when repeat visits matter more than first-visit
-  paint, or when the boundaries involved are low priority.
-
-**Serve the generated stylesheets.** `link` and `module` reference component
-stylesheets, which the WebUI build
-returns in `BuildResult::css_files` rather than writing to your client
-bundler's output directory. `webui build` writes them to disk and `webui serve`
-serves them for you, but a **custom server must serve them itself** — otherwise
-the markup and preload hints are correct while every stylesheet URL 404s and
-the page renders unstyled. The streaming example delegates this responsibility
-to `webui serve`.
-
-WebUI applies one strategy per build, so a page whose critical boundary wants
-`style` and whose repeated feed wants `link` must currently pick one. Choose for
-the highest-priority boundary.
-
-See [Hydration](/guide/concepts/hydration#progressive-streaming-hydration) for
-loading, lifecycle, CSP, and prioritization guidance.
+- [Rust streaming integration](/guide/integrations/rust#streaming-ssr)
+- [Node streaming sessions](/guide/integrations/node#progressive-streaming)
+- [WASM streaming sessions](/guide/integrations/wasm#streamingsession)
+- [C and FFI streaming sessions](/guide/integrations/ffi)
+- [Hydration lifecycle and diagnostics](/guide/concepts/hydration#progressive-streaming-hydration)
+- [Performance model](/guide/concepts/performance)

--- a/examples/app/streaming/package.json
+++ b/examples/app/streaming/package.json
@@ -16,7 +16,7 @@
     "start:test-server": "cargo run -p microsoft-webui-cli -- serve ./src --theme=@microsoft/webui-examples-theme --plugin=webui --projection-manifest ./dist/webui-projection.json --servedir ./dist --css style --port 3020 --api-port 3030",
     "start": "cargo xtask dev streaming",
     "test": "pnpm run test:server && playwright test",
-    "test:server": "tsx --test server/src/pacing.test.ts",
+    "test:server": "tsx --test server/src/*.test.ts",
     "test:update-snapshots": "playwright test --update-snapshots"
   },
   "devDependencies": {

--- a/examples/app/streaming/server/src/index.ts
+++ b/examples/app/streaming/server/src/index.ts
@@ -63,9 +63,11 @@ async function renderPage(
     sendJson(response, { state: STREAMING_STATE });
     return;
   }
-  if (activeStreams >= options.maxConcurrentStreams) {
-    response.setHeader('Content-Type', WEBUI_STREAM_MEDIA_TYPE);
-    sendText(response, 503, 'streaming render capacity is temporarily exhausted');
+  if (
+    activeStreams >= options.maxConcurrentStreams ||
+    (options.testControls && url.searchParams.get('refuse') === '1')
+  ) {
+    sendCapacityRefusal(response);
     return;
   }
 
@@ -101,6 +103,18 @@ async function renderPage(
     response.off('close', abortOnDisconnect);
     activeStreams--;
   }
+}
+
+/**
+ * Refuse a stream before any record is written.
+ *
+ * Shared by the real capacity guard and the `?refuse=1` test control so an
+ * end-to-end test observes the identical response a saturated server sends,
+ * rather than a parallel code path that could drift from it.
+ */
+function sendCapacityRefusal(response: ServerResponse): void {
+  response.setHeader('Content-Type', WEBUI_STREAM_MEDIA_TYPE);
+  sendText(response, 503, 'streaming render capacity is temporarily exhausted');
 }
 
 function resolveTestSession(url: URL, response: ServerResponse): TestSession | undefined {

--- a/examples/app/streaming/server/src/test-controls.test.ts
+++ b/examples/app/streaming/server/src/test-controls.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { TestControls } from './test-controls.js';
+
+const MAX_SESSIONS = 128;
+
+test('reuses the session registered under an id', () => {
+  const controls = new TestControls();
+  const first = controls.session('alpha');
+  assert.ok(first);
+  assert.equal(controls.session('alpha'), first);
+  assert.equal(controls.existingSession('alpha'), first);
+});
+
+test('rejects ids that are empty or contain unsupported characters', () => {
+  const controls = new TestControls();
+  assert.equal(controls.session(''), undefined);
+  assert.equal(controls.session('has space'), undefined);
+  assert.equal(controls.session('has/slash'), undefined);
+  assert.equal(controls.session('a'.repeat(65)), undefined);
+  assert.ok(controls.session('ok-id_9'));
+});
+
+test('never refuses a new session once the table is full', () => {
+  const controls = new TestControls();
+  for (let index = 0; index < MAX_SESSIONS; index++) {
+    assert.ok(controls.session(`fill-${index}`));
+  }
+
+  // Playwright reuses a running API across suite runs, so exhausting the table
+  // must not start failing every later test with a 400.
+  const overflow = controls.session('overflow');
+  assert.ok(overflow, 'a new session is still handed out when the table is full');
+  assert.equal(controls.existingSession('overflow'), overflow);
+});
+
+test('evicts the oldest session first and keeps the newest', () => {
+  const controls = new TestControls();
+  for (let index = 0; index < MAX_SESSIONS; index++) {
+    controls.session(`fill-${index}`);
+  }
+  const newest = controls.existingSession(`fill-${MAX_SESSIONS - 1}`);
+
+  controls.session('overflow');
+
+  assert.equal(controls.existingSession('fill-0'), undefined, 'oldest session was evicted');
+  assert.equal(
+    controls.existingSession(`fill-${MAX_SESSIONS - 1}`),
+    newest,
+    'newest session survived',
+  );
+});
+
+test('opens the gates of an evicted session so its stream can finish', async () => {
+  const controls = new TestControls();
+  const doomed = controls.session('doomed');
+  assert.ok(doomed);
+
+  // A stream parked on this gate becomes unreachable once the session leaves
+  // the table, so eviction must release it or it holds its concurrency slot
+  // for the life of the process. Race a timeout so a regression fails here
+  // instead of hanging the run.
+  const parked = Promise.all([doomed.waitForFeedGap(0), doomed.waitForWeather()]).then(
+    () => 'released' as const,
+  );
+  const timeout = new Promise<'stuck'>((resolve) => {
+    setTimeout(() => resolve('stuck'), 1_000).unref();
+  });
+
+  for (let index = 0; index < MAX_SESSIONS; index++) {
+    controls.session(`fill-${index}`);
+  }
+
+  assert.equal(await Promise.race([parked, timeout]), 'released');
+  assert.equal(controls.existingSession('doomed'), undefined);
+});

--- a/examples/app/streaming/server/src/test-controls.ts
+++ b/examples/app/streaming/server/src/test-controls.ts
@@ -77,9 +77,7 @@ export class TestControls {
     if (existing) {
       return existing;
     }
-    if (this.#sessions.size >= MAX_SESSIONS) {
-      return undefined;
-    }
+    this.#evictOldest();
     const session = new TestSession();
     this.#sessions.set(id, session);
     return session;
@@ -87,6 +85,32 @@ export class TestControls {
 
   existingSession(id: string): TestSession | undefined {
     return this.#sessions.get(id);
+  }
+
+  /**
+   * Keep the session table bounded without ever refusing a new run.
+   *
+   * Playwright reuses an already-running API across suite runs, so this process
+   * accumulates sessions for as long as a developer keeps it up. A hard cap
+   * would start rejecting every new session after a few hundred tests, which
+   * surfaces as unrelated tests failing on a 400 rather than as an obvious
+   * capacity error. Map iteration is insertion-ordered, so the first key is the
+   * oldest session.
+   */
+  #evictOldest(): void {
+    while (this.#sessions.size >= MAX_SESSIONS) {
+      const oldest = this.#sessions.keys().next();
+      if (oldest.done === true) {
+        return;
+      }
+      const evicted = this.#sessions.get(oldest.value);
+      this.#sessions.delete(oldest.value);
+      // An evicted session can still have a stream parked on one of its gates,
+      // and nothing can reach it to release it once it leaves the table. Open
+      // its gates on the way out so that stream finishes and gives back its
+      // slot against --max-concurrent-streams.
+      evicted?.releaseAll();
+    }
   }
 }
 

--- a/examples/app/streaming/src/index.html
+++ b/examples/app/streaming/src/index.html
@@ -54,7 +54,7 @@
 </head>
 <body>
   <header>
-    <h1>Home</h1>
+    <h1>Streaming Home</h1>
     <!--
       The shell commits immediately as an updatable boundary, so slow forecast
       work cannot hold back the composer. When that server work finishes, the

--- a/examples/app/streaming/tests/streaming.spec.ts
+++ b/examples/app/streaming/tests/streaming.spec.ts
@@ -117,6 +117,12 @@ test.describe('streaming priority hydration', () => {
     if (session) await release(page, session, 'all');
   });
 
+  test('identifies the streaming home page', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Streaming Home');
+  });
+
   test('composer paints and becomes interactive before DOMContentLoaded', async ({ page }) => {
     await instrumentPage(page);
     // 'commit' resolves as soon as the navigation's response headers are
@@ -240,6 +246,24 @@ test.describe('streaming priority hydration', () => {
 
     // The skeleton branch is torn down, not merely hidden.
     await expect(page.locator('weather-panel [data-testid="weather-skeleton"]')).toHaveCount(0);
+  });
+
+  test('applies a weather update that arrives before the deferred island activates', async ({ page }) => {
+    await page.route('**/weather-panel.js', async (route) => {
+      const response = await route.fetch();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      await route.fulfill({ response });
+    });
+    const session = await gotoControlled(page);
+    await release(page, session, 'all');
+
+    await expect(page.locator('weather-panel [data-testid="weather-summary"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('weather-panel [data-testid="weather-panel"]')).toHaveAttribute(
+      'data-status',
+      'ready',
+    );
   });
 
   test('the weather island loads its own module from inside its boundary', async ({ page }) => {
@@ -397,3 +421,198 @@ test.describe('streaming priority hydration', () => {
     expect(responseEnd).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Reload recovery.
+ *
+ * A reload is the hardest case for streaming hydration: the previous stream is
+ * aborted mid-flight, the module graph is already warm in the HTTP cache, and a
+ * fresh document begins committing boundaries before its islands are defined.
+ * That reorders activation against delivery in ways a cold first load never
+ * does, which is exactly where a boundary can be left holding a root that never
+ * came alive.
+ *
+ * These tests assert the user-visible contract rather than internals: after the
+ * dust settles the weather island is `ready`, its skeleton branch is gone, the
+ * feed is fully painted, no boundary scaffolding survives, and nothing threw.
+ */
+test.describe('streaming reload recovery', () => {
+  // Every session this block opens, so teardown can release all of them. A
+  // gated session whose stream is abandoned mid-flight keeps its slot against
+  // `--max-concurrent-streams` until something releases its gates, so leaving
+  // even one behind slowly starves the shared test API.
+  const openedSessions = new WeakMap<Page, Set<string>>();
+
+  function trackSession(page: Page, session: string): string {
+    let sessions = openedSessions.get(page);
+    if (!sessions) {
+      sessions = new Set<string>();
+      openedSessions.set(page, sessions);
+    }
+    sessions.add(session);
+    return session;
+  }
+
+  test.afterEach(async ({ page }) => {
+    for (const session of openedSessions.get(page) ?? []) {
+      // A session the API never created 404s here, which is fine: nothing to
+      // release. Teardown must not fail the test it is cleaning up after.
+      await page.request.post(`/api/__test/${session}/all`).catch(() => undefined);
+    }
+  });
+
+  /** Fail loudly on any uncaught error or console error the page reports. */
+  function trackPageErrors(page: Page): string[] {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(`pageerror: ${error.message}`));
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+    });
+    return errors;
+  }
+
+  /**
+   * Navigate and resolve once the document's stream is provably underway.
+   *
+   * `waitUntil: 'commit'` resolves on the CLI's response headers, which the CLI
+   * can emit before the API has seen the request and created the test session.
+   * Releasing a gate at that point races session creation and 404s. The
+   * composer ships in an immediate, ungated boundary, so its presence is proof
+   * the API is streaming this document and the session exists.
+   */
+  async function gotoStreaming(page: Page, session: string): Promise<void> {
+    trackSession(page, session);
+    await page.goto(`/?test=${session}`, { waitUntil: 'commit' });
+    await page.locator('message-composer').waitFor({ state: 'attached', timeout: 15_000 });
+  }
+
+  /** The full post-hydration contract for a healthy streamed document. */
+  async function expectFullyHydrated(page: Page): Promise<void> {
+    const panel = page.locator('weather-panel [data-testid="weather-panel"]');
+    await expect(panel).toHaveAttribute('data-status', 'ready', { timeout: 15_000 });
+    await expect(page.locator('weather-panel [data-testid="weather-summary"]')).toBeVisible();
+    await expect(page.locator('weather-panel [data-testid="weather-temperature"]')).not.toBeEmpty();
+    // The skeleton is torn down, not hidden: a surviving skeleton means the
+    // island re-rendered the branch the server had already replaced.
+    await expect(page.locator('weather-panel [data-testid="weather-skeleton"]')).toHaveCount(0);
+
+    // Every feed batch landed, so no checkpoint was dropped by the reload.
+    await expect(page.locator('feed-item')).toHaveCount(4);
+
+    // `data-ws` is the coordinator's work marker. Its absence here means every
+    // root it marked was resolved -- activated, or explicitly abandoned --
+    // rather than left parked forever waiting on a stream that is gone.
+    await expect(page.locator('[data-ws]')).toHaveCount(0);
+    await expect(page.locator('webui-hydrate')).toHaveCount(0);
+    await expect(page.locator('script[data-webui-boundary]')).toHaveCount(0);
+  }
+
+  // The island's module can arrive before, during, or after its boundary
+  // commits. The bug this locks in only appeared inside a narrow timing band,
+  // so sweep across it instead of trusting one delay to land there.
+  for (const delayMs of [0, 60, 200, 400]) {
+    test(`reloads cleanly with the island module delayed ${delayMs}ms`, async ({ page }) => {
+      const errors = trackPageErrors(page);
+      await page.route('**/weather-panel*.js', async (route) => {
+        const response = await route.fetch();
+        if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+        await route.fulfill({ response });
+      });
+
+      const first = `band-${delayMs}-${process.pid}-${sessionCounter++}`;
+      await gotoStreaming(page, first);
+      await release(page, first, 'all');
+      await expectFullyHydrated(page);
+
+      // Reload onto a fresh session so the second document is paced like a
+      // real one instead of replaying an already-drained session instantly.
+      await gotoStreaming(page, `${first}-r`);
+      await release(page, `${first}-r`, 'all');
+      await expectFullyHydrated(page);
+
+      expect(errors, 'reload produced page errors').toEqual([]);
+    });
+  }
+
+  test('recovers when a reload interrupts a stream that is still open', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    await instrumentPage(page);
+
+    // Commit the first document and let only feed batch 1 through, so the
+    // response is provably still open when the reload aborts it.
+    const first = `interrupt-${process.pid}-${sessionCounter++}`;
+    await gotoStreaming(page, first);
+    await release(page, first, 'feed');
+    await page.waitForFunction(() => window.__boundaryEvents.some((e) => e.sequence === 2));
+    expect(await page.evaluate(() => window.__hydrationCompleteFired)).toBe(false);
+
+    await gotoStreaming(page, `${first}-r`);
+    await release(page, `${first}-r`, 'all');
+
+    await page.waitForFunction(() => window.__hydrationCompleteFired, undefined, {
+      timeout: 15_000,
+    });
+    await expectFullyHydrated(page);
+    expect(errors, 'interrupted reload produced page errors').toEqual([]);
+  });
+
+  test('survives rapid consecutive reloads', async ({ page }) => {
+    const errors = trackPageErrors(page);
+    const base = `rapid-${process.pid}-${sessionCounter++}`;
+
+    // Navigate away repeatedly without ever letting a document finish. Each
+    // abort leaves the coordinator holding parked roots for a document that
+    // is being torn down -- the sequence behind the original blank-page report.
+    for (let index = 0; index < 5; index++) {
+      const session = trackSession(page, `${base}-${index}`);
+      await page.goto(`/?test=${session}`, { waitUntil: 'commit' });
+      // Open this document's gates immediately. The browser has already moved
+      // on, so nothing here changes what the client sees -- it just lets the
+      // orphaned server stream run to completion and give its slot back,
+      // instead of parking on a gate no one will ever open. A real server
+      // paces on timers, so it drains this way on its own.
+      await page.request.post(`/api/__test/${session}/all`).catch(() => undefined);
+    }
+
+    await gotoStreaming(page, `${base}-final`);
+    await release(page, `${base}-final`, 'all');
+
+    await expectFullyHydrated(page);
+    expect(errors, 'rapid reloads produced page errors').toEqual([]);
+  });
+
+  test('renders the app when the API refuses to open a stream', async ({ page }) => {
+    const errors = trackPageErrors(page);
+
+    // `?refuse=1` returns the identical 503 a saturated server sends. The CLI
+    // must degrade to a rendered page rather than proxying the upstream error
+    // body, which would surface as a text/plain error where the app should be.
+    const response = await page.goto('/?refuse=1');
+    expect(response?.status()).toBe(200);
+    expect(response?.headers()['content-type']).toContain('text/html');
+
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Streaming Home');
+    expect(await page.content()).not.toContain('streaming render capacity');
+
+    // The critical bundle still hydrates, so the shell is genuinely usable and
+    // not just static markup that happens to parse.
+    const input = page.locator('message-composer input.composer-input');
+    await expect(input).toBeVisible();
+    await input.fill('Usable even without a stream');
+    await page.locator('message-composer button.composer-submit').click();
+    await expect(page.locator('message-composer [data-testid="composer-posted"]')).toHaveText(
+      'Posted: Usable even without a stream',
+    );
+
+    // Degrading means no server data arrived, so the island stays in its
+    // loading branch. That is the honest state -- not an error, and not
+    // fabricated content.
+    await expect(page.locator('weather-panel [data-testid="weather-panel"]')).toHaveAttribute(
+      'data-status',
+      'loading',
+    );
+    await expect(page.locator('feed-item')).toHaveCount(0);
+    expect(errors, 'the degraded page produced errors').toEqual([]);
+  });
+});
+

--- a/packages/webui-framework/src/streaming-activation.ts
+++ b/packages/webui-framework/src/streaming-activation.ts
@@ -35,7 +35,7 @@ export function activateRootsBetween(
     root,
     endMarker,
     state,
-    updates ? { updates, retainedRoots: updates.roots } : undefined,
+    updates ? { updates, countRetention: true } : undefined,
   );
   if (!failure) return;
   abandonDeferredRange(startMarker, endMarker);

--- a/packages/webui-framework/src/streaming-coordinator.ts
+++ b/packages/webui-framework/src/streaming-coordinator.ts
@@ -47,6 +47,7 @@ import {
   RECORD_KIND_UPDATABLE_CHECKPOINT,
 } from './streaming-protocol.js';
 import type { BoundaryBootstrap } from './streaming-protocol.js';
+import { applyStateUpdate } from './streaming-state.js';
 
 const MAX_QUEUED_BOUNDARIES = 512;
 const MAX_UPDATABLE_BOUNDARIES = 128;
@@ -78,10 +79,6 @@ let coordinatorGeneration = 0;
 let retainedUpdateRoots = 0;
 
 type UpdatableBoundary = PendingBoundaryUpdates;
-
-type StateRoot = Element & {
-  setState?: (state: Record<string, unknown>) => void;
-};
 
 const updatableBoundaries = new Map<number, UpdatableBoundary>();
 
@@ -357,7 +354,7 @@ function commitCheckpoint(
     applyBoundaryBootstrap(bootstrap);
     if (range.start && range.end) {
       const boundary: UpdatableBoundary | undefined = updatable
-        ? { roots: [], pendingRoots: 0 }
+        ? { roots: [], retained: 0, pendingRoots: 0 }
         : undefined;
       activateRootsBetween(
         range.start,
@@ -367,7 +364,11 @@ function commitCheckpoint(
       );
       if (boundary) retainUpdatableBoundary(target, boundary);
     } else if (updatable) {
-      retainUpdatableBoundary(target, { roots: [], pendingRoots: 0 });
+      retainUpdatableBoundary(target, {
+        roots: [],
+        retained: 0,
+        pendingRoots: 0,
+      });
     }
     committed = true;
   } catch (error) {
@@ -400,14 +401,14 @@ function retainUpdatableBoundary(
     );
   }
   if (
-    retainedUpdateRoots + boundary.roots.length >
+    retainedUpdateRoots + boundary.retained >
     MAX_RETAINED_UPDATE_ROOTS
   ) {
     throw new Error(
       `retained update root count exceeds ${MAX_RETAINED_UPDATE_ROOTS}`,
     );
   }
-  retainedUpdateRoots += boundary.roots.length;
+  retainedUpdateRoots += boundary.retained;
   updatableBoundaries.set(target, boundary);
 }
 
@@ -431,21 +432,12 @@ function commitStateUpdate(
       }
     }
     for (let i = 0; i < boundary.roots.length; i++) {
-      const root = boundary.roots[i] as StateRoot;
-      if (root.hasAttribute('data-ws')) continue;
-      // Mirrors `reportActivationFailure`: an application component's own
-      // change handler throwing degrades that root only. Halting here would
-      // let one app-level bug strand every later boundary on the page.
-      try {
-        if (typeof root.setState !== 'function') {
-          throw new Error('no setState() method');
-        }
-        root.setState(patch);
-      } catch (error) {
-        console.error(
-          `[WebUI] streaming: state update failed for <${
+      const root = boundary.roots[i];
+      if (!applyStateUpdate(root, patch)) {
+        throw new Error(
+          `<${
             root.tagName.toLowerCase()
-          }>: ${streamingErrorMessage(error)}`,
+          }> activated without a setState() method`,
         );
       }
     }

--- a/packages/webui-framework/src/streaming-deferred.ts
+++ b/packages/webui-framework/src/streaming-deferred.ts
@@ -23,6 +23,7 @@ import {
   STREAMED_HOST_ATTR,
   STREAMING_BOUNDARY_ACTIVATE,
 } from './streaming-mode.js';
+import { applyStateUpdate } from './streaming-state.js';
 
 const ACTIVATION_ACTIVATED = 1;
 const ACTIVATION_STATIC_HOST_OPT_OUT = 2;
@@ -54,14 +55,31 @@ const NO_BOUNDARY_STATE: unique symbol = Symbol();
 
 /** One boundary-owned shallow patch shared by every deferred root. */
 export interface PendingBoundaryUpdates {
+  /**
+   * Live roots only — a root joins on successful activation and never joins
+   * otherwise. `data-ws` cannot answer this: it is a work marker the
+   * coordinator strips on success, on hook throw, and on abandon alike, so its
+   * absence means "finished with", not "activated".
+   */
   readonly roots: Element[];
+  /**
+   * Marked roots seen by the checkpoint scan, including ones still deferred or
+   * destined to fail. Bounds retention pessimistically so a boundary cannot
+   * grow past its budget by activating roots after it was retained.
+   */
+  retained: number;
   pendingRoots: number;
   patch?: Record<string, unknown>;
 }
 
 export interface DeferredActivationOptions {
   updates?: PendingBoundaryUpdates;
-  retainedRoots?: Element[];
+  /**
+   * Set only by the checkpoint scan, which owns the boundary's retention
+   * budget. A late activation re-walks a subtree the scan already counted, so
+   * counting there again would charge the same roots twice.
+   */
+  countRetention?: boolean;
 }
 
 type PendingRoot = Element & {
@@ -82,13 +100,38 @@ function fail(reason: string): void {
   failureHandler(reason);
 }
 
-/** Activate one marked root or retain it behind one per-tag definition waiter. */
-export function activateElement(
+/**
+ * Deliver a replayed patch, halting when the target cannot accept one.
+ *
+ * Only successfully activated roots reach this, and `setState` is defined on
+ * `TemplateElement` itself, so a missing one means something registered a
+ * boundary activation hook without the reactive surface behind it. The
+ * coordinator has already promised this boundary an update it can no longer
+ * deliver, and a page that silently drops every future update is worse than a
+ * loud stop.
+ */
+function requireStateUpdate(
+  el: Element,
+  patch: Record<string, unknown>,
+): void {
+  if (applyStateUpdate(el, patch)) return;
+  fail(
+    `<${el.tagName.toLowerCase()}> activated without a setState() method`,
+  );
+}
+
+/**
+ * Activate one marked root or retain it behind one per-tag definition waiter.
+ *
+ * The caller has already confirmed the `STREAMED_HOST_ATTR` marker. Re-reading
+ * it here would double the attribute lookups on the boundary scan, which is the
+ * hottest loop in streaming hydration.
+ */
+function activateMarkedElement(
   el: Element,
   state: Record<string, unknown> | undefined,
   updates?: PendingBoundaryUpdates,
 ): number {
-  if (!el.hasAttribute(STREAMED_HOST_ATTR)) return ELEMENT_IGNORED;
   const tag = el.tagName.toLowerCase();
   if (tag.indexOf('-') === -1) return ELEMENT_IGNORED;
 
@@ -177,13 +220,20 @@ function activatePendingRoot(
   let updates: PendingBoundaryUpdates | undefined;
   try {
     updates = takePendingUpdates(el);
-    const state = mergePendingUpdates(takePendingState(el), updates);
+    const state = takePendingState(el);
     const outcome = invokeActivationHook(el, state);
     if (outcome === ACTIVATION_MISSING_TEMPLATE) {
       abandonDeferredDescendants(el);
       abandonDeferredElement(el);
       fail(`template metadata missing while activating <${tag}>`);
       return;
+    }
+    // Parent first, and before the descendant walk: this root's own patch may
+    // tear down the branch its retained descendants live in, and activating a
+    // root inside an already-discarded branch is worse than never reaching it.
+    if (updates) {
+      updates.roots.push(el);
+      if (updates.patch) requireStateUpdate(el, updates.patch);
     }
     const failure = activateDeferredTree(
       firstNodeWithin(el),
@@ -221,6 +271,11 @@ export function activateDeferredTree(
   state: Record<string, unknown> | undefined,
   options?: DeferredActivationOptions,
 ): string | null {
+  // Hoisted out of the walk: these are read once per node otherwise, and this
+  // loop runs over every node of every boundary.
+  const updates = options?.updates;
+  const countRetention =
+    options?.countRetention === true && updates !== undefined;
   let node = first;
   let resumeAfterDeferred: Node | null = null;
   let skippingDeferredDescendants = false;
@@ -231,17 +286,16 @@ export function activateDeferredTree(
       return `streaming boundary walk exceeds ${MAX_MARKER_SCAN_NODES} nodes`;
     }
     visited++;
-    if (node.nodeType === 1 /* ELEMENT_NODE */) {
-      const el = node as Element;
-      if (
-        options?.retainedRoots &&
-        el.hasAttribute(STREAMED_HOST_ATTR)
-      ) {
-        if (options.retainedRoots.length >= MAX_ELEMENTS_PER_BOUNDARY) {
-          return `updatable streaming boundary exceeds ${MAX_ELEMENTS_PER_BOUNDARY} roots`;
-        }
-        options.retainedRoots.push(el);
+    const isElement = node.nodeType === 1 /* ELEMENT_NODE */;
+    // One attribute read per element, shared by the retention count below and
+    // the activation call further down.
+    const marked = isElement &&
+      (node as Element).hasAttribute(STREAMED_HOST_ATTR);
+    if (countRetention && marked) {
+      if (updates.retained >= MAX_ELEMENTS_PER_BOUNDARY) {
+        return `updatable streaming boundary exceeds ${MAX_ELEMENTS_PER_BOUNDARY} roots`;
       }
+      updates.retained++;
     }
     if (
       skippingDeferredDescendants &&
@@ -251,34 +305,47 @@ export function activateDeferredTree(
       continue;
     }
     skippingDeferredDescendants = false;
-    if (node.nodeType === 1 /* ELEMENT_NODE */) {
+    if (isElement) {
       if (elements >= MAX_ELEMENTS_PER_BOUNDARY) {
         return `streaming boundary exceeds ${MAX_ELEMENTS_PER_BOUNDARY} elements`;
       }
       elements++;
-      try {
-        const outcome = activateElement(
-          node as Element,
-          state,
-          options?.updates,
-        );
-        if (outcome === ACTIVATION_MISSING_TEMPLATE) {
-          return `template metadata missing while activating <${(
-            node as Element
-          ).tagName.toLowerCase()}>`;
+      // An unmarked element is never a streaming root, so it never needs the
+      // call at all -- and in a typical boundary most elements are unmarked.
+      if (marked) {
+        const el = node as Element;
+        try {
+          const outcome = activateMarkedElement(el, state, updates);
+          if (outcome === ACTIVATION_MISSING_TEMPLATE) {
+            return `template metadata missing while activating <${
+              el.tagName.toLowerCase()
+            }>`;
+          }
+          if (outcome === ELEMENT_LIMIT_FAILURE) {
+            return `pending undefined root count exceeds ${MAX_PENDING_UNDEFINED_ROOTS}`;
+          }
+          if (outcome === ELEMENT_DEFERRED) {
+            resumeAfterDeferred = nextAfterSubtreeWithin(node, root);
+            skippingDeferredDescendants = true;
+          } else if (
+            updates &&
+            (outcome === ACTIVATION_ACTIVATED ||
+              outcome === ACTIVATION_STATIC_HOST_OPT_OUT)
+          ) {
+            // Joining here, on a known-good outcome, is what keeps a failed or
+            // ignored element out of the update set for the life of the page.
+            updates.roots.push(el);
+            // Replayed rather than merged into hydration state: `$hydrate` wires
+            // bindings against the server's bytes without evaluating them, so
+            // seeding a post-render value first would bind the old branch while
+            // the element believed it held the new one.
+            if (updates.patch) {
+              requireStateUpdate(el, updates.patch);
+            }
+          }
+        } catch (error) {
+          reportActivationFailure(el.tagName.toLowerCase(), error);
         }
-        if (outcome === ELEMENT_LIMIT_FAILURE) {
-          return `pending undefined root count exceeds ${MAX_PENDING_UNDEFINED_ROOTS}`;
-        }
-        if (outcome === ELEMENT_DEFERRED) {
-          resumeAfterDeferred = nextAfterSubtreeWithin(node, root);
-          skippingDeferredDescendants = true;
-        }
-      } catch (error) {
-        reportActivationFailure(
-          (node as Element).tagName.toLowerCase(),
-          error,
-        );
       }
     }
     node = nextWithinRoot(node, root);
@@ -358,16 +425,6 @@ function takePendingUpdates(el: Element): PendingBoundaryUpdates | undefined {
   delete store[PENDING_BOUNDARY_UPDATES];
   if (updates) updates.pendingRoots--;
   return updates;
-}
-
-function mergePendingUpdates(
-  state: Record<string, unknown> | undefined,
-  updates: PendingBoundaryUpdates | undefined,
-): Record<string, unknown> | undefined {
-  if (!updates?.patch) return state;
-  return state
-    ? { ...state, ...updates.patch }
-    : { ...updates.patch };
 }
 
 function invokeActivationHook(

--- a/packages/webui-framework/src/streaming-pipeline.test.ts
+++ b/packages/webui-framework/src/streaming-pipeline.test.ts
@@ -384,6 +384,28 @@ function predefine(...tags: string[]): void {
   for (const tag of tags) definedTags.set(tag, class {});
 }
 
+/** Patches queued for late activation accumulate in a null-prototype object
+ *  (network-supplied keys must never reach `Object.prototype`), so copy them
+ *  into plain objects before strict deep-equality assertions. Keys are defined
+ *  rather than assigned so a `__proto__` key stays an own data property instead
+ *  of silently retargeting the copy's prototype and hiding a pollution bug. */
+function plainPatches(
+  patches: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  return patches.map((patch) => {
+    const plain: Record<string, unknown> = {};
+    for (const key of Object.keys(patch)) {
+      Object.defineProperty(plain, key, {
+        value: patch[key],
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+    return plain;
+  });
+}
+
 // ── Boundary DOM builders ────────────────────────────────────────────
 
 interface BuiltBoundary {
@@ -676,7 +698,7 @@ describe('streaming coordinator pipeline', () => {
     }
   });
 
-  test('merges updates that arrive before an island definition into activation state', async () => {
+  test('replays updates that arrive before an island definition after activation', async () => {
     const activations: Array<Record<string, unknown> | undefined> = [];
     const updates: Array<Record<string, unknown>> = [];
     const weather = element('weather-panel', {
@@ -708,15 +730,154 @@ describe('streaming coordinator pipeline', () => {
     defineTag('weather-panel');
     await flush();
     assert.deepEqual(activations, [{
-      status: 'ready',
+      status: 'loading',
       location: 'Seattle',
-      forecast: 'Rain',
     }]);
-    assert.deepEqual(updates, []);
+    assert.deepEqual(
+      plainPatches(updates),
+      [{
+        status: 'ready',
+        forecast: 'Rain',
+      }],
+    );
 
     enqueue(buildMarkerless(3, 1, {}).sentinel);
     await flush();
     assert.equal(__getLifecycleStateForTests().completed, true);
+  });
+
+  test('a root whose activation fails never receives later updates', async () => {
+    const previousError = console.error;
+    const errors: string[] = [];
+    console.error = (message?: unknown) => {
+      errors.push(String(message));
+    };
+    try {
+      const brokenUpdates: Array<Record<string, unknown>> = [];
+      const healthyUpdates: Array<Record<string, unknown>> = [];
+      const broken = element('broken-panel', {
+        hook() {
+          throw new Error('activation exploded');
+        },
+        setState(state) {
+          brokenUpdates.push(state);
+        },
+      });
+      const healthy = element('healthy-panel', {
+        hook() {},
+        setState(state) {
+          healthyUpdates.push(state);
+        },
+      });
+
+      enqueue(buildUpdatableBoundary(
+        0,
+        0,
+        [broken, healthy],
+        { state: { status: 'loading' } },
+      ).sentinel);
+      await flush();
+
+      defineTag('broken-panel');
+      defineTag('healthy-panel');
+      await flush();
+
+      assert.equal(
+        errors.some((message) =>
+          message.includes('late activation failed for <broken-panel>')
+        ),
+        true,
+        'the failing activation is reported',
+      );
+
+      enqueue(buildStateUpdate(1, 0, { status: 'ready' }).sentinel);
+      await flush();
+
+      // `data-ws` is stripped on the throwing path too, so inferring liveness
+      // from its absence would deliver this update to an inert root forever.
+      assert.deepEqual(
+        brokenUpdates,
+        [],
+        'a root that never activated is not an update target',
+      );
+      assert.deepEqual(
+        plainPatches(healthyUpdates),
+        [{ status: 'ready' }],
+        'its healthy sibling still receives the patch',
+      );
+      assert.equal(__isHaltedForTests(), false);
+
+      enqueue(buildMarkerless(2, 1, {}).sentinel);
+      await flush();
+      assert.equal(__getLifecycleStateForTests().completed, true);
+      assert.deepEqual(__streamingRetentionStateForTests(), [0, 0]);
+    } finally {
+      console.error = previousError;
+    }
+  });
+
+  test('one boundary mixing live and deferred roots updates both exactly once', async () => {
+    const liveUpdates: Array<Record<string, unknown>> = [];
+    const lateUpdates: Array<Record<string, unknown>> = [];
+    const live = element('live-panel', {
+      hook() {},
+      setState(state) {
+        liveUpdates.push(state);
+      },
+    });
+    const late = element('late-panel', {
+      hook() {},
+      setState(state) {
+        lateUpdates.push(state);
+      },
+    });
+    predefine('live-panel');
+
+    enqueue(buildUpdatableBoundary(
+      0,
+      0,
+      [live, late],
+      { state: { status: 'loading' } },
+    ).sentinel);
+    await flush();
+
+    enqueue(buildStateUpdate(1, 0, { status: 'ready' }).sentinel);
+    await flush();
+    assert.deepEqual(
+      plainPatches(liveUpdates),
+      [{ status: 'ready' }],
+      'the already-defined root updates immediately',
+    );
+    assert.deepEqual(lateUpdates, [], 'the deferred root waits');
+
+    defineTag('late-panel');
+    await flush();
+    assert.deepEqual(
+      plainPatches(lateUpdates),
+      [{ status: 'ready' }],
+      'the deferred root replays the queued patch exactly once on activation',
+    );
+    assert.deepEqual(
+      plainPatches(liveUpdates),
+      [{ status: 'ready' }],
+      'activating a sibling does not re-deliver the patch to a live root',
+    );
+
+    enqueue(buildStateUpdate(2, 0, { forecast: 'Sunny' }).sentinel);
+    await flush();
+    assert.deepEqual(
+      plainPatches(liveUpdates),
+      [{ status: 'ready' }, { forecast: 'Sunny' }],
+    );
+    assert.deepEqual(
+      plainPatches(lateUpdates),
+      [{ status: 'ready' }, { forecast: 'Sunny' }],
+      'both roots converge on the same final state',
+    );
+
+    enqueue(buildMarkerless(3, 1, {}).sentinel);
+    await flush();
+    assert.deepEqual(__streamingRetentionStateForTests(), [0, 0]);
   });
 
   test('updates nested roots retained behind an undefined outer island', async () => {
@@ -761,8 +922,8 @@ describe('streaming coordinator pipeline', () => {
     defineTag('outer-panel');
     await flush();
 
-    assert.deepEqual(outerActivations, [{ status: 'ready' }]);
-    assert.deepEqual(innerActivations, [{ status: 'ready' }]);
+    assert.deepEqual(outerActivations, [{ status: 'loading' }]);
+    assert.deepEqual(innerActivations, [{ status: 'loading' }]);
     assert.deepEqual(
       __streamingRetentionStateForTests(),
       [1, 2],
@@ -771,12 +932,120 @@ describe('streaming coordinator pipeline', () => {
 
     enqueue(buildStateUpdate(2, 0, { forecast: 'Sunny' }).sentinel);
     await flush();
-    assert.deepEqual(outerUpdates, [{ forecast: 'Sunny' }]);
-    assert.deepEqual(innerUpdates, [{ forecast: 'Sunny' }]);
+    assert.deepEqual(
+      plainPatches(outerUpdates),
+      [{ status: 'ready' }, { forecast: 'Sunny' }],
+    );
+    assert.deepEqual(
+      plainPatches(innerUpdates),
+      [{ status: 'ready' }, { forecast: 'Sunny' }],
+    );
 
     enqueue(buildMarkerless(3, 1, {}).sentinel);
     await flush();
     assert.deepEqual(__streamingRetentionStateForTests(), [0, 0]);
+  });
+
+  test('a queued patch that throws degrades one root without stranding its retained descendants', async () => {
+    const previousError = console.error;
+    const errors: string[] = [];
+    console.error = (message?: unknown) => {
+      errors.push(String(message));
+    };
+    try {
+      const innerActivations: Array<Record<string, unknown> | undefined> = [];
+      const innerUpdates: Array<Record<string, unknown>> = [];
+      const inner = element('inner-panel', {
+        hook(state) {
+          innerActivations.push(state);
+        },
+        setState(state) {
+          innerUpdates.push(state);
+        },
+      });
+      // The late-defining outer island's own change handler throws while
+      // replaying the patch queued during its deferral.
+      const outer = element('outer-panel', {
+        children: [inner],
+        hook() {},
+        setState() {
+          throw new Error('boom');
+        },
+      });
+      predefine('inner-panel');
+
+      enqueue(buildUpdatableBoundary(
+        0,
+        0,
+        [outer],
+        { state: { status: 'loading' } },
+      ).sentinel);
+      await flush();
+      enqueue(buildStateUpdate(1, 0, { status: 'ready' }).sentinel);
+      await flush();
+
+      defineTag('outer-panel');
+      await flush();
+
+      assert.equal(
+        errors.some((message) =>
+          message.includes('state update failed for <outer-panel>')
+        ),
+        true,
+        'the throwing root is reported as a state-update failure',
+      );
+      assert.deepEqual(
+        innerActivations,
+        [{ status: 'loading' }],
+        'the retained descendant still activates behind the failed patch',
+      );
+      assert.deepEqual(
+        plainPatches(innerUpdates),
+        [{ status: 'ready' }],
+        'the retained descendant still receives the queued patch',
+      );
+      assert.equal(hasWs(inner), false);
+      assert.equal(__isHaltedForTests(), false);
+
+      enqueue(buildMarkerless(2, 1, {}).sentinel);
+      await flush();
+      assert.equal(__getLifecycleStateForTests().completed, true);
+    } finally {
+      console.error = previousError;
+    }
+  });
+
+  test('a dormant compiler-owned host still receives its queued patch', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    // A static host opts out of boundary-commit activation but must stay a
+    // valid update target: an explicit state write is exactly what wakes it,
+    // and the immediate commit path already writes to it.
+    const staticHost = element('static-panel', {
+      hook() {},
+      activationOutcome: 2,
+      setState(state) {
+        updates.push(state);
+      },
+    });
+
+    enqueue(buildUpdatableBoundary(
+      0,
+      0,
+      [staticHost],
+      { state: { status: 'loading' } },
+    ).sentinel);
+    await flush();
+    enqueue(buildStateUpdate(1, 0, { status: 'ready' }).sentinel);
+    await flush();
+    assert.deepEqual(updates, [], 'the patch waits while the tag is undefined');
+
+    defineTag('static-panel');
+    await flush();
+    assert.deepEqual(plainPatches(updates), [{ status: 'ready' }]);
+
+    enqueue(buildMarkerless(2, 1, {}).sentinel);
+    await flush();
+    assert.equal(__getLifecycleStateForTests().completed, true);
   });
 
   test('rejects state updates for final boundaries', async () => {

--- a/packages/webui-framework/src/streaming-state.ts
+++ b/packages/webui-framework/src/streaming-state.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Shared application path for streamed state updates.
+ *
+ * An update never rehydrates: it drives the same reactive `setState()` a
+ * browser-side caller would use. Both the immediate commit path and the queued
+ * patch a late-defining island replays after activation land here, so every
+ * root converges on the same final state regardless of when its definition
+ * arrived. Convergence is the guarantee, not call-for-call equivalence: a root
+ * that was live throughout observes each update as it commits, while a root
+ * retained behind an undefined ancestor observes one collapsed patch.
+ */
+
+import { streamingErrorMessage } from './streaming-dom.js';
+
+type StateRoot = Element & {
+  setState?: (state: Record<string, unknown>) => void;
+};
+
+/**
+ * Apply one shallow patch to an activated root, isolating per-root failure.
+ *
+ * An application component's own setter or change handler throwing degrades
+ * that root alone. Rethrowing would let one app-level bug strand every later
+ * boundary on the page, so the failure is reported and the caller continues.
+ *
+ * Returns `false` only when the target has no `setState` at all. That is a
+ * framework invariant violation rather than an application error, so the
+ * decision to halt belongs to the caller that owns the stream.
+ */
+export function applyStateUpdate(
+  el: Element,
+  patch: Record<string, unknown>,
+): boolean {
+  const root = el as StateRoot;
+  if (typeof root.setState !== 'function') return false;
+  try {
+    root.setState(patch);
+  } catch (error) {
+    console.error(
+      `[WebUI] streaming: state update failed for <${
+        root.tagName.toLowerCase()
+      }>: ${streamingErrorMessage(error)}`,
+    );
+  }
+  return true;
+}


### PR DESCRIPTION
Follow-up to #409. Reloading the streaming example intermittently produced a page missing its streamed content, or no page at all. Three independent defects were behind it: one on each side of the boundary protocol, and one in how the coordinator decided a root was still alive.

## A queued update lost to the markup it was meant to replace

A boundary whose update arrives while its root is still retained behind an undefined ancestor had that patch merged into hydration state at activation. The SSR host attribute won that merge, so a server-rendered `status="loading"` outranked the queued `status="ready"` and the island stayed in its loading state permanently.

The patch is now replayed through `setState()` after activation, on the same path a browser-side caller uses, so it lands as the post-hydration update it always was.

Worth calling out, because it was my first instinct and it is wrong: merging into hydration state cannot work here. Hydration deliberately wires bindings *without* evaluating them, because the SSR DOM is trusted. A pre-seeded value would bind the branch the markup already shows while the element believed it held the new one, and the next equal-valued write would compare equal and skip the DOM patch entirely. That fails silently and never recovers. Replay is parent-first, because a parent's patch can tear down the branch its retained descendants live in, and outcome-gated, so a root that failed to activate never receives one.

## Liveness was inferred from a work marker

`data-ws` means "this root still needs activation". It is stripped on three different outcomes: successful activation, a throwing activation hook, and explicit abandonment. Reading its absence as "this root is live" left a root whose activation had *failed and been isolated* as an update target for the rest of the page's life.

A boundary now holds only roots that activated successfully. A root joins on success and never otherwise, so liveness is never re-derived from the DOM. Two side benefits: the update loop drops a per-root attribute probe and touches no DOM at all, and dead element references stop being retained for the life of the page. The retention budget is charged separately at scan time, so activating a root after its boundary was retained cannot grow it past its bound.

## A refused stream was proxied instead of degraded

The dev server passed a non-success status from a streaming backend straight through as `text/plain`. Every other backend failure already degrades: an unreachable API, a connection error, and an unparseable body all warn and render from fallback state. Only the streaming path hard-failed, which inverted the severity ordering, so an API that was completely down produced a working page while a transient 503 produced a blank one.

A refused request is an *acquisition* failure: no record was written and no boundary reached the browser, so rule 19 does not apply and the response can still render as a buffered page. A failure after the stream is live still fails the response, because committed boundaries cannot be rewound.

## Testing

Reload recovery is now covered end to end in the streaming example: a sweep across the island module timing band, a reload that interrupts a stream that is still open, rapid consecutive reloads, and a refused stream that must still render a usable app.

The four timing-band tests fail against the previous behaviour with the island stuck at `status="loading"`, which is exactly the reported symptom. Framework-level regression tests cover the failed-activation case and a boundary mixing live and deferred roots.

Writing the E2E tests surfaced two defects in the example's own test harness, both fixed here:

- The test session table refused every new session once it was full. Playwright reuses a running API across runs, so the suite silently began failing unrelated tests on a 400 after a few hundred sessions. It now evicts the oldest session, and opens that session's gates on the way out so an orphaned stream gives its concurrency slot back.
- The refusal path was only reachable by saturating the server. It is now reachable deterministically through a test-only flag that returns the same response the capacity guard sends, which also decouples the example's concurrency cap from its tests.

Verified with `cargo xtask check`, the framework unit suite and Playwright fixtures, and the streaming example suite run repeatedly against a reused server to confirm the harness no longer degrades.
