### PR TITLE
chore: bump version to 0.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "actix-web",
  "awc",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "cbindgen",
  "criterion",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "criterion",
  "memchr",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "clap",
  "criterion",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "criterion",
  "prost",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.23"
+version = "0.0.24"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -17,12 +17,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.23", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.23" }
+microsoft-webui = { path = "../webui", version = "0.0.24", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.24" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.24" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.24" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -44,7 +44,7 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -16,13 +16,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.24" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.24" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -31,7 +31,7 @@ cbindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
 
 [[bench]]
 name = "protocol_bench"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -16,17 +16,17 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.23" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.24" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.24" }
 memchr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.24" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.24" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -19,16 +19,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.23" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
+microsoft-webui = { path = "../webui", version = "0.0.24" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.24", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -27,8 +27,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.24" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -36,7 +36,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.24" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -20,10 +20,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.23", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
+microsoft-webui = { path = "../webui", version = "0.0.24", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.24" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.24" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -47,7 +47,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.23" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.24" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -19,7 +19,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.23" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.24" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -26,9 +26,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.24", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -19,11 +19,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.23" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.23" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.23" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.24" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.24" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.24" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -45,8 +45,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.23" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.23", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.24" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.24", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.23</Version>
+    <Version>0.0.24</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration and compiled-template path mapping.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -34,5 +34,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.24`.

Previous release tag: `v0.0.23`

## Changes since `v0.0.23`

Fixes:

- Azure release automation now uses the native rustup home, selects Rust 1.93 consistently, adds issue-based changelogs, and restricts production releases to `main` artifacts (fix: repair Azure release pipeline #436).
- Router navigation now bounds initial responses, cancels superseded deferred streams, rejects stale asynchronous work, and mounts pending/error boundaries against the destination hierarchy (fix: harden router navigation lifecycle #439).
- Complex parent `:` bindings preserve their state and reactive accessors when child custom elements upgrade late (fix: preserve parent state across delayed child upgrades #438).

Maintenance:

- GitHub Actions are pinned to immutable commit SHAs with a seven-day Dependabot cooldown, and the action set was refreshed (Pin GitHub Actions to full-length commit SHAs #437, chore(deps): bump the github-actions group with 9 updates #440).
- Published Rust crate archives now include the repository license text (chore: include license in crate packages #441).

## Validation

- `cargo xtask check`