### PR TITLE
fix: preserve compiled template metadata hierarchy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1782,6 +1782,12 @@ Both outlet spellings compile as one empty directive element. The compiler
 consumes the paired closing tag before assigning later binding slots, preserving
 the authored parent hierarchy for siblings after the outlet.
 
+The finalizer matches native HTML void tags ASCII-case-insensitively and counts
+the browser-implied `<colgroup>` / `<tbody>` parents around direct `<col>` /
+`<tr>` runs. Compiler-owned structural marker comments and trailing HTML
+whitespace remain inside the implied parent, matching the browser tree used for
+SSR hydration and client locator resolution.
+
 Component policies are visible to the Rust build because they live on the root
 component `<template>`, not on a TypeScript class. Under `DomStrategy::Shadow`
 that authored wrapper becomes the declarative shadow-root template after its

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,7 +260,7 @@ via `WebUIFragmentRoute` nesting.
 
 #### Outlet Fragment
 Outlet fragments mark where matched child route content renders inside a parent route component.
-The parser emits these from `<outlet />` elements.
+The parser emits these from `<outlet />` or paired `<outlet></outlet>` directives.
 ```rust
 pub struct WebUIFragmentOutlet {}
 ```
@@ -1776,7 +1776,11 @@ The Rust compiler (`generate_compiled_template` in `webui-parser/src/plugin/webu
 | `<template w-hydrate="lazy">`     | `wp: 1`                | policy wrapper/attributes stripped |
 | `<template w-render="lazy" w-reserve-block-size="72px">` | `wp: 2` | policy wrapper/attributes stripped |
 | `w-ref="{name}"`                     | *(stays)*              | *(unchanged)*                     |
-| `<outlet />`                         | *(stays)*              | `<outlet></outlet>`               |
+| `<outlet />`, `<outlet></outlet>`   | *(stays)*              | `<outlet></outlet>`               |
+
+Both outlet spellings compile as one empty directive element. The compiler
+consumes the paired closing tag before assigning later binding slots, preserving
+the authored parent hierarchy for siblings after the outlet.
 
 Component policies are visible to the Rust build because they live on the root
 component `<template>`, not on a TypeScript class. Under `DomStrategy::Shadow`

--- a/crates/webui-parser/src/html_parser.rs
+++ b/crates/webui-parser/src/html_parser.rs
@@ -382,6 +382,25 @@ pub(crate) fn find_matching_end(
     None
 }
 
+/// Return the end byte after a named element, accepting self-closing and paired forms.
+///
+/// The opening tag name is matched case-sensitively for WebUI directives. Paired
+/// elements include their matching closing tag in the consumed range.
+#[inline]
+pub(crate) fn find_element_end(input: &str, tag_name: &str) -> Option<usize> {
+    let tag = parse_tag(input)?;
+    if tag.closing || tag.name != tag_name {
+        return None;
+    }
+
+    let content_start = tag.close + 1;
+    if tag.self_closing {
+        return Some(content_start);
+    }
+
+    find_matching_end(input, tag_name, content_start).map(|(_, close_end)| close_end)
+}
+
 /// Return the end byte after an HTML comment starting at the beginning of
 /// `input`.
 #[inline]
@@ -608,6 +627,19 @@ mod tests {
     fn find_matching_end_handles_nested_same_tag() {
         let html = "<div><div>x</div></div><p></p>";
         assert_eq!(find_matching_end(html, "div", 5), Some((17, 23)));
+    }
+
+    #[test]
+    fn find_element_end_accepts_self_closing_and_paired_directives() {
+        assert_eq!(find_element_end("<outlet /></main>", "outlet"), Some(10));
+        assert_eq!(
+            find_element_end("<outlet></outlet></main>", "outlet"),
+            Some(17)
+        );
+        assert_eq!(
+            find_element_end("<outlet-card></outlet-card>", "outlet"),
+            None
+        );
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/fast_v2.rs
+++ b/crates/webui-parser/src/plugin/fast_v2.rs
@@ -9,7 +9,7 @@
 
 use super::{AttributeAction, ComponentTemplateArtifact, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
-use crate::html_parser::{find_tag_close, opening_tag_name};
+use crate::html_parser::{find_element_end, find_tag_close, opening_tag_name};
 use crate::{CssLinkOptions, CssStrategy, Result};
 use webui_protocol::FastElementData;
 
@@ -286,11 +286,9 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
 
     // <outlet /> is kept as a marker element in f-templates.
     // The client router finds it and replaces it with <webui-route> stubs.
-    if starts_with_tag_name(remaining, "outlet") {
-        if let Some(close) = find_tag_close(remaining) {
-            result.push_str("<outlet></outlet>");
-            return Some(close + 1);
-        }
+    if let Some(consumed) = find_element_end(remaining, "outlet") {
+        result.push_str("<outlet></outlet>");
+        return Some(consumed);
     }
 
     // Check for <if condition="...">
@@ -1106,9 +1104,13 @@ mod tests {
 
     #[test]
     fn outlet_kept_as_marker_in_f_template() {
-        let input = r#"<div><outlet /></div>"#;
-        let output = convert_btr_to_fast(input);
-        assert_eq!(output, r#"<div><outlet></outlet></div>"#);
+        for input in [
+            r#"<div><outlet /></div>"#,
+            r#"<div><outlet></outlet></div>"#,
+        ] {
+            let output = convert_btr_to_fast(input);
+            assert_eq!(output, r#"<div><outlet></outlet></div>"#);
+        }
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/fast_v3.rs
+++ b/crates/webui-parser/src/plugin/fast_v3.rs
@@ -9,7 +9,7 @@
 
 use super::{AttributeAction, ComponentTemplateArtifact, ParserPlugin, ParserPluginArtifacts};
 use crate::component_registry::Component;
-use crate::html_parser::{find_tag_close, opening_tag_name};
+use crate::html_parser::{find_element_end, find_tag_close, opening_tag_name};
 use crate::{CssLinkOptions, CssStrategy, Result};
 use webui_protocol::FastElementData;
 
@@ -286,11 +286,9 @@ fn try_convert_tag(input: &str, pos: usize, result: &mut String) -> Option<usize
 
     // <outlet /> is kept as a marker element in f-templates.
     // The client router finds it and replaces it with <webui-route> stubs.
-    if starts_with_tag_name(remaining, "outlet") {
-        if let Some(close) = find_tag_close(remaining) {
-            result.push_str("<outlet></outlet>");
-            return Some(close + 1);
-        }
+    if let Some(consumed) = find_element_end(remaining, "outlet") {
+        result.push_str("<outlet></outlet>");
+        return Some(consumed);
     }
 
     // Check for <if condition="...">
@@ -1106,9 +1104,13 @@ mod tests {
 
     #[test]
     fn outlet_kept_as_marker_in_f_template() {
-        let input = r#"<div><outlet /></div>"#;
-        let output = convert_btr_to_fast(input);
-        assert_eq!(output, r#"<div><outlet></outlet></div>"#);
+        for input in [
+            r#"<div><outlet /></div>"#,
+            r#"<div><outlet></outlet></div>"#,
+        ] {
+            let output = convert_btr_to_fast(input);
+            assert_eq!(output, r#"<div><outlet></outlet></div>"#);
+        }
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -67,7 +67,9 @@ use crate::comment_policy;
 use crate::component_policy::{parse_component_render_policy, ComponentRenderPolicy};
 use crate::component_registry::Component;
 use crate::diagnostic::{codes, Diagnostic};
-use crate::html_parser::{find_element_end, find_tag_close, parse_tag, style_element_bounds};
+use crate::html_parser::{
+    find_element_end, find_tag_close, is_void_element, parse_tag, style_element_bounds,
+};
 use crate::{ConditionParser, DomStrategy, ParserOptions, Result};
 use std::cell::Cell;
 use std::fmt::Write;
@@ -1620,7 +1622,7 @@ fn finalize_template_section(meta: &mut TemplateSectionMeta) {
     let raw_html = std::mem::take(&mut meta.html);
     let text_marker_offsets = std::mem::take(&mut meta.text_marker_offsets);
     let mut nodes = parse_fragment_nodes(&raw_html, &text_marker_offsets);
-    insert_implied_tbody(&mut nodes);
+    insert_implied_table_containers(&mut nodes);
     let text_bindings = meta.text_bindings.clone();
     let mut finalized_html = String::with_capacity(raw_html.len());
     let mut text_runs = Vec::new();
@@ -1943,22 +1945,22 @@ fn emit_html_attr_value(value: &str, out: &mut String) {
     }
 }
 
-/// Insert the `<tbody>` the HTML parser implies around bare `<tr>` in a table.
+/// Insert the containers the HTML parser implies around bare table children.
 ///
 /// Compiled locators are pre-order element indices, and the browser resolves
-/// them against its own parse of `h`.  A `<tr>` written directly inside
-/// `<table>` is moved into an implied `<tbody>` there, which inserts an element
-/// the compiler never counted and shifts every index after the table.  Adding
-/// the wrapper here keeps the emitted HTML and the numbering agreeing with what
-/// the browser will build.
+/// them against its own parse of `h`. Bare `<col>` and `<tr>` elements written
+/// directly inside `<table>` gain implied `<colgroup>` and `<tbody>` parents,
+/// which insert elements the compiler must count. Comments and whitespace
+/// after the first item remain in that implied parent in the browser.
 ///
-/// Only element *order* matters to the numbering, so the parser's other
-/// recovery rules — `<p>`/`<li>` auto-closing and friends — are irrelevant:
-/// they change nesting, not sequence.
+/// This pass is intentionally limited to the table containers browsers insert
+/// for otherwise valid table markup. Other HTML recovery rules can also change
+/// hierarchy or element count, so templates must still use browser-valid
+/// nesting.
 ///
 /// Iterative, and addressed by path so the borrow checker can see that only one
 /// child list is held at a time.  This runs once per component at build time.
-fn insert_implied_tbody(nodes: &mut Vec<FragmentNode>) {
+fn insert_implied_table_containers(nodes: &mut Vec<FragmentNode>) {
     let mut stack: Vec<Vec<usize>> = vec![Vec::new()];
 
     while let Some(path) = stack.pop() {
@@ -1969,7 +1971,8 @@ fn insert_implied_tbody(nodes: &mut Vec<FragmentNode>) {
         for index in 0..list.len() {
             if let Some(FragmentNode::Element(element)) = list.get_mut(index) {
                 if element.tag_name.eq_ignore_ascii_case("table") {
-                    wrap_table_rows(element);
+                    wrap_table_run(element, "col", "colgroup", false);
+                    wrap_table_run(element, "tr", "tbody", true);
                 }
             }
         }
@@ -2003,9 +2006,18 @@ fn child_list_at<'a>(
     Some(list)
 }
 
-/// Group each run of direct `<tr>` children of a table into one `<tbody>`.
-fn wrap_table_rows(table: &mut FragmentElement) {
-    if !table.children.iter().any(is_bare_row) {
+/// Group each run of direct table children into its browser-implied parent.
+fn wrap_table_run(
+    table: &mut FragmentElement,
+    item_tag: &str,
+    parent_tag: &str,
+    include_structural_markers: bool,
+) {
+    if !table
+        .children
+        .iter()
+        .any(|node| is_direct_element_named(node, item_tag))
+    {
         return;
     }
 
@@ -2013,45 +2025,44 @@ fn wrap_table_rows(table: &mut FragmentElement) {
     let mut run: Vec<FragmentNode> = Vec::new();
 
     for node in std::mem::take(&mut table.children) {
-        if is_bare_row(&node) {
+        if is_direct_element_named(&node, item_tag) {
             run.push(node);
             continue;
         }
-        // Whitespace between rows stays inside the section the browser builds.
-        if !run.is_empty() {
-            if let FragmentNode::Text(text) = &node {
-                if text.trim().is_empty() {
-                    run.push(node);
-                    continue;
-                }
-            }
+        if !run.is_empty() && is_table_run_trivia(&node, include_structural_markers) {
+            run.push(node);
+            continue;
         }
-        flush_row_run(&mut run, &mut rewritten);
+        flush_table_run(&mut run, &mut rewritten, parent_tag);
         rewritten.push(node);
     }
-    flush_row_run(&mut run, &mut rewritten);
+    flush_table_run(&mut run, &mut rewritten, parent_tag);
 
     table.children = rewritten;
 }
 
-fn flush_row_run(run: &mut Vec<FragmentNode>, out: &mut Vec<FragmentNode>) {
+fn flush_table_run(run: &mut Vec<FragmentNode>, out: &mut Vec<FragmentNode>, parent_tag: &str) {
     if run.is_empty() {
         return;
     }
-    // Trailing whitespace belongs after the section, matching the parser.
-    while matches!(run.last(), Some(FragmentNode::Text(text)) if text.trim().is_empty()) {
-        run.pop();
-    }
     out.push(FragmentNode::Element(FragmentElement {
-        tag_name: "tbody".to_string(),
+        tag_name: parent_tag.to_string(),
         attrs: Vec::new(),
         children: std::mem::take(run),
         self_closing: false,
     }));
 }
 
-fn is_bare_row(node: &FragmentNode) -> bool {
-    matches!(node, FragmentNode::Element(element) if element.tag_name.eq_ignore_ascii_case("tr"))
+fn is_direct_element_named(node: &FragmentNode, tag_name: &str) -> bool {
+    matches!(node, FragmentNode::Element(element) if element.tag_name.eq_ignore_ascii_case(tag_name))
+}
+
+fn is_table_run_trivia(node: &FragmentNode, include_structural_markers: bool) -> bool {
+    matches!(node, FragmentNode::Comment(data) if include_structural_markers
+        || (parse_marker_index(data, "c:").is_none() && parse_marker_index(data, "r:").is_none()))
+        || matches!(node, FragmentNode::Text(text) if text.bytes().all(
+            |byte| matches!(byte, b'\t' | b'\n' | 0x0C | b'\r' | b' ')
+        ))
 }
 
 fn parse_fragment_nodes(input: &str, text_marker_offsets: &[usize]) -> Vec<FragmentNode> {
@@ -2323,26 +2334,6 @@ fn parse_fragment_start_tag(input: &str) -> Option<(FragmentElement, usize)> {
         },
         end + 1,
     ))
-}
-
-fn is_void_element(tag_name: &str) -> bool {
-    matches!(
-        tag_name,
-        "area"
-            | "base"
-            | "br"
-            | "col"
-            | "embed"
-            | "hr"
-            | "img"
-            | "input"
-            | "link"
-            | "meta"
-            | "param"
-            | "source"
-            | "track"
-            | "wbr"
-    )
 }
 
 // ── Parsing helpers ────────────────────────────────────────────────
@@ -3998,6 +3989,20 @@ mod tests {
     }
 
     #[test]
+    fn test_uppercase_void_element_does_not_own_following_slots() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<div><INPUT><if condition="nested"><span>nested</span></if></div><if condition="root"><span>root</span></if>"#,
+        );
+
+        assert!(result.contains(r#""h":"<div><INPUT /></div>""#), "{result}");
+        assert!(
+            result.contains(r#""c":[[[0,["nested"]],0,[1,1]],[[1,["root"]],1,[0,1]]]"#,),
+            "{result}"
+        );
+    }
+
+    #[test]
     fn test_emoji_safe() {
         let result = generate_compiled_template("my-comp", r#"<span>📚 {{title}}</span>"#);
         assert!(result.contains("📚"));
@@ -4360,6 +4365,81 @@ mod tests {
             result.contains(r#""eg":[["click",[["go",[],5]]]]"#),
             "{result}"
         );
+    }
+
+    #[test]
+    fn test_implied_tbody_keeps_structural_slots_and_trailing_whitespace() {
+        let result = generate_compiled_template(
+            "my-comp",
+            "<table><tr><td>a</td></tr><if condition=\"show\"><tr><td>conditional</td></tr></if><tr><td>{{cell}}</td></tr>  </table><button @click=\"{go()}\"></button>",
+        );
+
+        assert!(
+            result.contains(
+                r#""h":"<table><tbody><tr><td>a</td></tr><tr><td></td></tr>  </tbody></table><button></button>""#,
+            ),
+            "{result}"
+        );
+        // table=1, tbody=2, first tr=3, td=4, second tr=5, td=6, button=7
+        assert!(result.contains(r#""tx":[[[6,0],[["cell"]]]]"#), "{result}");
+        assert!(
+            result.contains(r#""c":[[[0,["show"]],0,[2,1]]]"#),
+            "{result}"
+        );
+        assert!(
+            result.contains(r#""eg":[["click",[["go",[],7]]]]"#),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn test_bare_table_columns_gain_the_implied_colgroup() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<table><col><col><tr><td>{{cell}}</td></tr></table><button @click="{go()}"></button>"#,
+        );
+
+        assert!(
+            result.contains(
+                r#""h":"<table><colgroup><col /><col /></colgroup><tbody><tr><td></td></tr></tbody></table><button></button>""#,
+            ),
+            "{result}"
+        );
+        // table=1, colgroup=2, cols=3/4, tbody=5, tr=6, td=7, button=8
+        assert!(result.contains(r#""tx":[[[7,0],[["cell"]]]]"#), "{result}");
+        assert!(
+            result.contains(r#""eg":[["click",[["go",[],8]]]]"#),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn test_implied_colgroup_does_not_claim_following_row_repeat() {
+        let result = generate_compiled_template(
+            "my-comp",
+            r#"<table><col><for each="row in rows"><tr><td>{{row.value}}</td></tr></for></table>"#,
+        );
+
+        assert!(
+            result.contains(r#""h":"<table><colgroup><col /></colgroup></table>""#),
+            "{result}"
+        );
+        assert!(
+            result.contains(r#""r":[["rows","row",0,[1,1]]]"#),
+            "{result}"
+        );
+    }
+
+    #[test]
+    fn test_table_run_trivia_uses_html_whitespace() {
+        assert!(is_table_run_trivia(
+            &FragmentNode::Text("\t\n\u{000C}\r ".to_string()),
+            false
+        ));
+        assert!(!is_table_run_trivia(
+            &FragmentNode::Text("\u{00A0}".to_string()),
+            true
+        ));
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/webui.rs
+++ b/crates/webui-parser/src/plugin/webui.rs
@@ -67,7 +67,7 @@ use crate::comment_policy;
 use crate::component_policy::{parse_component_render_policy, ComponentRenderPolicy};
 use crate::component_registry::Component;
 use crate::diagnostic::{codes, Diagnostic};
-use crate::html_parser::{find_tag_close, parse_tag, style_element_bounds};
+use crate::html_parser::{find_element_end, find_tag_close, parse_tag, style_element_bounds};
 use crate::{ConditionParser, DomStrategy, ParserOptions, Result};
 use std::cell::Cell;
 use std::fmt::Write;
@@ -554,7 +554,7 @@ impl ConditionFunctionEmitter {
 /// | module adopted stylesheet specifier   | `sa`                       | stored from `<template>` wrapper  |
 /// | `@event="{handler(e)}"`               | `eg[]`                     | element kept marker-free          |
 /// | `w-ref="name"` / `w-ref={name}`       | *(stays in HTML)*          | *(unchanged)*                     |
-/// | `<outlet />` / `<outlet>`             | *(stays in HTML)*          | `<outlet></outlet>`               |
+/// | `<outlet />` / `<outlet></outlet>`    | *(stays in HTML)*          | `<outlet></outlet>`               |
 ///
 /// # Errors
 ///
@@ -1442,11 +1442,12 @@ fn compile_section(
                 continue;
             }
 
-            // <outlet ... /> → keep as <outlet></outlet>
+            // Normalize the complete outlet element so a paired closing tag
+            // cannot be mistaken for an ancestor close during finalization.
             if remaining.starts_with("<outlet") {
-                if let Some(close) = find_tag_close(remaining) {
+                if let Some(consumed) = find_element_end(remaining, "outlet") {
                     meta.html.push_str("<outlet></outlet>");
-                    i += close + 1;
+                    i += consumed;
                     continue;
                 }
             }
@@ -3979,9 +3980,21 @@ mod tests {
     }
 
     #[test]
-    fn test_outlet_converted() {
-        let result = generate_compiled_template("my-comp", r#"<main><outlet /></main>"#);
-        assert!(result.contains("<outlet></outlet>"));
+    fn test_outlet_forms_compile_identically_without_lifting_following_blocks() {
+        let self_closing = generate_compiled_template(
+            "my-comp",
+            r#"<div class="shell-content"><main><outlet /></main><if condition="showNestedAfter"><span>nested</span></if></div><if condition="showRootAfter"><span>root</span></if>"#,
+        );
+        let paired = generate_compiled_template(
+            "my-comp",
+            r#"<div class="shell-content"><main><outlet></outlet></main><if condition="showNestedAfter"><span>nested</span></if></div><if condition="showRootAfter"><span>root</span></if>"#,
+        );
+
+        assert_eq!(paired, self_closing);
+        assert!(paired.contains(r#"<main><outlet></outlet></main></div>"#));
+        assert!(paired.contains(
+            r#""c":[[[0,["showNestedAfter"]],0,[1,1]],[[1,["showRootAfter"]],1,[0,1]]]"#,
+        ));
     }
 
     #[test]

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -150,6 +150,15 @@ my-app/
 
 ## Template syntax
 
+### HTML structure
+
+Write browser-valid HTML nesting. Native void tags are matched
+case-insensitively, and direct `<col>` / `<tr>` runs receive the browser-implied
+`<colgroup>` / `<tbody>` in compiled client metadata. When an `<if>` or `<for>`
+controls table columns or rows, author the corresponding `<colgroup>` or
+`<tbody>` explicitly so both SSR hydration markers stay in the same browser
+parsing context.
+
 ### Text binding
 
 ```html

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -338,6 +338,9 @@ find the element that was hit.
 <main><outlet /></main>
 ```
 
+`<outlet></outlet>` is also valid, but outlets are empty directives and the
+self-closing form is preferred.
+
 ### Entry template
 
 ```html

--- a/docs/guide/concepts/components/index.md
+++ b/docs/guide/concepts/components/index.md
@@ -59,6 +59,12 @@ Include it explicitly when you need **root host events** - event listeners on th
 
 When you include the `<template>` tag, the framework uses yours instead of auto-injecting one.
 
+Component templates must use browser-valid HTML nesting. WebUI recognizes native
+void tags case-insensitively and accounts for the `<colgroup>` and `<tbody>` that
+browsers imply around direct `<col>` and `<tr>` runs. If an `<if>` or `<for>`
+controls table columns or rows, write the `<colgroup>` or `<tbody>` explicitly
+so its SSR hydration markers share one parser context.
+
 ## How Components Work
 
 When WebUI discovers components:

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -53,6 +53,9 @@ All WebUI apps with routes **must** include `<base href="/">`. Without it, relat
 <main><outlet /></main>
 ```
 
+The paired form `<outlet></outlet>` is also supported. Outlet directives are
+empty; prefer the shorter self-closing form.
+
 **3. Start the router:**
 
 ```typescript

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -67,6 +67,8 @@ Child routes use **relative paths** (no leading `/`). The nesting is the route t
 ```
 
 `<outlet />` marks where child route content renders. The nav and footer persist across navigations.
+The paired form `<outlet></outlet>` is also supported, but outlets are empty and
+the self-closing form is preferred.
 
 **3. Start the router after hydration:**
 


### PR DESCRIPTION
Paired `<outlet></outlet>` syntax was normalized to a complete outlet element while only its opening tag was consumed. The leftover closing tag could prematurely close ancestor nodes in compiled template metadata, lifting following structural bindings out of their authored wrapper and making Router-triggered hydration updates vulnerable to duplication.

This change:
- adds a shared allocation-free scanner that consumes self-closing and paired outlet forms as one directive element;
- uses the same normalization in the WebUI, FAST v2, and FAST v3 compilers;
- adds regressions proving both forms compile identically and preserve nested conditional parent slots;
- documents the supported paired form and preferred self-closing spelling.

A deeper review of the same finalization path found and fixes three adjacent browser-parity defects:
- the metadata finalizer had a duplicate case-sensitive void-element list, so uppercase native void tags could own later structural slots;
- bare `<col>` runs omitted the browser-implied `<colgroup>`, shifting every later locator index;
- implied `<tbody>` runs split at compiler-owned structural markers and discarded trailing HTML whitespace, diverging from the browser tree.

The table normalization remains tag-aware: a row-producing `<if>` or `<for>` after columns is not claimed by the implied `<colgroup>`. Explicit `<colgroup>` and `<tbody>` wrappers remain the recommended form around structural directives.

The exact nested-wrapper browser capture now maps the post-outlet conditional to its `.shell-content` parent (`parentIndex=10`) and preserves the badge/list counts (`1`/`2`) across soft navigation with no console or page errors.

## Validation

- `cargo test -p microsoft-webui-parser`
- `cargo xtask check`
- `cd docs && pnpm build`
- standalone Router SSR hydration Playwright capture