### PR TITLE
Update rust toolchain version and fix clippy warning

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -67,7 +67,7 @@ runs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.93
+        toolchain: 1.98
         targets: ${{ inputs.rust-targets }}
         components: ${{ inputs.rust-components }}
 

--- a/.github/actions/setup-wasm/action.yml
+++ b/.github/actions/setup-wasm/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.93
+        toolchain: 1.98
         targets: wasm32-unknown-unknown
 
     - name: Rust Cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://github.com/microsoft/webui"
 homepage = "https://microsoft.github.io/webui"
 

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-dev-server/Cargo.toml
+++ b/crates/webui-dev-server/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "Shared dev-server primitives for WebUI tooling: file watcher, SSE live reload, and URL-safe static file routing."

--- a/crates/webui-discovery/Cargo.toml
+++ b/crates/webui-discovery/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1359,12 +1359,9 @@ fn walk_route_children(
     let mut current = children;
     let mut base = route_base.to_string();
 
-    loop {
-        let Some((idx, ref rm)) =
-            select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
-        else {
-            break;
-        };
+    while let Some((idx, ref rm)) =
+        select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
+    {
         let matched = &current[idx];
         if matched.fragment_id.is_empty() {
             break;
@@ -1540,11 +1537,7 @@ fn collect_params_from_children(
     let mut current = children;
     let mut base = route_base.to_string();
 
-    loop {
-        let Some((idx, rm)) = select_best_child_route(current, request_path, &base, route_index)
-        else {
-            break;
-        };
+    while let Some((idx, rm)) = select_best_child_route(current, request_path, &base, route_index) {
         all_params.extend(rm.params);
         let matched = &current[idx];
         if matched.children.is_empty() {
@@ -1753,12 +1746,9 @@ fn walk_children_for_inventory_and_chain(
     let mut current = children;
     let mut base = route_base.to_string();
 
-    loop {
-        let Some((idx, ref rm)) =
-            select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
-        else {
-            break;
-        };
+    while let Some((idx, ref rm)) =
+        select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
+    {
         let matched = &current[idx];
         if matched.fragment_id.is_empty() {
             break;

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "High-performance Static Site Generator powered by WebUI Framework"

--- a/crates/webui-press/src/markdown.rs
+++ b/crates/webui-press/src/markdown.rs
@@ -333,7 +333,7 @@ pub fn render_markdown(
                 && !has_base_path_prefix(&link.url, base_prefix)
             {
                 // Prepend base_path to absolute internal links
-                link.url = format!("{base_prefix}{}", &link.url);
+                link.url = format!("{base_prefix}{}", link.url);
             } else if let Some(resolved) =
                 resolve_relative_link(base_path, link_base_url, &link.url)
             {

--- a/crates/webui-protocol/Cargo.toml
+++ b/crates/webui-protocol/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-python/Cargo.toml
+++ b/crates/webui-python/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file = "LICENSE"
 repository.workspace = true
 homepage.workspace = true
 publish = false

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-tokens/Cargo.toml
+++ b/crates/webui-tokens/Cargo.toml
@@ -3,7 +3,6 @@ name = "microsoft-webui-tokens"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -5,7 +5,6 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"

--- a/examples/app/commerce/server/src/state/catalog_pages.rs
+++ b/examples/app/commerce/server/src/state/catalog_pages.rs
@@ -213,7 +213,7 @@ fn catalog_grid_image_preloads(products: &[&Product]) -> Vec<String> {
     products
         .iter()
         .take(CATALOG_GRID_PRELOAD_COUNT)
-        .map(|product| format!("{}?w=640&q=75", &product.image_url))
+        .map(|product| format!("{}?w=640&q=75", product.image_url))
         .collect()
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.98"


### PR DESCRIPTION
## Summary

Update the pinned Rust toolchain from 1.93 to 1.98 to match the current Rust version used by Chromium, then resolve the Cargo and Clippy warnings surfaced by the newer toolchain.

This updates the development and CI toolchain without changing the workspace's declared Rust 1.93 MSRV.

## Cargo license warning

Cargo reports the following warning for packages that specify both license fields:

> only one of `license` or `license-file` is necessary

The workspace uses the standard MIT license, which has the SPDX identifier `MIT`. We therefore retain:

```toml
license = "MIT"