### PR TITLE
fix: preserve parent state across delayed child upgrades

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4053,6 +4053,18 @@ WebUI Framework hydration assumes the SSR DOM, hydration markers, and compiled m
   continue, then the collected error is rethrown. This supports arbitrarily deep
   definition order without recursion, per-depth promise allocation, lost state,
   or child mutation of authored-parent markers.
+- A complex `:` property has no durable HTML representation. During SSR
+  hydration, the parent resolves every known complex property in the existing
+  attribute-binding pass. An upgraded child receives the value through the
+  branded single-key state hook. An unupgraded compiled WebUI child retains its
+  instance-local values in a module-local weak map, then consumes them after its
+  own bootstrap state and before its first binding walk. Parent values therefore
+  override page-wide keys even when parent and child property names differ.
+  Parent updates that arrive after SSR rendering retain only a lazily allocated
+  root-name set and replay once after wiring. The common upgraded-child path
+  allocates nothing; the unresolved path creates no promise, strong element
+  registry, or cross-runtime state bridge. Undefined third-party custom elements
+  keep native direct-property assignment semantics.
 - Client-created DOM never reparses template syntax; it clones marker-free `h`,
   upgrades the detached custom-element subtree, resolves `tx`, `ag`, the slots
   embedded in `c` / `r`, and event target indices directly, then applies the first binding pass before

--- a/packages/webui-framework/RENDERING.md
+++ b/packages/webui-framework/RENDERING.md
@@ -41,7 +41,7 @@ Compile metadata        Inject SSR markers         existing DOM,
 3. **JavaScript loads.** The component class registers via `customElements.define`. The browser upgrades pre-existing tags and fires `connectedCallback`.
 4. **`$mount` decides client-or-SSR.** If a shadow root exists or the element already has children, the framework treats the DOM as SSR. Otherwise it parses the static template HTML (`meta.h`) into a detached staging root, upgrades custom elements, wires bindings, applies the first binding pass, and only then appends the nodes. Child `connectedCallback` methods see initial parent `:` property bindings.
 5. **`$applySSRState` seeds observables.** Backing fields (`_count`, `_title`, ...) are written directly from `window.__webui.state` so reactive bindings observe values that match the painted DOM.
-6. **`$hydrate` walks the DOM once.** One marker-aware pre-order pass numbers the subtree; text, attribute, conditional, repeat, and event bindings then resolve by index.
+6. **`$hydrate` walks the DOM once.** One marker-aware pre-order pass numbers the subtree; text, attribute, conditional, repeat, and event bindings then resolve by index. The attribute pass also transfers known complex `:` values. An unupgraded compiled WebUI child holds those values behind a weak key and consumes them after bootstrap but before its own binding walk, without a promise or strong retained element reference.
 7. **Stale markers are removed.** Item markers (`<!--wi-->`) and closing markers (`<!--/wc-->`, `<!--/wr-->`) are deleted; start markers (`<!--wc-->`, `<!--wr-->`) stay as anchors for runtime updates.
 8. **Path index is built lazily on the first reactive change.** Subsequent updates are O(affected bindings).
 

--- a/packages/webui-framework/src/template-element.test.ts
+++ b/packages/webui-framework/src/template-element.test.ts
@@ -66,6 +66,15 @@ Object.defineProperty(globalThis, 'window', {
   configurable: true,
 });
 
+Object.defineProperty(globalThis, 'customElements', {
+  value: {
+    get() {
+      return undefined;
+    },
+  },
+  configurable: true,
+});
+
 const { TemplateElement } = await import('./template-element.js');
 const { resetStreamingModeForTests } = await import('./streaming-mode.js');
 const {
@@ -86,6 +95,76 @@ function registerTemplate(tag: string): void {
     h: '<div></div>',
   };
 }
+
+interface ComplexPropertyWriter {
+  $writeComplexProperty(
+    element: Element,
+    name: string,
+    value: unknown,
+    replayAfterHydration: boolean,
+  ): void;
+}
+
+interface PendingParentStateConsumer {
+  $applyPendingParentState(replayAfterHydration: boolean): void;
+}
+
+describe('TemplateElement complex-property delivery', () => {
+  test('queues an unresolved WebUI child without creating an own property', () => {
+    const tag = 'test-pending-property';
+    registerTemplate(tag);
+    class PendingChild extends TemplateElement {
+      protected override $observableNames(): Set<string> {
+        return new Set(['payload']);
+      }
+    }
+    Object.defineProperty(PendingChild.prototype, 'payload', {
+      get(this: { _payload?: unknown }) {
+        return this._payload;
+      },
+      set(this: { _payload?: unknown }, value: unknown) {
+        this._payload = value;
+      },
+      configurable: true,
+    });
+
+    const parent = new TemplateElement();
+    const child = new PendingChild() as PendingChild & {
+      localName: string;
+      _payload?: unknown;
+    };
+    child.localName = tag;
+
+    (parent as unknown as ComplexPropertyWriter).$writeComplexProperty(
+      child,
+      'payload',
+      { label: 'from parent' },
+      false,
+    );
+
+    assert.equal(Object.hasOwn(child, 'payload'), false);
+    (child as unknown as PendingParentStateConsumer)
+      .$applyPendingParentState(false);
+    assert.deepEqual(child._payload, { label: 'from parent' });
+    assert.equal(Object.hasOwn(child, 'payload'), false);
+  });
+
+  test('preserves direct assignment for an unresolved third-party element', () => {
+    const parent = new TemplateElement();
+    const child = { localName: 'external-property-target' } as unknown as
+      Element & { payload?: unknown };
+
+    (parent as unknown as ComplexPropertyWriter).$writeComplexProperty(
+      child,
+      'payload',
+      { label: 'direct' },
+      false,
+    );
+
+    assert.deepEqual(child.payload, { label: 'direct' });
+    assert.equal(Object.hasOwn(child, 'payload'), true);
+  });
+});
 
 describe('TemplateElement.connectedCallback — streamed-host (data-ws) deferral', () => {
   test('defers a data-ws-marked streamed host without warning, even when metadata is missing', () => {

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -187,6 +187,40 @@ const ACTIVATION_MISSING_TEMPLATE = 3;
 const templateMetaByCtor = new WeakMap<Function, TemplateMeta>();
 const pendingAncestorDescendants = new WeakMap<Element, TemplateElement[]>();
 
+interface PendingParentState {
+  readonly values: Record<string, unknown>;
+  replay?: Set<string>;
+}
+
+const pendingParentStateByElement = new WeakMap<Element, PendingParentState>();
+
+function queuePendingParentState(
+  element: Element,
+  name: string,
+  value: unknown,
+  replayAfterHydration: boolean,
+): void {
+  let pending = pendingParentStateByElement.get(element);
+  if (!pending) {
+    pending = {
+      values: Object.create(null) as Record<string, unknown>,
+    };
+    pendingParentStateByElement.set(element, pending);
+  }
+  pending.values[name] = value;
+  if (replayAfterHydration) {
+    (pending.replay ??= new Set()).add(name);
+  }
+}
+
+function isUnupgradedWebUITarget(element: Element): boolean {
+  const tagName = element.localName;
+  if (tagName.indexOf('-') === -1) return false;
+  const ctor = customElements.get(tagName);
+  if (ctor) return ctor.prototype instanceof TemplateElement;
+  return getTemplate(tagName) !== undefined;
+}
+
 type TemplateObservedConstructor = CustomElementConstructor & {
   readonly observedAttributes?: readonly string[];
 };
@@ -609,17 +643,24 @@ export class TemplateElement extends HTMLElement {
       // Inject CSS module stylesheet after root is determined
       if (meta.sa) injectModuleStyle(meta.sa, this.shadowRoot);
 
-      if (isSSR) {
-        // Seed explicit authored state. A streamed activation (forceSSR) supplies
-        // its boundary-local state directly; ordinary hydration defaults to the
-        // global `window.__webui.state` handoff. Passing a boundary's state as-is
-        // (even when undefined) keeps a stateless streamed boundary from falling
-        // back to a later boundary's global state.
-        if (!reconnecting && this.$shouldApplySSRBootstrapState()) {
-          this.$applySSRState(
-            hasBoundaryState ? ssrState : window.__webui?.state,
-          );
+      if (!reconnecting) {
+        if (isSSR) {
+          // Seed explicit authored state. A streamed activation (forceSSR)
+          // supplies its boundary-local state directly; ordinary hydration
+          // defaults to the global `window.__webui.state` handoff. Passing a
+          // boundary's state as-is (even when undefined) keeps a stateless
+          // streamed boundary from falling back to a later boundary's global
+          // state.
+          if (this.$shouldApplySSRBootstrapState()) {
+            this.$applySSRState(
+              hasBoundaryState ? ssrState : window.__webui?.state,
+            );
+          }
         }
+        this.$applyPendingParentState(isSSR);
+      }
+
+      if (isSSR) {
         this.$root = this.$hydrate(root, meta, getTemplateDom(meta));
 
       } else {
@@ -999,6 +1040,7 @@ export class TemplateElement extends HTMLElement {
     if (this.$shouldApplySSRBootstrapState()) {
       this.$applySSRState(window.__webui?.state);
     }
+    this.$applyPendingParentState(true);
   }
 
   /**
@@ -1210,6 +1252,39 @@ export class TemplateElement extends HTMLElement {
         (this as Record<string, unknown>)[`_${key}`] = state[key];
       } else if (this.$usesTemplateState(key) && this.$shouldApplyTemplateStateFromSSR(key)) {
         this.$writeTemplateState(key, state[key]);
+      }
+    }
+  }
+
+  /**
+   * Apply instance-local state supplied by an SSR parent before this child
+   * walks its own bindings. Parent values override page-wide bootstrap keys.
+   */
+  private $applyPendingParentState(replayAfterHydration: boolean): void {
+    const pending = pendingParentStateByElement.get(this);
+    if (!pending) return;
+    pendingParentStateByElement.delete(this);
+
+    const state = pending.values;
+    const observableNames = this.$observableNames();
+    const keys = Object.keys(state);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (observableNames.has(key)) {
+        (this as Record<string, unknown>)[`_${key}`] = state[key];
+      } else if (this.$usesTemplateState(key)) {
+        this.$writeTemplateState(key, state[key]);
+      } else {
+        (this as Record<string, unknown>)[key] = state[key];
+      }
+    }
+    const replay = pending.replay;
+    if (replayAfterHydration && replay) {
+      const deferredWrites = this.$deferredWrites;
+      if (deferredWrites) {
+        for (const key of replay) deferredWrites.add(key);
+      } else {
+        this.$deferredWrites = replay;
       }
     }
   }
@@ -1665,7 +1740,13 @@ export class TemplateElement extends HTMLElement {
     }
 
     // Attribute bindings
-    this.$wireAttrs(instance, meta, scope, (i) => ssrElements[i] as Element);
+    this.$wireAttrs(
+      instance,
+      meta,
+      scope,
+      (i) => ssrElements[i] as Element,
+      true,
+    );
 
     // Conditional bindings — use <!--wc--> markers as anchors
     if (meta.c) {
@@ -2019,6 +2100,7 @@ export class TemplateElement extends HTMLElement {
     meta: TemplateBlockMeta,
     scope: ScopeFrame | undefined,
     resolve: (index: TemplateNodeIndex) => Node | null,
+    primeSSRComplexProperties = false,
   ): void {
     if (!meta.a || !meta.ag) return;
     for (let g = 0; g < meta.ag.length; g++) {
@@ -2027,9 +2109,65 @@ export class TemplateElement extends HTMLElement {
       if (!el || el.nodeType !== 1) continue;
       for (let j = 0; j < count; j++) {
         const entry = meta.a[start + j];
-        if (entry) instance.attrs.push(this.$makeAttr(el as Element, entry, scope));
+        if (!entry) continue;
+        const binding = this.$makeAttr(el as Element, entry, scope);
+        instance.attrs.push(binding);
+        if (
+          primeSSRComplexProperties &&
+          binding.kind === ATTR_KIND_COMPLEX &&
+          this.$attrStateIsKnown(binding)
+        ) {
+          this.$primeSSRComplexProperty(binding);
+        }
       }
     }
+  }
+
+  /**
+   * Complex properties have no HTML representation. Transfer known values
+   * during SSR hydration while keeping unupgraded compiled hosts accessor-safe.
+   */
+  private $primeSSRComplexProperty(binding: AttrBinding): void {
+    const element = binding.element;
+    const value = this.$resolveValue(binding.path!, binding.scope);
+    this.$writeComplexProperty(element, binding.name, value, false);
+  }
+
+  private $writeComplexProperty(
+    element: Element,
+    name: string,
+    value: unknown,
+    replayAfterHydration: boolean,
+  ): void {
+    const target = element as unknown as Record<string | symbol, unknown>;
+    const setStateKey = target[WEBUI_SET_STATE_KEY];
+    if (typeof setStateKey === 'function') {
+      if (
+        (setStateKey as (key: string, value: unknown) => boolean).call(
+          element,
+          name,
+          value,
+        )
+      ) {
+        const flush = target['$flushUpdates'];
+        if (typeof flush === 'function') (flush as () => void).call(element);
+        return;
+      }
+      target[name] = value;
+      return;
+    }
+
+    if (isUnupgradedWebUITarget(element)) {
+      queuePendingParentState(
+        element,
+        name,
+        value,
+        replayAfterHydration,
+      );
+      return;
+    }
+
+    target[name] = value;
   }
 
   /**
@@ -2262,16 +2400,7 @@ export class TemplateElement extends HTMLElement {
     switch (b.kind) {
       case ATTR_KIND_COMPLEX: {
         const v = this.$resolveValue(b.path!, b.scope);
-        const target = el as unknown as Record<string | symbol, unknown>;
-        const setStateKey = target[WEBUI_SET_STATE_KEY];
-        if (typeof setStateKey === 'function') {
-          if ((setStateKey as (key: string, value: unknown) => boolean).call(el, b.name, v)) {
-            const flush = target['$flushUpdates'];
-            if (typeof flush === 'function') (flush as () => void).call(el);
-            break;
-          }
-        }
-        target[b.name] = v;
+        this.$writeComplexProperty(el, b.name, v, true);
         break;
       }
       case ATTR_KIND_BOOLEAN: {

--- a/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
+++ b/packages/webui-framework/tests/fixtures/complex-prop/complex-prop.spec.ts
@@ -6,7 +6,7 @@
  * observable changes to child <for> loops.
  *
  * When a parent's @observable array is replaced (e.g. via setState
- * during SPA navigation), the complex binding `:items="{{items}}"` must
+ * during SPA navigation), the complex binding `:items="{{sourceItems}}"` must
  * push the new array to the child, causing the child's <for> loop to
  * re-render with the updated data.
  */
@@ -31,6 +31,59 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     });
 
     expect(items).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+
+  test('child-first hydration receives the renamed parent property', async ({ page }) => {
+    const result = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const list = host?.shadowRoot?.querySelector('test-item-list') as any;
+      return {
+        items: list?.items,
+        shadowsAccessor: Object.hasOwn(list, 'items'),
+      };
+    });
+
+    expect(result.items).toEqual([
+      { name: 'Alpha' },
+      { name: 'Beta' },
+      { name: 'Gamma' },
+    ]);
+    expect(result.shadowsAccessor).toBe(false);
+  });
+
+  test('waits for a delayed custom-element accessor before assigning a property', async ({
+    page,
+  }) => {
+    await page.waitForFunction(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector(
+        'test-delayed-prop-child',
+      ) as any;
+      return (
+        customElements.get('test-delayed-prop-child') !== undefined &&
+        child?.$ready === true
+      );
+    });
+    const result = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const child = host?.shadowRoot?.querySelector(
+        'test-delayed-prop-child',
+      ) as any;
+      return {
+        items: child?.items,
+        rendered: Array.from(
+          child?.shadowRoot?.querySelectorAll('.delayed-item') ?? [],
+        ).map((item: any) => item.textContent),
+        shadowsAccessor: Object.hasOwn(child, 'items'),
+      };
+    });
+
+    expect(result.items).toEqual([
+      { name: 'Late Alpha' },
+      { name: 'Late Beta' },
+    ]);
+    expect(result.rendered).toEqual(['Late Alpha', 'Late Beta']);
+    expect(result.shadowsAccessor).toBe(false);
   });
 
   test('replacing parent items updates child for-loop', async ({ page }) => {
@@ -83,7 +136,7 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     // Simulate what the router does during SPA navigation
     await page.evaluate(() => {
       const host = document.querySelector('#host') as any;
-      host.setState({ items: [{ name: 'X' }, { name: 'Y' }] });
+      host.setState({ sourceItems: [{ name: 'X' }, { name: 'Y' }] });
     });
 
     await page.waitForFunction(() => {
@@ -109,7 +162,9 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
     // transitions which snapshot the DOM right after the sync callback.
     const result = await page.evaluate(() => {
       const host = document.querySelector('#host') as any;
-      host.setState({ items: [{ name: 'Sync1' }, { name: 'Sync2' }, { name: 'Sync3' }] });
+      host.setState({
+        sourceItems: [{ name: 'Sync1' }, { name: 'Sync2' }, { name: 'Sync3' }],
+      });
 
       // Check IMMEDIATELY — no await, no microtask, no setTimeout
       const list = host?.shadowRoot?.querySelector('test-item-list');
@@ -122,6 +177,69 @@ test.describe('complex-prop: parent array changes propagate to child for-loop', 
 
     expect(result.count).toBe(3);
     expect(result.items).toEqual(['Sync1', 'Sync2', 'Sync3']);
+  });
+});
+
+test.describe('complex-prop: parent-first SSR hydration', () => {
+  test('queues renamed parent state until the child upgrades', async ({ page }) => {
+    await page.goto('/complex-prop/fixture.html?definitionOrder=parent-first');
+    await page.waitForFunction(() => {
+      const el = document.querySelector('#host') as any;
+      return el && el.$ready === true;
+    });
+
+    const result = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const list = host?.shadowRoot?.querySelector('test-item-list') as any;
+      return {
+        items: list?.items,
+        rendered: Array.from(
+          list?.shadowRoot?.querySelectorAll('.item') ?? [],
+        ).map((item: any) => item.textContent),
+        shadowsAccessor: Object.hasOwn(list, 'items'),
+      };
+    });
+
+    expect(result.items).toEqual([
+      { name: 'Alpha' },
+      { name: 'Beta' },
+      { name: 'Gamma' },
+    ]);
+    expect(result.rendered).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(result.shadowsAccessor).toBe(false);
+  });
+
+  test('queues state for a defined but detached unupgraded child', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/complex-prop/fixture.html?definitionOrder=detached-defined-child',
+    );
+    await page.waitForFunction(() => {
+      const host = document.querySelector('#host') as any;
+      const list = host?.shadowRoot?.querySelector('test-item-list') as any;
+      return host?.$ready === true && list?.$ready === true;
+    });
+
+    const result = await page.evaluate(() => {
+      const host = document.querySelector('#host') as any;
+      const list = host?.shadowRoot?.querySelector('test-item-list') as any;
+      return {
+        items: list?.items,
+        rendered: Array.from(
+          list?.shadowRoot?.querySelectorAll('.item') ?? [],
+        ).map((item: any) => item.textContent),
+        shadowsAccessor: Object.hasOwn(list, 'items'),
+      };
+    });
+
+    expect(result.items).toEqual([
+      { name: 'Alpha' },
+      { name: 'Beta' },
+      { name: 'Gamma' },
+    ]);
+    expect(result.rendered).toEqual(['Alpha', 'Beta', 'Gamma']);
+    expect(result.shadowsAccessor).toBe(false);
   });
 });
 

--- a/packages/webui-framework/tests/fixtures/complex-prop/element.ts
+++ b/packages/webui-framework/tests/fixtures/complex-prop/element.ts
@@ -13,20 +13,25 @@ export class TestCondChild extends WebUIElement {
 }
 
 export class TestItemHost extends WebUIElement {
-  @observable items: Array<{ name: string }> = [
+  @observable sourceItems: Array<{ name: string }> = [
     { name: 'Alpha' },
     { name: 'Beta' },
     { name: 'Gamma' },
   ];
 
   @observable condData = { showHeader: true, label: 'Hello' };
+  @observable delayedItems: Array<{ name: string }> = [
+    { name: 'Alpha' },
+    { name: 'Beta' },
+    { name: 'Gamma' },
+  ];
 
   replaceItems(): void {
-    this.items = [{ name: 'One' }, { name: 'Two' }];
+    this.sourceItems = [{ name: 'One' }, { name: 'Two' }];
   }
 
   clearItems(): void {
-    this.items = [];
+    this.sourceItems = [];
   }
 
   hideCondHeader(): void {
@@ -34,6 +39,43 @@ export class TestItemHost extends WebUIElement {
   }
 }
 
-TestItemList.define('test-item-list');
-TestCondChild.define('test-cond-child');
-TestItemHost.define('test-item-host');
+class TestDelayedPropChild extends WebUIElement {
+  @observable items: Array<{ name: string }> = [];
+}
+
+const defineTestItemHost = (): void => TestItemHost.define('test-item-host');
+const defineTestItemList = (): void => TestItemList.define('test-item-list');
+const defineTestCondChild = (): void => TestCondChild.define('test-cond-child');
+
+const hydratedHost = document.querySelector('#host') as TestItemHost | null;
+if (!hydratedHost) {
+  throw new Error('Complex-property test host is unavailable.');
+}
+
+const definitionOrder = new URL(window.location.href).searchParams.get(
+  'definitionOrder',
+);
+if (definitionOrder === 'parent-first') {
+  defineTestItemHost();
+  defineTestItemList();
+  defineTestCondChild();
+} else if (definitionOrder === 'detached-defined-child') {
+  hydratedHost.remove();
+  defineTestItemList();
+  defineTestCondChild();
+  defineTestItemHost();
+  document.body.append(hydratedHost);
+} else {
+  defineTestItemList();
+  defineTestCondChild();
+  defineTestItemHost();
+}
+
+hydratedHost.delayedItems = [
+  { name: 'Late Alpha' },
+  { name: 'Late Beta' },
+];
+
+queueMicrotask(() => {
+  TestDelayedPropChild.define('test-delayed-prop-child');
+});

--- a/packages/webui-framework/tests/fixtures/complex-prop/src/test-delayed-prop-child/test-delayed-prop-child.html
+++ b/packages/webui-framework/tests/fixtures/complex-prop/src/test-delayed-prop-child/test-delayed-prop-child.html
@@ -1,0 +1,3 @@
+<for each="item in items">
+  <span class="delayed-item">{{item.name}}</span>
+</for>

--- a/packages/webui-framework/tests/fixtures/complex-prop/src/test-item-host/test-item-host.html
+++ b/packages/webui-framework/tests/fixtures/complex-prop/src/test-item-host/test-item-host.html
@@ -3,5 +3,6 @@
   <button class="clear" @click="{clearItems()}">Clear</button>
   <button class="hide-cond" @click="{hideCondHeader()}">Hide Header</button>
 </div>
-<test-item-list :items="{{items}}"></test-item-list>
+<test-item-list :items="{{sourceItems}}"></test-item-list>
 <test-cond-child :data="{{condData}}"></test-cond-child>
+<test-delayed-prop-child :items="{{delayedItems}}"></test-delayed-prop-child>

--- a/packages/webui-framework/tests/fixtures/complex-prop/state.json
+++ b/packages/webui-framework/tests/fixtures/complex-prop/state.json
@@ -1,1 +1,1 @@
-{ "items": [{ "name": "Alpha" }, { "name": "Beta" }, { "name": "Gamma" }], "condData": { "showHeader": true, "label": "Hello" } }
+{ "sourceItems": [{ "name": "Alpha" }, { "name": "Beta" }, { "name": "Gamma" }], "delayedItems": [{ "name": "Alpha" }, { "name": "Beta" }, { "name": "Gamma" }], "condData": { "showHeader": true, "label": "Hello" } }


### PR DESCRIPTION
## Why this is needed

Complex `:` bindings pass structured JavaScript values such as arrays and objects from a parent template into a child component. Unlike text and scalar attributes, those values do not have a durable HTML representation.

That creates a definition-order gap during SSR hydration:

1. The server renders the child DOM from the parent state.
2. The browser can upgrade and hydrate the parent before the child class is defined.
3. The parent must transfer the complex value before the child walks its own bindings.
4. Directly assigning the value to an unresolved custom element creates an own property.
5. When the child later upgrades, that own property shadows the `@observable` accessor on the class prototype. The reactive setter never receives the parent value, and a field initializer can replace it with the default.

This is especially visible when the parent and child use different state names, for example `:items="{{sourceItems}}"`. Page-wide bootstrap state cannot seed the child's `items` field from the parent's `sourceItems` key, even though the SSR DOM was rendered correctly.

The result is a component whose rendered SSR content and JavaScript state disagree. Repeat and conditional bindings can retain stale state, future writes can bypass the accessor, and component behavior depends on whether the parent or child happened to be defined first.

## What changed

- Prime known complex properties during the existing SSR attribute-binding pass, preserving single-pass hydration.
- Keep the existing allocation-free branded state hook for children that are already upgraded.
- Retain values for an unresolved compiled WebUI child in a module-local `WeakMap<Element, PendingParentState>`.
- Apply the pending parent values after the child's own bootstrap state and before its first binding walk, for both SSR and client-created mounts.
- Preserve post-SSR parent updates with a lazily allocated root-name set and transfer that set into the child's existing deferred replay path without allocating a duplicate.
- Preserve normal direct-property assignment for undefined third-party custom elements.
- Document the contract only in `DESIGN.md` and the framework maintainer rendering notes. This is a transparent runtime fix, so no user-facing guide changes are included.

## Why this design

The first version considered for this fix stored three `Symbol.for(...)` values on every pending child and registered one `customElements.whenDefined()` continuation per element. That approach was not suitable for the framework runtime:

- each unresolved definition promise strongly retained its element until that tag was defined;
- a tag that was never defined retained removed elements indefinitely;
- `Symbol.for(...)` created a cross-runtime global protocol for private state;
- a class may be registered while a detached element is still unupgraded, so `customElements.get()` alone does not make direct assignment accessor-safe;
- the generic waiter changed semantics for third-party elements even though the defect is specific to compiled WebUI children.

The weak handoff keeps the normal upgraded-child path unchanged and allocation-free. Only a child that actually receives parent state before upgrade allocates one weak entry and one null-prototype value record. The replay `Set` is allocated only when a newer parent value must be reconciled after SSR wiring. There are no definition promises, retained-element sets, per-tag registries, or global pending-state bridges.

## Regression coverage

The framework tests now cover:

- child-first SSR hydration;
- parent-first SSR hydration;
- different parent and child property names;
- a defined but detached child that has not upgraded yet;
- a parent update queued before delayed child definition;
- replay of the newest value after initial SSR wiring;
- preservation of the child's prototype accessor with no shadowing own property;
- child repeat and conditional bindings driven by complex values;
- the existing non-observable authored-setter fallback;
- unchanged direct assignment for unresolved third-party elements.

## Performance and memory

The baseline below is the initial per-element `whenDefined()` pending-state implementation evaluated for this fix. The result is the weak handoff in this PR.

Hydration timings are medians from 7 serial Playwright runs. Bundle size is a minified browser ESM build with `__WEBUI_DEV__=false`. Retention was measured with a 2,000-element Chromium CDP stress probe followed by forced garbage collection.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Wide hydration, 150 instances | 10.0 ms | 9.0 ms | -10.0% |
| Deep hydration, 150 instances | 2.9 ms | 2.4 ms | -17.2% |
| Nested hydration, 40 instances | 2.3 ms | 2.1 ms | -8.7% |
| Production bundle | 48,471 bytes | 48,006 bytes | -465 bytes (-0.96%) |
| Unresolved elements retained after forced GC | 2,000 / 2,000 | 0 / 2,000 | -100% |

The timing results show no hydration regression; the deterministic bundle and retention results confirm the lower code and memory cost.

## Validation

- Full `@microsoft/webui-framework` unit and Playwright suites
- Focused complex-property and optional-state browser regressions
- Framework TypeScript and E2E type checking
- Documentation build
- `cargo xtask check`