### PR TITLE
chore: bump version to 0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "actix-web",
  "awc",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "cbindgen",
  "criterion",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "criterion",
  "memchr",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "clap",
  "criterion",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "criterion",
  "prost",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2739,28 +2739,47 @@ runtime dependency.
 
 ### Package architecture
 
-The `@microsoft/webui` package exposes one build-only subpath:
+The `@microsoft/webui` package exposes focused build-only subpaths:
 
 ```typescript
-import { compileProjection, esbuildProjection } from '@microsoft/webui/projection.js';
+import {
+  compileProjection,
+  ProjectionSession,
+} from '@microsoft/webui/projection/core.js';
+import { esbuildProjection } from '@microsoft/webui/projection/esbuild.js';
+import { rspackProjection } from '@microsoft/webui/projection/rspack.js';
+import { runConformanceSuite } from '@microsoft/webui/projection/testing.js';
 ```
 
 The root `@microsoft/webui` entry does **not** import or re-export the
 projection subpath so that render/build consumers do not load compiler or
 adapter code.
 
+`@microsoft/webui/projection.js` remains a backward-compatible facade that
+re-exports core, testing, and esbuild symbols. New integrations use the focused
+subpaths so bundler-specific types never enter the core declaration graph.
+Rspack remains isolated to its dedicated subpath and is not added to the legacy
+facade.
+
 Internal source organization:
 
 ```text
 packages/webui/src/projection/
   index.ts          — public subpath barrel
+  core.ts           — bundler-neutral public compiler/finalizer barrel
+  esbuild.ts        — esbuild-only public adapter barrel
+  rspack.ts         — Rspack-only public adapter barrel
+  testing.ts        — adapter conformance public barrel
   compiler.ts       — TypeScript AST analysis and symbol graph
   graph.ts          — normalized module graph types and adapter SPI
   manifest.ts       — manifest schema types and serialization
-  loader.ts         — manifest loading and filesystem validation
+  loader.ts         — lazy TypeScript/compiler loading and peer diagnostics
+  session.ts        — shared compile/serialize/atomic-finalize lifecycle
   diagnostics.ts    — stable diagnostic codes and error types
   adapters/
     esbuild.ts      — supported esbuild adapter
+    rspack.ts       — supported Rspack adapter
+    shared.ts       — filesystem, package, path, and version helpers
   fixtures/
     conformance.ts  — adapter conformance test helpers and reference cases
 ```
@@ -2772,26 +2791,30 @@ implementation and the Rust manifest consumer must satisfy.
 ### Optional peer dependency policy
 
 `typescript` and each officially supported bundler are optional peer
-dependencies of `@microsoft/webui`. The supported bundler is esbuild:
+dependencies of `@microsoft/webui`. The supported bundlers are esbuild and
+Rspack:
 
 ```json
 {
   "peerDependencies": {
+    "@rspack/core": "^2.0.1",
     "esbuild": "^0.28.1",
     "typescript": "^6.0.3"
   },
   "peerDependenciesMeta": {
+    "@rspack/core": { "optional": true },
     "esbuild": { "optional": true },
     "typescript": { "optional": true }
   }
 }
 ```
 
-**`esbuild` must not be a direct dependency and must not be bundled into
-`@microsoft/webui`.** The application owns the esbuild installation and version.
-Importing or invoking `@microsoft/webui/projection.js` without the required
-peer produces an actionable diagnostic (`PROJ-P001`/`PROJ-P002`; see
-[Diagnostic codes](#projection-diagnostic-codes)).
+**Bundlers must not be direct dependencies or be bundled into
+`@microsoft/webui`.** The application owns the bundler installation and version.
+Invoking a focused adapter with an unsupported peer produces an actionable
+diagnostic (`PROJ-P002` for esbuild and `PROJ-P004` for Rspack; see
+[Diagnostic codes](#projection-diagnostic-codes)). Compiler loading uses
+`PROJ-P001` for an unsupported TypeScript peer.
 
 Both peers are optional so users importing only the root build/render API do
 not receive dependency warnings for compiler tooling they do not use.
@@ -2901,8 +2924,8 @@ parsed as projection semantics.
 2. Populate `ModuleGraph`, retaining specifier-to-resolved-target edges.
 3. Populate `OutputMembership` from the bundler's emitted output→input map.
 4. Provide raw source text and exact emitted output bytes.
-5. Invoke `compileProjection(ctx)` (see below).
-6. Write the returned `ProjectionManifest` atomically to `manifestPath`.
+5. Invoke `ProjectionSession.finalize(ctx)`.
+6. Translate projection diagnostics into the bundler's native error model.
 
 **Compiler responsibilities (not adapter responsibilities):**
 
@@ -2912,6 +2935,55 @@ parsed as projection semantics.
 - `define()` association.
 - Manifest serialization.
 - Diagnostic reporting.
+
+### Projection finalization session
+
+`ProjectionSession` is the shared lifecycle around a complete immutable
+`AdapterContext`:
+
+```typescript
+const session = new ProjectionSession();
+const manifest = await session.finalize(context);
+```
+
+It preloads the TypeScript-backed compiler, serializes overlapping finalizations
+in invocation order, calls the pure `compileProjection()` function, writes the
+canonical compact JSON to a temporary file in the manifest directory, syncs and
+closes that file, then atomically renames it over the previous manifest. A
+compile or temporary-write failure leaves the previous manifest intact, and a
+later watch rebuild may reuse the same session.
+
+The session never owns bundler hooks, graph/source/output collection,
+manifest-path or build-root derivation, package resolution, bundler version
+validation, native diagnostic formatting, or cross-build graph caches. Adapters
+must invoke `finalize()` in compilation order.
+
+### Bundler adapter portability limit
+
+The normalized context is reusable; bundler plugin objects are not. An esbuild
+`Plugin` uses `setup()` and esbuild callbacks, while Rspack uses
+`apply(compiler)` and Tapable hooks. A generic wrapper can share registration
+convenience but cannot create graph facts the underlying bundler does not expose.
+
+An official adapter is conformant only when supported bundler APIs prove:
+
+1. every authored import/re-export specifier and its exact resolved target;
+2. the exact analyzable source used by that compilation;
+3. final post-tree-shake output-to-original-module membership, including
+   concatenated modules and multiple asset kinds;
+4. exact final output bytes.
+
+Rspack 2.x exposes the required facts through supported compilation objects.
+The adapter reads authored requests and targets from `module.dependencies` plus
+`moduleGraph`, expands every `ConcatenatedModule.modules` wrapper found in
+`chunkGraph` membership, and reads final asset sources in `afterEmit`. Duplicate
+`esm import` and `esm import specifier` records are collapsed by authored
+request, preferring a resolved base edge. Physical source is read from the
+resolved resource because `NormalModule.originalSource()` is loader-transformed.
+Virtual IDs use `libIdent({ context })` and never embed the workspace root.
+
+The adapter does not use experimental Rsdoctor hooks, chunk/file cross-products,
+emitted-code parsing, or resolution heuristics.
 
 ### TypeScript AST semantic rules
 
@@ -3506,6 +3578,7 @@ No color in diagnostic data; color is added only by `webui-cli` output layer.
 | `PROJ-P001` | error | Required peer `typescript` is absent or below the supported range |
 | `PROJ-P002` | error | Required peer `esbuild` is absent or below the supported range (esbuild adapter only) |
 | `PROJ-P003` | warning | Peer is present but above the tested range; results may differ |
+| `PROJ-P004` | error | Required peer `@rspack/core` is absent or below the supported range (Rspack adapter only) |
 
 #### Manifest diagnostics (PROJ-M*)
 
@@ -3563,6 +3636,12 @@ The Rust manifest consumer enforces the following before parsing manifest JSON:
 
 The canonical conformance test helpers and reference cases live in
 `packages/webui/src/projection/fixtures/conformance.ts`.
+
+These fixtures validate compiler behavior after an `AdapterContext` has been
+constructed. They do not prove that a real bundler adapter extracted exact
+native graph facts. Every official adapter additionally requires black-box
+bundler tests for resolution aliases, externals, tree shaking, code splitting,
+concatenation, output bytes, watch failure/recovery, and optional-peer isolation.
 
 #### Required fixture scenarios
 
@@ -3710,9 +3789,10 @@ The esbuild adapter:
    files during `onEnd` for `write: true` (esbuild has completed writes before
    `onEnd`).
 8. Chooses the common ancestor of the manifest, physical inputs, and outputs
-   as `rootDir`, constructs `AdapterContext`, and calls the shared compiler.
-9. Writes canonical compact JSON to a same-directory temporary file, flushes
-   it, and atomically renames it over the manifest.
+   as `rootDir`, constructs `AdapterContext`, and calls
+   `ProjectionSession.finalize()`.
+9. The shared session writes canonical compact JSON to a same-directory
+   temporary file, flushes it, and atomically renames it over the manifest.
 10. If the build or projection compiler has errors, the manifest is **not**
    written. An existing stale
    manifest from a prior run is left in place (not deleted).
@@ -3724,6 +3804,66 @@ A single `esbuild.build()` call with `metafile: true` and code splitting is
 fully supported. External components are absent from the application fragment
 and produce their own fragment when built separately with the same adapter.
 The adapter handles all outputs in one `onEnd` pass.
+
+### Rspack adapter specification
+
+The Rspack adapter is implemented in
+`packages/webui/src/projection/adapters/rspack.ts` and exported only from
+`@microsoft/webui/projection/rspack.js`.
+
+```typescript
+import type { Compilation, Compiler } from '@rspack/core';
+
+export interface RspackProjectionOptions {
+  /** Defaults to `<output.path>/webui-projection.json`. */
+  manifest?: string;
+  /**
+   * Runs after the manifest is atomically installed. Rspack awaits the result.
+   */
+  afterManifest?: (result: RspackProjectionResult) => void | Promise<void>;
+}
+
+export interface RspackProjectionResult {
+  readonly manifest: ProjectionManifest;
+  readonly context: AdapterContext;
+  readonly manifestPath: string;
+  readonly compiler: Compiler;
+  readonly compilation: Compilation;
+}
+
+export function rspackProjection(
+  options?: RspackProjectionOptions
+): { apply(compiler: Compiler): void };
+```
+
+The Rspack adapter:
+
+1. Validates `compiler.rspack.rspackVersion` against `^2.0.1`
+   (`PROJ-P004`) and keeps one `ProjectionSession` per compiler for watch
+   rebuild ordering and recovery.
+2. Groups original module instances by canonical physical or virtual ID.
+   `ConcatenatedModule` wrappers never become graph nodes.
+3. Walks `module.dependencies` and nested `AsyncDependenciesBlock` values
+   iteratively. Duplicate base/specifier records collapse by authored request
+   and static/dynamic kind; a resolved target wins over an unresolved duplicate,
+   then a base dependency wins over a specifier record.
+4. Marks `ExternalModule` targets external and proves bundled package identity
+   from the resolved file's nearest `package.json`.
+5. Reads authored UTF-8 disk source for physical modules. Loader-transformed
+   `originalSource()` is used only for virtual modules, whose IDs come from
+   root-relative `libIdent({ context })`.
+6. Expands concatenation wrappers from each chunk iteratively and assigns their
+   original modules only to JavaScript files in that chunk. Code-split chunks
+   therefore retain independent component ownership.
+7. Hashes exact final `compilation.getAsset(name).source.buffer()` bytes in
+   `afterEmit`; it never re-reads emitted JavaScript from disk.
+8. Preserves an existing manifest as a marked compilation asset before
+   `output.clean`, removes that temporary asset from the compilation view after
+   emit, then calls `ProjectionSession.finalize()` only after a successful emit.
+   A projection failure leaves the previous valid manifest intact.
+9. Awaits `afterManifest` after atomic installation. This is the sequencing
+   point for rebuilding `protocol.bin` with `--projection-manifest` before a
+   dependent SSR build. Callback rejection becomes a Rspack compilation error.
 
 ### webui-press integration
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3846,7 +3846,8 @@ The Rspack adapter:
 3. Walks `module.dependencies` and nested `AsyncDependenciesBlock` values
    iteratively. Duplicate base/specifier records collapse by authored request
    and static/dynamic kind; a resolved target wins over an unresolved duplicate,
-   then a base dependency wins over a specifier record.
+   then a base dependency wins over a specifier record. A remaining targetless
+   record is omitted because Rspack pruned it from the compiled graph.
 4. Marks `ExternalModule` targets external and proves bundled package identity
    from the resolved file's nearest `package.json`.
 5. Reads authored UTF-8 disk source for physical modules. Loader-transformed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3866,6 +3866,10 @@ The Rspack adapter:
    point for rebuilding `protocol.bin` with `--projection-manifest` before a
    dependent SSR build. Callback rejection becomes a Rspack compilation error.
 
+The protocol build and SSR runtime must use the same `@microsoft/webui` release.
+Cross-release protocol compatibility is not guaranteed, so split client/compiler
+and SSR deployments update atomically.
+
 ### webui-press integration
 
 `webui-press` invokes esbuild's JavaScript API once through

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.22", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.22" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.22" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.22" }
+microsoft-webui = { path = "../webui", version = "0.0.23", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.23" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -43,7 +43,7 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.23" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.22" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -30,7 +30,7 @@ cbindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
 
 [[bench]]
 name = "protocol_bench"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,17 +15,17 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.22" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.23" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.23" }
 memchr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.22" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.22" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.22" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22", features = ["projection-manifest"] }
+microsoft-webui = { path = "../webui", version = "0.0.23" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.22", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,8 +26,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.22" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,10 +19,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.22", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.22" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.22" }
+microsoft-webui = { path = "../webui", version = "0.0.23", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.22" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.23" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.22" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.22", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,11 +18,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.22" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22", features = ["projection-manifest"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.22" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.22" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -44,8 +44,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.22" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.22", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1085,7 +1085,9 @@ Add `@microsoft/webui-router` for client-side navigation. Passing
 Generate the manifest from the same client compilation with
 `esbuildProjection()` or `rspackProjection()`. For Rspack, use the awaited
 `afterManifest` callback to rebuild `protocol.bin` before a dependent SSR bundle
-runs. See [Hydration](/guide/concepts/hydration#build-time-state-projection).
+runs. Use the same `@microsoft/webui` release for the protocol build and SSR
+runtime, updating split pipelines atomically. See
+[Hydration](/guide/concepts/hydration#build-time-state-projection).
 
 ## Server integration
 

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1082,6 +1082,10 @@ Full flag tables, exit codes, and the error-code list:
 Add `@microsoft/webui-router` for client-side navigation. Passing
 `--projection-manifest` narrows hydration state to exactly the `@observable` and
 `@attr` fields your bundle uses; omitting it keeps full state.
+Generate the manifest from the same client compilation with
+`esbuildProjection()` or `rspackProjection()`. For Rspack, use the awaited
+`afterManifest` callback to rebuild `protocol.bin` before a dependent SSR bundle
+runs. See [Hydration](/guide/concepts/hydration#build-time-state-projection).
 
 ## Server integration
 

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -268,9 +268,8 @@ TypeScript. The application bundles its browser code first, and a bundler
 adapter emits `webui-projection.json` from the same resolved graph and output
 membership that produced the browser chunks.
 
-The projection compiler contract is bundler-neutral. The
-`@microsoft/webui/projection.js` subpath currently includes the supported
-esbuild adapter:
+The projection compiler contract is bundler-neutral. WebUI ships supported
+esbuild and Rspack adapters. With esbuild:
 
 ```bash
 npm install -D esbuild typescript
@@ -279,7 +278,7 @@ npm install -D esbuild typescript
 ```js
 // build-client.mjs
 import * as esbuild from 'esbuild';
-import { esbuildProjection } from '@microsoft/webui/projection.js';
+import { esbuildProjection } from '@microsoft/webui/projection/esbuild.js';
 
 await esbuild.build({
   entryPoints: ['src/index.ts'],
@@ -363,10 +362,40 @@ The adapter runs inside the application's existing esbuild invocation. It does
 not start a second bundler run, and it does not constrain chunking, dynamic
 imports, external modules, or output naming.
 
-Other bundlers are not coupled to esbuild. A Vite, Rollup, Rolldown, webpack,
-Rspack, or other adapter can construct the exported `AdapterContext`, call
-`compileProjection()`, and run the exported conformance suite. The official
-package currently ships and supports the esbuild adapter.
+For Rspack 2.x, use its native adapter:
+
+```typescript
+import { rspackProjection } from '@microsoft/webui/projection/rspack.js';
+import { rebuildProtocol } from './build-protocol.js';
+
+export default {
+  plugins: [
+    rspackProjection({
+      manifest: './dist/webui-projection.json',
+      afterManifest: ({ manifestPath }) =>
+        rebuildProtocol({ projectionManifest: manifestPath }),
+    }),
+  ],
+};
+```
+
+The Rspack adapter reads the actual dependency and chunk graphs, expands
+concatenated wrappers, removes duplicate import records, handles externals,
+retains code-split output membership, canonicalizes package and virtual module
+identity, and hashes exact in-memory asset bytes after emit.
+
+`afterManifest` runs after atomic manifest replacement and is awaited by Rspack.
+Use it to rebuild `protocol.bin` with that manifest before a dependent SSR
+bundle runs. A rejected callback fails the compilation.
+
+Bundler plugins remain non-interchangeable: an esbuild plugin cannot be passed
+to Rspack, and a generic Unplugin wrapper does not expose the exact final graph
+facts required by projection. Other adapter authors import the normalized
+contract and finalizer from `@microsoft/webui/projection/core.js`, then run the
+fixtures from `@microsoft/webui/projection/testing.js`. `ProjectionSession`
+compiles and atomically writes a complete `AdapterContext`; it never infers
+missing bundler facts. Without a conformant adapter, omit the projection
+manifest and WebUI preserves full state.
 
 ## State Sent to the Browser
 

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -388,6 +388,10 @@ identity, and hashes exact in-memory asset bytes after emit.
 Use it to rebuild `protocol.bin` with that manifest before a dependent SSR
 bundle runs. A rejected callback fails the compilation.
 
+The protocol build and SSR runtime must use the same `@microsoft/webui` release.
+Update split client/compiler and SSR dependencies atomically rather than serving
+a newly compiled protocol with an older runtime.
+
 Bundler plugins remain non-interchangeable: an esbuild plugin cannot be passed
 to Rspack, and a generic Unplugin wrapper does not expose the exact final graph
 facts required by projection. Other adapter authors import the normalized

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.22</Version>
+    <Version>0.0.23</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration and compiled-template path mapping.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.22"
+  "version": "0.0.23"
 }

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -170,6 +170,10 @@ Use it to rebuild `protocol.bin` with the new manifest before starting a
 dependent SSR bundle. If the callback rejects, the compilation fails. The
 callback receives `{ manifest, context, manifestPath, compiler, compilation }`.
 
+The protocol build and SSR runtime must use the same `@microsoft/webui` release.
+Update split client/compiler and SSR dependencies atomically rather than serving
+a newly compiled protocol with an older runtime.
+
 With no manifest, WebUI performs no JavaScript analysis and preserves full
 state. Once any manifest is supplied, coverage is strict: every scripted
 component compiled into the protocol must have exactly one entry. Shared

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -72,18 +72,31 @@ Misspelled literal-fallback tokens are returned as non-fatal warnings.
 
 ### Optional state projection
 
-The build-only `@microsoft/webui/projection.js` subpath exposes the
-bundler-neutral projection compiler and the supported esbuild adapter. esbuild
-and TypeScript are optional peer dependencies, so applications that do not use
-projection do not install or load them:
+The build-only projection subpaths keep the bundler-neutral compiler separate
+from bundler adapters:
+
+| Subpath | Purpose |
+|---|---|
+| `@microsoft/webui/projection/core.js` | `AdapterContext`, compiler, manifest API, and `ProjectionSession` |
+| `@microsoft/webui/projection/esbuild.js` | Supported esbuild adapter |
+| `@microsoft/webui/projection/rspack.js` | Supported Rspack adapter |
+| `@microsoft/webui/projection/testing.js` | Shared conformance fixtures for adapter authors |
+| `@microsoft/webui/projection.js` | Backward-compatible core + esbuild facade |
+
+esbuild, Rspack, and TypeScript are optional peer dependencies, so applications
+install only the peers used by their selected adapter:
 
 ```bash
 npm install -D esbuild typescript
 ```
 
+The compatible `@microsoft/webui/projection.js` facade does not export Rspack.
+Importing the focused Rspack subpath keeps projects without `@rspack/core`
+unaffected.
+
 ```js
 import * as esbuild from "esbuild";
-import { esbuildProjection } from "@microsoft/webui/projection.js";
+import { esbuildProjection } from "@microsoft/webui/projection/esbuild.js";
 
 await esbuild.build({
   entryPoints: ["src/index.ts"],
@@ -107,10 +120,55 @@ surfaces into `protocol.bin`. The adapter uses esbuild's resolved graph and
 emitted output membership, so code splitting, dynamic imports, output hashes,
 and external bundles remain application-owned.
 
-Other bundler adapters can use the exported `AdapterContext`,
-`compileProjection()`, and conformance fixtures without importing esbuild. The
-package currently ships and supports `esbuildProjection()` as its official
-adapter.
+Other bundler adapters can construct an exact `AdapterContext` and use the
+shared finalization lifecycle without importing esbuild:
+
+```js
+import { ProjectionSession } from "@microsoft/webui/projection/core.js";
+
+const session = new ProjectionSession();
+await session.finalize(context);
+```
+
+`ProjectionSession` compiles, canonically serializes, and atomically replaces
+the manifest. The adapter still owns graph extraction, path/root derivation,
+bundler version checks, and native diagnostic presentation. Import
+`runConformanceSuite` from `@microsoft/webui/projection/testing.js` to verify the
+normalized compiler contract.
+
+An esbuild plugin cannot be passed to Rspack because their plugin APIs differ,
+so WebUI provides a native Rspack adapter:
+
+```bash
+npm install -D @rspack/core@^2.0.1 typescript
+```
+
+```typescript
+import { fileURLToPath } from 'node:url';
+import { rspackProjection } from '@microsoft/webui/projection/rspack.js';
+import { rebuildProtocol } from './build-protocol.js';
+
+export default {
+  output: { path: fileURLToPath(new URL('./dist', import.meta.url)) },
+  plugins: [
+    rspackProjection({
+      manifest: './dist/webui-projection.json',
+      afterManifest: ({ manifestPath }) =>
+        rebuildProtocol({ projectionManifest: manifestPath }),
+    }),
+  ],
+};
+```
+
+The adapter reads Rspack 2.x's dependency graph, expands concatenated modules,
+preserves code-split chunk membership, and hashes exact in-memory asset bytes
+after emit. It canonicalizes package identity and virtual IDs, handles
+externals, and removes duplicate dependency records without parsing output text.
+
+`afterManifest` runs after atomic manifest replacement and is awaited by Rspack.
+Use it to rebuild `protocol.bin` with the new manifest before starting a
+dependent SSR bundle. If the callback rejects, the compilation fails. The
+callback receives `{ manifest, context, manifestPath, compiler, compilation }`.
 
 With no manifest, WebUI performs no JavaScript analysis and preserves full
 state. Once any manifest is supplied, coverage is strict: every scripted

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -23,7 +23,7 @@
     "build": "tsc",
     "postbuild": "node dist/install.js",
     "postinstall": "node --input-type=module -e \"try{await import('./dist/install.js')}catch{}\"",
-    "test": "tsc --project tsconfig.test.json && node --test dist/test/integration.test.js dist/test/native-addon-loading.test.js dist/test/projection-conformance.test.js dist/test/projection-compiler.test.js dist/test/projection-esbuild.test.js dist/test/projection-peers.test.js"
+    "test": "tsc --project tsconfig.test.json && node --test dist/test/integration.test.js dist/test/native-addon-loading.test.js dist/test/projection-conformance.test.js dist/test/projection-compiler.test.js dist/test/projection-esbuild.test.js dist/test/projection-peers.test.js dist/test/projection-session.test.js dist/test/projection-rspack.test.js"
   },
   "engines": {
     "node": ">=18"
@@ -46,6 +46,30 @@
         "types": "./dist/projection/index.d.ts",
         "default": "./dist/projection/index.js"
       }
+    },
+    "./projection/core.js": {
+      "import": {
+        "types": "./dist/projection/core.d.ts",
+        "default": "./dist/projection/core.js"
+      }
+    },
+    "./projection/esbuild.js": {
+      "import": {
+        "types": "./dist/projection/esbuild.d.ts",
+        "default": "./dist/projection/esbuild.js"
+      }
+    },
+    "./projection/rspack.js": {
+      "import": {
+        "types": "./dist/projection/rspack.d.ts",
+        "default": "./dist/projection/rspack.js"
+      }
+    },
+    "./projection/testing.js": {
+      "import": {
+        "types": "./dist/projection/testing.d.ts",
+        "default": "./dist/projection/testing.js"
+      }
     }
   },
   "optionalDependencies": {
@@ -57,10 +81,14 @@
     "@microsoft/webui-win32-x64": "workspace:*"
   },
   "peerDependencies": {
+    "@rspack/core": "^2.0.1",
     "esbuild": "^0.28.1",
     "typescript": "^6.0.3"
   },
   "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
     "esbuild": {
       "optional": true
     },
@@ -69,6 +97,7 @@
     }
   },
   "devDependencies": {
+    "@rspack/core": "catalog:",
     "@types/node": "catalog:",
     "esbuild": "catalog:",
     "typescript": "catalog:"

--- a/packages/webui/src/projection/adapters/esbuild.ts
+++ b/packages/webui/src/projection/adapters/esbuild.ts
@@ -9,11 +9,7 @@
  */
 
 import {
-  mkdir,
-  open,
   readFile,
-  rename,
-  rm,
 } from "node:fs/promises";
 import * as path from "node:path";
 import type {
@@ -34,14 +30,19 @@ import {
   createDiagnostic,
 } from "../diagnostics.js";
 import type { ProjectionDiagnostic } from "../diagnostics.js";
+import { compareUtf8 } from "../manifest.js";
+import { ProjectionSession } from "../session.js";
 import {
-  compareUtf8,
-  serializeManifestCanonical,
-} from "../manifest.js";
-import {
-  compileProjection,
-  preloadProjectionCompiler,
-} from "../loader.js";
+  adapterError,
+  commonAncestor,
+  comparePaths,
+  nearestPackageName,
+  packageNameFromSpecifier,
+  parseVersion,
+  pathKey,
+  readPhysicalSource,
+  samePath,
+} from "./shared.js";
 
 /** Configuration for the official esbuild projection adapter. */
 export interface EsbuildProjectionOptions {
@@ -62,8 +63,6 @@ interface InputRecord {
   readonly packageName: string | undefined;
 }
 
-let temporaryFileSequence = 0;
-
 /** Create the official esbuild projection plugin. */
 export function esbuildProjection(
   options: EsbuildProjectionOptions = {}
@@ -73,12 +72,9 @@ export function esbuildProjection(
     setup(build) {
       build.initialOptions.metafile = true;
       const versionError = validateEsbuildVersion(build.esbuild.version);
-      const compilerLoad = versionError
-        ? Promise.resolve(undefined)
-        : preloadProjectionCompiler().then(
-            () => undefined,
-            (error: unknown) => error
-          );
+      const session = versionError
+        ? undefined
+        : new ProjectionSession();
       if (versionError) {
         build.onStart(() => ({
           errors: [diagnosticMessage(versionError)],
@@ -86,11 +82,9 @@ export function esbuildProjection(
       }
 
       build.onEnd(async (result) => {
-        if (result.errors.length > 0 || versionError) return;
+        if (result.errors.length > 0 || versionError || !session) return;
         try {
-          const compilerError = await compilerLoad;
-          if (compilerError !== undefined) throw compilerError;
-          await emitProjectionManifest(build, result, options);
+          await emitProjectionManifest(build, result, options, session);
         } catch (error: unknown) {
           return {
             errors: errorMessages(error),
@@ -104,7 +98,8 @@ export function esbuildProjection(
 async function emitProjectionManifest(
   build: PluginBuild,
   result: BuildResult,
-  options: EsbuildProjectionOptions
+  options: EsbuildProjectionOptions,
+  session: ProjectionSession
 ): Promise<void> {
   const profile = process.env["WEBUI_PROJECTION_PROFILE"] === "1";
   const profileStart = profile ? performance.now() : 0;
@@ -179,16 +174,11 @@ async function emitProjectionManifest(
     bundlerName: "esbuild",
     bundlerVersion: build.esbuild.version,
   };
-  const manifest = await compileProjection(context);
-  const compiled = profile ? performance.now() : 0;
-  await writeAtomic(
-    manifestPath,
-    serializeManifestCanonical(manifest)
-  );
+  await session.finalize(context);
   if (profile) {
     const finished = performance.now();
     console.error(
-      `[webui-projection] graph=${(graphReady - profileStart).toFixed(1)}ms compile=${(compiled - graphReady).toFixed(1)}ms write=${(finished - compiled).toFixed(1)}ms total=${(finished - profileStart).toFixed(1)}ms`
+      `[webui-projection] graph=${(graphReady - profileStart).toFixed(1)}ms finalize=${(finished - graphReady).toFixed(1)}ms total=${(finished - profileStart).toFixed(1)}ms`
     );
   }
 }
@@ -295,18 +285,6 @@ async function loadInputRecords(
     );
   }
   return resolved;
-}
-
-async function readPhysicalSource(
-  filePath: string
-): Promise<string | undefined> {
-  try {
-    const bytes = await readFile(filePath);
-    return bytes.toString("utf8");
-  } catch (error: unknown) {
-    if (isMissingFile(error)) return undefined;
-    throw error;
-  }
 }
 
 function sourceForStdin(
@@ -491,141 +469,8 @@ async function loadOutputContents(
   return contents;
 }
 
-async function nearestPackageName(
-  filePath: string,
-  cache: Map<string, string | undefined>
-): Promise<string | undefined> {
-  let directory = path.dirname(filePath);
-  const visited: string[] = [];
-  while (true) {
-    if (cache.has(directory)) {
-      const cached = cache.get(directory);
-      for (const value of visited) cache.set(value, cached);
-      return cached;
-    }
-    visited.push(directory);
-    const packagePath = path.join(directory, "package.json");
-    try {
-      const text = await readFile(packagePath, "utf8");
-      const parsed = JSON.parse(text) as { name?: unknown };
-      const name =
-        typeof parsed.name === "string" && parsed.name.length > 0
-          ? parsed.name
-          : undefined;
-      for (const value of visited) cache.set(value, name);
-      return name;
-    } catch (error: unknown) {
-      if (!isMissingFile(error)) {
-        throw adapterError(
-          `could not read package identity from '${packagePath}'`,
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-    }
-    const parent = path.dirname(directory);
-    if (parent === directory) {
-      for (const value of visited) cache.set(value, undefined);
-      return undefined;
-    }
-    directory = parent;
-  }
-}
-
-function packageNameFromSpecifier(
-  specifier: string
-): string | undefined {
-  if (
-    specifier.length === 0 ||
-    specifier.startsWith(".") ||
-    specifier.startsWith("/") ||
-    path.isAbsolute(specifier)
-  ) {
-    return undefined;
-  }
-  const segments = specifier.split("/");
-  if (specifier.startsWith("@")) {
-    return segments.length >= 2
-      ? `${segments[0]}/${segments[1]}`
-      : undefined;
-  }
-  return segments[0];
-}
-
 function virtualModuleId(metafileId: string): string {
   return `\0esbuild:${metafileId}`;
-}
-
-function commonAncestor(paths: ReadonlyArray<string>): string {
-  if (paths.length === 0) {
-    throw adapterError(
-      "esbuild produced no physical projection artifacts",
-      "Provide at least one physical output file."
-    );
-  }
-  let ancestor = path.dirname(path.resolve(paths[0]!));
-  for (let index = 1; index < paths.length; index++) {
-    const directory = path.dirname(path.resolve(paths[index]!));
-    while (!isWithin(ancestor, directory)) {
-      const parent = path.dirname(ancestor);
-      if (parent === ancestor) {
-        throw adapterError(
-          "projection inputs and outputs do not share a filesystem root",
-          "Keep one bundler invocation on a single filesystem volume."
-        );
-      }
-      ancestor = parent;
-    }
-  }
-  return ancestor;
-}
-
-function isWithin(root: string, candidate: string): boolean {
-  const relative = path.relative(root, candidate);
-  return (
-    relative.length === 0 ||
-    (relative !== ".." &&
-      !relative.startsWith(`..${path.sep}`) &&
-      !path.isAbsolute(relative))
-  );
-}
-
-function comparePaths(left: string, right: string): number {
-  return Buffer.compare(
-    Buffer.from(left, "utf8"),
-    Buffer.from(right, "utf8")
-  );
-}
-
-function samePath(left: string, right: string): boolean {
-  return pathKey(left) === pathKey(right);
-}
-
-function pathKey(value: string): string {
-  const resolved = path.resolve(value);
-  return process.platform === "win32"
-    ? resolved.toLowerCase()
-    : resolved;
-}
-
-async function writeAtomic(
-  manifestPath: string,
-  contents: string
-): Promise<void> {
-  await mkdir(path.dirname(manifestPath), { recursive: true });
-  const sequence = temporaryFileSequence++;
-  const temporaryPath = `${manifestPath}.tmp-${process.pid}-${sequence}`;
-  try {
-    const handle = await open(temporaryPath, "wx");
-    try {
-      await handle.writeFile(contents, "utf8");
-      await handle.sync();
-    } finally {
-      await handle.close();
-    }
-    await rename(temporaryPath, manifestPath);
-  } finally {
-    await rm(temporaryPath, { force: true });
-  }
 }
 
 function validateEsbuildVersion(
@@ -643,31 +488,6 @@ function validateEsbuildVersion(
     });
   }
   return undefined;
-}
-
-function parseVersion(
-  value: string
-): { major: number; minor: number; patch: number } | undefined {
-  const segments = value.split(".");
-  if (segments.length < 3) return undefined;
-  const major = Number(segments[0]);
-  const minor = Number(segments[1]);
-  const patchText = segments[2]!;
-  let end = 0;
-  while (
-    end < patchText.length &&
-    patchText.charCodeAt(end) >= 48 &&
-    patchText.charCodeAt(end) <= 57
-  ) {
-    end++;
-  }
-  if (end === 0) return undefined;
-  const patch = Number(patchText.slice(0, end));
-  return Number.isInteger(major) &&
-    Number.isInteger(minor) &&
-    Number.isInteger(patch)
-    ? { major, minor, patch }
-    : undefined;
 }
 
 function errorMessages(error: unknown): PartialMessage[] {
@@ -707,19 +527,4 @@ function diagnosticMessage(
         }),
     detail: diagnostic,
   };
-}
-
-function adapterError(
-  title: string,
-  help: string
-): ProjectionError {
-  return new ProjectionError([
-    createDiagnostic("PROJ-C013", { help: `${title}. ${help}` }),
-  ]);
-}
-
-function isMissingFile(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const code = (error as Error & { code?: unknown }).code;
-  return code === "ENOENT" || code === "ENOTDIR";
 }

--- a/packages/webui/src/projection/adapters/rspack.ts
+++ b/packages/webui/src/projection/adapters/rspack.ts
@@ -381,10 +381,10 @@ function collectImports(
   const imports: ResolvedImport[] = [];
   for (const { edge } of choices.values()) {
     if (!edge.external && edge.resolvedId === undefined) {
-      throw adapterError(
-        `Rspack did not resolve '${edge.specifier}' from '${record.id}'`,
-        "The adapter requires every non-external authored edge to have a target."
-      );
+      // Rspack retains authored dependency records after tree-shaking their
+      // targets. Resolved duplicates already won above; a remaining targetless
+      // record is not part of the compiled graph.
+      continue;
     }
     imports.push(edge);
   }

--- a/packages/webui/src/projection/adapters/rspack.ts
+++ b/packages/webui/src/projection/adapters/rspack.ts
@@ -1,0 +1,768 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import type {
+  AssetInfo,
+  AsyncDependenciesBlock,
+  Compilation,
+  Compiler,
+  Dependency,
+  Module,
+} from "@rspack/core";
+import type {
+  AdapterContext,
+  ModuleKind,
+  ModuleNode,
+  ResolvedImport,
+} from "../graph.js";
+import type { ProjectionManifest } from "../manifest.js";
+import { ProjectionError, createDiagnostic } from "../diagnostics.js";
+import type { ProjectionDiagnostic } from "../diagnostics.js";
+import { ProjectionSession } from "../session.js";
+import {
+  adapterError,
+  commonAncestor,
+  comparePaths,
+  isMissingFile,
+  isWithin,
+  nearestPackageName,
+  packageNameFromSpecifier,
+  parseVersion,
+  readPhysicalSource,
+  samePath,
+} from "./shared.js";
+
+const PLUGIN_NAME = "webui-state-projection";
+const MANIFEST_FILENAME = "webui-projection.json";
+const MAX_CONCATENATION_DEPTH = 64;
+const PRESERVED_ASSET = "webuiProjectionPreserved";
+
+/** Configuration for the official Rspack projection adapter. */
+export interface RspackProjectionOptions {
+  /**
+   * Manifest path. Relative values resolve from `compiler.context`.
+   *
+   * Defaults to `<output.path>/webui-projection.json`.
+   */
+  readonly manifest?: string;
+
+  /**
+   * Runs after a valid manifest is atomically installed.
+   *
+   * Rspack awaits this callback, so it can rebuild `protocol.bin` before a
+   * dependent SSR compilation starts. Rejection fails the compilation.
+   */
+  readonly afterManifest?: (
+    result: RspackProjectionResult
+  ) => void | Promise<void>;
+}
+
+/** Values supplied to `RspackProjectionOptions.afterManifest`. */
+export interface RspackProjectionResult {
+  readonly manifest: ProjectionManifest;
+  readonly context: AdapterContext;
+  readonly manifestPath: string;
+  readonly compiler: Compiler;
+  readonly compilation: Compilation;
+}
+
+/** A plugin object accepted by Rspack's `plugins` array. */
+export interface RspackProjectionPlugin {
+  apply(compiler: Compiler): void;
+}
+
+/** Create the official Rspack projection plugin. */
+export function rspackProjection(
+  options: RspackProjectionOptions = {}
+): RspackProjectionPlugin {
+  return {
+    apply(compiler): void {
+      const version = compiler.rspack.rspackVersion;
+      const versionError = validateRspackVersion(version);
+      if (versionError) {
+        compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+          compilation.errors.push(
+            toCompilationError(new ProjectionError([versionError]))
+          );
+        });
+        return;
+      }
+
+      const manifestPath = resolveManifestPath(compiler, options);
+      const session = new ProjectionSession();
+      compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+        compilation.hooks.processAssets.tapPromise(
+          {
+            name: PLUGIN_NAME,
+            stage:
+              compiler.rspack.Compilation
+                .PROCESS_ASSETS_STAGE_ADDITIONAL,
+          },
+          () =>
+            preservePreviousManifest(
+              compiler,
+              compilation,
+              manifestPath
+            )
+        );
+      });
+      compiler.hooks.afterEmit.tapPromise(
+        PLUGIN_NAME,
+        async (compilation) => {
+          removePreservedManifestAsset(
+            compiler,
+            compilation,
+            manifestPath
+          );
+          if (compilation.errors.length > 0) return;
+          try {
+            const context = await buildAdapterContext(
+              compiler,
+              compilation,
+              manifestPath,
+              version
+            );
+            const manifest = await session.finalize(context);
+            await options.afterManifest?.({
+              manifest,
+              context,
+              manifestPath,
+              compiler,
+              compilation,
+            });
+          } catch (error: unknown) {
+            compilation.errors.push(toCompilationError(error));
+          }
+        }
+      );
+    },
+  };
+}
+
+interface ModuleFact {
+  readonly module: Module;
+  readonly id: string;
+  readonly kind: ModuleKind;
+  readonly source: string | undefined;
+  readonly packageName: string | undefined;
+}
+
+interface ModuleRecord {
+  readonly id: string;
+  readonly kind: ModuleKind;
+  readonly source: string | undefined;
+  readonly packageName: string | undefined;
+  readonly instances: Set<Module>;
+}
+
+async function buildAdapterContext(
+  compiler: Compiler,
+  compilation: Compilation,
+  manifestPath: string,
+  version: string
+): Promise<AdapterContext> {
+  const context = path.resolve(compiler.context);
+  const leaves = collectLeafModules(compiler, compilation);
+  const packageCache = new Map<string, string | undefined>();
+  const facts = await Promise.all(
+    [...leaves].map((module) =>
+      loadModuleFact(module, context, packageCache, compiler)
+    )
+  );
+  const records = groupModuleFacts(facts);
+  const idByModule = new Map<Module, string>();
+  for (const fact of facts) idByModule.set(fact.module, fact.id);
+  const resolveModuleId = (module: Module): string | undefined =>
+    resolvedModuleId(compiler, module, idByModule);
+
+  const modules = new Map<string, ModuleNode>();
+  for (const record of records.values()) {
+    modules.set(record.id, {
+      id: record.id,
+      kind: record.kind,
+      ...(record.packageName === undefined
+        ? {}
+        : { packageName: record.packageName }),
+      source: record.source,
+      imports: collectImports(
+        compiler,
+        compilation,
+        record,
+        records,
+        resolveModuleId
+      ),
+    });
+  }
+
+  const entries = collectEntries(
+    compilation,
+    modules,
+    resolveModuleId
+  );
+  const outputPath = outputDirectory(compiler);
+  const { outputs, outputContents } =
+    buildMembershipAndContents(
+      compiler,
+      compilation,
+      outputPath,
+      manifestPath,
+      idByModule
+    );
+  const rootDir = commonAncestor([
+    manifestPath,
+    ...[...records.values()]
+      .filter((record) => record.kind === "file")
+      .map((record) => record.id),
+    ...outputs.keys(),
+  ]);
+
+  return {
+    graph: { modules, entries },
+    membership: { outputs },
+    outputContents,
+    rootDir,
+    manifestPath,
+    bundlerName: "rspack",
+    bundlerVersion: version,
+  };
+}
+
+function collectLeafModules(
+  compiler: Compiler,
+  compilation: Compilation
+): Set<Module> {
+  const leaves = new Set<Module>();
+  const visited = new Set<Module>();
+  const pending = [...compilation.modules];
+  while (pending.length > 0) {
+    const module = pending.pop()!;
+    if (
+      visited.has(module) ||
+      module instanceof compiler.rspack.ExternalModule
+    ) {
+      continue;
+    }
+    visited.add(module);
+    if (module instanceof compiler.rspack.ConcatenatedModule) {
+      for (const nested of module.modules) pending.push(nested);
+    } else {
+      leaves.add(module);
+    }
+    forEachDependency(module, (dependency) => {
+      const target = dependencyTarget(compilation, dependency);
+      if (target) pending.push(target);
+    });
+  }
+  return leaves;
+}
+
+async function loadModuleFact(
+  module: Module,
+  context: string,
+  packageCache: Map<string, string | undefined>,
+  compiler: Compiler
+): Promise<ModuleFact> {
+  if (module instanceof compiler.rspack.NormalModule) {
+    const resource = physicalResource(module.resource);
+    if (resource !== undefined) {
+      const source = await readPhysicalSource(resource);
+      if (source !== undefined) {
+        const id = path.resolve(resource);
+        return {
+          module,
+          id,
+          kind: "file",
+          source,
+          packageName: await nearestPackageName(id, packageCache),
+        };
+      }
+    }
+  }
+  return {
+    module,
+    id: virtualModuleId(module, context),
+    kind: "virtual",
+    source: originalSourceText(module),
+    packageName: undefined,
+  };
+}
+
+function groupModuleFacts(
+  facts: ReadonlyArray<ModuleFact>
+): Map<string, ModuleRecord> {
+  const records = new Map<string, ModuleRecord>();
+  for (const fact of facts) {
+    const existing = records.get(fact.id);
+    if (existing === undefined) {
+      records.set(fact.id, {
+        id: fact.id,
+        kind: fact.kind,
+        source: fact.source,
+        packageName: fact.packageName,
+        instances: new Set([fact.module]),
+      });
+      continue;
+    }
+    if (
+      existing.kind !== fact.kind ||
+      existing.source !== fact.source ||
+      existing.packageName !== fact.packageName
+    ) {
+      throw adapterError(
+        `Rspack exposed conflicting module instances for '${fact.id}'`,
+        "Use one source and package identity for each normalized module."
+      );
+    }
+    existing.instances.add(fact.module);
+  }
+  return records;
+}
+
+interface EdgeChoice {
+  readonly edge: ResolvedImport;
+  readonly priority: number;
+}
+
+function collectImports(
+  compiler: Compiler,
+  compilation: Compilation,
+  record: ModuleRecord,
+  records: ReadonlyMap<string, ModuleRecord>,
+  resolveModuleId: (module: Module) => string | undefined
+): ResolvedImport[] {
+  const choices = new Map<string, EdgeChoice>();
+  for (const module of record.instances) {
+    forEachDependency(module, (dependency, fromBlock) => {
+      const request = dependency.request;
+      if (request === undefined || request.length === 0) return;
+      const type = dependency.type;
+      const kind: "static" | "dynamic" =
+        fromBlock || type === "import()" ? "dynamic" : "static";
+      const target = dependencyTarget(compilation, dependency);
+      const external =
+        target instanceof compiler.rspack.ExternalModule;
+      const resolvedId =
+        target === null || external
+          ? undefined
+          : resolveModuleId(target);
+      const packageName = external
+        ? packageNameFromSpecifier(target.userRequest ?? request)
+        : resolvedId === undefined
+          ? undefined
+          : records.get(resolvedId)?.packageName;
+      const edge: ResolvedImport = {
+        specifier: request,
+        resolvedId,
+        external,
+        kind,
+        ...(packageName === undefined ? {} : { packageName }),
+      };
+      const hasTarget = external || resolvedId !== undefined;
+      const priority =
+        (hasTarget ? 0 : 2) + (type.includes("specifier") ? 1 : 0);
+      const key = `${request}\0${kind}`;
+      const previous = choices.get(key);
+      if (previous === undefined || priority < previous.priority) {
+        choices.set(key, { edge, priority });
+      } else if (
+        priority === previous.priority &&
+        !sameImport(previous.edge, edge)
+      ) {
+        throw adapterError(
+          `Rspack exposed conflicting resolutions for '${request}' in '${record.id}'`,
+          "Ensure one authored import resolves to one module."
+        );
+      }
+    });
+  }
+
+  const imports: ResolvedImport[] = [];
+  for (const { edge } of choices.values()) {
+    if (!edge.external && edge.resolvedId === undefined) {
+      throw adapterError(
+        `Rspack did not resolve '${edge.specifier}' from '${record.id}'`,
+        "The adapter requires every non-external authored edge to have a target."
+      );
+    }
+    imports.push(edge);
+  }
+  imports.sort((left, right) =>
+    comparePaths(
+      `${left.specifier}\0${left.kind}\0${left.resolvedId ?? ""}`,
+      `${right.specifier}\0${right.kind}\0${right.resolvedId ?? ""}`
+    )
+  );
+  return imports;
+}
+
+function sameImport(
+  left: ResolvedImport,
+  right: ResolvedImport
+): boolean {
+  return (
+    left.resolvedId === right.resolvedId &&
+    left.external === right.external &&
+    left.packageName === right.packageName
+  );
+}
+
+function forEachDependency(
+  module: Module,
+  visit: (dependency: Dependency, fromBlock: boolean) => void
+): void {
+  for (const dependency of module.dependencies) {
+    visit(dependency, false);
+  }
+  const pending: AsyncDependenciesBlock[] = [...module.blocks];
+  while (pending.length > 0) {
+    const block = pending.pop()!;
+    for (const dependency of block.dependencies) {
+      visit(dependency, true);
+    }
+    for (const nested of block.blocks) pending.push(nested);
+  }
+}
+
+function dependencyTarget(
+  compilation: Compilation,
+  dependency: Dependency
+): Module | null {
+  return (
+    compilation.moduleGraph.getModule(dependency) ??
+    compilation.moduleGraph.getResolvedModule(dependency)
+  );
+}
+
+function collectEntries(
+  compilation: Compilation,
+  modules: ReadonlyMap<string, ModuleNode>,
+  resolveModuleId: (module: Module) => string | undefined
+): string[] {
+  const entries = new Set<string>();
+  for (const data of compilation.entries.values()) {
+    for (const dependency of data.dependencies) {
+      const target = dependencyTarget(compilation, dependency);
+      const id =
+        target === null ? undefined : resolveModuleId(target);
+      if (id !== undefined && modules.has(id)) {
+        entries.add(id);
+        break;
+      }
+      const request = dependency.request;
+      if (request !== undefined) {
+        const physical = physicalResource(request);
+        if (physical !== undefined && modules.has(physical)) {
+          entries.add(physical);
+          break;
+        }
+      }
+    }
+  }
+  if (entries.size === 0) {
+    throw adapterError(
+      "Rspack exposed no projection entry modules",
+      "Configure at least one physical or virtual client entry."
+    );
+  }
+  return [...entries].sort(comparePaths);
+}
+
+function buildMembershipAndContents(
+  compiler: Compiler,
+  compilation: Compilation,
+  outputPath: string,
+  manifestPath: string,
+  idByModule: ReadonlyMap<Module, string>
+): {
+  readonly outputs: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly outputContents: ReadonlyMap<string, Uint8Array>;
+} {
+  const outputs = new Map<string, Set<string>>();
+  const assets = new Map<string, string>();
+  for (const chunk of compilation.chunks) {
+    const members = collectChunkMembers(
+      compiler,
+      compilation,
+      chunk,
+      idByModule
+    );
+    for (const file of chunk.files) {
+      if (!isJavaScriptAsset(compilation, file)) continue;
+      const outputId = path.resolve(outputPath, file);
+      if (samePath(outputId, manifestPath)) {
+        throw adapterError(
+          "the projection manifest collides with a Rspack output",
+          `Choose a manifest path other than '${file}'.`
+        );
+      }
+      assets.set(outputId, file);
+      const existing = outputs.get(outputId);
+      if (existing === undefined) {
+        outputs.set(outputId, new Set(members));
+      } else {
+        for (const member of members) existing.add(member);
+      }
+    }
+  }
+  if (outputs.size === 0) {
+    throw adapterError(
+      "Rspack emitted no JavaScript chunks",
+      "Projection requires at least one emitted JavaScript asset."
+    );
+  }
+
+  const outputContents = new Map<string, Uint8Array>();
+  for (const [outputId, file] of assets) {
+    const asset = compilation.getAsset(file);
+    if (asset === undefined) {
+      throw adapterError(
+        `Rspack omitted final bytes for '${file}'`,
+        "Projection requires every final JavaScript compilation asset."
+      );
+    }
+    outputContents.set(outputId, asset.source.buffer());
+  }
+  return { outputs, outputContents };
+}
+
+function collectChunkMembers(
+  compiler: Compiler,
+  compilation: Compilation,
+  chunk: Parameters<
+    Compilation["chunkGraph"]["getChunkModulesIterable"]
+  >[0],
+  idByModule: ReadonlyMap<Module, string>
+): Set<string> {
+  const members = new Set<string>();
+  const visited = new Set<Module>();
+  const pending = [
+    ...compilation.chunkGraph.getChunkModulesIterable(chunk),
+  ];
+  while (pending.length > 0) {
+    const module = pending.pop()!;
+    if (visited.has(module)) continue;
+    visited.add(module);
+    if (module instanceof compiler.rspack.ConcatenatedModule) {
+      for (const nested of module.modules) pending.push(nested);
+      continue;
+    }
+    const id = idByModule.get(module);
+    if (id !== undefined) members.add(id);
+  }
+  return members;
+}
+
+function isJavaScriptAsset(
+  compilation: Compilation,
+  file: string
+): boolean {
+  const type = compilation.getAsset(file)?.info.assetType;
+  if (type !== undefined) {
+    return type === "javascript" || type === "js";
+  }
+  const clean = stripResourceSuffix(file);
+  return (
+    clean.endsWith(".js") ||
+    clean.endsWith(".mjs") ||
+    clean.endsWith(".cjs")
+  );
+}
+
+function resolvedModuleId(
+  compiler: Compiler,
+  module: Module,
+  idByModule: ReadonlyMap<Module, string>
+): string | undefined {
+  let current = module;
+  for (let depth = 0; depth < MAX_CONCATENATION_DEPTH; depth++) {
+    if (current instanceof compiler.rspack.ExternalModule) {
+      return undefined;
+    }
+    const direct = idByModule.get(current);
+    if (direct !== undefined) return direct;
+    if (!(current instanceof compiler.rspack.ConcatenatedModule)) {
+      return undefined;
+    }
+    current = current.rootModule;
+  }
+  return undefined;
+}
+
+function virtualModuleId(module: Module, context: string): string {
+  const identifier =
+    module.libIdent({ context }) ?? module.identifier();
+  return `\0rspack:${stableVirtualIdentifier(identifier, context)}`;
+}
+
+function stableVirtualIdentifier(
+  identifier: string,
+  context: string
+): string {
+  const normalized = toPosix(identifier);
+  let root = toPosix(path.resolve(context));
+  while (root.endsWith("/")) root = root.slice(0, -1);
+  const comparable =
+    process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  const comparableRoot =
+    process.platform === "win32" ? root.toLowerCase() : root;
+  let offset = 0;
+  let match = comparable.indexOf(comparableRoot);
+  let stable = "";
+  while (match >= 0) {
+    stable += `${normalized.slice(offset, match)}<root>`;
+    offset = match + root.length;
+    match = comparable.indexOf(comparableRoot, offset);
+  }
+  stable += normalized.slice(offset);
+  return stable.startsWith("./") ? stable.slice(2) : stable;
+}
+
+function physicalResource(value: string): string | undefined {
+  const clean = stripResourceSuffix(value);
+  return path.isAbsolute(clean) ? path.resolve(clean) : undefined;
+}
+
+function originalSourceText(module: Module): string | undefined {
+  const source = module.originalSource();
+  if (source === null) return undefined;
+  const value = source.source();
+  return typeof value === "string"
+    ? value
+    : value.toString("utf8");
+}
+
+async function preservePreviousManifest(
+  compiler: Compiler,
+  compilation: Compilation,
+  manifestPath: string
+): Promise<void> {
+  const outputPath = outputDirectory(compiler);
+  const name = manifestAssetName(outputPath, manifestPath);
+  if (name === undefined) return;
+  const existing = compilation.getAsset(name);
+  if (existing !== undefined) {
+    const preserved = existing.info[PRESERVED_ASSET];
+    if (preserved !== true) {
+      throw adapterError(
+        "the projection manifest collides with a Rspack asset",
+        `Choose a manifest path other than '${name}'.`
+      );
+    }
+    return;
+  }
+
+  const previous = await readPreviousManifest(manifestPath);
+  if (previous === undefined) return;
+  const info: AssetInfo = { [PRESERVED_ASSET]: true };
+  compilation.emitAsset(
+    name,
+    new compiler.rspack.sources.RawSource(previous),
+    info
+  );
+}
+
+function removePreservedManifestAsset(
+  compiler: Compiler,
+  compilation: Compilation,
+  manifestPath: string
+): void {
+  const name = manifestAssetName(
+    outputDirectory(compiler),
+    manifestPath
+  );
+  if (
+    name !== undefined &&
+    compilation.getAsset(name)?.info[PRESERVED_ASSET] === true
+  ) {
+    compilation.deleteAsset(name);
+  }
+}
+
+function manifestAssetName(
+  outputPath: string,
+  manifestPath: string
+): string | undefined {
+  if (!isWithin(outputPath, manifestPath)) return undefined;
+  const name = toPosix(path.relative(outputPath, manifestPath));
+  return name.length === 0 || name.startsWith("..")
+    ? undefined
+    : name;
+}
+
+async function readPreviousManifest(
+  manifestPath: string
+): Promise<Buffer | undefined> {
+  try {
+    return await readFile(manifestPath);
+  } catch (error: unknown) {
+    if (isMissingFile(error)) return undefined;
+    throw error;
+  }
+}
+
+function resolveManifestPath(
+  compiler: Compiler,
+  options: RspackProjectionOptions
+): string {
+  return options.manifest === undefined
+    ? path.join(outputDirectory(compiler), MANIFEST_FILENAME)
+    : path.resolve(compiler.context, options.manifest);
+}
+
+function outputDirectory(compiler: Compiler): string {
+  const outputPath = compiler.outputPath || compiler.options.output.path;
+  if (!outputPath) {
+    throw adapterError(
+      "the Rspack compiler did not define output.path",
+      "Configure output.path so projection outputs can be validated."
+    );
+  }
+  return path.resolve(outputPath);
+}
+
+function validateRspackVersion(
+  version: string
+): ProjectionDiagnostic | undefined {
+  const parsed = parseVersion(version);
+  if (
+    parsed === undefined ||
+    parsed.major !== 2 ||
+    (parsed.minor === 0 && parsed.patch < 1)
+  ) {
+    return createDiagnostic("PROJ-P004", {
+      help: `Install an application-owned @rspack/core peer compatible with ^2.0.1; found ${version}.`,
+    });
+  }
+  return undefined;
+}
+
+function toCompilationError(error: unknown): Error {
+  if (!(error instanceof ProjectionError)) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  const message = error.diagnostics
+    .map((diagnostic) =>
+      diagnostic.help === undefined
+        ? `${diagnostic.code}: ${diagnostic.title}`
+        : `${diagnostic.code}: ${diagnostic.title} - ${diagnostic.help}`
+    )
+    .join("\n");
+  const result = new Error(message || error.message);
+  result.name =
+    error.diagnostics[0]?.code ?? "ProjectionError";
+  return result;
+}
+
+function stripResourceSuffix(value: string): string {
+  const query = value.indexOf("?");
+  const hash = value.indexOf("#");
+  if (query === -1) return hash === -1 ? value : value.slice(0, hash);
+  if (hash === -1) return value.slice(0, query);
+  return value.slice(0, Math.min(query, hash));
+}
+
+function toPosix(value: string): string {
+  return value.split("\\").join("/");
+}

--- a/packages/webui/src/projection/adapters/shared.ts
+++ b/packages/webui/src/projection/adapters/shared.ts
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Bundler-neutral helpers shared by the official WebUI projection adapters.
+ *
+ * These utilities carry no bundler-specific semantics. They read authored disk
+ * source, prove package identity from the nearest `package.json`, derive a
+ * common build root, and parse semantic versions. Keeping one implementation
+ * lets the esbuild and Rspack adapters behave identically where the underlying
+ * facts are the same.
+ */
+
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { ProjectionError, createDiagnostic } from "../diagnostics.js";
+
+/** A parsed `major.minor.patch` triple; trailing pre-release text is ignored. */
+export interface SemanticVersion {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+/**
+ * Reads authored UTF-8 source for a physical file, returning `undefined` when
+ * the path does not exist. Missing files signal a virtual/non-physical module.
+ */
+export async function readPhysicalSource(
+  filePath: string
+): Promise<string | undefined> {
+  try {
+    const bytes = await readFile(filePath);
+    return bytes.toString("utf8");
+  } catch (error: unknown) {
+    if (isMissingFile(error)) return undefined;
+    throw error;
+  }
+}
+
+/**
+ * Resolves the nearest `package.json` `name` above a physical file.
+ *
+ * The walk is memoized per directory so repeated lookups across a large module
+ * graph stay cheap. This is how an alias that resolves to
+ * `@microsoft/webui-framework` keeps that semantic identity regardless of the
+ * on-disk path it was aliased to.
+ */
+export async function nearestPackageName(
+  filePath: string,
+  cache: Map<string, string | undefined>
+): Promise<string | undefined> {
+  let directory = path.dirname(filePath);
+  const visited: string[] = [];
+  while (true) {
+    if (cache.has(directory)) {
+      const cached = cache.get(directory);
+      for (const value of visited) cache.set(value, cached);
+      return cached;
+    }
+    visited.push(directory);
+    const packagePath = path.join(directory, "package.json");
+    try {
+      const text = await readFile(packagePath, "utf8");
+      const parsed = JSON.parse(text) as { name?: unknown };
+      const name =
+        typeof parsed.name === "string" && parsed.name.length > 0
+          ? parsed.name
+          : undefined;
+      for (const value of visited) cache.set(value, name);
+      return name;
+    } catch (error: unknown) {
+      if (!isMissingFile(error)) {
+        throw adapterError(
+          `could not read package identity from '${packagePath}'`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      for (const value of visited) cache.set(value, undefined);
+      return undefined;
+    }
+    directory = parent;
+  }
+}
+
+/**
+ * Derives a canonical package name from a bare specifier
+ * (`"@scope/name/sub"` → `"@scope/name"`, `"pkg/sub"` → `"pkg"`).
+ *
+ * Returns `undefined` for relative/absolute specifiers, which carry no package
+ * identity.
+ */
+export function packageNameFromSpecifier(
+  specifier: string
+): string | undefined {
+  if (
+    specifier.length === 0 ||
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    path.isAbsolute(specifier)
+  ) {
+    return undefined;
+  }
+  const segments = specifier.split("/");
+  if (specifier.startsWith("@")) {
+    return segments.length >= 2
+      ? `${segments[0]}/${segments[1]}`
+      : undefined;
+  }
+  return segments[0];
+}
+
+/**
+ * Computes the deepest directory that contains every supplied path.
+ *
+ * All physical inputs, outputs, and the manifest must share this root so the
+ * compiler can express them as root-relative manifest keys.
+ */
+export function commonAncestor(paths: ReadonlyArray<string>): string {
+  if (paths.length === 0) {
+    throw adapterError(
+      "the bundler produced no physical projection artifacts",
+      "Provide at least one physical output file."
+    );
+  }
+  let ancestor = path.dirname(path.resolve(paths[0]!));
+  for (let index = 1; index < paths.length; index++) {
+    const directory = path.dirname(path.resolve(paths[index]!));
+    while (!isWithin(ancestor, directory)) {
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) {
+        throw adapterError(
+          "projection inputs and outputs do not share a filesystem root",
+          "Keep one bundler invocation on a single filesystem volume."
+        );
+      }
+      ancestor = parent;
+    }
+  }
+  return ancestor;
+}
+
+/** Whether `candidate` is `root` itself or a descendant of it. */
+export function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative.length === 0 ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+/** Cross-platform equality for two absolute paths. */
+export function samePath(left: string, right: string): boolean {
+  return pathKey(left) === pathKey(right);
+}
+
+/** Case-folded (on Windows) resolved key for path comparison and lookup. */
+export function pathKey(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+/** Cross-language lexical ordering over raw UTF-8 bytes, ascending. */
+export function comparePaths(left: string, right: string): number {
+  return Buffer.compare(
+    Buffer.from(left, "utf8"),
+    Buffer.from(right, "utf8")
+  );
+}
+
+/** Parses a `major.minor.patch` prefix, ignoring any pre-release suffix. */
+export function parseVersion(value: string): SemanticVersion | undefined {
+  const segments = value.split(".");
+  if (segments.length < 3) return undefined;
+  const major = Number(segments[0]);
+  const minor = Number(segments[1]);
+  const patchText = segments[2]!;
+  let end = 0;
+  while (
+    end < patchText.length &&
+    patchText.charCodeAt(end) >= 48 &&
+    patchText.charCodeAt(end) <= 57
+  ) {
+    end++;
+  }
+  if (end === 0) return undefined;
+  const patch = Number(patchText.slice(0, end));
+  return Number.isInteger(major) &&
+    Number.isInteger(minor) &&
+    Number.isInteger(patch)
+    ? { major, minor, patch }
+    : undefined;
+}
+
+/** Builds a hard adapter-contract error (`PROJ-C013`) with actionable help. */
+export function adapterError(title: string, help: string): ProjectionError {
+  return new ProjectionError([
+    createDiagnostic("PROJ-C013", { help: `${title}. ${help}` }),
+  ]);
+}
+
+/** Whether an error is a benign "file not found" from the filesystem. */
+export function isMissingFile(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as Error & { code?: unknown }).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}

--- a/packages/webui/src/projection/core.ts
+++ b/packages/webui/src/projection/core.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Bundler-neutral state projection compiler and finalization API.
+ *
+ * This entry does not import any bundler adapter, so consumers only need the
+ * application-owned TypeScript peer when they invoke compilation.
+ */
+
+export type {
+  ModuleKind,
+  ResolvedImport,
+  ModuleNode,
+  ModuleGraph,
+  OutputMembership,
+  AdapterContext,
+} from "./graph.js";
+
+export type {
+  ProjectionManifest,
+  ProducerInfo,
+  AdapterInfo,
+  ComponentEntry,
+} from "./manifest.js";
+export {
+  MANIFEST_SCHEMA,
+  VIRTUAL_HASH,
+  hashContent,
+  computeBuildId,
+  serializeManifestCanonical,
+  validateManifestSchema,
+} from "./manifest.js";
+
+export type {
+  ProjectionCode,
+  DiagnosticSeverity,
+  ProjectionDiagnostic,
+} from "./diagnostics.js";
+export {
+  PROJECTION_CODES,
+  CODE_SEVERITY,
+  ProjectionError,
+} from "./diagnostics.js";
+
+export { compileProjection } from "./loader.js";
+export { ProjectionSession } from "./session.js";

--- a/packages/webui/src/projection/diagnostics.ts
+++ b/packages/webui/src/projection/diagnostics.ts
@@ -69,6 +69,11 @@ export const PROJECTION_CODES = {
   P002: "PROJ-P002",
   /** Peer is present but above the tested range; results may differ. */
   P003: "PROJ-P003",
+  /**
+   * Required peer `@rspack/core` is absent or below the supported range
+   * (Rspack adapter only).
+   */
+  P004: "PROJ-P004",
 
   // Manifest diagnostics
   /** Manifest file is missing or unreadable. */
@@ -179,6 +184,7 @@ export const CODE_SEVERITY: Readonly<Record<ProjectionCode, DiagnosticSeverity>>
   "PROJ-P001": "error",
   "PROJ-P002": "error",
   "PROJ-P003": "warning",
+  "PROJ-P004": "error",
   "PROJ-M001": "error",
   "PROJ-M002": "error",
   "PROJ-M003": "error",
@@ -216,6 +222,7 @@ export const CODE_TITLES: Readonly<Record<ProjectionCode, string>> = {
   "PROJ-P001": "Required peer 'typescript' is absent or below the supported range",
   "PROJ-P002": "Required peer 'esbuild' is absent or below the supported range",
   "PROJ-P003": "Peer is present but above the tested range",
+  "PROJ-P004": "Required peer '@rspack/core' is absent or below the supported range",
   "PROJ-M001": "Manifest file is missing or unreadable",
   "PROJ-M002": "Manifest schema version is unsupported",
   "PROJ-M003": "Declared input file hash does not match current file content",

--- a/packages/webui/src/projection/esbuild.ts
+++ b/packages/webui/src/projection/esbuild.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/** Official esbuild adapter for WebUI state projection. */
+
+export type { EsbuildProjectionOptions } from "./adapters/esbuild.js";
+export { esbuildProjection } from "./adapters/esbuild.js";

--- a/packages/webui/src/projection/index.ts
+++ b/packages/webui/src/projection/index.ts
@@ -20,64 +20,6 @@
  * authoritative specification.
  */
 
-// Module graph types and adapter SPI
-export type {
-  ModuleKind,
-  ResolvedImport,
-  ModuleNode,
-  ModuleGraph,
-  OutputMembership,
-  AdapterContext,
-} from "./graph.js";
-
-// Manifest schema types and validation
-export type {
-  ProjectionManifest,
-  ProducerInfo,
-  AdapterInfo,
-  ComponentEntry,
-} from "./manifest.js";
-export { MANIFEST_SCHEMA, validateManifestSchema } from "./manifest.js";
-
-// Diagnostic codes and error types
-export type {
-  ProjectionCode,
-  DiagnosticSeverity,
-  ProjectionDiagnostic,
-} from "./diagnostics.js";
-export {
-  PROJECTION_CODES,
-  CODE_SEVERITY,
-  ProjectionError,
-} from "./diagnostics.js";
-
-// Conformance fixtures and test helpers
-export type {
-  ConformanceCase,
-  ConformanceReport,
-  ConformanceFailure,
-  AdapterFactory,
-  ConformanceSuiteOptions,
-} from "./fixtures/conformance.js";
-export { runConformanceSuite, ALL_CASES } from "./fixtures/conformance.js";
-
-// Manifest serialization/hash/build-ID utilities
-export {
-  VIRTUAL_HASH,
-  hashContent,
-  computeBuildId,
-  serializeManifestCanonical,
-} from "./manifest.js";
-
-/**
- * Compile an exact state-projection manifest from an adapter-resolved graph.
- *
- * The implementation is loaded lazily so importing the subpath without the
- * optional TypeScript peer produces a structured `PROJ-P001` diagnostic
- * instead of Node's generic module-resolution error.
- */
-export { compileProjection } from "./loader.js";
-
-// Official adapters
-export type { EsbuildProjectionOptions } from "./adapters/esbuild.js";
-export { esbuildProjection } from "./adapters/esbuild.js";
+export * from "./core.js";
+export * from "./testing.js";
+export * from "./esbuild.js";

--- a/packages/webui/src/projection/rspack.ts
+++ b/packages/webui/src/projection/rspack.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Official Rspack adapter for WebUI state projection.
+ *
+ * This subpath is isolated from `@microsoft/webui/projection.js` so that
+ * legacy/esbuild consumers never load Rspack code or acquire the optional
+ * `@rspack/core` peer. The implementation uses type-only imports from
+ * `@rspack/core` and reads runtime classes/constants/sources/version from the
+ * compiler, so importing this subpath without the peer runtime stays isolated.
+ */
+
+export type {
+  RspackProjectionOptions,
+  RspackProjectionResult,
+  RspackProjectionPlugin,
+} from "./adapters/rspack.js";
+export { rspackProjection } from "./adapters/rspack.js";

--- a/packages/webui/src/projection/session.ts
+++ b/packages/webui/src/projection/session.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  mkdir,
+  open,
+  rename,
+  rm,
+} from "node:fs/promises";
+import * as path from "node:path";
+import type { AdapterContext } from "./graph.js";
+import type { ProjectionManifest } from "./manifest.js";
+import { serializeManifestCanonical } from "./manifest.js";
+import {
+  compileProjection,
+  preloadProjectionCompiler,
+} from "./loader.js";
+
+let temporaryFileSequence = 0;
+
+/**
+ * Finalizes complete bundler adapter contexts into projection manifests.
+ *
+ * A session serializes overlapping finalizations in invocation order.
+ * Adapters must invoke `finalize()` in compilation order; bundler-specific graph
+ * collection, path derivation, version checks, and diagnostic presentation
+ * remain adapter responsibilities.
+ */
+export class ProjectionSession {
+  readonly #compilerLoad = preloadProjectionCompiler().then(
+    () => ({ loaded: true as const }),
+    (error: unknown) => ({ loaded: false as const, error })
+  );
+  #pending: Promise<void> = Promise.resolve();
+
+  /**
+   * Compile and atomically replace the manifest declared by `context`.
+   *
+   * The previous manifest remains intact when compilation, serialization, or
+   * the temporary-file write fails.
+   */
+  finalize(context: AdapterContext): Promise<ProjectionManifest> {
+    const completion = this.#pending.then(async () => {
+      const compiler = await this.#compilerLoad;
+      if (!compiler.loaded) throw compiler.error;
+      const manifest = await compileProjection(context);
+      await writeAtomic(
+        context.manifestPath,
+        serializeManifestCanonical(manifest)
+      );
+      return manifest;
+    });
+    this.#pending = completion.then(
+      () => undefined,
+      () => undefined
+    );
+    return completion;
+  }
+}
+
+async function writeAtomic(
+  manifestPath: string,
+  contents: string
+): Promise<void> {
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  const sequence = temporaryFileSequence++;
+  const temporaryPath = `${manifestPath}.tmp-${process.pid}-${sequence}`;
+  try {
+    const handle = await open(temporaryPath, "wx");
+    try {
+      await handle.writeFile(contents, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(temporaryPath, manifestPath);
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}

--- a/packages/webui/src/projection/testing.ts
+++ b/packages/webui/src/projection/testing.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/** Shared conformance fixtures for projection compilers and adapters. */
+
+export type {
+  ConformanceCase,
+  ConformanceReport,
+  ConformanceFailure,
+  AdapterFactory,
+  ConformanceSuiteOptions,
+} from "./fixtures/conformance.js";
+export {
+  runConformanceSuite,
+  ALL_CASES,
+} from "./fixtures/conformance.js";

--- a/packages/webui/test/projection-peers.test.ts
+++ b/packages/webui/test/projection-peers.test.ts
@@ -20,6 +20,10 @@ import type {
   OnStartResult,
   PluginBuild,
 } from "esbuild";
+import type { Compiler } from "@rspack/core";
+import {
+  rspackProjection,
+} from "@microsoft/webui/projection/rspack.js";
 
 describe("projection optional peers", () => {
   test("reports PROJ-P001 when TypeScript is absent", async () => {
@@ -92,6 +96,32 @@ describe("projection optional peers", () => {
     assert.equal(result?.errors?.[0]?.id, "PROJ-P002");
   });
 
+  test("reports PROJ-P004 for an incompatible application Rspack", () => {
+    let onCompilation:
+      | ((compilation: { errors: Error[] }) => void)
+      | undefined;
+    const plugin = rspackProjection();
+    const fakeCompiler = {
+      rspack: { rspackVersion: "1.0.0" },
+      hooks: {
+        thisCompilation: {
+          tap(
+            _name: string,
+            callback: (compilation: { errors: Error[] }) => void
+          ) {
+            onCompilation = callback;
+          },
+        },
+      },
+    } as unknown as Compiler;
+
+    plugin.apply(fakeCompiler);
+    assert.ok(onCompilation);
+    const compilation = { errors: [] as Error[] };
+    onCompilation(compilation);
+    assert.equal(compilation.errors[0]?.name, "PROJ-P004");
+  });
+
   test("root entry does not import projection tooling", async () => {
     const rootEntry = await readFile(
       path.resolve("dist", "index.js"),
@@ -100,5 +130,43 @@ describe("projection optional peers", () => {
     assert.equal(rootEntry.includes("/projection/"), false);
     assert.equal(rootEntry.includes("typescript"), false);
     assert.equal(rootEntry.includes("esbuild"), false);
+  });
+
+  test("core projection entry does not import bundler adapters", async () => {
+    const coreEntry = await readFile(
+      path.resolve("dist", "projection", "core.js"),
+      "utf8"
+    );
+    assert.equal(coreEntry.includes("/adapters/"), false);
+    assert.equal(coreEntry.includes("esbuild"), false);
+    assert.equal(coreEntry.includes("@rspack/core"), false);
+  });
+
+  test("Rspack projection entry has no runtime bundler import", async () => {
+    const rspackEntry = await readFile(
+      path.resolve("dist", "projection", "adapters", "rspack.js"),
+      "utf8"
+    );
+    assert.equal(
+      rspackEntry.includes('from "@rspack/core"') ||
+        rspackEntry.includes("from '@rspack/core'"),
+      false
+    );
+    assert.equal(rspackEntry.includes("esbuild"), false);
+  });
+
+  test("dedicated projection subpaths expose isolated APIs", async () => {
+    const [core, esbuildAdapter, rspackAdapter, testing] =
+      await Promise.all([
+      import("@microsoft/webui/projection/core.js"),
+      import("@microsoft/webui/projection/esbuild.js"),
+      import("@microsoft/webui/projection/rspack.js"),
+      import("@microsoft/webui/projection/testing.js"),
+    ]);
+    assert.equal(typeof core.ProjectionSession, "function");
+    assert.equal(typeof core.compileProjection, "function");
+    assert.equal(typeof esbuildAdapter.esbuildProjection, "function");
+    assert.equal(typeof rspackAdapter.rspackProjection, "function");
+    assert.equal(typeof testing.runConformanceSuite, "function");
   });
 });

--- a/packages/webui/test/projection-rspack.test.ts
+++ b/packages/webui/test/projection-rspack.test.ts
@@ -1,0 +1,480 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from "node:assert";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import * as path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, test } from "node:test";
+import {
+  experiments,
+  rspack,
+} from "@rspack/core";
+import type {
+  Compiler,
+  Configuration,
+  Stats,
+} from "@rspack/core";
+import {
+  hashContent,
+  validateManifestSchema,
+} from "@microsoft/webui/projection/core.js";
+import type {
+  AdapterContext,
+  ProjectionManifest,
+} from "@microsoft/webui/projection/core.js";
+import {
+  rspackProjection,
+} from "@microsoft/webui/projection/rspack.js";
+import type {
+  RspackProjectionPlugin,
+} from "@microsoft/webui/projection/rspack.js";
+
+interface Fixture {
+  readonly root: string;
+  readonly entryPath: string;
+  readonly virtualPath: string;
+}
+
+interface CapturedProjection {
+  context: AdapterContext | undefined;
+  callbackComplete: boolean;
+  callbackCount: number;
+  rawBaseDependencies: number;
+  sawConcatenation: boolean;
+}
+
+async function createFixture(): Promise<Fixture> {
+  const root = await mkdtemp(
+    path.join(process.cwd(), ".tmp-rspack-projection-")
+  );
+  const sourceDirectory = path.join(root, "src");
+  const frameworkDirectory = path.join(root, "framework");
+  await Promise.all([
+    mkdir(sourceDirectory, { recursive: true }),
+    mkdir(frameworkDirectory, { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "rspack-projection-fixture" })
+    ),
+    writeFile(
+      path.join(frameworkDirectory, "package.json"),
+      JSON.stringify({
+        name: "@microsoft/webui-framework",
+        type: "module",
+      })
+    ),
+    writeFile(
+      path.join(frameworkDirectory, "index.ts"),
+      `
+export function observable(): void {}
+export function attr(): () => void { return () => {}; }
+export class WebUIElement {
+  static define(_name: string): void {}
+}
+`
+    ),
+    writeFile(
+      path.join(sourceDirectory, "base.ts"),
+      `
+import { WebUIElement, observable } from '@microsoft/webui-framework';
+export class BaseCard extends WebUIElement {
+  @observable baseValue = '';
+}
+`
+    ),
+    writeFile(
+      path.join(sourceDirectory, "lazy.ts"),
+      `
+import { WebUIElement, attr } from '@microsoft/webui-framework';
+class LazyCard extends WebUIElement {
+  @attr({ attribute: 'lazy-value' }) lazyValue = '';
+}
+LazyCard.define('lazy-card');
+`
+    ),
+  ]);
+  const entryPath = path.join(sourceDirectory, "entry.ts");
+  await writeValidEntry(entryPath, "mainValue");
+  return {
+    root,
+    entryPath,
+    virtualPath: path.join(sourceDirectory, "virtual.ts"),
+  };
+}
+
+async function writeValidEntry(
+  entryPath: string,
+  propertyName: string
+): Promise<void> {
+  await writeFile(
+    entryPath,
+    `
+import externalValue from 'external-lib';
+import { observable } from '@microsoft/webui-framework';
+import { BaseCard } from './base';
+import { virtualValue } from './virtual';
+
+class MainCard extends BaseCard {
+  @observable ${propertyName} = '';
+}
+MainCard.define('main-card');
+console.log(externalValue, virtualValue);
+void import('./lazy');
+`
+  );
+}
+
+function createConfiguration(
+  fixture: Fixture,
+  plugin: RspackProjectionPlugin
+): Configuration {
+  return {
+    context: fixture.root,
+    mode: "production",
+    target: "web",
+    entry: "./src/entry.ts",
+    devtool: false,
+    cache: false,
+    externals: {
+      "external-lib": "commonjs external-lib",
+    },
+    resolve: {
+      extensions: [".ts", ".js"],
+      alias: {
+        "@microsoft/webui-framework": path.join(
+          fixture.root,
+          "framework",
+          "index.ts"
+        ),
+      },
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: [
+            {
+              loader: "builtin:swc-loader",
+              options: {
+                jsc: {
+                  parser: {
+                    syntax: "typescript",
+                    decorators: true,
+                  },
+                  transform: {
+                    legacyDecorator: true,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    optimization: {
+      concatenateModules: true,
+      minimize: false,
+    },
+    output: {
+      path: path.join(fixture.root, "dist"),
+      filename: "[name].js",
+      chunkFilename: "[name]-[contenthash].js",
+      clean: true,
+    },
+    plugins: [
+      new experiments.VirtualModulesPlugin({
+        [fixture.virtualPath]: "export const virtualValue = 'virtual';\n",
+      }),
+      plugin,
+    ],
+  };
+}
+
+function runCompiler(
+  compiler: Compiler,
+  modifiedFile?: string
+): Promise<Stats> {
+  return new Promise((resolve, reject) => {
+    const callback = (error: Error | null, stats?: Stats): void => {
+      if (error) {
+        reject(error);
+      } else if (!stats) {
+        reject(new Error("Rspack returned no stats"));
+      } else {
+        resolve(stats);
+      }
+    };
+    if (modifiedFile === undefined) {
+      compiler.run(callback);
+    } else {
+      compiler.run(callback, {
+        modifiedFiles: new Set([modifiedFile]),
+      });
+    }
+  });
+}
+
+function closeCompiler(compiler: Compiler): Promise<void> {
+  return new Promise((resolve, reject) => {
+    compiler.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function manifestPath(root: string): string {
+  return path.join(root, "dist", "webui-projection.json");
+}
+
+async function readManifest(root: string): Promise<ProjectionManifest> {
+  return JSON.parse(
+    await readFile(manifestPath(root), "utf8")
+  ) as ProjectionManifest;
+}
+
+function findOutput(
+  context: AdapterContext,
+  predicate: (name: string) => boolean
+): string {
+  const output = [...context.membership.outputs.keys()].find((value) =>
+    predicate(path.basename(value))
+  );
+  assert.ok(output, "expected Rspack output was not present");
+  return output;
+}
+
+describe("rspackProjection", () => {
+  test("normalizes the production graph and awaits post-manifest work", async (t) => {
+    const fixture = await createFixture();
+    t.after(() => rm(fixture.root, { recursive: true, force: true }));
+    const captured: CapturedProjection = {
+      context: undefined,
+      callbackComplete: false,
+      callbackCount: 0,
+      rawBaseDependencies: 0,
+      sawConcatenation: false,
+    };
+    const plugin = rspackProjection({
+      async afterManifest(result) {
+        captured.callbackCount++;
+        captured.context = result.context;
+        captured.sawConcatenation = [
+          ...result.compilation.modules,
+        ].some(
+          (module) =>
+            module instanceof
+            result.compiler.rspack.ConcatenatedModule
+        );
+        const rawEntry = [...result.compilation.modules].find(
+          (module) =>
+            module instanceof result.compiler.rspack.NormalModule &&
+            path.resolve(module.resource) === fixture.entryPath
+        );
+        captured.rawBaseDependencies =
+          rawEntry?.dependencies.filter(
+            (dependency) => dependency.request === "./base"
+          ).length ?? 0;
+        const installed = await readManifest(fixture.root);
+        assert.equal(installed.buildId, result.manifest.buildId);
+        for (const [outputId, contents] of result.context.outputContents) {
+          assert.deepEqual(
+            Buffer.from(contents),
+            await readFile(outputId)
+          );
+        }
+        await delay(20);
+        captured.callbackComplete = true;
+      },
+    });
+    const compiler = rspack(createConfiguration(fixture, plugin));
+    t.after(() => closeCompiler(compiler));
+
+    const stats = await runCompiler(compiler);
+    assert.equal(stats.hasErrors(), false, stats.toString({ errors: true }));
+    assert.equal(captured.callbackComplete, true);
+    assert.equal(captured.callbackCount, 1);
+    assert.equal(captured.sawConcatenation, true);
+    assert.ok(captured.rawBaseDependencies >= 2);
+    const context = captured.context;
+    assert.ok(context);
+
+    const entryId = path.resolve(fixture.root, "src", "entry.ts");
+    const baseId = path.resolve(fixture.root, "src", "base.ts");
+    const lazyId = path.resolve(fixture.root, "src", "lazy.ts");
+    const entry = context.graph.modules.get(entryId);
+    assert.ok(entry);
+    const baseEdges = entry.imports.filter(
+      (edge) => edge.specifier === "./base"
+    );
+    assert.equal(baseEdges.length, 1);
+    assert.equal(baseEdges[0]?.kind, "static");
+    assert.equal(baseEdges[0]?.resolvedId, baseId);
+    assert.equal(baseEdges[0]?.external, false);
+
+    const frameworkEdge = entry.imports.find(
+      (edge) => edge.specifier === "@microsoft/webui-framework"
+    );
+    assert.equal(
+      frameworkEdge?.packageName,
+      "@microsoft/webui-framework"
+    );
+    const externalEdge = entry.imports.find(
+      (edge) => edge.specifier === "external-lib"
+    );
+    assert.equal(externalEdge?.external, true);
+    assert.equal(externalEdge?.resolvedId, undefined);
+    assert.equal(externalEdge?.packageName, "external-lib");
+    const lazyEdge = entry.imports.find(
+      (edge) => edge.specifier === "./lazy"
+    );
+    assert.equal(lazyEdge?.kind, "dynamic");
+    assert.equal(lazyEdge?.resolvedId, lazyId);
+
+    const virtualId = [...context.graph.modules.keys()].find(
+      (id) =>
+        id.startsWith("\0rspack:") &&
+        id.endsWith("src/virtual.ts")
+    );
+    assert.ok(virtualId, "expected a normalized virtual module id");
+    assert.equal(virtualId, "\0rspack:src/virtual.ts");
+    assert.equal(virtualId.includes(fixture.root), false);
+
+    const mainOutput = findOutput(
+      context,
+      (name) => name === "main.js"
+    );
+    const lazyOutput = findOutput(
+      context,
+      (name) => name !== "main.js" && name.endsWith(".js")
+    );
+    assert.ok(context.membership.outputs.get(mainOutput)?.has(entryId));
+    assert.ok(context.membership.outputs.get(mainOutput)?.has(baseId));
+    assert.ok(context.membership.outputs.get(lazyOutput)?.has(lazyId));
+    assert.equal(
+      context.membership.outputs.get(mainOutput)?.has(lazyId),
+      false
+    );
+
+    const manifest = await readManifest(fixture.root);
+    assert.deepEqual(validateManifestSchema(manifest), []);
+    assert.deepEqual(
+      manifest.components["main-card"]?.hydrationKeys,
+      ["baseValue", "mainValue"]
+    );
+    assert.deepEqual(
+      manifest.components["lazy-card"]?.hydrationKeys,
+      ["lazyValue"]
+    );
+    assert.equal(
+      manifest.components["main-card"]?.outputs.some((output) =>
+        output.endsWith("/main.js")
+      ),
+      true
+    );
+    assert.equal(
+      manifest.components["lazy-card"]?.outputs.some((output) =>
+        output.endsWith("/main.js")
+      ),
+      false
+    );
+    for (const [key, expectedHash] of Object.entries(manifest.outputs)) {
+      const outputPath = path.resolve(
+        path.dirname(manifestPath(fixture.root)),
+        ...manifest.root.split("/"),
+        ...key.split("/")
+      );
+      assert.equal(hashContent(await readFile(outputPath)), expectedHash);
+    }
+  });
+
+  test("preserves a valid manifest through clean failures and recovers", async (t) => {
+    const fixture = await createFixture();
+    t.after(() => rm(fixture.root, { recursive: true, force: true }));
+    let callbackCount = 0;
+    const plugin = rspackProjection({
+      afterManifest(result) {
+        assert.equal(
+          result.compilation.getAsset("webui-projection.json"),
+          undefined
+        );
+        callbackCount++;
+      },
+    });
+    const compiler = rspack(createConfiguration(fixture, plugin));
+    t.after(() => closeCompiler(compiler));
+
+    const initial = await runCompiler(compiler);
+    assert.equal(initial.hasErrors(), false);
+    const before = await readFile(manifestPath(fixture.root), "utf8");
+    assert.equal(callbackCount, 1);
+
+    await writeFile(
+      fixture.entryPath,
+      `
+import { BaseCard } from './base';
+const tag = 'main-card';
+class MainCard extends BaseCard {}
+MainCard.define(tag);
+`
+    );
+    const failed = await runCompiler(compiler, fixture.entryPath);
+    assert.equal(failed.hasErrors(), true);
+    assert.match(failed.toString({ errors: true }), /PROJ-C008/);
+    assert.equal(
+      await readFile(manifestPath(fixture.root), "utf8"),
+      before
+    );
+    assert.equal(callbackCount, 1);
+
+    await writeValidEntry(fixture.entryPath, "recoveredValue");
+    const recovered = await runCompiler(compiler, fixture.entryPath);
+    assert.equal(
+      recovered.hasErrors(),
+      false,
+      recovered.toString({ errors: true })
+    );
+    assert.deepEqual(
+      (await readManifest(fixture.root)).components["main-card"]
+        ?.hydrationKeys,
+      ["baseValue", "recoveredValue"]
+    );
+    assert.equal(callbackCount, 2);
+  });
+
+  test("reports a rejected post-manifest callback as a compilation error", async (t) => {
+    const fixture = await createFixture();
+    t.after(() => rm(fixture.root, { recursive: true, force: true }));
+    const compiler = rspack(
+      createConfiguration(
+        fixture,
+        rspackProjection({
+          afterManifest() {
+            throw new Error("protocol rebuild failed");
+          },
+        })
+      )
+    );
+    t.after(() => closeCompiler(compiler));
+
+    const stats = await runCompiler(compiler);
+    assert.equal(stats.hasErrors(), true);
+    assert.match(
+      stats.toString({ errors: true }),
+      /protocol rebuild failed/
+    );
+    assert.equal(
+      (await readManifest(fixture.root)).schema,
+      "webui.state-projection/v1"
+    );
+  });
+});

--- a/packages/webui/test/projection-rspack.test.ts
+++ b/packages/webui/test/projection-rspack.test.ts
@@ -48,6 +48,7 @@ interface CapturedProjection {
   callbackCount: number;
   rawBaseDependencies: number;
   sawConcatenation: boolean;
+  targetlessDependencyTypes: string[];
 }
 
 async function createFixture(): Promise<Fixture> {
@@ -63,7 +64,10 @@ async function createFixture(): Promise<Fixture> {
   await Promise.all([
     writeFile(
       path.join(root, "package.json"),
-      JSON.stringify({ name: "rspack-projection-fixture" })
+      JSON.stringify({
+        name: "rspack-projection-fixture",
+        sideEffects: ["*.css"],
+      })
     ),
     writeFile(
       path.join(frameworkDirectory, "package.json"),
@@ -101,6 +105,28 @@ class LazyCard extends WebUIElement {
 LazyCard.define('lazy-card');
 `
     ),
+    writeFile(
+      path.join(sourceDirectory, "barrel.ts"),
+      `
+import { importValue } from './pruned-import';
+export { importValue };
+export * from './pruned-export';
+export { specifierValue } from './pruned-specifier';
+export const keptValue = 'kept';
+`
+    ),
+    writeFile(
+      path.join(sourceDirectory, "pruned-import.ts"),
+      "export const importValue = 'unused';\n"
+    ),
+    writeFile(
+      path.join(sourceDirectory, "pruned-export.ts"),
+      "export const exportValue = 'unused';\n"
+    ),
+    writeFile(
+      path.join(sourceDirectory, "pruned-specifier.ts"),
+      "export const specifierValue = 'unused';\n"
+    ),
   ]);
   const entryPath = path.join(sourceDirectory, "entry.ts");
   await writeValidEntry(entryPath, "mainValue");
@@ -121,13 +147,14 @@ async function writeValidEntry(
 import externalValue from 'external-lib';
 import { observable } from '@microsoft/webui-framework';
 import { BaseCard } from './base';
+import { keptValue } from './barrel';
 import { virtualValue } from './virtual';
 
 class MainCard extends BaseCard {
   @observable ${propertyName} = '';
 }
 MainCard.define('main-card');
-console.log(externalValue, virtualValue);
+console.log(externalValue, keptValue, virtualValue);
 void import('./lazy');
 `
   );
@@ -263,6 +290,7 @@ describe("rspackProjection", () => {
       callbackCount: 0,
       rawBaseDependencies: 0,
       sawConcatenation: false,
+      targetlessDependencyTypes: [],
     };
     const plugin = rspackProjection({
       async afterManifest(result) {
@@ -284,6 +312,23 @@ describe("rspackProjection", () => {
           rawEntry?.dependencies.filter(
             (dependency) => dependency.request === "./base"
           ).length ?? 0;
+        const rawBarrel = [...result.compilation.modules].find(
+          (module) =>
+            module instanceof result.compiler.rspack.NormalModule &&
+            path.basename(module.resource) === "barrel.ts"
+        );
+        captured.targetlessDependencyTypes =
+          rawBarrel?.dependencies
+            .filter((dependency) => {
+              const target =
+                result.compilation.moduleGraph.getModule(dependency) ??
+                result.compilation.moduleGraph.getResolvedModule(dependency);
+              return (
+                dependency.request?.startsWith("./pruned-") === true &&
+                (target === undefined || target === null)
+              );
+            })
+            .map((dependency) => dependency.type) ?? [];
         const installed = await readManifest(fixture.root);
         assert.equal(installed.buildId, result.manifest.buildId);
         for (const [outputId, contents] of result.context.outputContents) {
@@ -305,10 +350,21 @@ describe("rspackProjection", () => {
     assert.equal(captured.callbackCount, 1);
     assert.equal(captured.sawConcatenation, true);
     assert.ok(captured.rawBaseDependencies >= 2);
+    for (const type of [
+      "esm import",
+      "esm export import",
+      "esm export import specifier",
+    ]) {
+      assert.ok(
+        captured.targetlessDependencyTypes.includes(type),
+        `expected a targetless ${type} dependency; saw ${captured.targetlessDependencyTypes.join(", ")}`
+      );
+    }
     const context = captured.context;
     assert.ok(context);
 
     const entryId = path.resolve(fixture.root, "src", "entry.ts");
+    const barrelId = path.resolve(fixture.root, "src", "barrel.ts");
     const baseId = path.resolve(fixture.root, "src", "base.ts");
     const lazyId = path.resolve(fixture.root, "src", "lazy.ts");
     const entry = context.graph.modules.get(entryId);
@@ -320,6 +376,12 @@ describe("rspackProjection", () => {
     assert.equal(baseEdges[0]?.kind, "static");
     assert.equal(baseEdges[0]?.resolvedId, baseId);
     assert.equal(baseEdges[0]?.external, false);
+    const barrel = context.graph.modules.get(barrelId);
+    assert.ok(barrel);
+    assert.equal(
+      barrel.imports.some((edge) => edge.specifier.startsWith("./pruned-")),
+      false
+    );
 
     const frameworkEdge = entry.imports.find(
       (edge) => edge.specifier === "@microsoft/webui-framework"

--- a/packages/webui/test/projection-session.test.ts
+++ b/packages/webui/test/projection-session.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from "node:assert";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { describe, test } from "node:test";
+import {
+  ProjectionSession,
+  serializeManifestCanonical,
+} from "@microsoft/webui/projection.js";
+import type {
+  AdapterContext,
+  ModuleNode,
+} from "@microsoft/webui/projection.js";
+
+function context(
+  root: string,
+  propertyName: string,
+  outputContents = "compiled-output"
+): AdapterContext {
+  const moduleId = path.join(root, "src", "card.ts");
+  const outputId = path.join(root, "dist", "index.js");
+  const module: ModuleNode = {
+    id: moduleId,
+    kind: "file",
+    source: `
+import { observable, WebUIElement } from '@microsoft/webui-framework';
+class Card extends WebUIElement { @observable ${propertyName} = ''; }
+Card.define('session-card');
+`,
+    imports: [
+      {
+        specifier: "@microsoft/webui-framework",
+        resolvedId: undefined,
+        external: true,
+        kind: "static",
+        packageName: "@microsoft/webui-framework",
+      },
+    ],
+  };
+  return {
+    graph: {
+      modules: new Map([[moduleId, module]]),
+      entries: [moduleId],
+    },
+    membership: {
+      outputs: new Map([[outputId, new Set([moduleId])]]),
+    },
+    outputContents: new Map([[outputId, outputContents]]),
+    rootDir: root,
+    manifestPath: path.join(root, "dist", "webui-projection.json"),
+    bundlerName: "session-test",
+    bundlerVersion: "1.0.0",
+  };
+}
+
+describe("ProjectionSession", () => {
+  test("serializes overlapping finalizations in invocation order", async (t) => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "webui-projection-session-")
+    );
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const session = new ProjectionSession();
+    const firstContext = context(root, "first");
+    const secondContext = context(root, "second");
+
+    const [first, second] = await Promise.all([
+      session.finalize(firstContext),
+      session.finalize(secondContext),
+    ]);
+
+    assert.deepEqual(
+      first.components["session-card"]?.hydrationKeys,
+      ["first"]
+    );
+    assert.deepEqual(
+      second.components["session-card"]?.hydrationKeys,
+      ["second"]
+    );
+    assert.equal(
+      await readFile(secondContext.manifestPath, "utf8"),
+      serializeManifestCanonical(second)
+    );
+    assert.equal(
+      (await readdir(path.dirname(secondContext.manifestPath))).some(
+        (name) => name.includes(".tmp-")
+      ),
+      false
+    );
+  });
+
+  test("preserves the previous manifest and recovers after failure", async (t) => {
+    const root = await mkdtemp(
+      path.join(tmpdir(), "webui-projection-session-recovery-")
+    );
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const session = new ProjectionSession();
+    const initialContext = context(root, "initial");
+    await session.finalize(initialContext);
+    const before = await readFile(initialContext.manifestPath, "utf8");
+    const invalidContext = {
+      ...context(root, "invalid"),
+      outputContents: new Map(),
+    };
+
+    await assert.rejects(
+      session.finalize(invalidContext),
+      /PROJ-C014/
+    );
+    assert.equal(
+      await readFile(initialContext.manifestPath, "utf8"),
+      before
+    );
+
+    const recovered = await session.finalize(context(root, "recovered"));
+    assert.deepEqual(
+      recovered.components["session-card"]?.hydrationKeys,
+      ["recovered"]
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     '@playwright/test':
       specifier: ^1.61.1
       version: 1.61.1
+    '@rspack/core':
+      specifier: 2.0.1
+      version: 2.0.1
     '@types/dom-navigation':
       specifier: ^1.0.7
       version: 1.0.7
@@ -440,6 +443,9 @@ importers:
 
   packages/webui:
     devDependencies:
+      '@rspack/core':
+        specifier: 'catalog:'
+        version: 2.0.1
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.0
@@ -540,325 +546,411 @@ importers:
 packages:
 
   '@codemirror/autocomplete@6.20.3':
-    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==, tarball: https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz}
 
   '@codemirror/commands@6.10.4':
-    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==, tarball: https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz}
 
   '@codemirror/lang-css@6.3.1':
-    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==, tarball: https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz}
 
   '@codemirror/lang-html@6.4.11':
-    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==, tarball: https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz}
 
   '@codemirror/lang-javascript@6.2.5':
-    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==, tarball: https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz}
 
   '@codemirror/lang-json@6.0.2':
-    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==, tarball: https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz}
 
   '@codemirror/language@6.12.4':
-    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==, tarball: https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz}
 
   '@codemirror/lint@6.9.7':
-    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==, tarball: https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz}
 
   '@codemirror/state@6.7.1':
-    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==, tarball: https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz}
 
   '@codemirror/theme-one-dark@6.1.3':
-    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==, tarball: https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz}
 
   '@codemirror/view@6.43.6':
-    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
+    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==, tarball: https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz}
 
   '@electron-internal/extract-zip@1.0.4':
-    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==, tarball: https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz}
     engines: {node: '>=22.12.0'}
 
   '@electron/get@5.0.0':
-    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==, tarball: https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz}
     engines: {node: '>=22.12.0'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==, tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==, tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==, tarball: https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
+
   '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==, tarball: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==, tarball: https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
   '@lezer/common@1.5.2':
-    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==, tarball: https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz}
 
   '@lezer/css@1.3.4':
-    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==}
+    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==, tarball: https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz}
 
   '@lezer/highlight@1.2.3':
-    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==, tarball: https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz}
 
   '@lezer/html@1.3.13':
-    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==, tarball: https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz}
 
   '@lezer/javascript@1.5.4':
-    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==, tarball: https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz}
 
   '@lezer/json@1.0.3':
-    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==, tarball: https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz}
 
   '@lezer/lr@1.4.10':
-    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==, tarball: https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz}
 
   '@marijn/find-cluster-break@1.0.3':
-    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==, tarball: https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz}
 
   '@microsoft/fast-element@3.0.1':
-    resolution: {integrity: sha512-euVlL8v7EAnkYD9gf6xhnY+XgzCkD0hHwC0MVsUVyhnKfGGhrNyBeD5kYnBOCcJ9afL2jTQoOA+oOpLEty3s+A==}
+    resolution: {integrity: sha512-euVlL8v7EAnkYD9gf6xhnY+XgzCkD0hHwC0MVsUVyhnKfGGhrNyBeD5kYnBOCcJ9afL2jTQoOA+oOpLEty3s+A==, tarball: https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-3.0.1.tgz}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==, tarball: https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@playwright/test@1.61.1':
-    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==, tarball: https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
+  '@rspack/binding-darwin-arm64@2.0.1':
+    resolution: {integrity: sha512-CGFO5zmajD1Itch1lxAI7+gvKiagzyqXopHv/jHG9Su2WWQ2/Nhn2/rkSpdp6ptE9ri6+6tCOOahf099/v/Xog==, tarball: https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.0.1.tgz}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.1':
+    resolution: {integrity: sha512-2vvBNBoS09/PurupBwSrlTZd8283o00B8v20ncsNUdEff41uCR/hzIrYoTIVWnVST+Gt5O1+cfcfORp397lajg==, tarball: https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.0.1.tgz}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.1':
+    resolution: {integrity: sha512-uvNXk6ahE3AH3h2avnd1Mgno68YQpS4cfX1OkOGWIC/roL+NrOP2XVXV4yfVAoydPALDO7AfbIfN0QdmBK3rsA==, tarball: https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.0.1.tgz}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.0.1':
+    resolution: {integrity: sha512-S/a6uN9PiZ5O/PjSqyIXhuRC1lVzeJkJV69NeLk5sIEUiDQ/aQGZG97uN+tluwpbo1tPbLJkdHYETfjspOX4Pg==, tarball: https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.0.1.tgz}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.0.1':
+    resolution: {integrity: sha512-C13Kk0OkZiocZVj187Sf753UH6pDXnuEu6vzUvi3qv9ltibG1ki0H2Y8isXBYL2cHQOV+hk0g1S6/4z3TTB97A==, tarball: https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.0.1.tgz}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.0.1':
+    resolution: {integrity: sha512-TQsiBFpEDGkuvK9tNdGj/Uc+AIytzqhxXH/1jKU6M24cWB1DTw/Cx7DdrkCBDyq3129K3POLdujvbWCGqBzQUw==, tarball: https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.0.1.tgz}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.0.1':
+    resolution: {integrity: sha512-wk3gyUgBW/ayP49bI54bkY8+EQnfBHxdoe9dz3oobSTZQc8AOWwmUUDEPltW8rUvPOM6dfHECTOUMnfaf2f5yA==, tarball: https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.0.1.tgz}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.1':
+    resolution: {integrity: sha512-rHjLcy3VcAC3+x+PxH+gwhwv6tPe0JdXTNT5eAOs9wgZIM6T9p4wre49+K4Qy98+Fb7TTbLX0ObUitlOkGwTSA==, tarball: https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.0.1.tgz}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.0.1':
+    resolution: {integrity: sha512-Ad1vVqMBBnd4T8rsORngu9sl2kyRTlS4kMlvFudjzl1X2UFArEDBe0YVGNN7ZvahM12CErUx2WiN8Sd8pb+qXQ==, tarball: https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.0.1.tgz}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.0.1':
+    resolution: {integrity: sha512-oPM2Jtm7HOlmxl/aBfleAVlL6t9VeHx6WvEets7BBJMInemFXAQd4CErRqybf7rXutACzLeUWBOue4Jpd1/ykw==, tarball: https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.0.1.tgz}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@2.0.1':
+    resolution: {integrity: sha512-ynV1gw4KqFtQ0P+ZZh76SUj49wBb2FuHW3zSmHverHWuxBhzvrZS6/dZ+fCFQG8bTTPtrPz0RQUTN3uEDbPVBQ==, tarball: https://registry.npmjs.org/@rspack/binding/-/binding-2.0.1.tgz}
+
+  '@rspack/core@2.0.1':
+    resolution: {integrity: sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA==, tarball: https://registry.npmjs.org/@rspack/core/-/core-2.0.1.tgz}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==, tarball: https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz}
+
   '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==, tarball: https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz}
 
   '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==, tarball: https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz}
 
   '@types/cors@2.8.19':
-    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==, tarball: https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz}
 
   '@types/dom-navigation@1.0.7':
-    resolution: {integrity: sha512-Di4W+i2faYquHUnyWUg3bBQp5pTNvjDDA7mIYfD/1WlLgan6sKkeVjGbdL78K0CuNEk5Pfc/c0rfelwkz10mnQ==}
+    resolution: {integrity: sha512-Di4W+i2faYquHUnyWUg3bBQp5pTNvjDDA7mIYfD/1WlLgan6sKkeVjGbdL78K0CuNEk5Pfc/c0rfelwkz10mnQ==, tarball: https://registry.npmjs.org/@types/dom-navigation/-/dom-navigation-1.0.7.tgz}
 
   '@types/dom-view-transitions@1.0.6':
-    resolution: {integrity: sha512-Q5IoDouTOcZKEs4nDpmUti2MXP48MQDBkS2nUQKFrsDeTFIaArVmhWUon28vlDfNkbbaK4EROu4Fv0iKObWjSg==}
+    resolution: {integrity: sha512-Q5IoDouTOcZKEs4nDpmUti2MXP48MQDBkS2nUQKFrsDeTFIaArVmhWUon28vlDfNkbbaK4EROu4Fv0iKObWjSg==, tarball: https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.6.tgz}
 
   '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==, tarball: https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz}
 
   '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==, tarball: https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz}
 
   '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==, tarball: https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz}
 
   '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==, tarball: https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz}
 
   '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==, tarball: https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz}
 
   '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==, tarball: https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz}
 
   '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==, tarball: https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz}
 
   '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==, tarball: https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz}
 
   '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==, tarball: https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz}
 
   accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==, tarball: https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz}
     engines: {node: '>= 0.6'}
 
   body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==, tarball: https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz}
     engines: {node: '>=18'}
 
   bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==, tarball: https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz}
     engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==, tarball: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==, tarball: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz}
     engines: {node: '>= 0.4'}
 
   content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==, tarball: https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==, tarball: https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz}
     engines: {node: '>= 0.6'}
 
   content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==, tarball: https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz}
     engines: {node: '>=18'}
 
   cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==, tarball: https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz}
     engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==, tarball: https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz}
     engines: {node: '>= 0.6'}
 
   cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==, tarball: https://registry.npmjs.org/cors/-/cors-2.8.6.tgz}
     engines: {node: '>= 0.10'}
 
   crelt@1.0.7:
-    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==, tarball: https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz}
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -867,299 +959,299 @@ packages:
         optional: true
 
   depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==, tarball: https://registry.npmjs.org/depd/-/depd-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==, tarball: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==, tarball: https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz}
 
   electron@43.0.0:
-    resolution: {integrity: sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==}
+    resolution: {integrity: sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==, tarball: https://registry.npmjs.org/electron/-/electron-43.0.0.tgz}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
   encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==, tarball: https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   env-paths@3.0.0:
-    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==, tarball: https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==, tarball: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==, tarball: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz}
     engines: {node: '>= 0.4'}
 
   es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==, tarball: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==, tarball: https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
   escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==, tarball: https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz}
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==, tarball: https://registry.npmjs.org/etag/-/etag-1.8.1.tgz}
     engines: {node: '>= 0.6'}
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==, tarball: https://registry.npmjs.org/express/-/express-5.2.1.tgz}
     engines: {node: '>= 18'}
 
   finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==, tarball: https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz}
     engines: {node: '>= 18.0.0'}
 
   forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==, tarball: https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==, tarball: https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz}
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==, tarball: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz}
     engines: {node: '>= 0.4'}
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==, tarball: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==, tarball: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==, tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz}
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==, tarball: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==, tarball: https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz}
     engines: {node: '>= 0.4'}
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==, tarball: https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz}
     engines: {node: '>= 0.8'}
 
   iconv-lite@0.7.3:
-    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==, tarball: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz}
     engines: {node: '>=0.10.0'}
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz}
 
   ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==, tarball: https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz}
     engines: {node: '>= 0.10'}
 
   is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==, tarball: https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz}
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==, tarball: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
   media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==, tarball: https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz}
     engines: {node: '>= 0.8'}
 
   merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==, tarball: https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz}
     engines: {node: '>=18'}
 
   mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==, tarball: https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==, tarball: https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz}
     engines: {node: '>=18'}
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
 
   negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==, tarball: https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz}
     engines: {node: '>= 0.6'}
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==, tarball: https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz}
     engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
   on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==, tarball: https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, tarball: https://registry.npmjs.org/once/-/once-1.4.0.tgz}
 
   parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==, tarball: https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz}
     engines: {node: '>= 0.8'}
 
   path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==, tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz}
 
   playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==, tarball: https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
   playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==, tarball: https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz}
     engines: {node: '>=18'}
     hasBin: true
 
   progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==, tarball: https://registry.npmjs.org/progress/-/progress-2.0.3.tgz}
     engines: {node: '>=0.4.0'}
 
   proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==, tarball: https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz}
     engines: {node: '>= 0.10'}
 
   qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.3.tgz}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
-    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==, tarball: https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz}
     engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==, tarball: https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz}
     engines: {node: '>= 0.10'}
 
   router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==, tarball: https://registry.npmjs.org/router/-/router-2.2.0.tgz}
     engines: {node: '>= 18'}
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, tarball: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz}
 
   semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==, tarball: https://registry.npmjs.org/semver/-/semver-7.8.5.tgz}
     engines: {node: '>=10'}
     hasBin: true
 
   send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==, tarball: https://registry.npmjs.org/send/-/send-1.2.1.tgz}
     engines: {node: '>= 18'}
 
   serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==, tarball: https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz}
     engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==, tarball: https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz}
 
   side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==, tarball: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==, tarball: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==, tarball: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==, tarball: https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz}
     engines: {node: '>= 0.4'}
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==, tarball: https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz}
     engines: {node: '>= 0.8'}
 
   style-mod@4.1.3:
-    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==, tarball: https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz}
 
   sumchecker@3.0.1:
-    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==, tarball: https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz}
     engines: {node: '>= 8.0'}
 
   toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==, tarball: https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz}
     engines: {node: '>=0.6'}
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz}
 
   tsx@4.23.0:
-    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==, tarball: https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
   type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==, tarball: https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz}
     engines: {node: '>= 18'}
 
   typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==, tarball: https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz}
     engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz}
 
   undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz}
 
   undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==, tarball: https://registry.npmjs.org/undici/-/undici-7.28.0.tgz}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==, tarball: https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   urlpattern-polyfill@10.1.0:
-    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==, tarball: https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz}
 
   vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
     engines: {node: '>= 0.8'}
 
   w3c-keyname@2.2.8:
-    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==, tarball: https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz}
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, tarball: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz}
 
 snapshots:
 
@@ -1259,6 +1351,22 @@ snapshots:
       undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1376,9 +1484,72 @@ snapshots:
 
   '@microsoft/fast-element@3.0.1': {}
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@rspack/binding-darwin-arm64@2.0.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.0.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.1':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.1':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.0.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.1':
+    optional: true
+
+  '@rspack/binding@2.0.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.1
+      '@rspack/binding-darwin-x64': 2.0.1
+      '@rspack/binding-linux-arm64-gnu': 2.0.1
+      '@rspack/binding-linux-arm64-musl': 2.0.1
+      '@rspack/binding-linux-x64-gnu': 2.0.1
+      '@rspack/binding-linux-x64-musl': 2.0.1
+      '@rspack/binding-wasm32-wasi': 2.0.1
+      '@rspack/binding-win32-arm64-msvc': 2.0.1
+      '@rspack/binding-win32-ia32-msvc': 2.0.1
+      '@rspack/binding-win32-x64-msvc': 2.0.1
+
+  '@rspack/core@2.0.1':
+    dependencies:
+      '@rspack/binding': 2.0.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/body-parser@1.19.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ catalog:
   '@codemirror/view': ^6.43.6
   '@microsoft/fast-element': 3.0.1
   '@playwright/test': ^1.61.1
+  '@rspack/core': 2.0.1
   '@types/dom-navigation': ^1.0.7
   '@types/dom-view-transitions': ^1.0.6
   urlpattern-polyfill: ^10.1.0


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.23`.

Previous release tag: `v0.0.22`

## Changes since `v0.0.22`

Features:

- adds an official Rspack 2.x state-projection adapter with exact graph normalization, code-split output membership, emitted-byte hashing, and an awaited post-manifest hook for dependent protocol and SSR builds (`chore: bump version to 0.0.23` #424).
- extracts a reusable bundler-neutral `ProjectionSession` and focused core, esbuild, Rspack, and testing package subpaths while preserving optional-peer isolation (`chore: bump version to 0.0.23` #424).

Fixes:

- omits targetless authored dependency records retained after Rspack tree shaking while continuing to prefer resolved duplicate edges (`chore: bump version to 0.0.23` #424).

Docs:

- documents the Rspack adapter API, lifecycle sequencing, supported peer range, migration from custom bundler adapters, and atomic protocol-build/SSR-runtime rollout requirement (`chore: bump version to 0.0.23` #424).

## Rollout

Update the protocol compiler/build and SSR runtime to the same `@microsoft/webui` release atomically. Cross-release protocol compatibility is not guaranteed.

## Validation

- `cargo xtask check`
- MSN Rspack 2.0.1 direct, split development/production, combined local, and SSR runtime pipelines passed with 28 projected components. The official and proven local manifests were semantically identical across 1,402 inputs, 17 outputs, and 120 hydration keys.