### PR TITLE
fix: distinguish route declarations by path

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -1135,11 +1135,9 @@ impl WebUIHandler {
 
                 // Emit matched <webui-route>
                 context.writer.write("<webui-route")?;
-                if !matched_child.path.is_empty() {
-                    context.writer.write(" path=\"")?;
-                    context.writer.write(&matched_child.path)?;
-                    context.writer.write("\"")?;
-                }
+                context.writer.write(" path=\"")?;
+                context.writer.write(&matched_child.path)?;
+                context.writer.write("\"")?;
                 context.writer.write(" component=\"")?;
                 context.writer.write(comp)?;
                 context.writer.write("\"")?;
@@ -1185,11 +1183,9 @@ impl WebUIHandler {
             let is_matched = best.as_ref().is_some_and(|(bi, _)| *bi == idx);
             if !is_matched && !child.fragment_id.is_empty() {
                 context.writer.write("<webui-route")?;
-                if !child.path.is_empty() {
-                    context.writer.write(" path=\"")?;
-                    context.writer.write(&child.path)?;
-                    context.writer.write("\"")?;
-                }
+                context.writer.write(" path=\"")?;
+                context.writer.write(&child.path)?;
+                context.writer.write("\"")?;
                 context.writer.write(" component=\"")?;
                 context.writer.write(&child.fragment_id)?;
                 context.writer.write("\"")?;
@@ -1276,11 +1272,9 @@ impl WebUIHandler {
             .is_some_and(|(best_key, _)| *best_key == route_frag.fragment_id);
 
         context.writer.write("<webui-route")?;
-        if !route_frag.path.is_empty() {
-            context.writer.write(" path=\"")?;
-            context.writer.write(&route_frag.path)?;
-            context.writer.write("\"")?;
-        }
+        context.writer.write(" path=\"")?;
+        context.writer.write(&route_frag.path)?;
+        context.writer.write("\"")?;
         if !route_frag.fragment_id.is_empty() {
             context.writer.write(" component=\"")?;
             context.writer.write(&route_frag.fragment_id)?;

--- a/packages/webui-router/src/chain.test.ts
+++ b/packages/webui-router/src/chain.test.ts
@@ -6,7 +6,11 @@ import './browser-shim.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { RouteChainEntry } from './cache.js';
-import { findChangeLevel, sameRouteDeclaration } from './chain.js';
+import {
+  findChangeLevel,
+  findOrCreateRouteElement,
+  sameRouteDeclaration,
+} from './chain.js';
 
 function routeEntry(
   path: string,
@@ -17,6 +21,24 @@ function routeEntry(
     path,
     params,
   };
+}
+
+function routeElement(
+  attributes: Record<string, string>,
+): HTMLElement {
+  return {
+    tagName: 'WEBUI-ROUTE',
+    style: {},
+    getAttribute(name: string) {
+      return Object.hasOwn(attributes, name) ? attributes[name] : null;
+    },
+    hasAttribute(name: string) {
+      return Object.hasOwn(attributes, name);
+    },
+    setAttribute(name: string, value: string) {
+      attributes[name] = value;
+    },
+  } as unknown as HTMLElement;
 }
 
 describe('route chain identity', () => {
@@ -40,5 +62,34 @@ describe('route chain identity', () => {
       sameRouteDeclaration(routeEntry('projects'), routeEntry('')),
       false,
     );
+  });
+
+  test('missing path is not treated as the empty-path declaration', () => {
+    const body = document.body as unknown as {
+      children: HTMLElement[];
+      appendChild(el: HTMLElement): void;
+    };
+    const originalChildren = body.children;
+    const originalAppendChild = body.appendChild;
+    const originalCreateElement = document.createElement;
+    const unpathed = routeElement({ component: 'shared-page' });
+    const created = routeElement({});
+
+    body.children = [unpathed];
+    body.appendChild = () => {};
+    document.createElement = () => created;
+
+    try {
+      const result = findOrCreateRouteElement(null, routeEntry(''));
+
+      assert.notEqual(result, unpathed);
+      assert.equal(result, created);
+      assert.equal(result.hasAttribute('path'), true);
+      assert.equal(result.getAttribute('path'), '');
+    } finally {
+      body.children = originalChildren;
+      body.appendChild = originalAppendChild;
+      document.createElement = originalCreateElement;
+    }
   });
 });

--- a/packages/webui-router/src/chain.test.ts
+++ b/packages/webui-router/src/chain.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import './browser-shim.js';
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { RouteChainEntry } from './cache.js';
+import { findChangeLevel, sameRouteDeclaration } from './chain.js';
+
+function routeEntry(
+  path: string,
+  params: Record<string, string> = {},
+): RouteChainEntry {
+  return {
+    component: 'shared-page',
+    path,
+    params,
+  };
+}
+
+describe('route chain identity', () => {
+  test('declared path changes the chain level', () => {
+    assert.equal(
+      findChangeLevel([routeEntry('projects')], [routeEntry('')]),
+      0,
+    );
+  });
+
+  test('parameter changes preserve declaration identity but change the chain instance', () => {
+    const oldEntry = routeEntry('items/:id', { id: '1' });
+    const newEntry = routeEntry('items/:id', { id: '2' });
+
+    assert.equal(sameRouteDeclaration(oldEntry, newEntry), true);
+    assert.equal(findChangeLevel([oldEntry], [newEntry]), 0);
+  });
+
+  test('shared components on different paths are distinct declarations', () => {
+    assert.equal(
+      sameRouteDeclaration(routeEntry('projects'), routeEntry('')),
+      false,
+    );
+  });
+});

--- a/packages/webui-router/src/chain.ts
+++ b/packages/webui-router/src/chain.ts
@@ -83,7 +83,7 @@ export function findChangeLevel(
   const len = Math.min(oldChain.length, newChain.length);
   for (let i = 0; i < len; i++) {
     if (
-      oldChain[i].component !== newChain[i].component ||
+      !sameRouteDeclaration(oldChain[i], newChain[i]) ||
       !paramsEqual(oldChain[i].params, newChain[i].params)
     ) {
       return i;
@@ -91,6 +91,50 @@ export function findChangeLevel(
   }
   // If chains differ in length, change starts at the shorter length
   return len;
+}
+
+/**
+ * Whether two chain entries represent the same authored route declaration.
+ * Bound params are intentionally excluded because one declaration owns all of
+ * its parameterized instances.
+ */
+export function sameRouteDeclaration(
+  a: Pick<RouteChainEntry, 'component' | 'path'>,
+  b: Pick<RouteChainEntry, 'component' | 'path'>,
+): boolean {
+  return a.component === b.component && a.path === b.path;
+}
+
+function findRouteElement(
+  elements: ArrayLike<Element>,
+  entry: RouteChainEntry,
+): HTMLElement | null {
+  let unpathedMatch: HTMLElement | null = null;
+  let componentMatchCount = 0;
+  let unpathedMatchCount = 0;
+
+  for (let i = 0; i < elements.length; i++) {
+    const child = elements[i];
+    if (
+      child.tagName !== 'WEBUI-ROUTE' ||
+      child.getAttribute('component') !== entry.component
+    ) {
+      continue;
+    }
+    componentMatchCount++;
+    const path = child.getAttribute('path') ?? '';
+    if (path === entry.path) return child as HTMLElement;
+    if (!child.hasAttribute('path')) {
+      unpathedMatch = child as HTMLElement;
+      unpathedMatchCount++;
+    }
+  }
+
+  // Older compiler output could omit a normalized non-empty path. Preserve
+  // that compatibility only when the component has one unambiguous placeholder.
+  return componentMatchCount === 1 && unpathedMatchCount === 1
+    ? unpathedMatch
+    : null;
 }
 
 /**
@@ -105,12 +149,8 @@ export function findOrCreateRouteElement(
 ): HTMLElement {
   // For top-level routes, search direct children of body
   if (!parent) {
-    for (const child of document.body.children) {
-      if (child.tagName === 'WEBUI-ROUTE' &&
-          child.getAttribute('component') === entry.component) {
-        return child as HTMLElement;
-      }
-    }
+    const routeEl = findRouteElement(document.body.children, entry);
+    if (routeEl) return routeEl;
     const el = createRouteStub(entry);
     document.body.appendChild(el);
     return el;
@@ -123,20 +163,8 @@ export function findOrCreateRouteElement(
       const root = renderRoot(compEl);
       const allRoutes = root.querySelectorAll(ROUTE_SELECTOR);
 
-      // Match by component + path for stronger identity
-      for (const child of allRoutes) {
-        if (child.getAttribute('component') === entry.component &&
-            child.getAttribute('path') === (entry.path || null)) {
-          return child as HTMLElement;
-        }
-      }
-      // Reuse the compiler-emitted route placeholder for this nested
-      // component when hydration has already normalized the route container.
-      for (const child of allRoutes) {
-        if (child.getAttribute('component') === entry.component) {
-          return child as HTMLElement;
-        }
-      }
+      const routeEl = findRouteElement(allRoutes, entry);
+      if (routeEl) return routeEl;
       // Not found — create stub and place in the correct container
       const stub = createRouteStub(entry);
 

--- a/packages/webui-router/src/chain.ts
+++ b/packages/webui-router/src/chain.ts
@@ -109,32 +109,17 @@ function findRouteElement(
   elements: ArrayLike<Element>,
   entry: RouteChainEntry,
 ): HTMLElement | null {
-  let unpathedMatch: HTMLElement | null = null;
-  let componentMatchCount = 0;
-  let unpathedMatchCount = 0;
-
   for (let i = 0; i < elements.length; i++) {
     const child = elements[i];
     if (
-      child.tagName !== 'WEBUI-ROUTE' ||
-      child.getAttribute('component') !== entry.component
+      child.tagName === 'WEBUI-ROUTE' &&
+      child.getAttribute('component') === entry.component &&
+      child.getAttribute('path') === entry.path
     ) {
-      continue;
-    }
-    componentMatchCount++;
-    const path = child.getAttribute('path') ?? '';
-    if (path === entry.path) return child as HTMLElement;
-    if (!child.hasAttribute('path')) {
-      unpathedMatch = child as HTMLElement;
-      unpathedMatchCount++;
+      return child as HTMLElement;
     }
   }
-
-  // Older compiler output could omit a normalized non-empty path. Preserve
-  // that compatibility only when the component has one unambiguous placeholder.
-  return componentMatchCount === 1 && unpathedMatchCount === 1
-    ? unpathedMatch
-    : null;
+  return null;
 }
 
 /**

--- a/packages/webui-router/src/route-element.ts
+++ b/packages/webui-router/src/route-element.ts
@@ -71,7 +71,7 @@ export function renderRoot(el: Element): Element | ShadowRoot {
 /** Create a hidden `<webui-route>` stub element. */
 export function createRouteStub(entry: { path?: string; component?: string; exact?: boolean }): HTMLElement {
   const el = document.createElement(ROUTE_SELECTOR);
-  if (entry.path) el.setAttribute('path', entry.path);
+  if (entry.path !== undefined) el.setAttribute('path', entry.path);
   if (entry.component) el.setAttribute('component', entry.component);
   if (entry.exact) el.setAttribute('exact', '');
   el.style.display = 'none';

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -49,7 +49,12 @@ import {
 } from './templates.js';
 import type { StreamingContext } from './streaming.js';
 import { ensureComponentLoaded, resolveLoaders, LOADER_FAILED } from './loaders.js';
-import { buildChainFromSSR, findChangeLevel, findOrCreateRouteElement } from './chain.js';
+import {
+  buildChainFromSSR,
+  findChangeLevel,
+  findOrCreateRouteElement,
+  sameRouteDeclaration,
+} from './chain.js';
 import { findErrorComponent, findPendingComponent } from './route-boundary.js';
 
 export { parseQuery, filterQuery, WebUIRouteElement };
@@ -840,7 +845,7 @@ export class WebUIRouter {
         const entry = newChain[i];
         const oldEntry = i < this.activeChain.length ? this.activeChain[i] : null;
         const parent = i > 0 ? newChain[i - 1] : null;
-        if (oldEntry?.component === entry.component && oldEntry?.el) {
+        if (oldEntry?.el && sameRouteDeclaration(oldEntry, entry)) {
           entry.el = oldEntry.el;
           entry.compEl = oldEntry.compEl;
           setRouteMeta(entry.el, {

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -820,10 +820,30 @@ export class WebUIRouter {
     const isQueryOnlyChange = changeLevel === newChain.length && newChain.length > 0;
 
     const commitNavigation = (): void => {
-      // Deactivate old chain from leaf up
+      // Deactivate old chain from leaf up. An entry whose declaration won't
+      // be reused by the incoming chain (a sibling route matched instead —
+      // e.g. two `<route>`s sharing a component but distinguished by path)
+      // has its mounted component destroyed so it doesn't linger, invisible,
+      // in the DOM. Entries kept for in-place reuse (same declaration, or
+      // opted into `keep-alive`) are left mounted.
       for (let i = this.activeChain.length - 1; i >= changeLevel; i--) {
-        if (this.activeChain[i].el) deactivateRoute(this.activeChain[i].el!);
-        this.activeChain[i].compEl = undefined; // Release component reference
+        const oldEntry = this.activeChain[i];
+        if (oldEntry.el) {
+          const newEntry = i < newChain.length ? newChain[i] : undefined;
+          const willReuse = newEntry !== undefined && sameRouteDeclaration(oldEntry, newEntry);
+          if (!willReuse) {
+            const isKeepAlive = oldEntry.keepAlive || getRouteMeta(oldEntry.el)?.keepAlive || false;
+            if (!isKeepAlive) {
+              const existing = oldEntry.compEl ?? oldEntry.el.firstElementChild;
+              if (existing && typeof (existing as unknown as { $destroy?: () => void }).$destroy === 'function') {
+                (existing as unknown as { $destroy: () => void }).$destroy();
+              }
+              oldEntry.el.textContent = '';
+            }
+          }
+          deactivateRoute(oldEntry.el);
+        }
+        oldEntry.compEl = undefined; // Release component reference
       }
       for (let i = 0; i < changeLevel; i++) {
         newChain[i].el = this.activeChain[i].el;

--- a/packages/webui-router/tests/fixtures/router-app/data/state.json
+++ b/packages/webui-router/tests/fixtures/router-app/data/state.json
@@ -1,5 +1,6 @@
 {
   "appTitle": "Router Test",
+  "dashboardTitle": "SSR Dashboard",
   "isHome": true,
   "isAlpha": false,
   "isBeta": false,

--- a/packages/webui-router/tests/fixtures/router-app/src/index.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.html
@@ -12,6 +12,15 @@
 </head>
 <body>
   <route path="/" component="route-shell">
+    <route path="" component="route-dashboard" exact
+           pending="loading-skeleton"
+           cache-tags="catalog-route"
+           invalidates="catalog-route" />
+    <route path="projects" component="route-dashboard" exact keep-alive
+           pending="error-display"
+           error="error-display"
+           cache-tags="projects-route"
+           invalidates="projects-route" />
     <route path="alpha" component="page-alpha" exact />
     <route path="beta" component="page-beta" exact />
     <route path="items/:itemId" component="page-detail" exact pending="error-display" />

--- a/packages/webui-router/tests/fixtures/router-app/src/index.ts
+++ b/packages/webui-router/tests/fixtures/router-app/src/index.ts
@@ -12,6 +12,7 @@ import { PageFailing } from './page-failing/page-failing';
 import { PageKeepAlive } from './page-keepalive/page-keepalive';
 import { PageLoader } from './page-loader/page-loader';
 import { PageSlow } from './page-slow/page-slow';
+import { RouteDashboard } from './route-dashboard/route-dashboard';
 import { RouteShell } from './route-shell/route-shell';
 
 // ── Shell component ──────────────────────────────────────────────
@@ -23,6 +24,8 @@ RouteShell.define('route-shell');
 PageAlpha.define('page-alpha');
 
 PageBeta.define('page-beta');
+
+RouteDashboard.define('route-dashboard');
 
 PageDetail.define('page-detail');
 
@@ -56,6 +59,7 @@ window.addEventListener('webui:hydration-complete', () => {
     loaders: {
       'page-alpha': () => Promise.resolve(),
       'page-beta': () => Promise.resolve(),
+      'route-dashboard': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
       'page-compose': () => Promise.resolve(),
       'page-keepalive': () => Promise.resolve(),
@@ -74,6 +78,7 @@ if (performance.getEntriesByName('webui:hydrate:total', 'measure').length > 0) {
     loaders: {
       'page-alpha': () => Promise.resolve(),
       'page-beta': () => Promise.resolve(),
+      'route-dashboard': () => Promise.resolve(),
       'page-detail': () => Promise.resolve(),
       'page-compose': () => Promise.resolve(),
       'page-keepalive': () => Promise.resolve(),

--- a/packages/webui-router/tests/fixtures/router-app/src/route-dashboard/route-dashboard.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-dashboard/route-dashboard.html
@@ -1,0 +1,3 @@
+<div class="page route-dashboard">
+  <div data-testid="dashboard-title">{{dashboardTitle}}</div>
+</div>

--- a/packages/webui-router/tests/fixtures/router-app/src/route-dashboard/route-dashboard.ts
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-dashboard/route-dashboard.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { WebUIElement, observable } from '@microsoft/webui-framework';
+
+export class RouteDashboard extends WebUIElement {
+  @observable dashboardTitle = '';
+}

--- a/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
+++ b/packages/webui-router/tests/fixtures/router-app/src/route-shell/route-shell.html
@@ -2,6 +2,7 @@
   <h1>Router Test</h1>
   <nav>
     <a href="/" ?active="{{isHome}}">Home</a>
+    <a href="/projects">Projects</a>
     <a href="/alpha" ?active="{{isAlpha}}">Alpha</a>
     <a href="/beta" ?active="{{isBeta}}">Beta</a>
     <a href="/items/1" ?active="{{isItem1}}">Item 1</a>

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -15,18 +15,232 @@
  */
 
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+interface DashboardPartial {
+  state?: Record<string, unknown>;
+  chain?: Array<{
+    component?: string;
+    path?: string;
+    keepAlive?: boolean;
+    pendingComponent?: string;
+    errorComponent?: string;
+    invalidates?: string[];
+  }>;
+  cacheTags?: string[];
+}
+
+async function waitForDashboardRoute(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const dashboard = document.querySelector('route-shell')?.shadowRoot
+      ?.querySelector('route-dashboard');
+    const router = (window as unknown as {
+      __testRouter?: { activeComponent?: string };
+    }).__testRouter;
+    return dashboard &&
+      (dashboard as unknown as { $ready?: boolean }).$ready === true &&
+      router?.activeComponent === 'route-dashboard';
+  });
+}
+
+async function interceptDashboardPartial(
+  page: Page,
+  pathname: string,
+  dashboardTitle?: string,
+  delayMs = 0,
+): Promise<{ response?: DashboardPartial }> {
+  const capture: { response?: DashboardPartial } = {};
+  await page.route('**/*', async route => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (
+      url.pathname !== pathname ||
+      !request.headers()['accept']?.includes('application/json')
+    ) {
+      await route.continue();
+      return;
+    }
+
+    if (delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    const response = await route.fetch();
+    const partial = await response.json() as DashboardPartial;
+    capture.response = partial;
+    const state = { ...partial.state };
+    if (dashboardTitle === undefined) {
+      delete state.dashboardTitle;
+    } else {
+      state.dashboardTitle = dashboardTitle;
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...partial,
+        state,
+      },
+    });
+  });
+  return capture;
+}
+
+async function dashboardRouteState(page: Page): Promise<{
+  path: string | null;
+  pending: string | null;
+  error: string | null;
+  keepAlive: boolean;
+  marker: string | null;
+}> {
+  return page.evaluate(() => {
+    const routes = document.querySelector('route-shell')?.shadowRoot
+      ?.querySelectorAll<HTMLElement>('webui-route');
+    const active = routes
+      ? Array.from(routes).find(route => route.hasAttribute('active'))
+      : undefined;
+    const dashboard = active?.querySelector('route-dashboard') as
+      | (HTMLElement & { __identityMarker?: string })
+      | null;
+    return {
+      path: active ? active.getAttribute('path') ?? '' : null,
+      pending: active?.getAttribute('pending') ?? null,
+      error: active?.getAttribute('error') ?? null,
+      keepAlive: active?.hasAttribute('keep-alive') ?? false,
+      marker: dashboard?.__identityMarker ?? null,
+    };
+  });
+}
 
 test.describe('SSR deep links', () => {
   test('root page renders shell with nav links', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Router Test');
-    await expect(page.locator('nav a')).toHaveCount(10);
+    await expect(page.locator('nav a')).toHaveCount(11);
   });
 
   test('alpha page renders via SSR', async ({ page }) => {
     await page.goto('/alpha');
     await expect(page.locator('h2')).toContainText('Alpha Page');
     await expect(page.locator('.content')).toContainText('Welcome to the Alpha page');
+  });
+
+  test.describe('route declaration identity', () => {
+    test('direct /projects SSR switches to the distinct root declaration', async ({ page }) => {
+      await page.goto('/projects');
+      await waitForDashboardRoute(page);
+      await expect(page.getByTestId('dashboard-title')).toHaveText('SSR Dashboard');
+
+      await page.evaluate(() => {
+        const dashboard = document.querySelector('route-shell')?.shadowRoot
+          ?.querySelector<HTMLElement>('webui-route[active] route-dashboard');
+        if (dashboard) {
+          (dashboard as HTMLElement & { __identityMarker?: string }).__identityMarker =
+            'projects-ssr';
+        }
+      });
+
+      expect(await dashboardRouteState(page)).toEqual({
+        path: 'projects',
+        pending: 'error-display',
+        error: 'error-display',
+        keepAlive: true,
+        marker: 'projects-ssr',
+      });
+
+      const rootPartial = await interceptDashboardPartial(page, '/', 'Catalog', 350);
+      await page.evaluate(() => {
+        window.navigation.navigate('/');
+      });
+
+      await expect(page.locator('loading-skeleton[data-webui-pending]')).toBeVisible();
+      await expect(
+        page.locator(
+          'route-shell webui-route[active] route-dashboard [data-testid="dashboard-title"]',
+        ),
+      ).toHaveText('Catalog');
+
+      expect(rootPartial.response?.chain?.at(-1)).toMatchObject({
+        component: 'route-dashboard',
+        path: '',
+        pendingComponent: 'loading-skeleton',
+        invalidates: ['catalog-route'],
+      });
+      expect(rootPartial.response?.chain?.at(-1)?.keepAlive).toBeUndefined();
+      expect(rootPartial.response?.cacheTags).toContain('catalog-route');
+      expect(await dashboardRouteState(page)).toEqual({
+        path: '',
+        pending: 'loading-skeleton',
+        error: null,
+        keepAlive: false,
+        marker: null,
+      });
+
+      await page.unroute('**/*');
+      await interceptDashboardPartial(page, '/projects');
+      await page.evaluate(() => {
+        window.navigation.navigate('/projects');
+      });
+      await expect(
+        page.locator(
+          'route-shell webui-route[active] route-dashboard [data-testid="dashboard-title"]',
+        ),
+      ).toHaveText('SSR Dashboard');
+      expect(await dashboardRouteState(page)).toEqual({
+        path: 'projects',
+        pending: 'error-display',
+        error: 'error-display',
+        keepAlive: true,
+        marker: 'projects-ssr',
+      });
+    });
+
+    test('direct root SSR switches to the distinct /projects declaration', async ({ page }) => {
+      await page.goto('/');
+      await waitForDashboardRoute(page);
+      await expect(page.getByTestId('dashboard-title')).toHaveText('SSR Dashboard');
+
+      expect(await dashboardRouteState(page)).toEqual({
+        path: '',
+        pending: 'loading-skeleton',
+        error: null,
+        keepAlive: false,
+        marker: null,
+      });
+
+      const projectsPartial = await interceptDashboardPartial(
+        page,
+        '/projects',
+        'Projects',
+        350,
+      );
+      await page.evaluate(() => {
+        window.navigation.navigate('/projects');
+      });
+
+      await page.waitForTimeout(250);
+      await expect(page.locator('[data-webui-pending]')).toHaveCount(0);
+      await expect(
+        page.locator(
+          'route-shell webui-route[active] route-dashboard [data-testid="dashboard-title"]',
+        ),
+      ).toHaveText('Projects');
+
+      expect(projectsPartial.response?.chain?.at(-1)).toMatchObject({
+        component: 'route-dashboard',
+        path: 'projects',
+        keepAlive: true,
+        pendingComponent: 'error-display',
+        errorComponent: 'error-display',
+        invalidates: ['projects-route'],
+      });
+      expect(projectsPartial.response?.cacheTags).toContain('projects-route');
+      expect(await dashboardRouteState(page)).toEqual({
+        path: 'projects',
+        pending: 'error-display',
+        error: 'error-display',
+        keepAlive: true,
+        marker: null,
+      });
+    });
   });
 
   test('beta page renders via SSR', async ({ page }) => {


### PR DESCRIPTION
Two sibling route declarations can render the same component while owning different paths and route policy. The Router previously compared only component and params, so navigating between those declarations could apply the new server state while leaving the old `<webui-route>` active with stale pending, error, cache, and keep-alive metadata.

This change treats the authored path as part of declaration identity alongside the component. DOM route lookup uses the same identity, while bound params continue to identify instances of a parameterized declaration.

Regression coverage exercises both directions from a direct SSR load:
- `/projects` to `/`
- `/` to `/projects`

The browser tests assert server-provided state, active route path, declaration-specific metadata, cache tags, pending behavior, and keep-alive instance reuse.

No public API or protocol changes are introduced.

## Validation

- `@microsoft/webui-router`: 75 unit tests passed
- Playwright: 30 passed, 4 intentional skips