### PR TITLE
fix: resolve relative WebUI Press links

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3736,6 +3736,14 @@ canonical artifact identities. A page using one prepared source clones only
 the `Arc`; mixed prepared/fresh sources retain artifact identities so
 conflicting hashes still fail with `PROJ-M007`.
 
+Every generated page uses `<base href>` for root-relative site assets.
+Markdown links are therefore normalized during conversion: relative paths are
+resolved from the source Markdown file's directory, root-absolute internal
+paths receive `basePath`, and fragment-only or query-only links target the
+current canonical page. External and protocol-relative URLs remain unchanged.
+This preserves normal Markdown link semantics for both `index.md` and leaf
+pages without relying on browser resolution against the site root.
+
 To preserve build throughput without exposing a public compile/finalize split,
 press uses a hidden orchestration barrier:
 

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -503,6 +503,7 @@ Powered by [comrak](https://github.com/kivikakk/comrak), GitHub-flavored markdow
 
 - Tables, task lists, autolinks, footnotes, strikethrough
 - Header anchors auto-injected (`<a class="header-anchor" href="#...">#</a>`)
+- Relative links resolve from the Markdown source directory and remain valid under `basePath`
 - Fenced code blocks wrapped in `<code-block>` (copy button + dual-theme highlighting)
 - Raw HTML pass-through, including custom elements
 

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
-use crate::markdown::{render_markdown_with_link_base, Highlighter};
+use crate::markdown::{render_markdown, Highlighter};
 use crate::state::{load_render_states, merge_page_state, LoadedStates};
 use crate::types::{DocsConfig, NavLink, PageDescriptor, SidebarItem, SidebarSection};
 
@@ -499,7 +499,7 @@ pub(crate) fn process_content_with_states(
                         };
                         let link_base_url =
                             markdown_link_base_url(full_path, content_dir, base_path);
-                        html = render_markdown_with_link_base(
+                        html = render_markdown(
                             body,
                             highlighter,
                             base_path,

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
-use crate::markdown::{render_markdown, Highlighter};
+use crate::markdown::{render_markdown_with_link_base, Highlighter};
 use crate::state::{load_render_states, merge_page_state, LoadedStates};
 use crate::types::{DocsConfig, NavLink, PageDescriptor, SidebarItem, SidebarSection};
 
@@ -198,6 +198,28 @@ fn page_url_path(rel_path: &str, base_path: &str, sources: &HashMap<&str, &str>)
     } else {
         format!("{prefix}/{trimmed}")
     }
+}
+
+fn markdown_link_base_url(source_path: &Path, content_dir: &Path, base_path: &str) -> String {
+    let parent = source_path
+        .strip_prefix(content_dir)
+        .ok()
+        .and_then(Path::parent);
+    let parent = parent
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_default();
+
+    let prefix = base_path.trim_end_matches('/');
+    let parent = parent.trim_matches('/');
+    let mut url = String::with_capacity(prefix.len() + parent.len() + 2);
+    url.push_str(prefix);
+    url.push('/');
+    if !parent.is_empty() {
+        url.push_str(parent);
+        url.push('/');
+    }
+    url
 }
 
 /// Map each nav entry that declares a `source` file to its configured link.
@@ -475,7 +497,15 @@ pub(crate) fn process_content_with_states(
                         } else {
                             format!("{url_path}/")
                         };
-                        html = render_markdown(body, highlighter, base_path, &page_url)?;
+                        let link_base_url =
+                            markdown_link_base_url(full_path, content_dir, base_path);
+                        html = render_markdown_with_link_base(
+                            body,
+                            highlighter,
+                            base_path,
+                            &page_url,
+                            &link_base_url,
+                        )?;
                     }
 
                     if let Some(d) = fm.description {
@@ -841,6 +871,31 @@ mod tests {
         // A nav link like "/ai?v=2" must route to "/ai", not "/ai?v=2".
         let map = sources(&[("ai/SKILL.md", "/ai?v=2")]);
         assert_eq!(page_url_path("ai/SKILL.md", "/webui/", &map), "/webui/ai");
+    }
+
+    #[test]
+    fn markdown_link_base_uses_source_directory_for_index_and_leaf_pages() {
+        let content_dir = Path::new("docs");
+        assert_eq!(
+            markdown_link_base_url(Path::new("docs/guide/index.md"), content_dir, "/webui/"),
+            "/webui/guide/"
+        );
+        assert_eq!(
+            markdown_link_base_url(
+                Path::new("docs/guide/installation.md"),
+                content_dir,
+                "/webui/"
+            ),
+            "/webui/guide/"
+        );
+        assert_eq!(
+            markdown_link_base_url(
+                Path::new("docs/guide/topic/index.md"),
+                content_dir,
+                "/webui/"
+            ),
+            "/webui/guide/topic/"
+        );
     }
 
     // --- nav_source_overrides ---------------------------------------------

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -214,6 +214,20 @@ fn has_uri_scheme(url: &str) -> bool {
     false
 }
 
+fn has_base_path_prefix(url: &str, base_prefix: &str) -> bool {
+    if base_prefix.is_empty() {
+        return true;
+    }
+    let Some(suffix) = url.strip_prefix(base_prefix) else {
+        return false;
+    };
+    suffix.is_empty()
+        || suffix
+            .as_bytes()
+            .first()
+            .is_some_and(|byte| matches!(*byte, b'/' | b'?' | b'#'))
+}
+
 fn resolve_relative_link(base_path: &str, link_base_url: &str, target: &str) -> Option<String> {
     if target.is_empty()
         || target.starts_with('/')
@@ -294,6 +308,7 @@ pub fn render_markdown(
     options.render.r#unsafe = true; // Allow raw HTML passthrough
 
     let root = parse_document(&arena, content, &options);
+    let base_prefix = base_path.trim_end_matches('/');
 
     // Multi-pass approach: collect node pointers first, then modify.
     // This avoids modifying the tree during iteration and lets heading
@@ -315,11 +330,10 @@ pub fn render_markdown(
                 link.url = format!("{page_url}{}", link.url);
             } else if link.url.starts_with('/')
                 && !link.url.starts_with("//")
-                && !link.url.starts_with(base_path)
-                && base_path != "/"
+                && !has_base_path_prefix(&link.url, base_prefix)
             {
                 // Prepend base_path to absolute internal links
-                link.url = format!("{}{}", base_path.trim_end_matches('/'), &link.url);
+                link.url = format!("{base_prefix}{}", &link.url);
             } else if let Some(resolved) =
                 resolve_relative_link(base_path, link_base_url, &link.url)
             {
@@ -551,6 +565,38 @@ mod tests {
             html.contains(r#"<a href="/webui/guide/current/"></a>"#),
             "empty destination should target the current page: {html}"
         );
+    }
+
+    #[test]
+    fn absolute_internal_links_respect_base_path_boundaries() {
+        let h = Highlighter::new();
+        for base_path in ["/webui/", "/webui"] {
+            let html = render_markdown(
+                "[Root](/webui) [Nested](/webui/guide) [Query](/webui?tab=1) [Sibling](/webui-press)",
+                &h,
+                base_path,
+                "/webui/guide/current/",
+                "/webui/guide/",
+            )
+            .unwrap();
+
+            assert!(
+                html.contains(r#"<a href="/webui">Root</a>"#),
+                "base root should not be double-prefixed: {html}"
+            );
+            assert!(
+                html.contains(r#"<a href="/webui/guide">Nested</a>"#),
+                "nested base path should not be double-prefixed: {html}"
+            );
+            assert!(
+                html.contains(r#"<a href="/webui?tab=1">Query</a>"#),
+                "query on the base root should not be double-prefixed: {html}"
+            );
+            assert!(
+                html.contains(r#"<a href="/webui/webui-press">Sibling</a>"#),
+                "a similarly named path should still receive basePath: {html}"
+            );
+        }
     }
 
     #[test]

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -195,8 +195,74 @@ fn collect_node_text<'a>(
     (plain, html)
 }
 
+fn has_uri_scheme(url: &str) -> bool {
+    let mut bytes = url.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+
+    for byte in bytes {
+        match byte {
+            b':' => return true,
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'+' | b'-' | b'.' => {}
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn resolve_relative_link(link_base_url: &str, target: &str) -> Option<String> {
+    if target.is_empty()
+        || target.starts_with('/')
+        || target.starts_with('#')
+        || target.starts_with('?')
+        || has_uri_scheme(target)
+    {
+        return None;
+    }
+
+    let suffix_start = target.find(['?', '#']).unwrap_or(target.len());
+    let path = &target[..suffix_start];
+    if path.is_empty() {
+        return None;
+    }
+
+    let trailing_slash = path.ends_with('/') || path == "." || path == "..";
+    let segment_capacity = link_base_url.bytes().filter(|byte| *byte == b'/').count()
+        + path.bytes().filter(|byte| *byte == b'/').count()
+        + 1;
+    let mut segments = Vec::with_capacity(segment_capacity);
+    for segment in link_base_url.split('/').chain(path.split('/')) {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            _ => segments.push(segment),
+        }
+    }
+
+    let mut resolved = String::with_capacity(link_base_url.len() + target.len() + 1);
+    resolved.push('/');
+    for (index, segment) in segments.iter().enumerate() {
+        if index > 0 {
+            resolved.push('/');
+        }
+        resolved.push_str(segment);
+    }
+    if trailing_slash && !resolved.ends_with('/') {
+        resolved.push('/');
+    }
+    resolved.push_str(&target[suffix_start..]);
+    Some(resolved)
+}
+
 /// Render markdown content to HTML with syntax-highlighted code blocks.
-/// Internal links (starting with `/`) are prefixed with `base_path`.
+/// Root-absolute internal links are prefixed with `base_path`, and relative
+/// links are resolved from `page_url`.
 ///
 /// `page_url` is the current page's canonical URL path (base-prefixed, with a
 /// trailing slash — e.g. `/webui/guide/`). In-page fragment links (heading
@@ -204,11 +270,22 @@ fn collect_node_text<'a>(
 /// (`{page_url}#slug`) rather than bare `#slug`. A bare fragment would resolve
 /// against the document's `<base href>` — which points at the site root — and
 /// navigate away from the current page instead of scrolling within it.
+#[allow(dead_code)] // Public library API; the binary uses the source-aware helper below.
 pub fn render_markdown(
     content: &str,
     highlighter: &Highlighter,
     base_path: &str,
     page_url: &str,
+) -> Result<String> {
+    render_markdown_with_link_base(content, highlighter, base_path, page_url, page_url)
+}
+
+pub(crate) fn render_markdown_with_link_base(
+    content: &str,
+    highlighter: &Highlighter,
+    base_path: &str,
+    page_url: &str,
+    link_base_url: &str,
 ) -> Result<String> {
     let arena = Arena::new();
     let mut options = Options::default();
@@ -228,16 +305,26 @@ pub fn render_markdown(
     for node in root.descendants() {
         let mut data = node.data.borrow_mut();
         if let NodeValue::Link(ref mut link) = data.value {
-            if link.url.starts_with('#') {
+            if link.url.is_empty() {
+                link.url = page_url.to_string();
+            } else if link.url.starts_with('#') {
                 // In-page fragment link. Make it absolute to the current page so
                 // it isn't resolved against `<base href>` (the site root).
                 link.url = format!("{page_url}{}", link.url);
+            } else if link.url.starts_with('?') {
+                // Query-only links also target the current page, not the site root.
+                link.url = format!("{page_url}{}", link.url);
             } else if link.url.starts_with('/')
+                && !link.url.starts_with("//")
                 && !link.url.starts_with(base_path)
                 && base_path != "/"
             {
                 // Prepend base_path to absolute internal links
                 link.url = format!("{}{}", base_path.trim_end_matches('/'), &link.url);
+            } else if let Some(resolved) = resolve_relative_link(link_base_url, &link.url) {
+                // The document-level `<base href>` points at the site root, so
+                // relative Markdown links must be resolved during the build.
+                link.url = resolved;
             }
         }
     }
@@ -394,6 +481,58 @@ mod tests {
         assert!(
             html.contains(r##"<a href="/webui/guide/#hello">below</a>"##),
             "in-content fragment link should be absolute to the page: {html}"
+        );
+    }
+
+    #[test]
+    fn relative_links_are_absolute_to_the_markdown_source_directory() {
+        let h = Highlighter::new();
+        let html = render_markdown_with_link_base(
+            "[Sibling](./sibling) [Parent](../parent) [Bare](other?tab=1#details)",
+            &h,
+            "/webui/",
+            "/webui/guide/current/",
+            "/webui/guide/",
+        )
+        .unwrap();
+
+        assert!(
+            html.contains(r#"<a href="/webui/guide/sibling">Sibling</a>"#),
+            "dot-relative link should use the source directory: {html}"
+        );
+        assert!(
+            html.contains(r#"<a href="/webui/parent">Parent</a>"#),
+            "parent-relative link should normalize dot segments: {html}"
+        );
+        assert!(
+            html.contains(r#"<a href="/webui/guide/other?tab=1#details">Bare</a>"#),
+            "bare relative link should preserve its query and fragment: {html}"
+        );
+    }
+
+    #[test]
+    fn non_relative_links_keep_their_existing_semantics() {
+        let h = Highlighter::new();
+        let html = render_markdown_with_link_base(
+            "[External](https://example.com/docs) [Network](//cdn.example.com/docs) [Query](?tab=1)",
+            &h,
+            "/webui/",
+            "/webui/guide/current/",
+            "/webui/guide/",
+        )
+        .unwrap();
+
+        assert!(
+            html.contains(r#"<a href="https://example.com/docs">External</a>"#),
+            "absolute external link should remain unchanged: {html}"
+        );
+        assert!(
+            html.contains(r#"<a href="//cdn.example.com/docs">Network</a>"#),
+            "protocol-relative link should remain unchanged: {html}"
+        );
+        assert!(
+            html.contains(r#"<a href="/webui/guide/current/?tab=1">Query</a>"#),
+            "query-only link should target the current page: {html}"
         );
     }
 

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -214,7 +214,7 @@ fn has_uri_scheme(url: &str) -> bool {
     false
 }
 
-fn resolve_relative_link(link_base_url: &str, target: &str) -> Option<String> {
+fn resolve_relative_link(base_path: &str, link_base_url: &str, target: &str) -> Option<String> {
     if target.is_empty()
         || target.starts_with('/')
         || target.starts_with('#')
@@ -234,12 +234,18 @@ fn resolve_relative_link(link_base_url: &str, target: &str) -> Option<String> {
     let segment_capacity = link_base_url.bytes().filter(|byte| *byte == b'/').count()
         + path.bytes().filter(|byte| *byte == b'/').count()
         + 1;
+    let base_segment_count = base_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .count();
     let mut segments = Vec::with_capacity(segment_capacity);
     for segment in link_base_url.split('/').chain(path.split('/')) {
         match segment {
             "" | "." => {}
             ".." => {
-                segments.pop();
+                if segments.len() > base_segment_count {
+                    segments.pop();
+                }
             }
             _ => segments.push(segment),
         }
@@ -314,7 +320,9 @@ pub fn render_markdown(
             {
                 // Prepend base_path to absolute internal links
                 link.url = format!("{}{}", base_path.trim_end_matches('/'), &link.url);
-            } else if let Some(resolved) = resolve_relative_link(link_base_url, &link.url) {
+            } else if let Some(resolved) =
+                resolve_relative_link(base_path, link_base_url, &link.url)
+            {
                 // The document-level `<base href>` points at the site root, so
                 // relative Markdown links must be resolved during the build.
                 link.url = resolved;
@@ -502,6 +510,46 @@ mod tests {
         assert!(
             html.contains(r#"<a href="/webui/guide/other?tab=1#details">Bare</a>"#),
             "bare relative link should preserve its query and fragment: {html}"
+        );
+    }
+
+    #[test]
+    fn relative_links_cannot_escape_the_base_path() {
+        let h = Highlighter::new();
+        let html = match render_markdown(
+            "[Clamped](../../x)",
+            &h,
+            "/webui/",
+            "/webui/guide/",
+            "/webui/guide/",
+        ) {
+            Ok(html) => html,
+            Err(e) => panic!("render_markdown should succeed: {e}"),
+        };
+
+        assert!(
+            html.contains(r#"<a href="/webui/x">Clamped</a>"#),
+            "parent segments should stop at the base path: {html}"
+        );
+    }
+
+    #[test]
+    fn empty_link_destination_targets_the_current_page() {
+        let h = Highlighter::new();
+        let html = match render_markdown(
+            "[]()",
+            &h,
+            "/webui/",
+            "/webui/guide/current/",
+            "/webui/guide/",
+        ) {
+            Ok(html) => html,
+            Err(e) => panic!("render_markdown should succeed: {e}"),
+        };
+
+        assert!(
+            html.contains(r#"<a href="/webui/guide/current/"></a>"#),
+            "empty destination should target the current page: {html}"
         );
     }
 

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -315,10 +315,10 @@ pub fn render_markdown(
     // rendering see original code-span nodes before they are converted to raw
     // HTML for WebUI template-signal escaping.
 
-    // Pass 1: Rewrite internal links before custom heading rendering.
+    // Pass 1: Rewrite internal links and images before custom heading rendering.
     for node in root.descendants() {
         let mut data = node.data.borrow_mut();
-        if let NodeValue::Link(ref mut link) = data.value {
+        if let NodeValue::Link(ref mut link) | NodeValue::Image(ref mut link) = data.value {
             if link.url.is_empty() {
                 link.url = page_url.to_string();
             } else if link.url.starts_with('#') {
@@ -524,6 +524,24 @@ mod tests {
         assert!(
             html.contains(r#"<a href="/webui/guide/other?tab=1#details">Bare</a>"#),
             "bare relative link should preserve its query and fragment: {html}"
+        );
+    }
+
+    #[test]
+    fn relative_images_are_absolute_to_the_markdown_source_directory() {
+        let h = Highlighter::new();
+        let html = render_markdown(
+            "![Diagram](./images/diagram.png)",
+            &h,
+            "/webui/",
+            "/webui/guide/current/",
+            "/webui/guide/",
+        )
+        .unwrap();
+
+        assert!(
+            html.contains(r#"<img src="/webui/guide/images/diagram.png" alt="Diagram" />"#),
+            "relative image should use the source directory: {html}"
         );
     }
 

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -262,7 +262,7 @@ fn resolve_relative_link(link_base_url: &str, target: &str) -> Option<String> {
 
 /// Render markdown content to HTML with syntax-highlighted code blocks.
 /// Root-absolute internal links are prefixed with `base_path`, and relative
-/// links are resolved from `page_url`.
+/// links are resolved from `link_base_url`.
 ///
 /// `page_url` is the current page's canonical URL path (base-prefixed, with a
 /// trailing slash — e.g. `/webui/guide/`). In-page fragment links (heading
@@ -270,17 +270,10 @@ fn resolve_relative_link(link_base_url: &str, target: &str) -> Option<String> {
 /// (`{page_url}#slug`) rather than bare `#slug`. A bare fragment would resolve
 /// against the document's `<base href>` — which points at the site root — and
 /// navigate away from the current page instead of scrolling within it.
-#[allow(dead_code)] // Public library API; the binary uses the source-aware helper below.
+///
+/// `link_base_url` is the URL directory corresponding to the Markdown source
+/// file. It can differ from `page_url` when configuration overrides the route.
 pub fn render_markdown(
-    content: &str,
-    highlighter: &Highlighter,
-    base_path: &str,
-    page_url: &str,
-) -> Result<String> {
-    render_markdown_with_link_base(content, highlighter, base_path, page_url, page_url)
-}
-
-pub(crate) fn render_markdown_with_link_base(
     content: &str,
     highlighter: &Highlighter,
     base_path: &str,
@@ -432,7 +425,8 @@ mod tests {
         // must not be interpreted as a WebUI signal binding by the template
         // parser — escape `{` and `}` to HTML entities.
         let h = Highlighter::new();
-        let html = render_markdown("Use `{{value}}` for escaped output.", &h, "/", "/").unwrap();
+        let html =
+            render_markdown("Use `{{value}}` for escaped output.", &h, "/", "/", "/").unwrap();
         assert!(
             html.contains("&#123;&#123;value&#125;&#125;"),
             "inline code braces should be escaped: {html}"
@@ -446,7 +440,7 @@ mod tests {
     #[test]
     fn heading_inline_code_survives_custom_anchor_rendering() {
         let h = Highlighter::new();
-        let html = match render_markdown("# `<for>` Loop Directive\n", &h, "/", "/") {
+        let html = match render_markdown("# `<for>` Loop Directive\n", &h, "/", "/", "/") {
             Ok(html) => html,
             Err(e) => panic!("render_markdown should succeed: {e}"),
         };
@@ -471,6 +465,7 @@ mod tests {
             &h,
             "/webui/",
             "/webui/guide/",
+            "/webui/guide/",
         )
         .unwrap();
 
@@ -487,7 +482,7 @@ mod tests {
     #[test]
     fn relative_links_are_absolute_to_the_markdown_source_directory() {
         let h = Highlighter::new();
-        let html = render_markdown_with_link_base(
+        let html = render_markdown(
             "[Sibling](./sibling) [Parent](../parent) [Bare](other?tab=1#details)",
             &h,
             "/webui/",
@@ -513,7 +508,7 @@ mod tests {
     #[test]
     fn non_relative_links_keep_their_existing_semantics() {
         let h = Highlighter::new();
-        let html = render_markdown_with_link_base(
+        let html = render_markdown(
             "[External](https://example.com/docs) [Network](//cdn.example.com/docs) [Query](?tab=1)",
             &h,
             "/webui/",
@@ -541,7 +536,7 @@ mod tests {
         // Fenced code blocks must also escape braces so example template
         // snippets render literally instead of being parsed as bindings.
         let h = Highlighter::new();
-        let html = render_markdown("```html\n<p>{{name}}</p>\n```\n", &h, "/", "/").unwrap();
+        let html = render_markdown("```html\n<p>{{name}}</p>\n```\n", &h, "/", "/", "/").unwrap();
         assert!(
             html.contains("&#123;&#123;name&#125;&#125;"),
             "code block braces should be escaped: {html}"


### PR DESCRIPTION
WebUI Press pages use a site-root `<base href>`, which caused relative Markdown links to resolve under `basePath` instead of the source document's directory. This produced 404s for otherwise valid links in generated documentation.

## Changes

- Resolve relative Markdown destinations from each source file's directory at build time.
- Normalize parent segments while preserving queries and fragments.
- Leave external and protocol-relative URLs unchanged.
- Cover both `index.md` and leaf-page routing semantics and document the behavior.

## Validation

- `cargo xtask check`
- Live crawl of 35 generated pages, 66 unique internal targets, 22 external targets, and all fragments with no failures