### PR TITLE
fix: defer authored define() whenever template metadata is missing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2111,9 +2111,14 @@ contract rather than introduce a parallel one.
    removed on activation, rejection, or abandonment. An element without it
    mounts normally even while a streaming response is still open.
 10. **Definitions and waiters are metadata-gated by tag name.** The browser
-    snapshots `observedAttributes` during `customElements.define()`, so a
-    streaming `.define(tag)` request waits until that tag's template metadata is
-    registered. Undefined custom elements then share one
+    snapshots `observedAttributes` during `customElements.define()`, so any
+    `.define(tag)` request whose compiled template metadata has not yet
+    registered waits until it arrives — not only during streaming. Ordinary
+    (non-streaming) WebUI Router partial navigation can eagerly import an
+    authored nested component whose `define(tag)` call runs before the
+    router registers that route's metadata; deferring there too keeps
+    `observedAttributes` complete instead of permanently missing
+    template-only attributes. Undefined custom elements then share one
     `customElements.whenDefined` reaction per tag with a bounded root set,
     never one promise closure per root instance.
 11. **Undefined parents are activation barriers.** If an outer streamed root is

--- a/packages/webui-framework/src/template-element.test.ts
+++ b/packages/webui-framework/src/template-element.test.ts
@@ -76,6 +76,7 @@ Object.defineProperty(globalThis, 'customElements', {
 });
 
 const { TemplateElement } = await import('./template-element.js');
+const { registerTemplateData } = await import('./template.js');
 const { resetStreamingModeForTests } = await import('./streaming-mode.js');
 const {
   beginStreamingGate,
@@ -401,6 +402,102 @@ describe('TemplateElement — streamed-host activation ownership', () => {
     assert.ok(raw.$meta, 'boundary commit caches metadata without mounting');
     el.setState({ message: 'wake' });
     assert.equal(activationMeta, raw.$meta, 'the later state write can activate from cached metadata');
+  });
+});
+
+describe('TemplateElement.define — ordinary (non-streaming) authored definition', () => {
+  test('defers an eagerly authored define() until later-registered metadata completes it, even outside streaming mode', () => {
+    // Ordinary WebUI Router partial navigation eagerly imports an authored
+    // nested component module — which calls the compiler-emitted
+    // `MyComponent.define(tag)` at top level — *before* the router has
+    // registered that route's compiled template metadata. Native
+    // `customElements.define()` snapshots `observedAttributes` at call time,
+    // so defining now (as the old streaming-only guard did) would forever
+    // miss template-only attributes like `title` below.
+    const documentFake = document as unknown as {
+      querySelector(selector: string): unknown;
+    };
+    const previousQuerySelector = documentFake.querySelector;
+    documentFake.querySelector = () => null; // no streaming meta tag present
+    resetStreamingModeForTests();
+
+    const customElementsFake = customElements as unknown as {
+      get(name: string): CustomElementConstructor | undefined;
+      define?(name: string, ctor: CustomElementConstructor): void;
+    };
+    const previousGet = customElementsFake.get;
+    const previousDefine = customElementsFake.define;
+    const registry = new Map<string, CustomElementConstructor>();
+    customElementsFake.get = (name: string) => registry.get(name);
+    customElementsFake.define = (name: string, ctor: CustomElementConstructor) => {
+      registry.set(name, ctor);
+    };
+
+    const tag = `test-router-nested-widget-${Date.now()}`;
+
+    try {
+      // No `@attr`/`@observable` for `title` — a template-only binding
+      // entirely owned by compiled metadata (`tr`/`ta`).
+      class AuthoredNestedWidget extends TemplateElement {}
+      const AuthoredNestedWidgetCtor = AuthoredNestedWidget as unknown as {
+        define(tagName: string): void;
+      };
+
+      AuthoredNestedWidgetCtor.define(tag);
+
+      assert.equal(
+        customElements.get(tag),
+        undefined,
+        'must stay pending — an ordinary (non-streaming) page must not define an incomplete observer surface either',
+      );
+
+      // A second eager define() call for the same still-pending tag must
+      // preserve the existing duplicate-definition diagnostic.
+      assert.throws(
+        () => AuthoredNestedWidgetCtor.define(tag),
+        /already pending definition/,
+      );
+
+      // The router registers this route's compiled template metadata once
+      // its partial navigation response resolves.
+      registerTemplateData({
+        [tag]: {
+          h: '<div><span></span></div>',
+          tr: ['title'],
+          ta: ['title'],
+        },
+      });
+
+      const ctor = customElements.get(tag) as (CustomElementConstructor & {
+        observedAttributes?: string[];
+      }) | undefined;
+      assert.ok(ctor, 'the deferred definition must complete once metadata registers');
+      assert.deepEqual(
+        ctor!.observedAttributes,
+        ['title'],
+        'observedAttributes must include the template-derived attribute the browser would otherwise have missed',
+      );
+
+      const el = new (ctor as CustomElementConstructor)() as unknown as {
+        attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void;
+        $templateState: Record<string, unknown> | null;
+      };
+
+      // A client-created host now carries `title` in `observedAttributes`,
+      // so the browser calls `attributeChangedCallback` for it.
+      el.attributeChangedCallback('title', null, 'Hello from router nav');
+
+      assert.equal(
+        el.$templateState?.title,
+        'Hello from router nav',
+        'the template-only binding must receive and update from the client-created host attribute',
+      );
+    } finally {
+      documentFake.querySelector = previousQuerySelector;
+      resetStreamingModeForTests();
+      customElementsFake.get = previousGet;
+      customElementsFake.define = previousDefine;
+    }
   });
 });
 

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -478,10 +478,17 @@ export class TemplateElement extends HTMLElement {
   static define(tagName: string): void {
     const ctor = this as TemplateObservedConstructor;
     const meta = getTemplate(tagName);
-    if (!meta && isStreamingHydrationMode()) {
+    if (!meta) {
       // Metadata supplies template-derived observed attributes. The browser
-      // snapshots that list at native define() time, so a streamed page must
-      // wait rather than permanently define an incomplete observer surface.
+      // snapshots that list at native define() time, so any page must wait
+      // rather than permanently define an incomplete observer surface —
+      // not only a streamed one. Ordinary (non-streaming) WebUI Router
+      // partial navigation can register a route's template metadata after
+      // an eagerly imported authored nested component module has already
+      // run its top-level `define()` call; deferring here lets that later
+      // registration (`registerTemplateData()`) complete the definition
+      // with the full attribute list instead of leaving it stuck with only
+      // the host's own compiled attributes.
       deferTemplateDefinition(tagName, ctor, () => {
         defineTemplateConstructor(ctor, tagName, getTemplate(tagName));
       });

--- a/packages/webui-framework/src/template.ts
+++ b/packages/webui-framework/src/template.ts
@@ -198,7 +198,7 @@ export function prepareAssetTemplateData(
 }
 
 /**
- * Hold an authored custom-element definition until streamed metadata arrives.
+ * Hold an authored custom-element definition until compiled metadata arrives.
  *
  * Internal to the framework package; the public registration surface remains
  * `TemplateElement.define()`.

--- a/packages/webui-framework/tests/fixtures/client-runtime/client-runtime.spec.ts
+++ b/packages/webui-framework/tests/fixtures/client-runtime/client-runtime.spec.ts
@@ -70,6 +70,35 @@ test('early streaming definition waits for metadata and native observedAttribute
   });
 });
 
+test('ordinary Router definition waits for metadata and renders template-only attributes', async ({ page }) => {
+  await page.goto('/client-runtime/router.html');
+
+  expect(await page.evaluate(() => customElements.get('test-runtime-life') === undefined)).toBe(true);
+
+  const result = await page.evaluate(() => {
+    window.registerClientRuntimeTemplates();
+    const ctor = customElements.get('test-runtime-life');
+    const el = document.createElement('test-runtime-life') as TestRuntimeLife;
+    el.setAttribute('label', 'ready');
+    document.body.appendChild(el);
+    return {
+      authoredWon: ctor === window.TestRuntimeLife,
+      observed: (ctor as CustomElementConstructor & {
+        observedAttributes?: readonly string[];
+      } | undefined)?.observedAttributes,
+      changes: el.attributeChanges,
+      text: (el.shadowRoot ?? el).querySelector('span')?.textContent,
+    };
+  });
+
+  expect(result).toEqual({
+    authoredWon: true,
+    observed: ['label'],
+    changes: ['label'],
+    text: 'ready',
+  });
+});
+
 test('streamed activation fires once, including detached late definition', async ({ page }) => {
   await page.goto('/client-runtime/streaming.html');
 

--- a/packages/webui-framework/tests/fixtures/client-runtime/element.ts
+++ b/packages/webui-framework/tests/fixtures/client-runtime/element.ts
@@ -10,6 +10,9 @@ import {
 const templates: Record<string, TemplateMeta> = {
   'test-runtime-life': {
     h: '<span></span>',
+    tx: [
+      [[1, 0], [['label']]],
+    ],
     tr: ['label'],
     ta: ['label'],
     th: 1,
@@ -58,10 +61,11 @@ function registerTemplates(): void {
 }
 
 const streaming = !!document.querySelector('meta[name="webui-streaming"][content="1"]');
-// Ordinary pages define immediately; streaming pages hold this definition
-// until the same metadata registration used by the authored components.
+const routerLate = !!document.querySelector('meta[name="webui-router-late"][content="1"]');
+// Ordinary pages publish metadata synchronously; streaming and Router-late
+// pages hold definitions until that same metadata registration arrives.
 TestRuntimeImmediate.define('test-runtime-immediate');
-if (!streaming) {
+if (!streaming && !routerLate) {
   registerTemplates();
 }
 

--- a/packages/webui-framework/tests/fixtures/client-runtime/router.html
+++ b/packages/webui-framework/tests/fixtures/client-runtime/router.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="webui-router-late" content="1">
+  <title>Client runtime Router metadata race</title>
+  <script src="/dist/client-runtime/element.js"></script>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
## Why

`TemplateElement.define(tagName)` only deferred `customElements.define()` when compiled template metadata was absent and streaming hydration was active. Ordinary (non-streaming) WebUI Router partial navigation can also register a route's template metadata after an eagerly imported authored nested component has already called `define()` at module load time.

Native `customElements.define()` snapshots `observedAttributes` at call time, so in that race the host's own compiled attributes were present but template-only child bindings (attributes contributed by `ta`/`tr` metadata) were silently and permanently dropped once metadata arrived late - the custom element was defined too early with an incomplete observer surface.

## Approach

Broaden the guard in `TemplateElement.define()` from `!meta && isStreamingHydrationMode()` to `!meta`, so authored definitions defer whenever compiled metadata is unavailable, regardless of streaming mode. The existing `deferTemplateDefinition()` / `pendingTemplateDefinitions` drain path, already shared by both the streaming coordinator and `registerTemplateData()`, completes the deferred definition once metadata registers, so pending/duplicate-definition diagnostics and static-host ownership checks are unchanged.

`isStreamingHydrationMode` remains used elsewhere in `template-element.ts` (the `connectedCallback` `data-ws` check), so no import cleanup was needed there. Confirmed no other call site (`element.ts`, `streaming-install.ts`, `streaming-mode.ts`, the lazy-hydration fixture) depends on the old streaming-only defer behavior; `WebUIElement extends TemplateElement` without overriding `define()`, so it inherits the fix automatically.

## Changes

- `packages/webui-framework/src/template-element.ts` - core fix: broadened `define()` defer condition
- `packages/webui-framework/src/template.ts` - doc comment update (`deferTemplateDefinition`: "streamed" to "compiled" metadata)
- `packages/webui-framework/src/template-element.test.ts` - new unit regression: eager `define()` defers outside streaming mode, duplicate-define diagnostic, completion via `registerTemplateData()`, correct `observedAttributes`, and `attributeChangedCallback` populating template state for a template-only binding
- `packages/webui-framework/tests/fixtures/client-runtime/{element.ts,client-runtime.spec.ts,router.html}` - new Playwright e2e fixture/spec proving a client-created host attribute renders/updates its template-only binding via real DOM once ordinary Router-style late metadata registration completes the deferred definition
- `DESIGN.md` (section 10) - generalized the metadata-gated definition rule to cover ordinary Router partial navigation, not just streaming

## Testing

- `pnpm test:unit` (webui-framework): 251/251 passing, 40 suites, 0 failures
- `tsc -p tsconfig.unit-test.json --noEmit`: clean
- `tsc -p tsconfig.test.json --noEmit`: clean (e2e spec type-checks)
- `pnpm build`: clean
- Playwright e2e (`client-runtime.spec.ts`): validated separately in a follow-up environment with the native addon built - 5/5 passing, and a real `/settings` to `/` reproduction rendered 122/122 cards with zero empty cards and all seven observed attributes present

## Performance

`define()` runs once per custom-element class at module load, not on any hot path (parsing, expression evaluation, rendering, protocol serialization). The common case (`meta` already present) is unaffected. The `!meta` branch, when taken, no longer evaluates `isStreamingHydrationMode()` at all, so there is no added per-call cost. The tradeoff is latency, not CPU: a tag whose metadata never registers now stays undefined instead of defining early with a broken attribute set, the same tradeoff already accepted for the streaming path.