### PR TITLE
feat: polish WebUI documentation experience

### DIFF
--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -493,7 +493,8 @@ Generated root and page entries also receive build-time `<link rel="modulepreloa
 | `<webui-press-tab>`         | Tab triggers                                           |
 | `<webui-press-tab-panel>`   | Tab content panels                                     |
 
-Plus shadow components used by the chrome itself: `<docs-search>`, `<docs-theme-toggle>`.
+Plus shadow components used by the chrome itself: `<docs-site-navigation>`,
+`<docs-sidebar-navigation>`, `<docs-search>`, and `<docs-theme-toggle>`.
 
 ---
 
@@ -502,10 +503,17 @@ Plus shadow components used by the chrome itself: `<docs-search>`, `<docs-theme-
 Powered by [comrak](https://github.com/kivikakk/comrak), GitHub-flavored markdown:
 
 - Tables, task lists, autolinks, footnotes, strikethrough
-- Header anchors auto-injected (`<a class="header-anchor" href="#...">#</a>`)
+- Header anchors auto-injected with descriptive accessible labels
 - Relative links resolve from the Markdown source directory and remain valid under `basePath`
 - Fenced code blocks wrapped in `<code-block>` (copy button + dual-theme highlighting)
 - Raw HTML pass-through, including custom elements
+
+The generated shell uses a native `<dialog>` inside `<docs-site-navigation>`,
+native `<details>` disclosures inside `<docs-sidebar-navigation>`, and a
+skip-to-content link. The active documentation branch starts expanded. Normal
+documentation pages use the cross-document fade; navigation into or out of a
+`full` custom page skips that transition so viewport-filling app surfaces and
+their page-specific bundles paint immediately.
 
 ### Syntax highlighting
 

--- a/crates/webui-press/components/webui-blockquote/webui-blockquote.css
+++ b/crates/webui-press/components/webui-blockquote/webui-blockquote.css
@@ -6,7 +6,7 @@
 .blockquote {
   border-radius: var(--docs-radius-l, 8px);
   padding: var(--docs-space-m, 16px) 20px;
-  border-left: 4px solid var(--bq-accent, var(--docs-color-brand, #4f46e5));
+  border: 1px solid var(--bq-accent, var(--docs-color-brand, #4f46e5));
   background: var(--bq-bg, var(--docs-color-brand-bg, #eef2ff));
 }
 

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -285,6 +285,40 @@ fn build_page_registry(
     pages
 }
 
+fn build_sidebar_item_state(item: &SidebarItem, base: &str, url_path: &str) -> (Value, bool) {
+    let item_path = normalize_link(base, &item.link);
+    let active = !item_path.is_empty() && item_path == url_path;
+    let mut descendant_active = false;
+    let children: Vec<Value> = item
+        .items
+        .iter()
+        .map(|child| {
+            let child_path = normalize_link(base, &child.link);
+            let child_active = !child_path.is_empty() && child_path == url_path;
+            descendant_active |= child_active;
+            json_obj([
+                ("text", Value::String(child.text.clone())),
+                ("link", Value::String(child_path)),
+                ("active", Value::Bool(child_active)),
+                ("hasChildren", Value::Bool(false)),
+                ("children", Value::Array(vec![])),
+            ])
+        })
+        .collect();
+    let expanded = active || descendant_active;
+    (
+        json_obj([
+            ("text", Value::String(item.text.clone())),
+            ("link", Value::String(item_path)),
+            ("active", Value::Bool(active)),
+            ("expanded", Value::Bool(expanded)),
+            ("hasChildren", Value::Bool(!children.is_empty())),
+            ("children", Value::Array(children)),
+        ]),
+        expanded,
+    )
+}
+
 fn build_sidebar_state(url_path: &str, config: &DocsConfig) -> serde_json::Value {
     let base = &config.base_path;
 
@@ -300,38 +334,23 @@ fn build_sidebar_state(url_path: &str, config: &DocsConfig) -> serde_json::Value
         .map(|(_, s)| s.as_slice())
         .unwrap_or(&config.sidebar);
 
-    // Convert a SidebarItem to a JSON value (iterative via stack for children)
-    let item_to_value = |item: &SidebarItem| -> Value {
-        let item_path = normalize_link(base, &item.link);
-        let active = !item_path.is_empty() && item_path == url_path;
-        let children: Vec<Value> = item
-            .items
-            .iter()
-            .map(|child| {
-                let child_path = normalize_link(base, &child.link);
-                let child_active = !child_path.is_empty() && child_path == url_path;
-                json_obj([
-                    ("text", Value::String(child.text.clone())),
-                    ("link", Value::String(child_path)),
-                    ("active", Value::Bool(child_active)),
-                    ("hasChildren", Value::Bool(false)),
-                    ("children", Value::Array(vec![])),
-                ])
-            })
-            .collect();
-        json_obj([
-            ("text", Value::String(item.text.clone())),
-            ("link", Value::String(item_path)),
-            ("active", Value::Bool(active)),
-            ("hasChildren", Value::Bool(!children.is_empty())),
-            ("children", Value::Array(children)),
-        ])
-    };
-
+    let mut current_section = String::new();
     let sections: Vec<Value> = active_sidebar
         .iter()
         .map(|section| {
-            let items: Vec<Value> = section.items.iter().map(item_to_value).collect();
+            let mut section_active = false;
+            let items: Vec<Value> = section
+                .items
+                .iter()
+                .map(|item| {
+                    let (value, branch_active) = build_sidebar_item_state(item, base, url_path);
+                    section_active |= branch_active;
+                    value
+                })
+                .collect();
+            if section_active {
+                current_section.clone_from(&section.title);
+            }
             json_obj([
                 ("title", Value::String(section.title.clone())),
                 ("items", Value::Array(items)),
@@ -339,7 +358,10 @@ fn build_sidebar_state(url_path: &str, config: &DocsConfig) -> serde_json::Value
         })
         .collect();
 
-    json_obj([("sections", Value::Array(sections))])
+    json_obj([
+        ("sections", Value::Array(sections)),
+        ("currentSection", Value::String(current_section)),
+    ])
 }
 
 fn find_sidebar_text(url_path: &str, config: &DocsConfig) -> Option<String> {
@@ -401,6 +423,10 @@ pub(crate) fn process_content_with_states(
         .nav
         .iter()
         .map(|item| {
+            let full_layout = config
+                .custom_pages
+                .get(&item.link)
+                .is_some_and(|page| page.layout() == "full");
             let (link, section) = if item.link.starts_with("http") {
                 // External links can never match a docs section. Use the URL
                 // itself as a unique sentinel so the equality check below
@@ -422,6 +448,7 @@ pub(crate) fn process_content_with_states(
                 ("text", Value::String(item.text.clone())),
                 ("link", Value::String(link)),
                 ("section", Value::String(section)),
+                ("fullLayout", Value::Bool(full_layout)),
             ])
         })
         .collect();
@@ -615,6 +642,7 @@ pub(crate) fn process_content_with_states(
                             ("isHome", Value::Bool(is_home)),
                             ("layout", Value::String(layout)),
                             ("section", Value::String(page_section)),
+                            ("mobileNavigationOpen", Value::Bool(false)),
                         ]),
                     ),
                     ("hero", hero_val),
@@ -761,6 +789,26 @@ mod tests {
         // `&link[1..]` would have panicked here on UTF-8 boundary.
         let out = normalize_link("/webui/", "é-page");
         assert!(out.ends_with("é-page"), "got {out}");
+    }
+
+    #[test]
+    fn sidebar_item_expands_for_active_descendant() {
+        let item = SidebarItem {
+            text: "Template Syntax".to_string(),
+            link: "/guide/concepts/directives".to_string(),
+            items: vec![SidebarItem {
+                text: "Signals".to_string(),
+                link: "/guide/concepts/directives/signals".to_string(),
+                items: Vec::new(),
+            }],
+        };
+
+        let (state, branch_active) =
+            build_sidebar_item_state(&item, "/webui/", "/webui/guide/concepts/directives/signals");
+
+        assert!(branch_active);
+        assert_eq!(state["expanded"], Value::Bool(true));
+        assert_eq!(state["children"][0]["active"], Value::Bool(true));
     }
 
     // --- normalize_path_as_index -----------------------------------------

--- a/crates/webui-press/src/content.rs
+++ b/crates/webui-press/src/content.rs
@@ -40,6 +40,10 @@ fn normalize_link(base: &str, link: &str) -> String {
     }
 }
 
+fn config_paths_match(left: &str, right: &str) -> bool {
+    left.trim_end_matches('/') == right.trim_end_matches('/')
+}
+
 /// Build a JSON object from key-value pairs without using `json!` (which calls `unwrap`).
 fn json_obj<const N: usize>(entries: [(&str, Value); N]) -> Value {
     let mut map = Map::with_capacity(N);
@@ -423,10 +427,10 @@ pub(crate) fn process_content_with_states(
         .nav
         .iter()
         .map(|item| {
-            let full_layout = config
-                .custom_pages
-                .get(&item.link)
-                .is_some_and(|page| page.layout() == "full");
+            let full_layout = !item.link.starts_with("http")
+                && config.custom_pages.iter().any(|(path, page)| {
+                    config_paths_match(path, &item.link) && page.layout() == "full"
+                });
             let (link, section) = if item.link.starts_with("http") {
                 // External links can never match a docs section. Use the URL
                 // itself as a unique sentinel so the equality check below
@@ -789,6 +793,13 @@ mod tests {
         // `&link[1..]` would have panicked here on UTF-8 boundary.
         let out = normalize_link("/webui/", "é-page");
         assert!(out.ends_with("é-page"), "got {out}");
+    }
+
+    #[test]
+    fn config_paths_match_with_or_without_trailing_slash() {
+        assert!(config_paths_match("/playground", "/playground/"));
+        assert!(config_paths_match("/playground/", "/playground"));
+        assert!(!config_paths_match("/playground", "/guide/"));
     }
 
     #[test]

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -361,8 +361,9 @@ pub fn render_markdown(
             }
         };
         let slug = slugify(&plain_text);
+        let anchor_label = html_escape::encode_double_quoted_attribute(&plain_text);
         let html = format!(
-            "<h{level} id=\"{slug}\">{html_text} <a class=\"header-anchor\" href=\"{page_url}#{slug}\">#</a></h{level}>"
+            "<h{level} id=\"{slug}\">{html_text} <a class=\"header-anchor\" href=\"{page_url}#{slug}\" aria-label=\"Link to {anchor_label}\">#</a></h{level}>"
         );
         // Detach children first, then replace value. The heading is a
         // block-level node, so its raw-HTML replacement must be an
@@ -494,6 +495,10 @@ mod tests {
         assert!(
             html.contains(r##"href="/webui/guide/#hello""##),
             "heading anchor should be absolute to the page: {html}"
+        );
+        assert!(
+            html.contains(r##"aria-label="Link to Hello""##),
+            "heading anchor should have a descriptive accessible name: {html}"
         );
         assert!(
             html.contains(r##"<a href="/webui/guide/#hello">below</a>"##),

--- a/crates/webui-press/template/docs-search/docs-search.css
+++ b/crates/webui-press/template/docs-search/docs-search.css
@@ -3,10 +3,12 @@
 }
 
 .trigger {
+  box-sizing: border-box;
+  height: var(--docs-header-control-height, 36px);
   background: none;
   border: 1px solid var(--docs-color-border);
   border-radius: var(--docs-radius-m);
-  padding: var(--docs-space-xs) var(--docs-space-m);
+  padding: 0 var(--docs-space-m);
   cursor: pointer;
   color: var(--docs-color-text-3);
   font-size: var(--docs-font-size-s);
@@ -35,6 +37,20 @@ kbd {
   border-radius: 3px;
   border: 1px solid var(--docs-color-border);
   font-family: var(--docs-font-sans);
+}
+
+@media (max-width: 520px) {
+  .trigger {
+    width: 44px;
+    height: 44px;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .label,
+  kbd {
+    display: none;
+  }
 }
 
 dialog {
@@ -123,6 +139,7 @@ input::placeholder {
 
 .result-title .result-segment {
   font-size: var(--docs-font-size-m);
+  white-space: pre-wrap;
 }
 
 .result-title code.result-segment {

--- a/crates/webui-press/template/docs-search/docs-search.test.ts
+++ b/crates/webui-press/template/docs-search/docs-search.test.ts
@@ -21,6 +21,108 @@ const MIME_TYPES = new Map([
   ['.wasm', 'application/wasm'],
 ]);
 
+test('nested documentation components hydrate without page errors', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.goto(`${server.origin}/webui/`, { waitUntil: 'networkidle' });
+  await waitForDocsSearch(page);
+  await page.goto(`${server.origin}/webui/guide/`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
+
+  assert.deepEqual(pageErrors, []);
+});
+
+test('Playground initializes after navigation from the docs home page', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.goto(`${server.origin}/webui/`, { waitUntil: 'networkidle' });
+  await waitForDocsSearch(page);
+  const navigationState = await page
+    .locator('docs-site-navigation')
+    .evaluate((navigation) => ({
+      count: navigation.navigation?.length ?? 0,
+      playgroundFullLayout:
+        navigation.navigation?.find((link) => link.text === 'Playground')
+          ?.fullLayout ?? false,
+    }));
+  assert.ok(navigationState.count > 0);
+  assert.equal(navigationState.playgroundFullLayout, true);
+  const playgroundLink = page
+    .locator('docs-site-navigation')
+    .locator('a')
+    .filter({ hasText: 'Playground' })
+    .first();
+
+  await Promise.all([
+    page.waitForURL('**/webui/playground/**'),
+    playgroundLink.click(),
+  ]);
+  await page.waitForFunction(
+    () =>
+      !(document as Document & { activeViewTransition?: unknown })
+        .activeViewTransition,
+  );
+  await page.waitForFunction(() => {
+    const playground = document.querySelector('docs-playground');
+    return Boolean(
+      customElements.get('docs-playground') &&
+        playground?.shadowRoot?.querySelector('.pg'),
+    );
+  });
+
+  const playground = await page.locator('docs-playground').evaluate((host) => {
+    const rect = host.getBoundingClientRect();
+    return {
+      width: rect.width,
+      height: rect.height,
+      editor: Boolean(host.shadowRoot?.querySelector('.editor-wrap .cm-editor')),
+    };
+  });
+
+  assert.ok(playground.width > 0);
+  assert.ok(playground.height > 0);
+  assert.equal(playground.editor, true);
+
+  const guideLink = page
+    .locator('docs-site-navigation')
+    .locator('a')
+    .filter({ hasText: 'Guide' })
+    .first();
+  await Promise.all([
+    page.waitForURL('**/webui/guide/**'),
+    guideLink.click(),
+  ]);
+  await page.waitForFunction(
+    () =>
+      !(document as Document & { activeViewTransition?: unknown })
+        .activeViewTransition,
+  );
+  assert.ok(
+    (await page.locator('.doc-content h1').innerText()).startsWith(
+      'What is WebUI Framework?',
+    ),
+  );
+  assert.deepEqual(pageErrors, []);
+});
+
 function resolveDocsDist(): string {
   let current = process.cwd();
   loop: while (true) {
@@ -219,14 +321,24 @@ test('scrollbars and search highlights use theme-specific colors', async (t) => 
   });
   await waitForDocsSearch(page);
 
-  const light = await page.evaluate(() => {
-    const main = document.querySelector('.main-content');
-    const style = getComputedStyle(main);
-    return {
-      thumb: style.getPropertyValue('--docs-scrollbar-thumb').trim(),
-      track: style.getPropertyValue('--docs-scrollbar-track').trim(),
-    };
-  });
+  const light = await page
+    .locator('docs-site-navigation')
+    .evaluate((navigation) => {
+      const main = document.querySelector('.main-content');
+      const search = navigation.shadowRoot
+        ?.querySelector('docs-search')
+        ?.shadowRoot?.querySelector('.trigger');
+      const theme = navigation.shadowRoot
+        ?.querySelector('docs-theme-toggle')
+        ?.shadowRoot?.querySelector('button');
+      const style = getComputedStyle(main);
+      return {
+        thumb: style.getPropertyValue('--docs-scrollbar-thumb').trim(),
+        track: style.getPropertyValue('--docs-scrollbar-track').trim(),
+        searchHeight: search?.getBoundingClientRect().height ?? 0,
+        themeHeight: theme?.getBoundingClientRect().height ?? 0,
+      };
+    });
 
   await page.evaluate(() => {
     document.documentElement.setAttribute('data-theme', 'dark');
@@ -253,14 +365,264 @@ test('scrollbars and search highlights use theme-specific colors', async (t) => 
 
   assert.equal(light.thumb, '#9ca3af');
   assert.equal(light.track, '#f3f4f6');
+  assert.equal(light.searchHeight, 36);
+  assert.equal(light.themeHeight, light.searchHeight);
   assert.equal(dark.thumb, '#4b5563');
   assert.equal(dark.track, '#111827');
   assert.equal(dark.markBg, 'rgb(183, 121, 31)');
 });
 
+test('search highlighting preserves spaces between title segments', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage();
+  await page.goto(`${server.origin}/webui/guide/concepts/directives/signals/`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
+
+  const title = await page.locator('docs-search').evaluate(async (el) => {
+    el.openSearch();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const input = el.shadowRoot.querySelector('input');
+    input.value = 'signal';
+    el.onInput();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const result = [...el.shadowRoot.querySelectorAll('.result')].find((item) =>
+      item.getAttribute('href')?.endsWith('/guide/concepts/directives/signals'),
+    );
+    return (result?.querySelector('.result-title') as HTMLElement | null)
+      ?.innerText ?? '';
+  });
+
+  assert.equal(title.trim().replace(/\s+/g, ' '), 'Signal Directives');
+});
+
+test('mobile navigation opens everywhere and restores focus on escape', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.goto(`${server.origin}/webui/`, { waitUntil: 'networkidle' });
+
+  const component = page.locator('docs-site-navigation');
+  const trigger = component.locator('.mobile-menu-btn');
+  const navigation = component.locator('.mobile-navigation');
+  const header = await page.evaluate(() => {
+    const nav = document.querySelector('.nav-bar');
+    const menu = document
+      .querySelector('docs-site-navigation')
+      ?.shadowRoot?.querySelector('.mobile-menu-btn');
+    const navRect = nav?.getBoundingClientRect();
+    const menuRect = menu?.getBoundingClientRect();
+    return {
+      scrollWidth: nav?.scrollWidth ?? 0,
+      clientWidth: nav?.clientWidth ?? 0,
+      menuRight: menuRect?.right ?? 0,
+      navRight: navRect?.right ?? 0,
+    };
+  });
+  assert.ok(header.scrollWidth <= header.clientWidth);
+  assert.ok(header.menuRight <= header.navRight);
+  assert.equal(await navigation.isHidden(), true);
+
+  await trigger.click();
+  assert.equal(await trigger.getAttribute('aria-expanded'), 'true');
+  assert.equal(await navigation.isVisible(), true);
+  assert.equal(
+    await component.evaluate(
+      (element) =>
+        element.shadowRoot?.activeElement?.classList.contains(
+          'mobile-navigation-close',
+        ) ?? false,
+    ),
+    true,
+  );
+
+  await page.keyboard.press('Escape');
+  await page.waitForFunction(() => {
+    const navigation = document.querySelector('docs-site-navigation');
+    const trigger = navigation?.shadowRoot?.querySelector('.mobile-menu-btn');
+    return trigger?.getAttribute('aria-expanded') === 'false';
+  });
+  assert.equal(await trigger.getAttribute('aria-expanded'), 'false');
+  assert.equal(await navigation.isHidden(), true);
+  assert.equal(
+    await component.evaluate(
+      (element) =>
+        element.shadowRoot?.activeElement?.classList.contains(
+          'mobile-menu-btn',
+        ) ?? false,
+    ),
+    true,
+  );
+});
+
+test('documentation shell preserves semantic hierarchy and reading measure', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.goto(`${server.origin}/webui/`, { waitUntil: 'networkidle' });
+  const homeHeadings = await page
+    .locator('#main-content h1, #main-content h2, #main-content h3')
+    .evaluateAll((nodes) => nodes.map((node) => node.tagName));
+  assert.equal(homeHeadings[0], 'H1');
+  assert.ok(homeHeadings.slice(1).every((tag) => tag === 'H2'));
+
+  await page.goto(
+    `${server.origin}/webui/guide/concepts/directives/signals/`,
+    { waitUntil: 'networkidle' },
+  );
+  const shell = await page.evaluate(() => {
+    const sidebar = document.querySelector(
+      '.sidebar docs-sidebar-navigation',
+    );
+    const sidebarRoot = sidebar?.shadowRoot;
+    const sidebarTitles = [
+      ...(sidebarRoot?.querySelectorAll('.sidebar-title') ?? []),
+    ];
+    const anchor = document.querySelector('.doc-content .header-anchor');
+    const article = document.querySelector('.doc-content');
+    const main = document.querySelector('.main-content');
+    const templateDetails = [
+      ...(sidebarRoot?.querySelectorAll<HTMLDetailsElement>(
+        '.sidebar-branch',
+      ) ?? []),
+    ].find((details) =>
+      details
+        .querySelector('.sidebar-summary')
+        ?.textContent?.includes('Template Syntax'),
+    );
+    const cliDetails = [
+      ...(sidebarRoot?.querySelectorAll<HTMLDetailsElement>(
+        '.sidebar-branch',
+      ) ?? []),
+    ].find((details) =>
+      details
+        .querySelector('.sidebar-summary')
+        ?.textContent?.includes('CLI Reference'),
+    );
+    return {
+      sidebarTitleTags: sidebarTitles.map((title) => title.tagName),
+      anchorLabel: anchor?.getAttribute('aria-label') ?? '',
+      articleWidth: article?.getBoundingClientRect().width ?? 0,
+      mainWidth: main?.getBoundingClientRect().width ?? 0,
+      templateExpanded: templateDetails?.open,
+      cliExpanded: cliDetails?.open,
+      customNavigationDefined: Boolean(
+        customElements.get('docs-site-navigation'),
+      ),
+      nativeDisclosureCount:
+        sidebarRoot?.querySelectorAll('details.sidebar-branch').length ?? 0,
+    };
+  });
+
+  assert.ok(shell.sidebarTitleTags.every((tag) => tag === 'DIV'));
+  assert.ok(shell.anchorLabel.startsWith('Link to '));
+  assert.ok(shell.articleWidth > 0 && shell.articleWidth <= 800);
+  assert.ok(shell.articleWidth < shell.mainWidth);
+  assert.equal(shell.templateExpanded, true);
+  assert.equal(shell.cliExpanded, false);
+  assert.equal(shell.customNavigationDefined, true);
+  assert.ok(shell.nativeDisclosureCount > 0);
+
+  const templateDisclosure = page
+    .locator('.sidebar docs-sidebar-navigation')
+    .locator('details.sidebar-branch')
+    .filter({ hasText: 'Template Syntax' });
+  await templateDisclosure.locator('summary').click();
+  assert.equal(await templateDisclosure.getAttribute('open'), null);
+});
+
+test('playground runtime failures offer recovery without exposing raw details', async (t) => {
+  const server = await startDocsServer();
+  t.after(() => server.close());
+
+  const browser = await chromium.launch({ headless: true });
+  t.after(() => browser.close());
+
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  let loadAttempts = 0;
+  await page.route('**/wasm/all/webui_wasm_all.js*', async (route) => {
+    loadAttempts += 1;
+    await route.abort();
+  });
+  await page.goto(`${server.origin}/webui/playground/`, {
+    waitUntil: 'networkidle',
+  });
+  await page.waitForFunction(() =>
+    document
+      .querySelector('docs-playground')
+      ?.shadowRoot?.querySelector('.error-recovery'),
+  );
+
+  const failure = await page.locator('docs-playground').evaluate((el) => {
+    const root = el.shadowRoot;
+    const panel = root.querySelector('.error-panel');
+    const addButton = root.querySelector('.tab-add-btn');
+    const activeTab = root.querySelector('.tab[active]');
+    const activeTabButton = activeTab?.querySelector('.tab-select');
+    const activeTabName = activeTabButton?.querySelector('.tab-name');
+    const closeButton = root.querySelector('.tab-close-btn');
+    const hostRect = el.getBoundingClientRect();
+    const addRect = addButton?.getBoundingClientRect();
+    return {
+      title: root.querySelector('.error-panel-title')?.textContent?.trim(),
+      retry: root.querySelector('.error-retry-btn')?.textContent?.trim(),
+      expanded: panel?.hasAttribute('data-expanded'),
+      addWidth: addRect?.width ?? 0,
+      addInsideHost: addRect ? addRect.right <= hostRect.right : false,
+      tabGroupRole: root.querySelector('.tab-strip')?.getAttribute('role'),
+      activeTabTag: activeTabButton?.tagName,
+      activeTabPressed: activeTabButton?.getAttribute('aria-pressed'),
+      activeTabNameVisible: activeTabName
+        ? activeTabName.scrollWidth <= activeTabName.clientWidth
+        : false,
+      addLabel: addButton?.getAttribute('aria-label'),
+      closeLabel: closeButton?.getAttribute('aria-label') ?? '',
+      editorLabel: root.querySelector('.editor-wrap')?.getAttribute('aria-label'),
+      previewTitle: root.querySelector('.preview-frame')?.getAttribute('title'),
+    };
+  });
+
+  assert.equal(failure.title, "Preview couldn't load.");
+  assert.equal(failure.retry, 'Retry preview');
+  assert.equal(failure.expanded, false);
+  assert.ok(failure.addWidth >= 44);
+  assert.equal(failure.addInsideHost, true);
+  assert.equal(failure.tabGroupRole, 'group');
+  assert.equal(failure.activeTabTag, 'BUTTON');
+  assert.equal(failure.activeTabPressed, 'true');
+  assert.equal(failure.activeTabNameVisible, true);
+  assert.equal(failure.addLabel, 'New file');
+  assert.ok(failure.closeLabel.startsWith('Close '));
+  assert.equal(failure.editorLabel, 'Code editor');
+  assert.equal(failure.previewTitle, 'Rendered preview');
+
+  await page.locator('docs-playground').locator('.error-retry-btn').click();
+  await page.waitForFunction(() => {
+    const host = document.querySelector('docs-playground');
+    return host?.shadowRoot?.querySelector('.error-retry-btn');
+  });
+  assert.ok(loadAttempts >= 2, `loadAttempts=${loadAttempts}`);
+});
+
 async function waitForDocsSearch(page: Page): Promise<void> {
   await page.waitForFunction(() => {
-    const el = document.querySelector('docs-search');
+    const el = document
+      .querySelector('docs-site-navigation')
+      ?.shadowRoot?.querySelector('docs-search');
     return (
       el &&
       customElements.get('docs-search') &&

--- a/crates/webui-press/template/docs-search/docs-search.test.ts
+++ b/crates/webui-press/template/docs-search/docs-search.test.ts
@@ -38,6 +38,10 @@ test('nested documentation components hydrate without page errors', async (t) =>
     waitUntil: 'networkidle',
   });
   await waitForDocsSearch(page);
+  await page.goto(`${server.origin}/webui/#%E0%A4`, {
+    waitUntil: 'networkidle',
+  });
+  await waitForDocsSearch(page);
 
   assert.deepEqual(pageErrors, []);
 });
@@ -580,6 +584,7 @@ test('playground runtime failures offer recovery without exposing raw details', 
     return {
       title: root.querySelector('.error-panel-title')?.textContent?.trim(),
       retry: root.querySelector('.error-retry-btn')?.textContent?.trim(),
+      help: root.querySelector('.error-help-text')?.textContent?.trim(),
       expanded: panel?.hasAttribute('data-expanded'),
       addWidth: addRect?.width ?? 0,
       addInsideHost: addRect ? addRect.right <= hostRect.right : false,
@@ -598,6 +603,7 @@ test('playground runtime failures offer recovery without exposing raw details', 
 
   assert.equal(failure.title, "Preview couldn't load.");
   assert.equal(failure.retry, 'Retry preview');
+  assert.ok(failure.help?.includes('cargo xtask build-wasm'));
   assert.equal(failure.expanded, false);
   assert.ok(failure.addWidth >= 44);
   assert.equal(failure.addInsideHost, true);

--- a/crates/webui-press/template/docs-search/docs-search.ts
+++ b/crates/webui-press/template/docs-search/docs-search.ts
@@ -52,6 +52,32 @@ export class DocsSearch extends WebUIElement {
   // Each input change clears nested <for> result rows before re-inserting the
   // next set. The version guard drops stale microtasks from rapid typing.
   private renderVersion = 0;
+  private listenersAttached = false;
+  private dialogClickHandler = (event: Event): void => {
+    if (event.target === this.dialog) {
+      this.dialog.close();
+    }
+  };
+  private documentKeydownHandler = (event: KeyboardEvent): void => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+      event.preventDefault();
+      this.openSearch();
+    }
+    if (!this.dialog.open) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.setActiveIdx(
+        Math.min(this.activeIdx + 1, this.resultItems.length - 1),
+      );
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.setActiveIdx(Math.max(this.activeIdx - 1, 0));
+    }
+    if (event.key === "Enter" && this.resultItems[this.activeIdx]) {
+      window.location.href = this.resultItems[this.activeIdx].path;
+    }
+  };
 
   // Keep title matches decisively above heading matches, and heading matches
   // above body/path matches. Sorting remains deterministic via title/path ties.
@@ -62,32 +88,29 @@ export class DocsSearch extends WebUIElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    if (this.dialog) {
+      this.attachListeners();
+    }
+  }
 
-    // Close on backdrop click (click on <dialog> itself, not its children)
-    this.dialog.addEventListener("click", (e: Event) => {
-      if (e.target === this.dialog) this.dialog.close();
-    });
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.listenersAttached) {
+      this.dialog.removeEventListener("click", this.dialogClickHandler);
+      document.removeEventListener("keydown", this.documentKeydownHandler);
+      this.listenersAttached = false;
+    }
+  }
 
-    document.addEventListener("keydown", (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        this.openSearch();
-      }
-      if (!this.dialog.open) return;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        this.setActiveIdx(
-          Math.min(this.activeIdx + 1, this.resultItems.length - 1),
-        );
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        this.setActiveIdx(Math.max(this.activeIdx - 1, 0));
-      }
-      if (e.key === "Enter" && this.resultItems[this.activeIdx]) {
-        window.location.href = this.resultItems[this.activeIdx].path;
-      }
-    });
+  protected hydratedCallback(): void {
+    this.attachListeners();
+  }
+
+  private attachListeners(): void {
+    if (this.listenersAttached) return;
+    this.dialog.addEventListener("click", this.dialogClickHandler);
+    document.addEventListener("keydown", this.documentKeydownHandler);
+    this.listenersAttached = true;
   }
 
   openSearch(): void {

--- a/crates/webui-press/template/docs-sidebar-navigation/docs-sidebar-navigation.css
+++ b/crates/webui-press/template/docs-sidebar-navigation/docs-sidebar-navigation.css
@@ -1,0 +1,117 @@
+:host {
+  display: block;
+}
+
+.sidebar-group {
+  margin-bottom: var(--docs-space-l);
+}
+
+.sidebar-title {
+  margin-bottom: var(--docs-space-s);
+  color: var(--docs-color-text-3);
+  font-size: var(--docs-font-size-s);
+  font-weight: var(--docs-font-weight-bold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sidebar-items,
+.sidebar-children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.sidebar-items li {
+  margin-bottom: 2px;
+}
+
+.sidebar-children {
+  padding-inline-start: var(--docs-space-m);
+}
+
+.sidebar-children li {
+  margin-bottom: 1px;
+}
+
+.sidebar-link,
+.sidebar-summary {
+  border-radius: var(--docs-radius-m);
+  color: var(--docs-color-text-2);
+  font-size: var(--docs-font-size-m);
+  transition: color 0.15s, background 0.15s;
+}
+
+.sidebar-link {
+  display: block;
+  padding: var(--docs-space-xs) var(--docs-space-m);
+  text-decoration: none;
+}
+
+.sidebar-link:hover,
+.sidebar-link:focus-visible,
+.sidebar-summary:hover,
+.sidebar-summary:focus-visible {
+  background: var(--docs-color-brand-bg);
+  color: var(--docs-color-brand);
+}
+
+.sidebar-link-active,
+.sidebar-summary[active] {
+  background: var(--docs-color-brand-bg);
+  color: var(--docs-color-brand);
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.sidebar-summary {
+  display: flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--docs-space-s);
+  padding: var(--docs-space-xs) var(--docs-space-s) var(--docs-space-xs) var(--docs-space-m);
+  cursor: pointer;
+  font-weight: var(--docs-font-weight-semibold);
+  list-style: none;
+}
+
+.sidebar-summary::-webkit-details-marker {
+  display: none;
+}
+
+.sidebar-summary::after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.15s ease;
+}
+
+.sidebar-branch[open] > .sidebar-summary::after {
+  transform: rotate(225deg);
+}
+
+.sidebar-link:focus-visible,
+.sidebar-summary:focus-visible {
+  outline: 2px solid var(--docs-color-brand);
+  outline-offset: 2px;
+}
+
+:host([variant="mobile"]) .sidebar-link,
+:host([variant="mobile"]) .sidebar-summary {
+  min-height: 44px;
+}
+
+:host([variant="mobile"]) .sidebar-link {
+  display: flex;
+  align-items: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-summary::after {
+    transition: none;
+  }
+}

--- a/crates/webui-press/template/docs-sidebar-navigation/docs-sidebar-navigation.html
+++ b/crates/webui-press/template/docs-sidebar-navigation/docs-sidebar-navigation.html
@@ -1,0 +1,50 @@
+<nav class="sidebar-navigation" aria-label="Documentation sections">
+  <for each="section in sections">
+    <div class="sidebar-group">
+      <div class="sidebar-title">{{section.title}}</div>
+      <ul class="sidebar-items">
+        <for each="item in section.items">
+          <li>
+            <if condition="item.hasChildren">
+              <details class="sidebar-branch" ?open="{{item.expanded}}">
+                <summary class="sidebar-summary" ?active="{{item.active}}">
+                  <span>{{item.text}}</span>
+                </summary>
+                <ul class="sidebar-children">
+                  <if condition="item.link">
+                    <li>
+                      <if condition="item.active">
+                        <a href="{{item.link}}" class="sidebar-link sidebar-link-active">Overview</a>
+                      </if>
+                      <if condition="!item.active">
+                        <a href="{{item.link}}" class="sidebar-link">Overview</a>
+                      </if>
+                    </li>
+                  </if>
+                  <for each="child in item.children">
+                    <li>
+                      <if condition="child.active">
+                        <a href="{{child.link}}" class="sidebar-link sidebar-link-active">{{child.text}}</a>
+                      </if>
+                      <if condition="!child.active">
+                        <a href="{{child.link}}" class="sidebar-link">{{child.text}}</a>
+                      </if>
+                    </li>
+                  </for>
+                </ul>
+              </details>
+            </if>
+            <if condition="!item.hasChildren">
+              <if condition="item.active">
+                <a href="{{item.link}}" class="sidebar-link sidebar-link-active">{{item.text}}</a>
+              </if>
+              <if condition="!item.active">
+                <a href="{{item.link}}" class="sidebar-link">{{item.text}}</a>
+              </if>
+            </if>
+          </li>
+        </for>
+      </ul>
+    </div>
+  </for>
+</nav>

--- a/crates/webui-press/template/docs-site-navigation/docs-site-navigation.css
+++ b/crates/webui-press/template/docs-site-navigation/docs-site-navigation.css
@@ -1,0 +1,155 @@
+:host {
+  display: block;
+  margin-inline-start: auto;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--docs-space-l);
+}
+
+.nav-link {
+  color: var(--docs-color-text-2);
+  font-size: var(--docs-font-size-m);
+  font-weight: var(--docs-font-weight-medium);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible,
+.nav-link[active] {
+  color: var(--docs-color-brand);
+}
+
+.nav-link[active] {
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.mobile-menu-btn {
+  display: none;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--docs-radius-m);
+  background: transparent;
+  color: var(--docs-color-text);
+  cursor: pointer;
+  font-size: var(--docs-font-size-xl);
+}
+
+.mobile-menu-btn:hover,
+.mobile-menu-btn:focus-visible,
+.mobile-navigation-close:hover {
+  background: var(--docs-color-brand-bg);
+}
+
+.mobile-menu-btn:focus-visible,
+.mobile-navigation-close:focus-visible {
+  outline: 2px solid var(--docs-color-brand);
+  outline-offset: 2px;
+}
+
+.mobile-navigation {
+  position: fixed;
+  inset: var(--docs-nav-height) 0 0 auto;
+  width: min(88vw, 360px);
+  max-width: none;
+  height: calc(100dvh - var(--docs-nav-height));
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-left: 1px solid var(--docs-color-border);
+  background: var(--docs-color-bg);
+  color: var(--docs-color-text);
+  box-shadow: -12px 0 36px rgba(14, 17, 27, 0.18);
+}
+
+.mobile-navigation[open] {
+  display: block;
+}
+
+.mobile-navigation::backdrop {
+  background: rgba(14, 17, 27, 0.56);
+}
+
+.mobile-navigation-panel {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.mobile-navigation-header {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--docs-space-m);
+  padding: var(--docs-space-s) var(--docs-space-m) var(--docs-space-s) var(--docs-space-l);
+  border-bottom: 1px solid var(--docs-color-border);
+}
+
+.mobile-navigation-close {
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--docs-radius-m);
+  background: transparent;
+  color: var(--docs-color-text);
+  cursor: pointer;
+  font-size: var(--docs-font-size-xl);
+}
+
+.mobile-primary-nav {
+  display: grid;
+  padding: var(--docs-space-m);
+  border-bottom: 1px solid var(--docs-color-border);
+}
+
+.mobile-primary-nav a {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  padding: 0 var(--docs-space-s);
+  border-radius: var(--docs-radius-m);
+  color: var(--docs-color-text-2);
+  font-weight: var(--docs-font-weight-medium);
+  text-decoration: none;
+}
+
+.mobile-primary-nav a:hover,
+.mobile-primary-nav a:focus-visible,
+.mobile-primary-nav a[active] {
+  background: var(--docs-color-brand-bg);
+  color: var(--docs-color-brand);
+}
+
+.mobile-section-nav {
+  padding: var(--docs-space-l);
+}
+
+@media (max-width: 768px) {
+  .mobile-menu-btn {
+    display: inline-flex;
+  }
+
+  .nav-link {
+    display: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .nav-links {
+    gap: var(--docs-space-s);
+  }
+}

--- a/crates/webui-press/template/docs-site-navigation/docs-site-navigation.html
+++ b/crates/webui-press/template/docs-site-navigation/docs-site-navigation.html
@@ -1,0 +1,58 @@
+<nav class="nav-links" aria-label="Primary navigation">
+  <for each="link in navigation">
+    <a
+      href="{{link.link}}"
+      class="nav-link"
+      ?active="{{link.section == section}}"
+      @click="{onNavigate(link.fullLayout, e)}"
+    >{{link.text}}</a>
+  </for>
+  <docs-search></docs-search>
+  <docs-theme-toggle></docs-theme-toggle>
+  <button
+    class="mobile-menu-btn"
+    type="button"
+    aria-label="Open navigation"
+    aria-controls="mobile-navigation"
+    aria-expanded="{{open}}"
+    @click="{openMenu()}"
+  ><span aria-hidden="true">☰</span></button>
+</nav>
+
+<dialog
+  class="mobile-navigation"
+  id="mobile-navigation"
+  aria-labelledby="mobile-navigation-title"
+  w-ref="{dialog}"
+  @click="{onDialogClick(e)}"
+  @close="{onDialogClose()}"
+>
+  <div class="mobile-navigation-panel">
+    <div class="mobile-navigation-header">
+      <strong id="mobile-navigation-title">Browse WebUI</strong>
+      <button
+        class="mobile-navigation-close"
+        type="button"
+        aria-label="Close navigation"
+        @click="{closeMenu()}"
+      ><span aria-hidden="true">×</span></button>
+    </div>
+    <nav class="mobile-primary-nav" aria-label="Primary navigation">
+      <for each="link in navigation">
+        <a
+          href="{{link.link}}"
+          ?active="{{link.section == section}}"
+          @click="{onNavigate(link.fullLayout, e)}"
+        >{{link.text}}</a>
+      </for>
+    </nav>
+    <if condition="!home">
+      <div class="mobile-section-nav">
+        <docs-sidebar-navigation
+          variant="mobile"
+          :sections="{{sections}}"
+        ></docs-sidebar-navigation>
+      </div>
+    </if>
+  </div>
+</dialog>

--- a/crates/webui-press/template/docs-site-navigation/docs-site-navigation.ts
+++ b/crates/webui-press/template/docs-site-navigation/docs-site-navigation.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { WebUIElement, attr, observable } from "@microsoft/webui-framework";
+
+import "../docs-search/docs-search.js";
+import "../docs-theme-toggle/docs-theme-toggle.js";
+
+interface NavigationLink {
+  text: string;
+  link: string;
+  section: string;
+  fullLayout: boolean;
+}
+
+interface SidebarItem {
+  text: string;
+  link: string;
+  active: boolean;
+  expanded: boolean;
+  hasChildren: boolean;
+  children: SidebarItem[];
+}
+
+interface SidebarSection {
+  title: string;
+  items: SidebarItem[];
+}
+
+export class DocsSiteNavigation extends WebUIElement {
+  @attr section = "";
+  @attr({ mode: "boolean" }) home = false;
+  @attr({ attribute: "full-layout", mode: "boolean" }) fullLayout = false;
+  @observable navigation: NavigationLink[] = [];
+  @observable open = false;
+
+  declare sections: SidebarSection[];
+  dialog!: HTMLDialogElement;
+  private pageSwapAttached = false;
+  private skipNextTransition = false;
+
+  private resizeHandler = (): void => {
+    if (window.innerWidth > 768) {
+      this.closeMenu();
+    }
+  };
+  private pageSwapHandler = (event: Event): void => {
+    if (!this.skipNextTransition) return;
+    const pageSwap = event as Event & {
+      viewTransition?: { skipTransition(): void } | null;
+    };
+    pageSwap.viewTransition?.skipTransition();
+    this.skipNextTransition = false;
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener("resize", this.resizeHandler);
+    if (!this.pageSwapAttached) {
+      window.addEventListener("pageswap", this.pageSwapHandler);
+      this.pageSwapAttached = true;
+    }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener("resize", this.resizeHandler);
+    // Chromium dispatches `pageswap` after custom elements disconnect. Keep
+    // this listener for the old window's remaining lifetime so it can cancel
+    // transitions into or out of full-layout pages.
+  }
+
+  openMenu(): void {
+    if (this.dialog.open) return;
+    this.dialog.showModal();
+    this.open = true;
+  }
+
+  closeMenu(): void {
+    if (this.dialog.open) {
+      this.dialog.close();
+    }
+  }
+
+  onDialogClick(event: Event): void {
+    if (event.target === this.dialog) {
+      this.closeMenu();
+    }
+  }
+
+  onDialogClose(): void {
+    this.open = false;
+  }
+
+  onNavigate(targetFullLayout: boolean, event: MouseEvent): void {
+    const primaryNavigation =
+      event.button === 0 &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.shiftKey;
+    this.skipNextTransition =
+      primaryNavigation && Boolean(this.fullLayout || targetFullLayout);
+  }
+}
+
+DocsSiteNavigation.define("docs-site-navigation");

--- a/crates/webui-press/template/docs-site-navigation/docs-site-navigation.ts
+++ b/crates/webui-press/template/docs-site-navigation/docs-site-navigation.ts
@@ -47,9 +47,21 @@ export class DocsSiteNavigation extends WebUIElement {
   private pageSwapHandler = (event: Event): void => {
     if (!this.skipNextTransition) return;
     const pageSwap = event as Event & {
-      viewTransition?: { skipTransition(): void } | null;
+      viewTransition?: {
+        ready: Promise<void>;
+        skipTransition(): void;
+      } | null;
     };
-    pageSwap.viewTransition?.skipTransition();
+    const transition = pageSwap.viewTransition;
+    if (transition) {
+      void transition.ready.catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        console.error("[WebUI Press] View transition failed", error);
+      });
+      transition.skipTransition();
+    }
     this.skipNextTransition = false;
   };
 

--- a/crates/webui-press/template/docs-theme-toggle/docs-theme-toggle.css
+++ b/crates/webui-press/template/docs-theme-toggle/docs-theme-toggle.css
@@ -3,10 +3,13 @@
 }
 
 button {
+  box-sizing: border-box;
+  width: var(--docs-header-control-height, 36px);
+  height: var(--docs-header-control-height, 36px);
   background: none;
   border: 1px solid var(--docs-color-border);
   border-radius: var(--docs-radius-m);
-  padding: var(--docs-space-s) var(--docs-space-s);
+  padding: 0;
   cursor: pointer;
   color: var(--docs-color-text-2);
   font-size: var(--docs-font-size-base);
@@ -17,4 +20,12 @@ button {
 button:hover {
   color: var(--docs-color-brand);
   border-color: var(--docs-color-brand);
+}
+
+@media (max-width: 520px) {
+  button {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+  }
 }

--- a/crates/webui-press/template/docs.css
+++ b/crates/webui-press/template/docs.css
@@ -96,8 +96,9 @@
 
   /* ── Layout ────────────────────────── */
   --docs-nav-height: 64px;
+  --docs-header-control-height: 36px;
   --docs-sidebar-width: 260px;
-  --docs-content-max-width: 800px;
+  --docs-content-max-width: 75ch;
 
   /* ── Component tokens ───────────────── */
   --docs-btn-brand-bg: var(--docs-color-brand);
@@ -199,6 +200,25 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+.skip-link {
+  position: fixed;
+  top: var(--docs-space-s);
+  left: var(--docs-space-s);
+  z-index: 400;
+  padding: 10px var(--docs-space-m);
+  border-radius: var(--docs-radius-m);
+  background: var(--docs-btn-brand-bg);
+  color: var(--docs-btn-brand-text);
+  font-weight: var(--docs-font-weight-semibold);
+  text-decoration: none;
+  transform: translateY(calc(-100% - var(--docs-space-l)));
+  transition: transform 0.15s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 .sidebar,
 .main-content {
   scrollbar-color: var(--docs-scrollbar-thumb) var(--docs-scrollbar-track);
@@ -262,48 +282,6 @@ body {
   width: 28px;
 }
 
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: var(--docs-space-l);
-}
-
-.mobile-menu-btn {
-  display: none;
-  background: none;
-  border: none;
-  font-size: var(--docs-font-size-xl);
-  cursor: pointer;
-  color: var(--docs-color-text);
-}
-
-@media (max-width: 768px) {
-  .mobile-menu-btn {
-    display: block;
-  }
-
-  .nav-links .nav-link {
-    display: none;
-  }
-}
-
-.nav-link {
-  text-decoration: none;
-  color: var(--docs-color-text-2);
-  font-size: var(--docs-font-size-m);
-  font-weight: var(--docs-font-weight-medium);
-  transition: color 0.2s;
-}
-
-.nav-link:hover {
-  color: var(--docs-color-brand);
-}
-
-.nav-link[active] {
-  color: var(--docs-color-brand);
-  font-weight: var(--docs-font-weight-semibold, 600);
-}
-
 /* ── Layout ────────────────────────────────────────── */
 
 .layout {
@@ -327,67 +305,6 @@ body {
   overflow-y: auto;
 }
 
-.sidebar-group {
-  margin-bottom: var(--docs-space-l);
-}
-
-.sidebar-title {
-  font-size: var(--docs-font-size-s);
-  font-weight: var(--docs-font-weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--docs-color-text-3);
-  margin-bottom: var(--docs-space-s);
-}
-
-.sidebar-items {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.sidebar-items li {
-  margin-bottom: 2px;
-}
-
-.sidebar-link {
-  display: block;
-  padding: var(--docs-space-xs) var(--docs-space-m);
-  border-radius: var(--docs-radius-m);
-  text-decoration: none;
-  color: var(--docs-color-text-2);
-  font-size: var(--docs-font-size-m);
-  transition: color 0.15s, background 0.15s;
-}
-
-.sidebar-link:hover {
-  color: var(--docs-color-brand);
-  background: var(--docs-color-brand-bg);
-}
-
-.sidebar-link-active {
-  color: var(--docs-color-brand);
-  font-weight: var(--docs-font-weight-semibold);
-  background: var(--docs-color-brand-bg);
-}
-
-.sidebar-children {
-  list-style: none;
-  padding-left: var(--docs-space-m);
-}
-
-.sidebar-children li {
-  margin-bottom: 1px;
-}
-
-.sidebar-parent-label {
-  display: block;
-  padding: var(--docs-space-xs) var(--docs-space-m);
-  font-size: var(--docs-font-size-s);
-  font-weight: var(--docs-font-weight-semibold);
-  color: var(--docs-color-text-2);
-}
-
 /* ── Main content ──────────────────────────────────── */
 
 .main-content {
@@ -399,6 +316,18 @@ body {
   padding: var(--docs-space-xl) var(--docs-space-2xl) var(--docs-space-3xl);
 }
 
+.doc-content,
+.page-nav,
+.main-content > .site-footer {
+  width: 100%;
+  max-width: var(--docs-content-max-width);
+  margin-inline: auto;
+}
+
+.mobile-page-context {
+  display: none;
+}
+
 /* ── Article typography ─────────────────────────────── */
 
 .doc-content h1 {
@@ -407,6 +336,7 @@ body {
   line-height: 1.25;
   margin-bottom: var(--docs-space-m);
   letter-spacing: -0.02em;
+  text-wrap: balance;
 }
 
 .doc-content h2 {
@@ -416,6 +346,7 @@ body {
   margin-bottom: var(--docs-space-m);
   padding-bottom: var(--docs-space-s);
   border-bottom: 1px solid var(--docs-color-border);
+  text-wrap: balance;
 }
 
 .doc-content h3 {
@@ -423,6 +354,7 @@ body {
   font-weight: var(--docs-font-weight-semibold);
   margin-top: var(--docs-space-xl);
   margin-bottom: var(--docs-space-m);
+  text-wrap: balance;
 }
 
 .doc-content p {
@@ -544,16 +476,19 @@ body {
 }
 
 .doc-content blockquote {
-  border-left: 3px solid var(--docs-color-brand);
+  border: 1px solid var(--docs-color-border);
   padding: var(--docs-space-m);
   margin-bottom: var(--docs-space-m);
   background: var(--docs-color-brand-bg);
-  border-radius: 0 var(--docs-radius-l) var(--docs-radius-l) 0;
+  border-radius: var(--docs-radius-l);
   color: var(--docs-color-text-2);
 }
 
 .doc-content table {
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   margin-bottom: var(--docs-space-m);
   font-size: var(--docs-font-size-m);
@@ -609,17 +544,14 @@ body {
 
 .home-hero {
   text-align: center;
-  padding: var(--docs-space-l) 0 var(--docs-space-2xl);
+  padding: var(--docs-space-l) 0 0;
 }
 
 .home-hero h1 {
   font-size: var(--docs-font-size-3xl);
   font-weight: var(--docs-font-weight-extrabold);
   letter-spacing: -0.03em;
-  background: var(--docs-hero-gradient);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--docs-color-text);
   margin-bottom: var(--docs-space-m);
 }
 
@@ -659,6 +591,17 @@ body {
   transition: all 0.2s;
 }
 
+.home-actions .btn-alt {
+  padding-inline: var(--docs-space-s);
+  border-color: transparent;
+  color: var(--docs-color-text-2);
+  font-weight: var(--docs-font-weight-medium);
+}
+
+.home-actions .btn-alt:hover {
+  background: var(--docs-color-brand-bg);
+}
+
 .btn-brand {
   background: var(--docs-btn-brand-bg);
   color: var(--docs-btn-brand-text);
@@ -685,29 +628,25 @@ body {
   font-size: var(--docs-font-size-m);
   color: var(--docs-color-text-3);
   max-width: 720px;
-  margin: var(--docs-space-2xl) auto 0;
+  margin: var(--docs-space-xl) auto 0;
   line-height: 1.6;
 }
 
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--docs-space-l);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: var(--docs-space-2xl);
   padding: var(--docs-space-xl) 0 var(--docs-space-3xl);
 }
 
 .feature-card {
-  padding: var(--docs-space-l);
-  border-radius: var(--docs-radius-xl);
-  border: 1px solid var(--docs-card-border);
-  background: var(--docs-card-bg);
-  box-shadow: var(--docs-card-shadow);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  padding: var(--docs-space-l) 0 var(--docs-space-xl);
+  border-top: 1px solid var(--docs-card-border);
+  transition: border-color 0.2s;
 }
 
 .feature-card:hover {
   border-color: var(--docs-color-brand);
-  box-shadow: var(--docs-card-hover-shadow);
 }
 
 .feature-card-header {
@@ -718,11 +657,18 @@ body {
 }
 
 .feature-icon {
-  font-size: 28px;
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  color: var(--docs-color-brand);
+  font-size: var(--docs-font-size-xl);
+  font-weight: var(--docs-font-weight-semibold);
   line-height: 1;
 }
 
-.feature-card h3 {
+.feature-card h2 {
   font-size: var(--docs-font-size-base);
   font-weight: var(--docs-font-weight-semibold);
   margin: 0;
@@ -741,24 +687,49 @@ body {
     display: none;
   }
 
-  .sidebar.open {
-    display: block;
-    position: fixed;
-    top: var(--docs-nav-height);
-    left: 0;
-    width: 280px;
-    height: calc(100vh - var(--docs-nav-height));
-    background: var(--docs-color-bg);
-    z-index: 50;
-    border-right: 1px solid var(--docs-color-border);
-  }
-
   .main-content {
     padding: var(--docs-space-l) var(--docs-space-m) var(--docs-space-2xl);
   }
 
+  .mobile-page-context {
+    display: flex;
+    align-items: center;
+    gap: var(--docs-space-s);
+    width: 100%;
+    max-width: var(--docs-content-max-width);
+    margin: 0 auto var(--docs-space-l);
+    color: var(--docs-color-text-2);
+    font-size: var(--docs-font-size-s);
+  }
+
+  .mobile-page-context strong {
+    overflow: hidden;
+    color: var(--docs-color-text);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .home-hero h1 {
     font-size: var(--docs-font-size-2xl);
+  }
+
+  .home-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--docs-space-s);
+  }
+
+  .home-actions a {
+    min-height: 44px;
+    justify-content: center;
+  }
+
+  .home-actions .btn-brand {
+    grid-column: 1 / -1;
+  }
+
+  .home-actions .btn-alt {
+    padding-inline: var(--docs-space-xs);
   }
 
   .features-grid {
@@ -766,19 +737,31 @@ body {
   }
 }
 
+@media (max-width: 520px) {
+  .nav-bar {
+    padding-inline: var(--docs-space-m);
+  }
+
+  .logo span {
+    display: none;
+  }
+
+}
+
 @media (min-width: 769px) and (max-width: 1024px) {
   .features-grid {
     grid-template-columns: repeat(2, 1fr);
+    column-gap: var(--docs-space-xl);
   }
 }
 
 /* Admonitions */
 .tip {
-  border-left: 3px solid var(--docs-color-brand);
+  border: 1px solid var(--docs-color-border);
   padding: var(--docs-space-m);
   margin-bottom: var(--docs-space-m);
   background: var(--docs-color-brand-bg);
-  border-radius: 0 var(--docs-radius-l) var(--docs-radius-l) 0;
+  border-radius: var(--docs-radius-l);
 }
 
 .tip p {
@@ -844,6 +827,8 @@ body[data-layout="full"] .main-content {
 
 body[data-layout="full"] .doc-content {
   flex: 1;
+  width: 100%;
+  max-width: none;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -862,6 +847,12 @@ body[data-layout="page"] .main-content {
   max-width: none;
 }
 
+body[data-layout="page"] .doc-content,
+body[data-layout="page"] .page-nav,
+body[data-layout="page"] .main-content > .site-footer {
+  max-width: none;
+}
+
 /* ── Heading anchors ───────────────────────────────── */
 
 .header-anchor {
@@ -876,12 +867,19 @@ body[data-layout="page"] .main-content {
 h1:hover .header-anchor,
 h2:hover .header-anchor,
 h3:hover .header-anchor,
-h4:hover .header-anchor {
+h4:hover .header-anchor,
+.header-anchor:focus-visible {
   opacity: 1;
 }
 
 .header-anchor:hover {
   color: var(--docs-color-brand);
+}
+
+@media (hover: none) {
+  .header-anchor {
+    opacity: 0.7;
+  }
 }
 
 h1 code,

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -88,23 +88,24 @@
 </head>
 
 <body data-layout="{{page.layout}}">
+  <a class="skip-link" href="#main-content">Skip to content</a>
   <header class="nav-bar">
     <a href="{{site.base}}" class="logo">
       <img src="{{site.base}}logo.svg" alt="{{site.title}}" />
       <span>{{site.title}}</span>
     </a>
-    <nav class="nav-links">
-      <for each="link in navigation">
-        <a href="{{link.link}}" class="nav-link" ?active="{{link.section == page.section}}">{{link.text}}</a>
-      </for>
-      <docs-search></docs-search>
-      <docs-theme-toggle></docs-theme-toggle>
-      <button class="mobile-menu-btn" id="mobile-menu-btn" aria-label="Toggle menu">☰</button>
-    </nav>
+    <docs-site-navigation
+      :navigation="{{navigation}}"
+      :sections="{{sidebar.sections}}"
+      section="{{page.section}}"
+      ?home="{{page.isHome}}"
+      ?full-layout="{{page.layout == 'full'}}"
+      :open="{{page.mobileNavigationOpen}}"
+    ></docs-site-navigation>
   </header>
 
   <if condition="page.isHome">
-    <main class="main-content" tabindex="-1">
+    <main class="main-content" id="main-content" tabindex="-1">
       <div class="home-container">
         <if condition="hero">
           <div class="home-hero">
@@ -132,7 +133,7 @@
               <div class="feature-card">
                 <div class="feature-card-header">
                   <div class="feature-icon">{{feature.icon}}</div>
-                  <h3>{{feature.title}}</h3>
+                  <h2>{{feature.title}}</h2>
                 </div>
                 <p>{{feature.description}}</p>
               </div>
@@ -150,54 +151,20 @@
 
   <if condition="!page.isHome">
     <div class="layout">
-    <aside class="sidebar">
-      <for each="section in sidebar.sections">
-        <div class="sidebar-group">
-          <h3 class="sidebar-title">{{section.title}}</h3>
-          <ul class="sidebar-items">
-            <for each="item in section.items">
-              <li>
-                <if condition="item.hasChildren">
-                  <if condition="item.link">
-                    <if condition="item.active">
-                      <a href="{{item.link}}" class="sidebar-link sidebar-link-active">{{item.text}}</a>
-                    </if>
-                    <if condition="!item.active">
-                      <a href="{{item.link}}" class="sidebar-link">{{item.text}}</a>
-                    </if>
-                  </if>
-                  <if condition="!item.link">
-                    <span class="sidebar-parent-label">{{item.text}}</span>
-                  </if>
-                  <ul class="sidebar-children">
-                    <for each="child in item.children">
-                      <li>
-                        <if condition="child.active">
-                          <a href="{{child.link}}" class="sidebar-link sidebar-link-active">{{child.text}}</a>
-                        </if>
-                        <if condition="!child.active">
-                          <a href="{{child.link}}" class="sidebar-link">{{child.text}}</a>
-                        </if>
-                      </li>
-                    </for>
-                  </ul>
-                </if>
-                <if condition="!item.hasChildren">
-                  <if condition="item.active">
-                    <a href="{{item.link}}" class="sidebar-link sidebar-link-active">{{item.text}}</a>
-                  </if>
-                  <if condition="!item.active">
-                    <a href="{{item.link}}" class="sidebar-link">{{item.text}}</a>
-                  </if>
-                </if>
-              </li>
-            </for>
-          </ul>
-        </div>
-      </for>
+    <aside class="sidebar" aria-label="Documentation sections">
+      <docs-sidebar-navigation
+        :sections="{{sidebar.sections}}"
+      ></docs-sidebar-navigation>
     </aside>
 
-    <main class="main-content" tabindex="-1">
+    <main class="main-content" id="main-content" tabindex="-1">
+      <if condition="sidebar.currentSection">
+        <div class="mobile-page-context" aria-label="Current location">
+          <span>{{sidebar.currentSection}}</span>
+          <span aria-hidden="true">/</span>
+          <strong>{{page.title}}</strong>
+        </div>
+      </if>
       <article class="doc-content">
         {{{page.content}}}
       </article>

--- a/crates/webui-press/template/index.ts
+++ b/crates/webui-press/template/index.ts
@@ -8,6 +8,14 @@ import "./docs-site-navigation/docs-site-navigation.js";
 
 // Hash anchor scrolling
 if (window.location.hash) {
-  const anchor = decodeURIComponent(window.location.hash.slice(1));
+  const rawAnchor = window.location.hash.slice(1);
+  let anchor = rawAnchor;
+  try {
+    anchor = decodeURIComponent(rawAnchor);
+  } catch (error) {
+    if (!(error instanceof URIError)) {
+      throw error;
+    }
+  }
   document.getElementById(anchor)?.scrollIntoView();
 }

--- a/crates/webui-press/template/index.ts
+++ b/crates/webui-press/template/index.ts
@@ -4,20 +4,10 @@
 // WebUI Docs — hydration entry point.
 // Imports interactive components for client-side behavior.
 
-import "./docs-theme-toggle/docs-theme-toggle.js";
-import "./docs-search/docs-search.js";
+import "./docs-site-navigation/docs-site-navigation.js";
 
 // Hash anchor scrolling
 if (window.location.hash) {
-  const el = document.querySelector(window.location.hash);
-  if (el) el.scrollIntoView();
-}
-
-// Mobile sidebar toggle
-const mobileBtn = document.getElementById("mobile-menu-btn");
-if (mobileBtn) {
-  mobileBtn.addEventListener("click", () => {
-    const sidebar = document.querySelector(".sidebar");
-    if (sidebar) sidebar.classList.toggle("open");
-  });
+  const anchor = decodeURIComponent(window.location.hash.slice(1));
+  document.getElementById(anchor)?.scrollIntoView();
 }

--- a/docs/.webui-press/components/docs-playground/docs-playground.css
+++ b/docs/.webui-press/components/docs-playground/docs-playground.css
@@ -50,19 +50,16 @@
 .tab {
   display: flex;
   align-items: center;
-  gap: 6px;
   box-sizing: border-box;
   position: relative;
-  padding: 0 16px;
+  padding-inline-start: 12px;
   font-size: 12px;
   color: var(--docs-color-text-2);
   background: transparent;
-  cursor: pointer;
   border: none;
   border-right: 1px solid var(--docs-color-border);
   border-bottom: 2px solid transparent;
   white-space: nowrap;
-  font-family: var(--docs-font-mono);
   transition: color 0.12s, background 0.12s, border-color 0.12s;
   user-select: none;
 }
@@ -70,7 +67,7 @@
   color: var(--docs-color-text);
   background: var(--docs-color-bg-alt);
 }
-.tab:focus-visible {
+.tab:focus-within {
   outline: 1px solid var(--docs-color-brand);
   outline-offset: -2px;
 }
@@ -81,6 +78,25 @@
 }
 .tab[data-editing] {
   padding: 0 8px;
+}
+
+.tab-select {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px 0 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-family: var(--docs-font-mono);
+  white-space: nowrap;
+}
+
+.tab-select:focus-visible {
+  outline: none;
 }
 
 .tab-icon {
@@ -182,7 +198,9 @@
   line-height: 1;
   transition: opacity 0.12s;
 }
-.tab:hover .tab-close-btn { opacity: 1; }
+.tab:hover .tab-close-btn,
+.tab:focus-within .tab-close-btn,
+.tab[active] .tab-close-btn { opacity: 1; }
 .tab-close-btn:hover {
   color: var(--docs-color-text);
   background: var(--docs-color-bg-alt);
@@ -445,6 +463,38 @@
   transform: rotate(0deg);
 }
 
+.error-recovery {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px 10px 38px;
+  color: var(--docs-color-text-2);
+  line-height: 1.45;
+}
+
+.error-retry-btn {
+  min-height: 32px;
+  flex-shrink: 0;
+  padding: 0 12px;
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  background: transparent;
+  color: #d04848;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.error-retry-btn:hover {
+  background: rgba(208, 72, 72, 0.08);
+}
+
+.error-retry-btn:focus-visible {
+  outline: 2px solid var(--docs-color-brand);
+  outline-offset: 2px;
+}
+
 /* Collapsible body: animate the grid row from 0fr to 1fr for a smooth,
    height-agnostic expand/collapse. */
 .error-panel-body-wrap {
@@ -534,4 +584,50 @@
     grid-template-rows: 1fr 1px 1fr;
   }
   .panel-divider { width: 100%; height: 1px; }
+}
+
+@media (max-width: 600px) {
+  :host {
+    --pg-bar-height: 44px;
+  }
+
+  .tab {
+    min-width: max-content;
+    padding-inline-start: 10px;
+    scroll-snap-align: start;
+  }
+
+  .tab-strip {
+    scroll-padding-inline: 8px;
+    scroll-snap-type: x proximity;
+  }
+
+  .tab-select {
+    min-width: 44px;
+    padding: 0 10px 0 6px;
+  }
+
+  .tab-add-btn {
+    width: 44px;
+    min-width: 44px;
+  }
+
+  .error-recovery {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-left: 14px;
+  }
+
+  .error-retry-btn {
+    min-height: 44px;
+  }
+}
+
+@media (hover: none) {
+  .tab-close-btn {
+    width: 32px;
+    height: 32px;
+    margin-right: 4px;
+    opacity: 1;
+  }
 }

--- a/docs/.webui-press/components/docs-playground/docs-playground.html
+++ b/docs/.webui-press/components/docs-playground/docs-playground.html
@@ -1,7 +1,7 @@
 <div class="pg">
   <div class="editor-pane">
     <div class="tab-bar">
-      <div class="tab-strip">
+      <div class="tab-strip" role="group" aria-label="Playground files">
         <for each="file in files">
           <div
             class="tab"
@@ -9,11 +9,8 @@
             ?data-editing="{{file.editing}}"
             title="{{file.name}}"
             data-name="{{file.name}}"
-            role="button"
-            tabindex="0"
             @click="{selectTab(e)}"
             @dblclick="{startFileRename(e)}"
-            @keydown="{onTabKeydown(e)}"
           >
             <span class="tab-icon tab-icon-html" aria-hidden="true">
               <svg viewBox="0 0 16 16" focusable="false">
@@ -50,12 +47,20 @@
               />
             </if>
             <if condition="!file.editing">
-              <span class="tab-name">{{file.name}}</span>
+              <button
+                class="tab-select"
+                type="button"
+                aria-label="Open {{file.name}}"
+                aria-pressed="{{file.active}}"
+              >
+                <span class="tab-name">{{file.name}}</span>
+              </button>
               <if condition="!file.locked">
                 <button
                   class="tab-close-btn"
                   type="button"
                   title="Close file"
+                  aria-label="Close {{file.name}}"
                   data-name="{{file.name}}"
                   @click="{closeFile(e)}"
                   @dblclick="{stopTabEvent(e)}"
@@ -67,9 +72,9 @@
           </div>
         </for>
       </div>
-      <button class="tab-add-btn" type="button" title="New file" @click="{openNewFileInput()}">+</button>
+      <button class="tab-add-btn" type="button" title="New file" aria-label="New file" @click="{openNewFileInput()}">+</button>
     </div>
-    <div class="editor-wrap" w-ref="{editorWrap}"></div>
+    <div class="editor-wrap" role="region" aria-label="Code editor" w-ref="{editorWrap}"></div>
   </div>
   <div class="panel-divider"></div>
   <div class="preview-pane">
@@ -88,7 +93,7 @@
         <button class="share-btn" type="button" @click="{sharePlayground()}">Share</button>
       </div>
     </div>
-    <iframe sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
+    <iframe title="Rendered preview" sandbox="allow-scripts" class="preview-frame" srcdoc="{{previewSrcdoc}}"></iframe>
     <if condition="hasError">
       <div
         class="error-panel"
@@ -117,6 +122,12 @@
             </svg>
           </span>
         </button>
+        <if condition="errorCanRetry">
+          <div class="error-recovery">
+            <span>The preview runtime did not load. Your files are safe.</span>
+            <button class="error-retry-btn" type="button" @click="{retryPreview()}">Retry preview</button>
+          </div>
+        </if>
         <div class="error-panel-body-wrap">
           <div class="error-panel-body">
             <if condition="errorSnippet">

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -295,6 +295,7 @@ export class DocsPlayground extends WebUIElement {
   @observable errorSnippet = "";
   @observable errorHelp = "";
   @observable errorRaw = "";
+  @observable errorCanRetry = false;
 
   private active: string = ENTRY_FILE;
   private entry: string = ENTRY_FILE;
@@ -305,6 +306,7 @@ export class DocsPlayground extends WebUIElement {
   private toastTimer: ReturnType<typeof setTimeout> | null = null;
   private themeObserver: MutationObserver | null = null;
   private suppressNextEditBlur = false;
+  private wasmLoadAttempt = 0;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -482,12 +484,6 @@ export class DocsPlayground extends WebUIElement {
     this.setActive(name);
     this.setupEditor();
     this.scrollTabIntoView(name);
-  }
-
-  onTabKeydown(ev: KeyboardEvent): void {
-    if (ev.key !== "Enter" && ev.key !== " ") return;
-    ev.preventDefault();
-    this.selectTab(ev);
   }
 
   closeFile(e: Event): void {
@@ -799,6 +795,7 @@ export class DocsPlayground extends WebUIElement {
     this.errorSnippet = "";
     this.errorHelp = "";
     this.errorRaw = "";
+    this.errorCanRetry = false;
   }
 
   /**
@@ -848,13 +845,21 @@ export class DocsPlayground extends WebUIElement {
       this.errorRaw = rest;
     }
 
-    this.errorExpanded = true;
+    this.errorExpanded = Boolean(head);
     this.hasError = true;
   }
 
   /** Toggle the expand/collapse state of the error panel. */
   toggleError(): void {
     this.errorExpanded = !this.errorExpanded;
+  }
+
+  /** Retry loading the preview runtime after a recoverable network failure. */
+  retryPreview(): void {
+    this.wasm = null;
+    this.wasmLoadAttempt += 1;
+    this.clearError();
+    void this.loadWasm();
   }
 
   private scheduleRender(): void {
@@ -945,17 +950,20 @@ export class DocsPlayground extends WebUIElement {
       this.setPreviewStatus("Loading WASM", "loading");
       const baseMeta = document.querySelector('meta[name="base"]');
       const base = baseMeta?.getAttribute("content") || "/";
-      const wasmUrl = base + "wasm/all/webui_wasm_all.js";
+      const retrySuffix =
+        this.wasmLoadAttempt > 0 ? `?retry=${this.wasmLoadAttempt}` : "";
+      const wasmUrl = base + "wasm/all/webui_wasm_all.js" + retrySuffix;
       const mod = await import(/* @vite-ignore */ wasmUrl);
       await mod.default();
       this.wasm = mod;
       this.doRender();
     } catch (e) {
-      this.setPreviewStatus("Failed", "failed");
-      this.setError(
-        'WASM not available at "wasm/all/webui_wasm_all.js". Run "cargo xtask build-wasm" to enable the playground.\n\n' +
-          String(e),
-      );
+      this.setPreviewStatus("Unavailable", "failed");
+      this.setError(`Preview couldn't load.\n\n${String(e)}`);
+      this.errorHelp =
+        "The WebAssembly runtime could not be downloaded. Check your connection, then retry the preview.";
+      this.errorCanRetry = true;
+      this.errorExpanded = false;
     }
   }
 }

--- a/docs/.webui-press/components/docs-playground/docs-playground.ts
+++ b/docs/.webui-press/components/docs-playground/docs-playground.ts
@@ -961,7 +961,7 @@ export class DocsPlayground extends WebUIElement {
       this.setPreviewStatus("Unavailable", "failed");
       this.setError(`Preview couldn't load.\n\n${String(e)}`);
       this.errorHelp =
-        "The WebAssembly runtime could not be downloaded. Check your connection, then retry the preview.";
+        "The WebAssembly runtime could not be loaded. Check your connection, or run `cargo xtask build-wasm` when developing locally, then retry the preview.";
       this.errorCanRetry = true;
       this.errorExpanded = false;
     }

--- a/docs/.webui-press/config.json
+++ b/docs/.webui-press/config.json
@@ -75,7 +75,7 @@
         ]
       },
       {
-        "title": "Core Concepts",
+        "title": "Core Foundations",
         "items": [
           {
             "text": "How It Works",
@@ -122,7 +122,12 @@
           {
             "text": "Interactivity",
             "link": "/guide/concepts/interactivity"
-          },
+          }
+        ]
+      },
+      {
+        "title": "Application Architecture",
+        "items": [
           {
             "text": "State Management",
             "link": "/guide/concepts/state-management"
@@ -266,32 +271,32 @@
     ],
     "features": [
       {
-        "icon": "⚡",
+        "icon": "↯",
         "title": "Compiled, not interpreted",
         "description": "Templates and Web Components compile at build time into a binary Protocol Buffer. The server's hot path is just filling holes and streaming bytes. No template parsing, no AST walking, no interpretation at runtime."
       },
       {
-        "icon": "🌐",
+        "icon": "◎",
         "title": "Render from any language",
         "description": "SSR has historically been a Node.js privilege. WebUI changes that. Stream pages from Rust, Go, Python, C#, Bun, Deno, Node.js, or WASM running at the edge or in the browser. The protocol is just bytes; any runtime that can read bytes and write strings can serve a site."
       },
       {
-        "icon": "🔄",
+        "icon": "⇄",
         "title": "Isomorphic anywhere",
         "description": "Same Web Components can render on a fast native server, at the edge, or in a service worker. Cache the compiled UI on a CDN, stream dynamic state through the lightweight handler, then hydrate against the existing DOM. Isomorphic apps without making Node.js the rendering boundary."
       },
       {
-        "icon": "🧩",
+        "icon": "◇",
         "title": "webui-framework",
         "description": "A tiny client runtime for Web Components, tuned for rendering speed and low memory. Built on Declarative Shadow DOM and native browser APIs. No virtual DOM, no proprietary component model, no JSX."
       },
       {
-        "icon": "🧭",
+        "icon": "↗",
         "title": "webui-router",
         "description": "Routes declared in HTML and compiled at build time. The server matches every navigation and returns the route chain as JSON; the client diffs against the current chain and remounts only the level that changed. Tagged caching and invalidation graphs are validated by the compiler, not configured at runtime."
       },
       {
-        "icon": "📰",
+        "icon": "▤",
         "title": "webui-press",
         "description": "A blazing-fast static site generator powered by the framework itself. Compiles markdown and components in parallel into a fully static site. Perfect for GitHub Pages, CDNs, and anywhere that just serves files. (You are reading a site built with it.)"
       }

--- a/docs/.webui-press/theme.css
+++ b/docs/.webui-press/theme.css
@@ -5,16 +5,16 @@
   --docs-max-width: none;
   
   /* Brand */
-  --docs-color-brand: #a25a02;
-  --docs-color-brand-hover: #c87b0a;
-  --docs-color-brand-bg: rgba(162, 90, 2, 0.06);
+  --docs-color-brand: #8a4800;
+  --docs-color-brand-hover: #6f3900;
+  --docs-color-brand-bg: rgba(138, 72, 0, 0.08);
 
   /* Surfaces */
   --docs-color-bg: #efeae7;
   --docs-color-bg-alt: #ddd7d1;
   --docs-color-text: #272320;
   --docs-color-text-2: rgba(39, 35, 32, 0.70);
-  --docs-color-text-3: rgba(39, 35, 32, 0.44);
+  --docs-color-text-3: #68615c;
   --docs-color-border: rgba(39, 35, 32, 0.10);
 
   /* Code */
@@ -34,7 +34,7 @@
   --docs-card-hover-shadow: 0 8px 32px rgba(39, 35, 32, 0.06);
   --docs-nav-bg: rgba(239, 234, 231, 0.85);
   --docs-nav-backdrop: blur(12px);
-  --docs-hero-gradient: linear-gradient(135deg, #a25a02, #c87b0a 40%, #8a4b03);
+  --docs-hero-gradient: linear-gradient(135deg, #8a4800, #a25a02 40%, #6f3900);
 }
 
 [data-theme="dark"] {
@@ -42,7 +42,7 @@
   --docs-color-bg-alt: #0b0d15;
   --docs-color-text: #d4cfc7;
   --docs-color-text-2: rgba(212, 207, 199, 0.70);
-  --docs-color-text-3: rgba(212, 207, 199, 0.44);
+  --docs-color-text-3: #99928a;
   --docs-color-border: rgba(212, 207, 199, 0.10);
   --docs-color-brand: #c87b0a;
   --docs-color-brand-hover: #e0a040;
@@ -62,7 +62,7 @@
     --docs-color-bg-alt: #0b0d15;
     --docs-color-text: #d4cfc7;
     --docs-color-text-2: rgba(212, 207, 199, 0.70);
-    --docs-color-text-3: rgba(212, 207, 199, 0.44);
+    --docs-color-text-3: #99928a;
     --docs-color-border: rgba(212, 207, 199, 0.10);
     --docs-color-brand: #c87b0a;
     --docs-color-brand-hover: #e0a040;


### PR DESCRIPTION
## Why

The documentation site had broken mobile navigation, weak accessibility semantics, dense reading layouts, and a Playground route that could remain visually blank during cross-document navigation. This update makes the docs easier to read and operate across desktop and mobile while using WebUI's own component model for the interactive shell.

## What changed

- Add WebUI-native site and sidebar navigation components using bound state, a native dialog, and native details disclosures instead of document-level DOM mutation.
- Improve heading semantics, contrast, reading measure, responsive tables, search lifecycle behavior, and the homepage feature presentation.
- Harden Playground loading and recovery states, make mobile file tabs readable, and add accessible control names.
- Skip cross-document fades when entering or leaving full-layout custom pages so page-specific bundles paint immediately.
- Add browser regression coverage for navigation, hydration, accessibility, responsive layout, search, and Playground recovery.

## Validation

- `cargo xtask check`
- `pnpm --filter @webui/webui-press test`

## Review note

Full-layout pages intentionally skip the normal documentation crossfade. Chromium can otherwise keep the transition active while a viewport-filling custom page initializes, visually hiding content that is already present and hydrated.