### PR TITLE
chore: cross-compile release artifacts on Linux

### DIFF
--- a/.ado/pipelines/azure-pipelines-build.yml
+++ b/.ado/pipelines/azure-pipelines-build.yml
@@ -112,23 +112,70 @@ stages:
     sourceDateEpoch: $[ stageDependencies.PrepareRelease.SelectRelease.outputs['release.sourceDateEpoch'] ]
     CARGO_CACHE_HOME: $(Pipeline.Workspace)/.cargo
     PNPM_STORE_PATH: $(Pipeline.Workspace)/.pnpm-store
+    # Pinned cross-compilation toolchain versions. All six target legs build
+    # on Linux; Windows and macOS legs cross-compile instead of running on
+    # native hosted pools, so these versions gate reproducibility for them.
+    # Bump deliberately, and update the matching `toolchainIdentity` cache
+    # label below alongside any version bump so stale caches are dropped.
+    cargoXwinVersion: '0.23.0'
+    llvmAptVersion: '18'
+    cargoZigbuildVersion: '0.23.0'
+    zigVersion: '0.13.0'
+    # Official SHA-256 of https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz.
+    # Update this alongside zigVersion if the pin is ever bumped.
+    zigSha256: 'd45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea'
+    # Name of the Azure DevOps Library secure file holding the Apple SDK used
+    # by macOS legs. The file itself is uploaded out-of-band by release
+    # engineering from a legally obtained Xcode/Apple SDK distribution; it is
+    # never embedded in source control.
+    appleSdkSecureFileName: 'WebUI-MacOSX-SDK.tar.xz'
+    # The Apple SDK archive's expected SHA-256 is intentionally NOT a pipeline
+    # variable here: it must never be committed as a placeholder. It comes
+    # from the required `WEBUI_APPLE_SDK_SHA256` Azure Pipelines/Library
+    # variable (set in the pipeline's variable group), validated for format
+    # and folded into the Cargo cache identity below so a rotated SDK busts
+    # stale macOS caches instead of silently reusing them.
   jobs:
-  - job: BuildLinuxAssets
-    displayName: Build Linux release asset
+  - job: BuildReleaseAssets
+    displayName: Build release asset
     strategy:
       matrix:
         LinuxX64:
           targetTriple: x86_64-unknown-linux-gnu
           artifactName: stage-linux-x64
+          backend: linux
           installArm64Linker: 'false'
           manylinuxCrossImage: messense/manylinux2014-cross:x86_64@sha256:13670ccc63c35e072661938181c046243c01d7bca7976b3914177fb9b162998d
-          pythonNativeTest: 'true'
+          toolchainIdentity: manylinux2014-x86_64-13670ccc
         LinuxArm64:
           targetTriple: aarch64-unknown-linux-gnu
           artifactName: stage-linux-arm64
+          backend: linux
           installArm64Linker: 'true'
           manylinuxCrossImage: messense/manylinux2014-cross:aarch64@sha256:32c92568ebee8db53e0598c21bcd06a6dd1649d45d507646a8a49313c50325f8
-          pythonNativeTest: 'false'
+          toolchainIdentity: manylinux2014-aarch64-32c92568
+        WindowsX64:
+          targetTriple: x86_64-pc-windows-msvc
+          artifactName: stage-windows-x64
+          backend: windows
+          toolchainIdentity: xwin-0.23.0-llvm-18
+        WindowsArm64:
+          targetTriple: aarch64-pc-windows-msvc
+          artifactName: stage-windows-arm64
+          backend: windows
+          toolchainIdentity: xwin-0.23.0-llvm-18
+        MacOSX64:
+          targetTriple: x86_64-apple-darwin
+          artifactName: stage-macos-x64
+          backend: macos
+          macosDeploymentTarget: '10.12'
+          toolchainIdentity: zigbuild-0.23.0-zig-0.13.0-sdk-10.12
+        MacOSArm64:
+          targetTriple: aarch64-apple-darwin
+          artifactName: stage-macos-arm64
+          backend: macos
+          macosDeploymentTarget: '11.0'
+          toolchainIdentity: zigbuild-0.23.0-zig-0.13.0-sdk-11.0
     pool:
       vmImage: ubuntu-latest
     steps:
@@ -138,23 +185,126 @@ stages:
       displayName: Use Python 3.11
       inputs:
         versionSpec: '3.11'
+    - task: Bash@3
+      displayName: Resolve Apple SDK cache identity
+      name: appleSdkCacheIdentity
+      inputs:
+        targetType: inline
+        script: |
+          # Copyright (c) Microsoft Corporation.
+          # Licensed under the MIT license.
+
+          set -euo pipefail
+
+          # Runs for every leg (not just macOS) so the Cargo cache key below
+          # can reference a single variable regardless of backend. Non-macOS
+          # legs never need the Apple SDK, so their cache identity segment is
+          # a fixed constant that never changes and never busts their cache.
+          if [[ "$BACKEND" != "macos" ]]; then
+            echo "##vso[task.setvariable variable=digest;isOutput=true]none"
+            exit 0
+          fi
+
+          : "${WEBUI_APPLE_SDK_SHA256:?WEBUI_APPLE_SDK_SHA256 is required for macOS legs. Set it as an Azure Pipelines/Library variable containing the Apple SDK secure file's SHA-256 digest.}"
+
+          if [[ ! "$WEBUI_APPLE_SDK_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "##vso[task.logissue type=error]WEBUI_APPLE_SDK_SHA256 must be exactly 64 lowercase hex characters."
+            exit 1
+          fi
+
+          # Also feeds the Cargo cache key: rotating the Apple SDK changes
+          # this value, which invalidates every macOS leg's stale cache.
+          echo "##vso[task.setvariable variable=digest;isOutput=true]$WEBUI_APPLE_SDK_SHA256"
+      env:
+        BACKEND: $(backend)
+        WEBUI_APPLE_SDK_SHA256: $(WEBUI_APPLE_SDK_SHA256)
     - task: Cache@2
       displayName: Restore Cargo cache
       inputs:
-        key: 'cargo-home | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
+        key: 'cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
         restoreKeys: |
-          cargo-home | "$(Agent.OS)" | "$(targetTriple)"
-          cargo-home | "$(Agent.OS)"
+          cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
+          cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)"
         path: $(CARGO_CACHE_HOME)
     - task: Cache@2
       displayName: Restore target cache
       inputs:
-        key: 'cargo-target | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
+        key: 'cargo-target | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
         restoreKeys: |
-          cargo-target | "$(Agent.OS)" | "$(targetTriple)"
+          cargo-target | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
         path: $(Build.SourcesDirectory)/target
+    - task: DownloadSecureFile@1
+      name: appleSdkSecureFile
+      displayName: Download Apple SDK secure file
+      condition: eq(variables['backend'], 'macos')
+      inputs:
+        secureFile: $(appleSdkSecureFileName)
     - task: Bash@3
-      displayName: Build and stage $(targetTriple)
+      displayName: Verify and extract Apple SDK
+      condition: eq(variables['backend'], 'macos')
+      inputs:
+        targetType: inline
+        script: |
+          # Copyright (c) Microsoft Corporation.
+          # Licensed under the MIT license.
+
+          set -euo pipefail
+
+          : "${SECURE_FILE_PATH:?SECURE_FILE_PATH is required}"
+          : "${EXPECTED_SHA256:?EXPECTED_SHA256 is required}"
+          : "${AGENT_TEMP_DIRECTORY:?AGENT_TEMP_DIRECTORY is required}"
+
+          # EXPECTED_SHA256 is the validated WEBUI_APPLE_SDK_SHA256 digest
+          # (format-checked by the "Resolve Apple SDK cache identity" step
+          # above); re-validate here too so this step fails safely even if
+          # invoked on its own.
+          if [[ ! "$EXPECTED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "##vso[task.logissue type=error]EXPECTED_SHA256 must be exactly 64 lowercase hex characters."
+            exit 1
+          fi
+
+          actual_sha256=$(sha256sum "$SECURE_FILE_PATH" | awk '{print $1}')
+          if [[ "$actual_sha256" != "$EXPECTED_SHA256" ]]; then
+            echo "##vso[task.logissue type=error]Apple SDK archive SHA-256 mismatch: expected $EXPECTED_SHA256, received $actual_sha256."
+            exit 1
+          fi
+
+          # Extracted only under a fixed path below Agent.TempDirectory: never
+          # cached, never published. The cleanup step always removes this
+          # exact path, even if this step fails partway through, so it never
+          # depends on a variable that only gets set on success.
+          sdk_extract_dir="$AGENT_TEMP_DIRECTORY/apple-sdk"
+          rm -rf "$sdk_extract_dir"
+          mkdir -p "$sdk_extract_dir"
+          tar -xf "$SECURE_FILE_PATH" -C "$sdk_extract_dir"
+
+          mapfile -t sdk_dirs < <(find "$sdk_extract_dir" -maxdepth 2 -type d -name '*.sdk')
+          if [[ ${#sdk_dirs[@]} -ne 1 ]]; then
+            echo "##vso[task.logissue type=error]Expected exactly one *.sdk directory inside the extracted Apple SDK archive, found ${#sdk_dirs[@]}."
+            exit 1
+          fi
+
+          # Resolve symlinks/relative segments and confirm the SDK root did
+          # not escape the fixed extraction directory (e.g. via a symlinked
+          # archive entry), before ever pointing SDKROOT at it.
+          sdk_root=$(realpath "${sdk_dirs[0]}")
+          sdk_extract_dir_resolved=$(realpath "$sdk_extract_dir")
+          case "$sdk_root" in
+            "$sdk_extract_dir_resolved"/*) ;;
+            *)
+              echo "##vso[task.logissue type=error]Resolved Apple SDK path $sdk_root escapes the extraction directory $sdk_extract_dir_resolved."
+              exit 1
+              ;;
+          esac
+
+          echo "##vso[task.setvariable variable=appleSdkRoot]$sdk_root"
+      env:
+        SECURE_FILE_PATH: $(appleSdkSecureFile.secureFilePath)
+        EXPECTED_SHA256: $(appleSdkCacheIdentity.digest)
+        AGENT_TEMP_DIRECTORY: $(Agent.TempDirectory)
+    - task: Bash@3
+      displayName: Build and stage $(targetTriple) (Linux)
+      condition: eq(variables['backend'], 'linux')
       inputs:
         targetType: inline
         workingDirectory: '$(Build.SourcesDirectory)'
@@ -190,7 +340,8 @@ stages:
         INSTALL_ARM64_LINKER: $(installArm64Linker)
         TARGET_TRIPLE: $(targetTriple)
     - task: Bash@3
-      displayName: Build Python wheel ($(targetTriple))
+      displayName: Build Python wheel ($(targetTriple)) in manylinux container
+      condition: eq(variables['backend'], 'linux')
       inputs:
         targetType: inline
         workingDirectory: '$(Build.SourcesDirectory)'
@@ -208,50 +359,9 @@ stages:
         SOURCE_DATE_EPOCH: $(sourceDateEpoch)
         TARGET_TRIPLE: $(targetTriple)
         WHEEL_OUT: $(Build.ArtifactStagingDirectory)/$(artifactName)
-    - task: PublishPipelineArtifact@1
-      displayName: Upload $(targetTriple) artifact
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)/$(artifactName)'
-        artifactName: $(artifactName)
-
-  - job: BuildMacOSAssets
-    displayName: Build macOS release asset
-    strategy:
-      matrix:
-        MacOSArm64:
-          targetTriple: aarch64-apple-darwin
-          artifactName: stage-macos-arm64
-          pythonNativeTest: 'false'
-        MacOSX64:
-          targetTriple: x86_64-apple-darwin
-          artifactName: stage-macos-x64
-          pythonNativeTest: 'true'
-    pool:
-      vmImage: macOS-latest
-    steps:
-    - checkout: self
-      clean: true
-    - task: UsePythonVersion@0
-      displayName: Use Python 3.11
-      inputs:
-        versionSpec: '3.11'
-    - task: Cache@2
-      displayName: Restore Cargo cache
-      inputs:
-        key: 'cargo-home | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
-        restoreKeys: |
-          cargo-home | "$(Agent.OS)" | "$(targetTriple)"
-          cargo-home | "$(Agent.OS)"
-        path: $(CARGO_CACHE_HOME)
-    - task: Cache@2
-      displayName: Restore target cache
-      inputs:
-        key: 'cargo-target | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
-        restoreKeys: |
-          cargo-target | "$(Agent.OS)" | "$(targetTriple)"
-        path: $(Build.SourcesDirectory)/target
     - task: Bash@3
-      displayName: Build and stage $(targetTriple)
+      displayName: Build and stage $(targetTriple) (Windows via cargo-xwin)
+      condition: eq(variables['backend'], 'windows')
       inputs:
         targetType: inline
         workingDirectory: '$(Build.SourcesDirectory)'
@@ -265,138 +375,133 @@ stages:
           : "${BUILD_ARTIFACT_STAGING_DIRECTORY:?BUILD_ARTIFACT_STAGING_DIRECTORY is required}"
           : "${TARGET_TRIPLE:?TARGET_TRIPLE is required}"
           : "${ARTIFACT_NAME:?ARTIFACT_NAME is required}"
+          : "${CARGO_XWIN_VERSION:?CARGO_XWIN_VERSION is required}"
+          : "${LLVM_APT_VERSION:?LLVM_APT_VERSION is required}"
 
-          if ! command -v protoc >/dev/null 2>&1; then
-            brew install protobuf
+          sudo apt-get update -q
+          sudo apt-get install -y -q protobuf-compiler "clang-${LLVM_APT_VERSION}" "lld-${LLVM_APT_VERSION}"
+          sudo ln -sf "/usr/bin/clang-${LLVM_APT_VERSION}" /usr/local/bin/clang-cl
+          sudo ln -sf "/usr/bin/lld-link-${LLVM_APT_VERSION}" /usr/local/bin/lld-link
+          export CARGO_HOME="$CARGO_CACHE_HOME"
+          export PATH="$CARGO_HOME/bin:/usr/local/bin:$PATH"
+
+          installed_xwin_version=$(cargo-xwin --version 2>/dev/null || true)
+          if [[ "$installed_xwin_version" != "cargo-xwin ${CARGO_XWIN_VERSION}" ]]; then
+            cargo install cargo-xwin --locked --version "$CARGO_XWIN_VERSION"
           fi
           rustup toolchain install 1.93 --profile minimal --target "$TARGET_TRIPLE"
 
-          CARGO_HOME="$CARGO_CACHE_HOME" cargo +1.93 xtask publish-build \
+          # publish-build's full (non --native-only) run also builds the
+          # Python wheel through maturin, cross-compiled with its --xwin flag.
+          python3.11 -m pip install --upgrade "maturin==1.14.1"
+
+          # cargo-xwin downloads the Windows SDK/CRT itself once the license is
+          # accepted; XWIN_CACHE_DIR lives under the cached Cargo home so
+          # repeat runs reuse it instead of re-downloading every build.
+          export XWIN_ACCEPT_LICENSE=1
+          export XWIN_CACHE_DIR="$CARGO_CACHE_HOME/xwin-cache"
+          mkdir -p "$XWIN_CACHE_DIR"
+
+          cargo +1.93 xtask publish-build \
             --target "$TARGET_TRIPLE" \
             --profile release \
             --output "$BUILD_ARTIFACT_STAGING_DIRECTORY/$ARTIFACT_NAME"
       env:
         ARTIFACT_NAME: $(artifactName)
         BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
+        CARGO_XWIN_VERSION: $(cargoXwinVersion)
+        LLVM_APT_VERSION: $(llvmAptVersion)
         TARGET_TRIPLE: $(targetTriple)
-    - task: PublishPipelineArtifact@1
-      displayName: Upload $(targetTriple) artifact
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)/$(artifactName)'
-        artifactName: $(artifactName)
-
-  - job: BuildWindowsAssets
-    displayName: Build Windows release asset
-    strategy:
-      matrix:
-        WindowsX64:
-          targetTriple: x86_64-pc-windows-msvc
-          artifactName: stage-windows-x64
-          pythonNativeTest: 'true'
-        WindowsArm64:
-          targetTriple: aarch64-pc-windows-msvc
-          artifactName: stage-windows-arm64
-          pythonNativeTest: 'false'
-    pool:
-      vmImage: windows-latest
-    steps:
-    - checkout: self
-      clean: true
-    - task: UsePythonVersion@0
-      displayName: Use Python 3.11
-      inputs:
-        versionSpec: '3.11'
-    - task: Cache@2
-      displayName: Restore Cargo cache
-      inputs:
-        key: 'cargo-home | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
-        restoreKeys: |
-          cargo-home | "$(Agent.OS)" | "$(targetTriple)"
-          cargo-home | "$(Agent.OS)"
-        path: $(CARGO_CACHE_HOME)
-    - task: Cache@2
-      displayName: Restore target cache
-      inputs:
-        key: 'cargo-target | "$(Agent.OS)" | "$(targetTriple)" | Cargo.lock'
-        restoreKeys: |
-          cargo-target | "$(Agent.OS)" | "$(targetTriple)"
-        path: $(Build.SourcesDirectory)/target
-    - task: PowerShell@2
-      displayName: Build and stage $(targetTriple)
+    - task: Bash@3
+      displayName: Build and stage $(targetTriple) (macOS via cargo-zigbuild)
+      condition: eq(variables['backend'], 'macos')
       inputs:
         targetType: inline
-        pwsh: true
         workingDirectory: '$(Build.SourcesDirectory)'
         script: |
+          #!/usr/bin/env bash
           # Copyright (c) Microsoft Corporation.
           # Licensed under the MIT license.
 
-          $ErrorActionPreference = 'Stop'
-          $PSNativeCommandUseErrorActionPreference = $true
+          set -euo pipefail
 
-          if (-not $env:BUILD_ARTIFACT_STAGING_DIRECTORY) {
-              throw 'BUILD_ARTIFACT_STAGING_DIRECTORY is required.'
-          }
-          if (-not $env:TARGET_TRIPLE) {
-              throw 'TARGET_TRIPLE is required.'
-          }
-          if (-not $env:ARTIFACT_NAME) {
-              throw 'ARTIFACT_NAME is required.'
-          }
+          : "${BUILD_ARTIFACT_STAGING_DIRECTORY:?BUILD_ARTIFACT_STAGING_DIRECTORY is required}"
+          : "${TARGET_TRIPLE:?TARGET_TRIPLE is required}"
+          : "${ARTIFACT_NAME:?ARTIFACT_NAME is required}"
+          : "${CARGO_ZIGBUILD_VERSION:?CARGO_ZIGBUILD_VERSION is required}"
+          : "${ZIG_VERSION:?ZIG_VERSION is required}"
+          : "${ZIG_SHA256:?ZIG_SHA256 is required}"
+          : "${MACOSX_DEPLOYMENT_TARGET:?MACOSX_DEPLOYMENT_TARGET is required}"
+          : "${SDKROOT:?SDKROOT is required; the Apple SDK extraction step must run first}"
+          : "${AGENT_TEMP_DIRECTORY:?AGENT_TEMP_DIRECTORY is required}"
 
-          if (-not (Get-Command protoc -ErrorAction SilentlyContinue)) {
-              $version = '29.5'
-              $expectedSha256 = '633d3e555fc97f0a1f55b4adb03256cd94b8059e51e7abbae98ff39e58a9dfa5'
-              $zip = "$env:AGENT_TEMP_DIRECTORY\protoc.zip"
-              $dest = "$env:AGENT_TEMP_DIRECTORY\protoc"
-              Invoke-WebRequest `
-                  -Uri "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-win64.zip" `
-                  -OutFile $zip
-              $actualSha256 = (Get-FileHash -Path $zip -Algorithm SHA256).Hash
-              if (-not $actualSha256.Equals($expectedSha256, [System.StringComparison]::OrdinalIgnoreCase)) {
-                  Remove-Item $zip -Force
-                  throw "protoc archive SHA-256 mismatch: expected $expectedSha256, received $actualSha256."
-              }
-              Expand-Archive -Path $zip -DestinationPath $dest -Force
-              $env:PATH = "$dest\bin;$env:PATH"
-          }
+          sudo apt-get update -q
+          sudo apt-get install -y -q protobuf-compiler xz-utils
 
-          rustup toolchain install 1.93 --profile minimal --target $env:TARGET_TRIPLE
+          zig_dir="$AGENT_TEMP_DIRECTORY/zig-${ZIG_VERSION}"
+          if [[ ! -x "$zig_dir/zig" ]]; then
+            rm -rf "$zig_dir"
+            mkdir -p "$zig_dir"
+            zig_archive="$AGENT_TEMP_DIRECTORY/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+            curl -fsSL -o "$zig_archive" \
+              "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+            if ! echo "${ZIG_SHA256}  ${zig_archive}" | sha256sum --check --status; then
+              echo "##vso[task.logissue type=error]Zig archive SHA-256 mismatch for ${zig_archive}; expected ${ZIG_SHA256}."
+              exit 1
+            fi
+            tar -xJf "$zig_archive" -C "$zig_dir" --strip-components=1
+            rm -f "$zig_archive"
+          fi
+          export CARGO_HOME="$CARGO_CACHE_HOME"
+          export PATH="$CARGO_HOME/bin:$zig_dir:$PATH"
 
-          $env:CARGO_HOME = $env:CARGO_CACHE_HOME
-          cargo +1.93 xtask publish-build `
-              --target $env:TARGET_TRIPLE `
-              --profile release `
-              --output "$env:BUILD_ARTIFACT_STAGING_DIRECTORY\$env:ARTIFACT_NAME"
+          installed_zigbuild_version=$(cargo-zigbuild --version 2>/dev/null || true)
+          if [[ "$installed_zigbuild_version" != "cargo-zigbuild ${CARGO_ZIGBUILD_VERSION}" ]]; then
+            cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
+          fi
+          rustup toolchain install 1.93 --profile minimal --target "$TARGET_TRIPLE"
+
+          # publish-build's full (non --native-only) run also builds the
+          # Python wheel through maturin, cross-compiled with its --zig flag.
+          python3.11 -m pip install --upgrade "maturin==1.14.1"
+
+          cargo +1.93 xtask publish-build \
+            --target "$TARGET_TRIPLE" \
+            --profile release \
+            --output "$BUILD_ARTIFACT_STAGING_DIRECTORY/$ARTIFACT_NAME"
       env:
         AGENT_TEMP_DIRECTORY: $(Agent.TempDirectory)
         ARTIFACT_NAME: $(artifactName)
         BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
+        CARGO_ZIGBUILD_VERSION: $(cargoZigbuildVersion)
+        MACOSX_DEPLOYMENT_TARGET: $(macosDeploymentTarget)
+        SDKROOT: $(appleSdkRoot)
         TARGET_TRIPLE: $(targetTriple)
+        ZIG_VERSION: $(zigVersion)
+        ZIG_SHA256: $(zigSha256)
+    - task: Bash@3
+      displayName: Remove Apple SDK from agent
+      condition: and(always(), eq(variables['backend'], 'macos'))
+      inputs:
+        targetType: inline
+        script: |
+          set -euo pipefail
+          # Fixed path, matching the extraction step above exactly: cleanup
+          # must not depend on a variable that is only set after a successful
+          # extraction, so a failed or partial extraction is still removed.
+          rm -rf "${AGENT_TEMP_DIRECTORY}/apple-sdk"
+      env:
+        AGENT_TEMP_DIRECTORY: $(Agent.TempDirectory)
     - task: PublishPipelineArtifact@1
       displayName: Upload $(targetTriple) artifact
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)/$(artifactName)'
         artifactName: $(artifactName)
 
-  # Microsoft-hosted pools have no ARM64 Linux or Windows vmImage, and
-  # macOS-latest is Intel x64, so the ARM64 wheels built above can only be
-  # cross-compiled on those hosted pools, never genuinely executed there.
-  # Each of the following three jobs is a compile-time template conditional:
-  # if the matching pool parameter is set, it downloads the pre-built wheel
-  # and smoke-tests it on real matching hardware; otherwise it hard-fails
-  # with actionable guidance instead of silently skipping the test or
-  # claiming the wheel was validated when it was not.
-  # The configured self-hosted pool's agent must already have a Python 3.11
-  # interpreter on PATH (as `python3.11` on Linux/macOS, `python` on
-  # Windows) - UsePythonVersion@0 is not used here because its tool cache
-  # is not guaranteed to be provisioned on arbitrary self-hosted agents.
   - job: AssembleRelease
     displayName: Assemble release packages
     dependsOn:
-    - BuildLinuxAssets
-    - BuildMacOSAssets
-    - BuildWindowsAssets
+    - BuildReleaseAssets
     pool:
       vmImage: ubuntu-latest
     steps:

--- a/.ado/pipelines/azure-pipelines-build.yml
+++ b/.ado/pipelines/azure-pipelines-build.yml
@@ -121,6 +121,7 @@ stages:
     llvmAptVersion: '18'
     cargoZigbuildVersion: '0.23.0'
     zigVersion: '0.13.0'
+    rustToolchain: '1.98'
     # Official SHA-256 of https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz.
     # Update this alongside zigVersion if the pin is ever bumped.
     zigSha256: 'd45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea'
@@ -221,17 +222,17 @@ stages:
     - task: Cache@2
       displayName: Restore Cargo cache
       inputs:
-        key: 'cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
+        key: 'cargo-home | "$(Agent.OS)" | "$(rustToolchain)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
         restoreKeys: |
-          cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
-          cargo-home | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)"
+          cargo-home | "$(Agent.OS)" | "$(rustToolchain)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
+          cargo-home | "$(Agent.OS)" | "$(rustToolchain)" | "$(targetTriple)" | "$(backend)"
         path: $(CARGO_CACHE_HOME)
     - task: Cache@2
       displayName: Restore target cache
       inputs:
-        key: 'cargo-target | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
+        key: 'cargo-target | "$(Agent.OS)" | "$(rustToolchain)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)" | Cargo.lock'
         restoreKeys: |
-          cargo-target | "$(Agent.OS)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
+          cargo-target | "$(Agent.OS)" | "$(rustToolchain)" | "$(targetTriple)" | "$(backend)" | "$(toolchainIdentity)" | "$(appleSdkCacheIdentity.digest)"
         path: $(Build.SourcesDirectory)/target
     - task: DownloadSecureFile@1
       name: appleSdkSecureFile
@@ -276,7 +277,18 @@ stages:
           sdk_extract_dir="$AGENT_TEMP_DIRECTORY/apple-sdk"
           rm -rf "$sdk_extract_dir"
           mkdir -p "$sdk_extract_dir"
-          tar -xf "$SECURE_FILE_PATH" -C "$sdk_extract_dir"
+          python3.11 - "$SECURE_FILE_PATH" "$sdk_extract_dir" <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          archive = pathlib.Path(sys.argv[1])
+          destination = pathlib.Path(sys.argv[2])
+          if not hasattr(tarfile, "data_filter"):
+              raise RuntimeError("Python tarfile.data_filter is required for safe SDK extraction")
+          with tarfile.open(archive) as sdk_archive:
+              sdk_archive.extractall(destination, filter=tarfile.data_filter)
+          PY
 
           mapfile -t sdk_dirs < <(find "$sdk_extract_dir" -maxdepth 2 -type d -name '*.sdk')
           if [[ ${#sdk_dirs[@]} -ne 1 ]]; then
@@ -325,11 +337,11 @@ stages:
             sudo apt-get install -y -q gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           fi
-          rustup toolchain install 1.93 --profile minimal --target "$TARGET_TRIPLE"
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --target "$TARGET_TRIPLE"
 
           # Natives build on the host, but the wheel must link an old glibc, so
           # the container step below runs the same command with --python-only.
-          CARGO_HOME="$CARGO_CACHE_HOME" cargo +1.93 xtask publish-build \
+          CARGO_HOME="$CARGO_CACHE_HOME" cargo xtask publish-build \
             --target "$TARGET_TRIPLE" \
             --profile release \
             --native-only \
@@ -338,6 +350,7 @@ stages:
         ARTIFACT_NAME: $(artifactName)
         BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
         INSTALL_ARM64_LINKER: $(installArm64Linker)
+        RUSTUP_TOOLCHAIN: $(rustToolchain)
         TARGET_TRIPLE: $(targetTriple)
     - task: Bash@3
       displayName: Build Python wheel ($(targetTriple)) in manylinux container
@@ -379,9 +392,10 @@ stages:
           : "${LLVM_APT_VERSION:?LLVM_APT_VERSION is required}"
 
           sudo apt-get update -q
-          sudo apt-get install -y -q protobuf-compiler "clang-${LLVM_APT_VERSION}" "lld-${LLVM_APT_VERSION}"
+          sudo apt-get install -y -q protobuf-compiler "clang-${LLVM_APT_VERSION}" "lld-${LLVM_APT_VERSION}" "llvm-${LLVM_APT_VERSION}"
           sudo ln -sf "/usr/bin/clang-${LLVM_APT_VERSION}" /usr/local/bin/clang-cl
           sudo ln -sf "/usr/bin/lld-link-${LLVM_APT_VERSION}" /usr/local/bin/lld-link
+          sudo ln -sf "/usr/bin/llvm-lib-${LLVM_APT_VERSION}" /usr/local/bin/llvm-lib
           export CARGO_HOME="$CARGO_CACHE_HOME"
           export PATH="$CARGO_HOME/bin:/usr/local/bin:$PATH"
 
@@ -389,10 +403,12 @@ stages:
           if [[ "$installed_xwin_version" != "cargo-xwin ${CARGO_XWIN_VERSION}" ]]; then
             cargo install cargo-xwin --locked --version "$CARGO_XWIN_VERSION"
           fi
-          rustup toolchain install 1.93 --profile minimal --target "$TARGET_TRIPLE"
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --target "$TARGET_TRIPLE"
 
           # publish-build's full (non --native-only) run also builds the
-          # Python wheel through maturin, cross-compiled with its --xwin flag.
+          # Python wheel through maturin. maturin has no built-in `--xwin`
+          # flag, so `xtask` exports cargo-xwin's own linker/SDK environment
+          # (from `cargo xwin env`) onto the maturin process instead.
           python3.11 -m pip install --upgrade "maturin==1.14.1"
 
           # cargo-xwin downloads the Windows SDK/CRT itself once the license is
@@ -402,7 +418,7 @@ stages:
           export XWIN_CACHE_DIR="$CARGO_CACHE_HOME/xwin-cache"
           mkdir -p "$XWIN_CACHE_DIR"
 
-          cargo +1.93 xtask publish-build \
+          cargo xtask publish-build \
             --target "$TARGET_TRIPLE" \
             --profile release \
             --output "$BUILD_ARTIFACT_STAGING_DIRECTORY/$ARTIFACT_NAME"
@@ -411,6 +427,8 @@ stages:
         BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
         CARGO_XWIN_VERSION: $(cargoXwinVersion)
         LLVM_APT_VERSION: $(llvmAptVersion)
+        RUSTUP_TOOLCHAIN: $(rustToolchain)
+        SOURCE_DATE_EPOCH: $(sourceDateEpoch)
         TARGET_TRIPLE: $(targetTriple)
     - task: Bash@3
       displayName: Build and stage $(targetTriple) (macOS via cargo-zigbuild)
@@ -459,13 +477,13 @@ stages:
           if [[ "$installed_zigbuild_version" != "cargo-zigbuild ${CARGO_ZIGBUILD_VERSION}" ]]; then
             cargo install cargo-zigbuild --locked --version "$CARGO_ZIGBUILD_VERSION"
           fi
-          rustup toolchain install 1.93 --profile minimal --target "$TARGET_TRIPLE"
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --target "$TARGET_TRIPLE"
 
           # publish-build's full (non --native-only) run also builds the
           # Python wheel through maturin, cross-compiled with its --zig flag.
           python3.11 -m pip install --upgrade "maturin==1.14.1"
 
-          cargo +1.93 xtask publish-build \
+          cargo xtask publish-build \
             --target "$TARGET_TRIPLE" \
             --profile release \
             --output "$BUILD_ARTIFACT_STAGING_DIRECTORY/$ARTIFACT_NAME"
@@ -475,7 +493,9 @@ stages:
         BUILD_ARTIFACT_STAGING_DIRECTORY: $(Build.ArtifactStagingDirectory)
         CARGO_ZIGBUILD_VERSION: $(cargoZigbuildVersion)
         MACOSX_DEPLOYMENT_TARGET: $(macosDeploymentTarget)
+        RUSTUP_TOOLCHAIN: $(rustToolchain)
         SDKROOT: $(appleSdkRoot)
+        SOURCE_DATE_EPOCH: $(sourceDateEpoch)
         TARGET_TRIPLE: $(targetTriple)
         ZIG_VERSION: $(zigVersion)
         ZIG_SHA256: $(zigSha256)
@@ -588,7 +608,7 @@ stages:
           : "${SOURCE_DATE_EPOCH:?SOURCE_DATE_EPOCH is required}"
           sudo apt-get update -q
           sudo apt-get install -y -q protobuf-compiler
-          rustup toolchain install 1.93 --profile minimal
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
           corepack enable
           pnpm install --frozen-lockfile --store-dir "$PNPM_STORE_PATH"
           # Needed for the `cargo xtask publish-stage --pack-only` sdist step
@@ -597,7 +617,7 @@ stages:
           # Versioned package archives are outputs, not reusable compilation artifacts.
           rm -rf target/package
           trap 'rm -rf target/package' EXIT
-          CARGO_HOME="$CARGO_CACHE_HOME" cargo +1.93 xtask publish-stage --pack-only --profile release
+          CARGO_HOME="$CARGO_CACHE_HOME" cargo xtask publish-stage --pack-only --profile release
           python crates/webui-python/tests/validate_artifacts.py \
             "publish/python/microsoft_webui-${RELEASE_VERSION}-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
             "publish/python/microsoft_webui-${RELEASE_VERSION}-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" \
@@ -609,6 +629,7 @@ stages:
       env:
         PNPM_STORE_PATH: $(PNPM_STORE_PATH)
         RELEASE_VERSION: $(releaseVersion)
+        RUSTUP_TOOLCHAIN: $(rustToolchain)
         SOURCE_DATE_EPOCH: $(sourceDateEpoch)
     - task: Bash@3
       displayName: Write release metadata

--- a/.ado/pipelines/azure-pipelines-cd.yml
+++ b/.ado/pipelines/azure-pipelines-cd.yml
@@ -44,8 +44,8 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: OneESPool
-        image: HostedPoolWindowsImage
-        os: windows
+        image: HostedPoolLinuxImage
+        os: linux
     settings:
       networkIsolationPolicy: Permissive
     stages:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,5 +1,5 @@
 name: Build WebUI
-description: Shared build steps for WebUI — installs protoc, Rust, Node.js, pnpm, and optionally .NET. Linux runners only.
+description: Shared build steps for WebUI — installs protoc, Rust, Node.js, pnpm, and optionally .NET.
 
 inputs:
   shared-cache-key:
@@ -22,6 +22,10 @@ inputs:
     description: Install .NET SDK (set to version like '8.0.x' to enable)
     required: false
     default: ''
+  protoc-version:
+    description: Protobuf compiler version to install
+    required: false
+    default: '29.5'
   skip-build:
     description: Skip cargo build and build-examples steps
     required: false
@@ -30,9 +34,35 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install protoc
+    - name: Disable Windows Defender on build dirs
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE"
+        Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
+
+    - name: Install protoc (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
+
+    - name: Install protoc (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install protobuf
+
+    - name: Install protoc (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $version = "${{ inputs.protoc-version }}"
+        $url = "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-win64.zip"
+        $zip = "$env:RUNNER_TEMP\protoc.zip"
+        $dest = "$env:RUNNER_TEMP\protoc"
+        Invoke-WebRequest -Uri $url -OutFile $zip
+        Expand-Archive -Path $zip -DestinationPath $dest -Force
+        echo "$dest\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo "PROTOC=$dest\bin\protoc.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,5 +1,5 @@
 name: Build WebUI
-description: Shared build steps for WebUI — installs protoc, Rust, Node.js, pnpm, and optionally .NET.
+description: Shared build steps for WebUI — installs protoc, Rust, Node.js, pnpm, and optionally .NET. Linux runners only.
 
 inputs:
   shared-cache-key:
@@ -22,10 +22,6 @@ inputs:
     description: Install .NET SDK (set to version like '8.0.x' to enable)
     required: false
     default: ''
-  protoc-version:
-    description: Protobuf compiler version to install
-    required: false
-    default: '29.5'
   skip-build:
     description: Skip cargo build and build-examples steps
     required: false
@@ -34,35 +30,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Disable Windows Defender on build dirs
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE"
-        Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
-
-    - name: Install protoc (Linux)
-      if: runner.os == 'Linux'
+    - name: Install protoc
       shell: bash
       run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
-
-    - name: Install protoc (macOS)
-      if: runner.os == 'macOS'
-      shell: bash
-      run: brew install protobuf
-
-    - name: Install protoc (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $version = "${{ inputs.protoc-version }}"
-        $url = "https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-win64.zip"
-        $zip = "$env:RUNNER_TEMP\protoc.zip"
-        $dest = "$env:RUNNER_TEMP\protoc"
-        Invoke-WebRequest -Uri $url -OutFile $zip
-        Expand-Archive -Path $zip -DestinationPath $dest -Force
-        echo "$dest\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-        echo "PROTOC=$dest\bin\protoc.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
-  # ── Phase 2: Build (Linux + macOS + Windows) ────────────────────────
+  # ── Phase 2: Build (Linux + macOS) / cross-build (Windows) ─────────
   build-linux:
     name: Build (Linux)
     runs-on: ubuntu-latest
@@ -69,13 +69,57 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build
 
-  build-windows:
-    name: Build (Windows)
-    runs-on: windows-latest
+  # Windows release artifacts build on Linux with the same cargo-xwin path
+  # used by Azure release production. One invocation stages the CLI, FFI,
+  # Node addon, and abi3 Python wheel for each architecture.
+  windows-cross:
+    name: Windows cross-build (${{ matrix.platform.label }})
+    runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - label: x64
+            target: x86_64-pc-windows-msvc
+            platform_tag: win_amd64
+          - label: ARM64
+            target: aarch64-pc-windows-msvc
+            platform_tag: win_arm64
+    env:
+      WINDOWS_STAGE: target/windows-stage
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build
+        with:
+          skip-build: 'true'
+          rust-targets: ${{ matrix.platform.target }}
+          shared-cache-key: windows-cross-${{ matrix.platform.target }}
+
+      - name: Install cargo-xwin and pin its LLVM toolchain
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq clang-18 lld-18 llvm-18
+          sudo ln -sf /usr/bin/clang-18 /usr/local/bin/clang-cl
+          sudo ln -sf /usr/bin/lld-link-18 /usr/local/bin/lld-link
+          sudo ln -sf /usr/bin/llvm-lib-18 /usr/local/bin/llvm-lib
+          cargo install --locked cargo-xwin --version 0.23.0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Build native artifacts and abi3 wheel
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade "maturin==1.14.1"
+          mkdir -p "$XWIN_CACHE_DIR"
+          cargo xtask publish-build --target ${{ matrix.platform.target }} \
+            --output "$WINDOWS_STAGE"
+        env:
+          XWIN_ACCEPT_LICENSE: '1'
+          XWIN_CACHE_DIR: ${{ github.workspace }}/target/xwin-cache
 
   # ── Phase 3: E2E (Ubuntu, after Linux build) ───────────────────────
   e2e:
@@ -193,10 +237,9 @@ jobs:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/debug
 
   # ── Phase 2: Python wheels ─────────────────────────────────────────
-  # Build every wheel in the release contract. The x64 wheels feed python-test
-  # below; the ARM64 wheels are cross-compiled exactly as the release pipeline
-  # cross-compiles them, so an ARM64 build break surfaces on the PR that causes
-  # it. They are never installed here - that needs ARM64 hardware.
+  # Build Linux and macOS wheels here. Windows wheels are built by windows-cross
+  # through the same Linux-hosted path as release production. The x64 wheels
+  # feed python-test below; ARM64 wheels are build-validated but not installed.
   python-wheel:
     name: Python wheel (${{ matrix.platform.label }})
     runs-on: ${{ matrix.platform.os }}
@@ -216,11 +259,6 @@ jobs:
             target: x86_64-apple-darwin
             platform_tag: macosx_10_12_x86_64
             artifact: python-wheel-macos-x64
-          - label: Windows x64
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform_tag: win_amd64
-            artifact: python-wheel-windows-x64
           - label: Linux ARM64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -231,11 +269,6 @@ jobs:
             os: macos-latest-large
             target: aarch64-apple-darwin
             platform_tag: macosx_11_0_arm64
-            artifact: ''
-          - label: Windows ARM64
-            os: windows-latest
-            target: aarch64-pc-windows-msvc
-            platform_tag: win_arm64
             artifact: ''
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -253,8 +286,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      # abi3 needs no target interpreter and `generate-import-lib` synthesizes
-      # the Windows ARM64 import library, so every target cross-compiles here.
+      # abi3 needs no target interpreter, so both macOS architectures can build
+      # from the hosted macOS runner without architecture-specific Python.
       - name: Build wheel
         if: runner.os != 'Linux'
         shell: bash
@@ -292,8 +325,8 @@ jobs:
 
   # ── Phase 3: Python tests (after wheels) ───────────────────────────
   # One abi3 wheel must serve every supported interpreter, so the Linux wheel is
-  # installed on each CPython. macOS and Windows only re-verify that the wheel
-  # loads on its platform, which 3.11 already proves.
+  # installed on each CPython. macOS re-verifies that the x64 wheel loads on its
+  # platform; the ARM64 wheel is build-validated in the matrix above.
   python-test:
     name: Python test (${{ matrix.platform.label }} / CPython ${{ matrix.python }})
     runs-on: ${{ matrix.platform.os }}
@@ -311,11 +344,6 @@ jobs:
               label: macOS x64
               os: macos-latest-large
               artifact: python-wheel-macos-x64
-            python: '3.11'
-          - platform:
-              label: Windows x64
-              os: windows-latest
-              artifact: python-wheel-windows-x64
             python: '3.11'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -413,7 +441,7 @@ jobs:
       - test
       - build-linux
       - build-macos
-      - build-windows
+      - windows-cross
       - e2e
       - wasm
       - docs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5380,10 +5380,10 @@ Zig.
 macOS legs require a legally obtained Apple SDK uploaded as the
 `WebUI-MacOSX-SDK.tar.xz` Azure secure file. Its expected digest comes from the
 required `WEBUI_APPLE_SDK_SHA256` pipeline/library variable. The pipeline
-validates the digest, extracts exactly one contained `*.sdk` below
+validates the digest, safely extracts exactly one contained `*.sdk` below
 `Agent.TempDirectory`, sets `SDKROOT` and the target-specific
-`MACOSX_DEPLOYMENT_TARGET` (10.12 for x64, 11.0 for ARM64), and removes the SDK
-after the leg. SDK contents are never cached or published; the digest participates
+`MACOSX_DEPLOYMENT_TARGET` (10.12 for x64 and 11.0 for ARM64), and removes the
+SDK after the leg. SDK contents are never cached or published; the digest participates
 in the macOS Cargo cache key. The pinned Zig archive is also checksum-verified.
 
 Each target leg runs `cargo xtask publish-build`, producing the CLI, FFI library,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5369,7 +5369,39 @@ Native assets are split into `Microsoft.WebUI.Runtime.<rid>` packages for each s
 
 `dotnet/Directory.Build.props` applies NuGet metadata to packable .NET projects: `Authors=Microsoft`, `PackageOwners=Microsoft`, the SPDX `MIT` license expression with `PackageRequireLicenseAcceptance=true`, project and repository URLs, Source Link, release notes links, discoverability tags, the required `© Microsoft Corporation. All rights reserved.` copyright notice, and `.snupkg` symbol package generation. `cargo xtask publish-stage --pack-only` invokes `dotnet pack` on `dotnet/Microsoft.WebUI.sln` and stages both `.nupkg` and `.snupkg` files under `publish/nuget`.
 
-Azure release automation uses the `.ado/pipelines/azure-pipelines-build.yml` and `.ado/pipelines/azure-pipelines-cd.yml` definitions. `Web UI - CD Build` triggers on `main` and can also be queued manually. Each target leg runs `cargo xtask publish-build`, which produces that target's native binaries and its Python wheel together. Linux is the one split: the natives build on the host with `--native-only`, then the same command runs with `--python-only` inside a digest-pinned `manylinux2014` cross image so the wheel links an old glibc. Export is mode-aware, so the second run adds `publish/python/` without disturbing the natives the first run staged. All six wheels are cross-compiled on Microsoft-hosted x64 pools, the same way this pipeline has always produced the ARM64 npm, NuGet, FFI, and CLI binaries. `Web UI - CD` has no direct CI or pull-request trigger and starts only from a successful `BuildArtifacts` pipeline resource event on `main` or a manual queue. Its `PrepareRelease` stage selects an untagged stable workspace version. Production build and CD runs require the release build source to be `refs/heads/main`; other branches are accepted only in validation mode, which prevents feature-branch commits from becoming public release tags. `BuildArtifacts` runs three OS matrix jobs with two target legs each, providing six parallel native builds; each leg restores target-specific Cargo caches before invoking the single-target `cargo xtask publish-build`. The assembly job merges those six outputs and restores its Cargo, target, and pnpm caches. It preserves reusable Cargo compilation artifacts while removing `target/package` before and after `cargo xtask publish-stage --pack-only`, because that directory contains versioned release archives rather than incremental build inputs. The packer generates WASM, npm, crate, NuGet, Python, and standalone artifacts and validates the exact 9 npm, 15 crate, 8 NuGet package, 2 NuGet symbol package, 6 Python wheel, 1 Python sdist, and 20 standalone asset contract before Azure publishes the unsigned artifact sets and release metadata. Completion of `BuildArtifacts` on `main` triggers the unscheduled 1ES Official `Web UI - CD` pipeline. Its `SignArtifacts` stage restores the build outputs with Azure artifact tasks and runs ESRP signing. For production runs, `TagRelease` creates or verifies the annotated Git tag. `PublishRelease` publishes npm and Rust crates, then creates the GitHub Release after the Rust crates are available. Python wheels and the sdist are attached to the GitHub Release as downloadable assets. WebUI does not publish them to PyPI; that remains an explicit future step once package ownership and signing policy are settled. GitHub Releases include an issue-based changelog covering changes since the last full release instead of a static placeholder description. Validation runs stop after signing and retain unsigned npm tarballs, unsigned crate and Python archives, signed `.nupkg` and `.snupkg` files, and standalone assets for inspection. `standalone_release_assets` contains the six direct-download native binaries, twelve WASM files, `README.md`, and `package.json`. The GitHub Release uploads all five folders for 61 explicit assets, while GitHub supplies the source ZIP and tarball as two additional downloads. Publishing to NuGet.org remains a manual operation using `signed_nuget_packages`. Before NuGet.org publishing, ownership must be limited to the approved Microsoft package owner/co-owner accounts, every Authenticode-signable file in the package must be signed, and each `.nupkg` must be signed with the Microsoft certificate through the approved signing process. The queue-time `validationMode` parameter defaults to `false`; selecting `true` in both pipelines permits an existing-version artifact rebuild while omitting tag creation and external publication. The selected validation mode is carried in release metadata, and CD rejects builds whose mode does not match its own configuration.
+Azure release automation uses `.ado/pipelines/azure-pipelines-build.yml` and
+`.ado/pipelines/azure-pipelines-cd.yml`. `Web UI - CD Build` triggers on `main`
+and can also be queued manually. All six target legs build in one Linux-hosted
+matrix job. Linux natives build on the host and Linux wheels build in
+digest-pinned `manylinux2014` cross images. Windows targets use pinned
+`cargo-xwin` plus LLVM/LLD, while macOS targets use pinned `cargo-zigbuild` and
+Zig.
+
+macOS legs require a legally obtained Apple SDK uploaded as the
+`WebUI-MacOSX-SDK.tar.xz` Azure secure file. Its expected digest comes from the
+required `WEBUI_APPLE_SDK_SHA256` pipeline/library variable. The pipeline
+validates the digest, extracts exactly one contained `*.sdk` below
+`Agent.TempDirectory`, sets `SDKROOT` and the target-specific
+`MACOSX_DEPLOYMENT_TARGET` (10.12 for x64, 11.0 for ARM64), and removes the SDK
+after the leg. SDK contents are never cached or published; the digest participates
+in the macOS Cargo cache key. The pinned Zig archive is also checksum-verified.
+
+Each target leg runs `cargo xtask publish-build`, producing the CLI, FFI library,
+Node addon, and Python wheel for that target. The Linux-only pipeline treats
+successful cross-linking, staging, and package assembly as its target validation;
+it does not inspect binary headers or execute Windows/macOS artifacts. Runtime
+qualification remains a separate release step on matching hardware.
+
+The assembly job merges all six outputs, restores its Cargo, target, and pnpm
+caches, and runs `cargo xtask publish-stage --pack-only`. The packer validates
+the exact 9 npm, 15 crate, 8 NuGet package, 2 NuGet symbol package, 6 Python
+wheel, 1 Python sdist, and 20 standalone asset contract. Completion on `main`
+triggers the unscheduled 1ES Official `Web UI - CD` pipeline, whose main and SDL
+source-analysis pools are Linux. It signs artifacts, creates or verifies the
+annotated release tag, publishes npm and Rust crates, and creates the GitHub
+Release. Python artifacts are attached to GitHub rather than published to PyPI;
+NuGet publication remains manual. Validation mode permits existing-version
+artifact rebuilds while omitting tags and external publication.
 
 ### Python Distribution
 

--- a/README.md
+++ b/README.md
@@ -69,19 +69,24 @@ Common commands:
 | `cargo xtask build` | Build the workspace and examples |
 | `cargo xtask dev <app>` | Run an example app in development mode |
 | `cargo xtask bench <target>` | Run benchmarks |
-| `cargo xtask build-windows-local` | Manually build and stage Windows MSVC artifacts on macOS |
+| `cargo xtask build-windows-local` | Manually build and stage Windows MSVC artifacts on Linux or macOS |
 
-### Manual Windows builds on macOS
+### Manual Windows cross-builds
 
 `cargo xtask build-windows-local` is a local-only helper for producing Windows
-x64 and ARM64 release bits from macOS. It does not run in CI and does not
-install tools automatically.
+x64 and ARM64 release bits from Linux or macOS. It does not install tools
+automatically.
 
-Install the build prerequisites once:
+Install LLVM, LLD, and the pinned cargo-xwin release once:
 
 ```bash
+# Ubuntu/Debian
+sudo apt-get install clang lld llvm
+
+# macOS
 brew install llvm lld
-cargo install cargo-xwin --version 0.23.0
+
+cargo install --locked cargo-xwin --version 0.23.0
 rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
 ```
 
@@ -103,6 +108,35 @@ The command stages artifacts into `publish/native/`, `packages/webui-win32-*`,
 and `dotnet/runtimes/win-*/native/`. `cargo-xwin` downloads Microsoft Windows
 SDK and CRT assets; using it requires accepting the Microsoft SDK license terms
 referenced by cargo-xwin.
+
+### Manual macOS cross-builds on Linux
+
+macOS release artifacts build through cargo-zigbuild with a legally obtained
+Apple SDK. Install Zig 0.13.0, cargo-zigbuild, maturin, and both Rust targets:
+
+```bash
+zig version # must print 0.13.0
+cargo install --locked cargo-zigbuild --version 0.23.0
+python3.11 -m pip install "maturin==1.14.1"
+rustup target add x86_64-apple-darwin aarch64-apple-darwin
+```
+
+Point `SDKROOT` at the extracted SDK and retain the release contract's minimum
+deployment version for each architecture:
+
+```bash
+export SDKROOT=/absolute/path/to/MacOSX.sdk
+
+MACOSX_DEPLOYMENT_TARGET=10.12 \
+  cargo xtask publish-build --target x86_64-apple-darwin
+
+MACOSX_DEPLOYMENT_TARGET=11.0 \
+  cargo xtask publish-build --target aarch64-apple-darwin
+```
+
+The command stages the CLI, Node addon, FFI library, and abi3 Python wheel.
+Apple SDK contents are licensed inputs: do not commit, publish, or expose them
+to untrusted builds.
 
 For a quick local sanity check of the x64 CLI artifact, install Wine Stable:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For Python server-side bindings:
 pip install ./microsoft_webui-<version>-cp311-abi3-<platform>.whl
 ```
 
-`microsoft-webui` is a native PyO3 binding (not `ctypes`) for CPython 3.11+, distributed as prebuilt wheels for Windows, macOS, and manylinux on x86_64 and ARM64, plus one sdist. It is runtime-only: render `webui build` output, but don't compile templates from Python.
+`microsoft-webui` is a native PyO3 binding (not `ctypes`) for CPython 3.11+, distributed as prebuilt x86_64/ARM64 wheels for Windows, macOS, and manylinux, alongside one sdist. It is runtime-only: render `webui build` output, but don't compile templates from Python.
 
 ## Learn
 

--- a/crates/webui-python/scripts/build-manylinux-wheel.sh
+++ b/crates/webui-python/scripts/build-manylinux-wheel.sh
@@ -18,7 +18,7 @@ output="${2:-}"
 
 rustup_version=1.29.0
 rustup_sha256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
-rust_toolchain=1.93
+rust_toolchain=1.98
 maturin_version=1.14.1
 
 # Both cross images run as amd64; a mismatch means the wrong image was pulled.

--- a/docs/guide/integrations/python.md
+++ b/docs/guide/integrations/python.md
@@ -290,9 +290,8 @@ already escaped yourself.
 
 `microsoft-webui` builds against PyO3's `abi3-py311` stable ABI, so one wheel
 per platform serves every CPython 3.11+ interpreter — no per-minor-version
-build matrix. v1 ships six wheels (Windows, macOS, and manylinux, each for
-x86_64 and ARM64; macOS ships separate x86_64/ARM64 wheels, not a
-`universal2` fat binary) plus one `sdist`.
+build matrix. v1 ships six wheels: x86_64 and ARM64 for Windows, macOS, and
+manylinux, alongside one `sdist`.
 
 v1 is **runtime-only**: it renders compiled protocols and does not expose a
 build/compile API. Produce `protocol.bin` with `webui build` (the npm or Rust

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -11,10 +11,9 @@ npm install @microsoft/webui
 ```
 
 The package automatically installs the correct platform-specific native binary
-for your OS and architecture (Windows, macOS, Linux - x64 and arm64). The Node
-API requires that native addon and surfaces loading errors directly. It never
-falls back to a subprocess. Use the `webui` CLI explicitly for filesystem
-builds.
+for Windows, macOS, and Linux on x64 or ARM64. The Node API requires that
+native addon and surfaces loading errors directly. It never falls back to a
+subprocess. Use the `webui` CLI explicitly for filesystem builds.
 
 ## Quick start
 

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -141,19 +141,18 @@ pub(crate) enum Backend {
     /// `cargo xwin build`, cross-compiles the two Windows MSVC targets using
     /// an embedded MSVC-compatible toolchain (headers, import libs, CRT).
     CargoXwin,
-    /// `cargo zigbuild`, cross-compiles the two Apple Darwin targets using
-    /// Zig as the C/Obj-C cross linker.
+    /// `cargo zigbuild`, cross-compiles Apple Darwin targets using Zig as the
+    /// C/Obj-C cross linker.
     CargoZigbuild,
 }
 
 impl Backend {
-    /// The `cargo` subcommand inserted before `build`, e.g. `cargo xwin
-    /// build`. `None` for plain `cargo build`.
-    fn subcommand(self) -> Option<&'static str> {
+    /// Cargo arguments that select the backend's build command.
+    fn build_command(self) -> &'static [&'static str] {
         match self {
-            Backend::Cargo => None,
-            Backend::CargoXwin => Some("xwin"),
-            Backend::CargoZigbuild => Some("zigbuild"),
+            Backend::Cargo => &["build"],
+            Backend::CargoXwin => &["xwin", "build"],
+            Backend::CargoZigbuild => &["zigbuild"],
         }
     }
 }
@@ -744,10 +743,14 @@ fn python_interpreter() -> String {
 /// interpreter makes maturin match the host interpreter against the target
 /// architecture and skip it, which breaks every cross build.
 ///
-/// `backend` adds the maturin flag for the cross toolchain it maps to
-/// (`--xwin` for `CargoXwin`, `--zig` for `CargoZigbuild`); `Backend::Cargo`
-/// adds nothing, since that is either a native build or a Linux target,
-/// where the `manylinux` container's own cross toolchain applies instead.
+/// `backend` adds the maturin flag for the cross toolchain it maps to.
+/// `CargoZigbuild` gets maturin's own `--zig` flag; `Backend::Cargo` adds
+/// nothing, since that is either a native build or a Linux target, where the
+/// `manylinux` container's own cross toolchain applies instead. `CargoXwin`
+/// also adds nothing here: unlike `--zig`, maturin has no built-in `--xwin`
+/// flag (passing one is a clap error), so Windows MSVC cross builds instead
+/// export `cargo-xwin`'s own linker/SDK environment onto the `maturin`
+/// process; see [`cargo_xwin_env`].
 fn maturin_build_args<'a>(
     manifest: &'a str,
     triple: &'a str,
@@ -772,12 +775,52 @@ fn maturin_build_args<'a>(
     if triple.ends_with("-linux-gnu") {
         args.extend_from_slice(&["--compatibility", "manylinux_2_17"]);
     }
-    match backend {
-        Backend::Cargo => {}
-        Backend::CargoXwin => args.push("--xwin"),
-        Backend::CargoZigbuild => args.push("--zig"),
+    if backend == Backend::CargoZigbuild {
+        args.push("--zig");
     }
     args
+}
+
+/// The cross-compilation environment variables `cargo xwin build` would set
+/// for `triple` (the MSVC linker, `CC`/`CXX`/`AR`, and the downloaded CRT/SDK
+/// include and lib paths), obtained via `cargo xwin env` instead of
+/// duplicating cargo-xwin's toolchain/SDK resolution here.
+///
+/// maturin invokes `cargo` itself to build the extension module; it has no
+/// `--xwin` flag to ask it to route that invocation through cargo-xwin
+/// (unlike its `--zig` flag for cargo-zigbuild). Exporting the same
+/// environment cargo-xwin uses onto the `maturin` process makes its internal
+/// `cargo build` cross-link against the MSVC target exactly like the
+/// `cargo xwin build` step that stages the native binaries.
+fn cargo_xwin_env(triple: &str) -> Result<Vec<(String, String)>, String> {
+    let output = build_command("cargo", &["xwin", "env", "--target", triple])
+        .output()
+        .map_err(|e| format!("failed to run cargo xwin env: {e}"))?;
+    if !output.status.success() {
+        let mut msg = String::from_utf8_lossy(&output.stderr).into_owned();
+        if msg.is_empty() {
+            msg = format!("exit code {}", output.status.code().unwrap_or(1));
+        }
+        return Err(format!("cargo xwin env failed for {triple}: {msg}"));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_cargo_xwin_env(&stdout))
+}
+
+/// Parse `cargo xwin env`'s `export KEY="VALUE";` lines into key/value pairs.
+/// Split out from [`cargo_xwin_env`] so the parsing logic is unit-testable
+/// without actually invoking `cargo xwin`.
+fn parse_cargo_xwin_env(output: &str) -> Vec<(String, String)> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim().strip_prefix("export ")?;
+            let rest = rest.strip_suffix(';').unwrap_or(rest);
+            let (key, value) = rest.split_once('=')?;
+            let value = value.trim_matches('"');
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 fn build_python_wheel(root: &Path, triple: &str, out_dir: &Path) -> Result<String, String> {
@@ -804,9 +847,24 @@ fn build_python_wheel(root: &Path, triple: &str, out_dir: &Path) -> Result<Strin
     let manifest_arg = manifest_path.to_string_lossy().into_owned();
     let out_arg = out_dir.to_string_lossy().into_owned();
     let maturin_args = maturin_build_args(&manifest_arg, triple, &out_arg, backend);
-    let env = macos_deployment_target_env(triple);
 
-    run_command_quiet_with_env(&interpreter, &maturin_args, root, env.as_slice())
+    // `CargoZigbuild` reaches its cross toolchain through maturin's own
+    // `--zig` flag, so only `MACOSX_DEPLOYMENT_TARGET` needs exporting.
+    // `CargoXwin` has no equivalent maturin flag: export cargo-xwin's own
+    // linker/SDK environment (see `cargo_xwin_env`) so maturin's internal
+    // `cargo build` cross-links the same way the native binaries did.
+    let mut env: Vec<(String, String)> = macos_deployment_target_env(triple)
+        .map(|(key, value)| vec![(key.to_string(), value.to_string())])
+        .unwrap_or_default();
+    if backend == Backend::CargoXwin {
+        env.extend(cargo_xwin_env(triple)?);
+    }
+    let env_refs: Vec<(&str, &str)> = env
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+
+    run_command_quiet_with_env(&interpreter, &maturin_args, root, &env_refs)
         .map_err(|e| format!("maturin build failed: {e}"))?;
 
     let expected = format!(
@@ -920,10 +978,7 @@ pub(crate) fn native_build_args<'a>(
     backend: Backend,
 ) -> Result<Vec<&'a str>, String> {
     let mut args = Vec::with_capacity(14);
-    if let Some(subcommand) = backend.subcommand() {
-        args.push(subcommand);
-    }
-    args.push("build");
+    args.extend_from_slice(backend.build_command());
     match profile {
         "release" => args.push("--release"),
         "debug" => {}
@@ -2460,7 +2515,8 @@ mod tests {
 
         let zigbuild = native_build_args("aarch64-apple-darwin", "release", Backend::CargoZigbuild)
             .expect("zigbuild backend should be supported");
-        assert_eq!(&zigbuild[..2], &["zigbuild", "build"]);
+        assert_eq!(zigbuild[0], "zigbuild");
+        assert_ne!(zigbuild.get(1), Some(&"build"));
 
         // Every backend still builds the same three native packages.
         for args in [&cargo, &xwin, &zigbuild] {
@@ -2534,10 +2590,10 @@ mod tests {
     }
 
     #[test]
-    fn backend_subcommand_matches_expected_cargo_plugin() {
-        assert_eq!(Backend::Cargo.subcommand(), None);
-        assert_eq!(Backend::CargoXwin.subcommand(), Some("xwin"));
-        assert_eq!(Backend::CargoZigbuild.subcommand(), Some("zigbuild"));
+    fn backend_build_command_matches_cargo_plugin_contract() {
+        assert_eq!(Backend::Cargo.build_command(), &["build"]);
+        assert_eq!(Backend::CargoXwin.build_command(), &["xwin", "build"]);
+        assert_eq!(Backend::CargoZigbuild.build_command(), &["zigbuild"]);
     }
 
     #[test]
@@ -2551,13 +2607,16 @@ mod tests {
         assert!(!cargo.contains(&"--xwin"));
         assert!(!cargo.contains(&"--zig"));
 
+        // maturin has no `--xwin` flag (unlike `--zig`): passing one is a
+        // clap error. The `CargoXwin` backend instead exports cargo-xwin's
+        // environment onto the maturin process; see `cargo_xwin_env`.
         let xwin = maturin_build_args(
             "Cargo.toml",
             "x86_64-pc-windows-msvc",
             "out",
             Backend::CargoXwin,
         );
-        assert!(xwin.contains(&"--xwin"));
+        assert!(!xwin.contains(&"--xwin"));
         assert!(!xwin.contains(&"--zig"));
 
         let zigbuild = maturin_build_args(
@@ -2568,6 +2627,34 @@ mod tests {
         );
         assert!(zigbuild.contains(&"--zig"));
         assert!(!zigbuild.contains(&"--xwin"));
+    }
+
+    #[test]
+    fn parse_cargo_xwin_env_extracts_exported_pairs() {
+        let output = "export CC_x86_64_pc_windows_msvc=\"clang-cl\";\n\
+                       export CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=\"lld-link\";\n\
+                       \n\
+                       not an export line\n";
+        let vars = parse_cargo_xwin_env(output);
+        assert_eq!(
+            vars,
+            vec![
+                (
+                    "CC_x86_64_pc_windows_msvc".to_string(),
+                    "clang-cl".to_string()
+                ),
+                (
+                    "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER".to_string(),
+                    "lld-link".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_cargo_xwin_env_ignores_blank_and_malformed_lines() {
+        assert!(parse_cargo_xwin_env("").is_empty());
+        assert!(parse_cargo_xwin_env("export NO_VALUE;\n").is_empty());
     }
 
     #[test]

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -13,7 +13,7 @@
 //! - `publish/standalone/` — legacy direct-download native and WASM assets
 //! - `publish/python/`  — pre-staged wheels plus the generated source distribution
 
-use crate::util::{build_command, run_command, run_command_quiet};
+use crate::util::{build_command, run_command_quiet};
 use crate::version;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -33,6 +33,11 @@ struct PlatformEntry {
     platform_suffix: &'static str,
     /// Exact platform tag emitted by the pinned maturin build for this target.
     python_platform_tag: &'static str,
+    /// `MACOSX_DEPLOYMENT_TARGET` to pin when cross-compiling this target with
+    /// `cargo zigbuild` / `maturin --zig`, so the embedded minimum OS version
+    /// matches `python_platform_tag` regardless of toolchain defaults.
+    /// `None` for non-Darwin targets, which never use that backend.
+    macos_deployment_target: Option<&'static str>,
 }
 
 const PLATFORMS: &[PlatformEntry] = &[
@@ -45,6 +50,7 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui",
         platform_suffix: "linux-x64",
         python_platform_tag: "manylinux_2_17_x86_64.manylinux2014_x86_64",
+        macos_deployment_target: None,
     },
     PlatformEntry {
         triple: "aarch64-unknown-linux-gnu",
@@ -55,6 +61,7 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui",
         platform_suffix: "linux-arm64",
         python_platform_tag: "manylinux_2_17_aarch64.manylinux2014_aarch64",
+        macos_deployment_target: None,
     },
     PlatformEntry {
         triple: "x86_64-pc-windows-msvc",
@@ -65,6 +72,7 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui.exe",
         platform_suffix: "win32-x64",
         python_platform_tag: "win_amd64",
+        macos_deployment_target: None,
     },
     PlatformEntry {
         triple: "aarch64-pc-windows-msvc",
@@ -75,6 +83,7 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui.exe",
         platform_suffix: "win32-arm64",
         python_platform_tag: "win_arm64",
+        macos_deployment_target: None,
     },
     PlatformEntry {
         triple: "x86_64-apple-darwin",
@@ -85,6 +94,7 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui",
         platform_suffix: "darwin-x64",
         python_platform_tag: "macosx_10_12_x86_64",
+        macos_deployment_target: Some("10.12"),
     },
     PlatformEntry {
         triple: "aarch64-apple-darwin",
@@ -95,8 +105,96 @@ const PLATFORMS: &[PlatformEntry] = &[
         cli_binary: "webui",
         platform_suffix: "darwin-arm64",
         python_platform_tag: "macosx_11_0_arm64",
+        macos_deployment_target: Some("11.0"),
     },
 ];
+
+// ── Cross-compilation backend selection ─────────────────────────────────
+
+/// Host operating system running `publish-build`, distinct from the target
+/// triple being built.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HostOs {
+    Linux,
+    MacOs,
+    Windows,
+    Other,
+}
+
+fn current_host_os() -> HostOs {
+    if cfg!(target_os = "linux") {
+        HostOs::Linux
+    } else if cfg!(target_os = "macos") {
+        HostOs::MacOs
+    } else if cfg!(target_os = "windows") {
+        HostOs::Windows
+    } else {
+        HostOs::Other
+    }
+}
+
+/// Cargo wrapper used to build a target triple's native artifacts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Backend {
+    /// Plain `cargo build`, for a host's own target and for Linux targets.
+    Cargo,
+    /// `cargo xwin build`, cross-compiles the two Windows MSVC targets using
+    /// an embedded MSVC-compatible toolchain (headers, import libs, CRT).
+    CargoXwin,
+    /// `cargo zigbuild`, cross-compiles the two Apple Darwin targets using
+    /// Zig as the C/Obj-C cross linker.
+    CargoZigbuild,
+}
+
+impl Backend {
+    /// The `cargo` subcommand inserted before `build`, e.g. `cargo xwin
+    /// build`. `None` for plain `cargo build`.
+    fn subcommand(self) -> Option<&'static str> {
+        match self {
+            Backend::Cargo => None,
+            Backend::CargoXwin => Some("xwin"),
+            Backend::CargoZigbuild => Some("zigbuild"),
+        }
+    }
+}
+
+/// Choose the cargo backend for building `triple` on `host`.
+///
+/// Linux is the primary cross-compilation host: it builds its own Linux
+/// targets with native `cargo build`, reaches Windows MSVC through `cargo
+/// xwin build`, and reaches Apple Darwin through `cargo zigbuild`. A host
+/// building its own native target family — a macOS runner building
+/// `*-apple-darwin`, or a Windows runner building `*-pc-windows-msvc` —
+/// always uses plain `cargo build` there instead, since no cross toolchain
+/// is required. This mirrors the existing `build-windows-local` behavior
+/// (macOS host, Windows MSVC target, `cargo-xwin`) as one case of the same
+/// rule, so both entry points can share it.
+fn select_backend_for_host(host: HostOs, triple: &str) -> Backend {
+    match host {
+        HostOs::MacOs if triple.ends_with("-apple-darwin") => Backend::Cargo,
+        HostOs::Windows if triple.ends_with("-pc-windows-msvc") => Backend::Cargo,
+        _ if triple.ends_with("-linux-gnu") => Backend::Cargo,
+        _ if triple.ends_with("-pc-windows-msvc") => Backend::CargoXwin,
+        _ if triple.ends_with("-apple-darwin") => Backend::CargoZigbuild,
+        _ => Backend::Cargo,
+    }
+}
+
+pub(crate) fn select_backend(triple: &str) -> Backend {
+    select_backend_for_host(current_host_os(), triple)
+}
+
+/// The `MACOSX_DEPLOYMENT_TARGET` env value to pin for `triple`, when
+/// cross-compiling with `cargo zigbuild` (native build) or `maturin --zig`
+/// (Python wheel). Both call sites derive the same value from `PLATFORMS`,
+/// so the two build paths cannot drift apart. `None` for non-Darwin targets.
+fn macos_deployment_target_env(triple: &str) -> Option<(&'static str, &'static str)> {
+    PLATFORMS
+        .iter()
+        .find(|platform| platform.triple == triple)
+        .and_then(|platform| platform.macos_deployment_target)
+        .map(|version| ("MACOSX_DEPLOYMENT_TARGET", version))
+}
 
 /// Subdirectories created inside `publish/`.
 const PUBLISH_SUBDIRS: &[&str] = &[
@@ -645,7 +743,17 @@ fn python_interpreter() -> String {
 /// the ABI tag from the feature and the platform tag from `--target`. Naming an
 /// interpreter makes maturin match the host interpreter against the target
 /// architecture and skip it, which breaks every cross build.
-fn maturin_build_args<'a>(manifest: &'a str, triple: &'a str, out: &'a str) -> Vec<&'a str> {
+///
+/// `backend` adds the maturin flag for the cross toolchain it maps to
+/// (`--xwin` for `CargoXwin`, `--zig` for `CargoZigbuild`); `Backend::Cargo`
+/// adds nothing, since that is either a native build or a Linux target,
+/// where the `manylinux` container's own cross toolchain applies instead.
+fn maturin_build_args<'a>(
+    manifest: &'a str,
+    triple: &'a str,
+    out: &'a str,
+    backend: Backend,
+) -> Vec<&'a str> {
     let mut args = vec![
         "-m",
         "maturin",
@@ -663,6 +771,11 @@ fn maturin_build_args<'a>(manifest: &'a str, triple: &'a str, out: &'a str) -> V
     // every other target derives its platform tag from the triple alone.
     if triple.ends_with("-linux-gnu") {
         args.extend_from_slice(&["--compatibility", "manylinux_2_17"]);
+    }
+    match backend {
+        Backend::Cargo => {}
+        Backend::CargoXwin => args.push("--xwin"),
+        Backend::CargoZigbuild => args.push("--zig"),
     }
     args
 }
@@ -684,12 +797,16 @@ fn build_python_wheel(root: &Path, triple: &str, out_dir: &Path) -> Result<Strin
         ));
     }
 
+    let backend = select_backend(triple);
+    preflight_backend(backend)?;
+
     let interpreter = python_interpreter();
     let manifest_arg = manifest_path.to_string_lossy().into_owned();
     let out_arg = out_dir.to_string_lossy().into_owned();
-    let maturin_args = maturin_build_args(&manifest_arg, triple, &out_arg);
+    let maturin_args = maturin_build_args(&manifest_arg, triple, &out_arg, backend);
+    let env = macos_deployment_target_env(triple);
 
-    run_command_quiet(&interpreter, &maturin_args, Some(root))
+    run_command_quiet_with_env(&interpreter, &maturin_args, root, env.as_slice())
         .map_err(|e| format!("maturin build failed: {e}"))?;
 
     let expected = format!(
@@ -784,12 +901,28 @@ fn set_build_mode(current: BuildMode, requested: BuildMode) -> Result<BuildMode,
 }
 
 fn build_native_target(root: &Path, triple: &str, profile: &str) -> Result<(), String> {
-    let args = native_build_args(triple, profile)?;
-    run_command("cargo", &args, Some(root))
+    let backend = select_backend(triple);
+    preflight_backend(backend)?;
+
+    let args = native_build_args(triple, profile, backend)?;
+    let env = macos_deployment_target_env(triple);
+    run_command_with_env("cargo", &args, root, env.as_slice())
 }
 
-fn native_build_args<'a>(triple: &'a str, profile: &str) -> Result<Vec<&'a str>, String> {
-    let mut args = Vec::with_capacity(13);
+/// Assemble the `cargo build` arguments for one target, prefixed with the
+/// backend's cargo subcommand (e.g. `xwin`, `zigbuild`) when it needs one.
+///
+/// `pub(crate)` so `windows_local::build_target` can share it for the
+/// `CargoXwin` backend instead of duplicating the argument list.
+pub(crate) fn native_build_args<'a>(
+    triple: &'a str,
+    profile: &str,
+    backend: Backend,
+) -> Result<Vec<&'a str>, String> {
+    let mut args = Vec::with_capacity(14);
+    if let Some(subcommand) = backend.subcommand() {
+        args.push(subcommand);
+    }
     args.push("build");
     match profile {
         "release" => args.push("--release"),
@@ -807,6 +940,251 @@ fn native_build_args<'a>(triple: &'a str, profile: &str) -> Result<Vec<&'a str>,
         "microsoft-webui-node",
     ]);
     Ok(args)
+}
+
+/// Actionable preflight checks for the backend chosen for a target, so a
+/// missing or mis-pinned cross toolchain fails immediately with install
+/// guidance instead of a confusing linker error partway through the build.
+/// Reuses `build-windows-local`'s cargo-xwin/LLVM checks rather than
+/// duplicating them, since both entry points depend on the same toolchain.
+fn preflight_backend(backend: Backend) -> Result<(), String> {
+    match backend {
+        Backend::Cargo => Ok(()),
+        Backend::CargoXwin => {
+            crate::windows_local::ensure_cargo_xwin()?;
+            crate::windows_local::ensure_llvm_tools()
+        }
+        Backend::CargoZigbuild => {
+            ensure_cargo_zigbuild()?;
+            ensure_zig()?;
+            ensure_sdkroot_for_zigbuild(current_host_os())
+        }
+    }
+}
+
+/// Pinned `cargo-zigbuild` version, matching the `cargo-xwin` pin in
+/// `windows_local.rs` so both cross toolchains stay reproducible.
+const CARGO_ZIGBUILD_VERSION: &str = "0.23.0";
+
+fn ensure_cargo_zigbuild() -> Result<(), String> {
+    match installed_cargo_zigbuild_version()? {
+        Some(found) if found == CARGO_ZIGBUILD_VERSION => Ok(()),
+        Some(found) => Err(format!(
+            "cargo-zigbuild {CARGO_ZIGBUILD_VERSION} is required, found {found}.\n  help: install the pinned version with: cargo install cargo-zigbuild --version {CARGO_ZIGBUILD_VERSION} --locked"
+        )),
+        None => Err(format!(
+            "cargo-zigbuild {CARGO_ZIGBUILD_VERSION} is required but was not found on PATH.\n  help: install it with: cargo install cargo-zigbuild --version {CARGO_ZIGBUILD_VERSION} --locked"
+        )),
+    }
+}
+
+fn installed_cargo_zigbuild_version() -> Result<Option<String>, String> {
+    let output = match std::process::Command::new("cargo-zigbuild")
+        .arg("--version")
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("failed to run cargo-zigbuild --version: {error}")),
+    };
+
+    if !output.status.success() {
+        return Err(format!(
+            "cargo-zigbuild --version failed with {}",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(cargo_zigbuild_version(&stdout).map(str::to_string))
+}
+
+fn cargo_zigbuild_version(output: &str) -> Option<&str> {
+    let mut parts = output.split_whitespace();
+    if parts.next() == Some("cargo-zigbuild") {
+        return parts.next();
+    }
+    None
+}
+
+/// Pinned Zig version, matching the Azure release pipeline's toolchain pin
+/// so `cargo zigbuild`'s cross-linking behavior stays reproducible between
+/// a Linux developer machine and CI.
+const ZIG_VERSION: &str = "0.13.0";
+
+/// Environment variable naming an alternate `zig` executable, for machines
+/// where the pinned Zig isn't the one on `PATH` (e.g. a version manager or
+/// a toolchain cache directory). Mirrors `cargo-zigbuild`'s own lookup.
+const CARGO_ZIGBUILD_ZIG_PATH_VAR: &str = "CARGO_ZIGBUILD_ZIG_PATH";
+
+/// Resolve which `zig` executable to check/run: a non-empty
+/// `CARGO_ZIGBUILD_ZIG_PATH` override, or the default `zig` on `PATH`.
+///
+/// Pure and independent of `std::env` so it can be unit-tested with mock
+/// inputs; `zig_executable` below is the real entry point that reads the
+/// actual environment variable.
+fn resolve_zig_executable(env_value: Option<&str>) -> &str {
+    match env_value {
+        Some(value) if !value.trim().is_empty() => value,
+        _ => "zig",
+    }
+}
+
+fn zig_executable() -> String {
+    let value = std::env::var(CARGO_ZIGBUILD_ZIG_PATH_VAR).ok();
+    resolve_zig_executable(value.as_deref()).to_string()
+}
+
+/// Verify Zig is on the resolved executable path and matches [`ZIG_VERSION`].
+///
+/// `cargo zigbuild` shells out to `zig cc`/`zig c++` as its cross linker, so
+/// a missing or mismatched Zig produces confusing link-time errors rather
+/// than an actionable message; this fails fast with install guidance instead.
+fn ensure_zig() -> Result<(), String> {
+    let executable = zig_executable();
+    match installed_zig_version(&executable)? {
+        Some(found) if found == ZIG_VERSION => Ok(()),
+        Some(found) => Err(format!(
+            "Zig {ZIG_VERSION} is required for cargo zigbuild (matching the Azure release pipeline's pin), found {found} via {executable}.\n  help: install Zig {ZIG_VERSION} from https://ziglang.org/download/, or set {CARGO_ZIGBUILD_ZIG_PATH_VAR} to a Zig {ZIG_VERSION} binary"
+        )),
+        None => Err(format!(
+            "Zig {ZIG_VERSION} is required for cargo zigbuild but {executable} was not found.\n  help: install Zig {ZIG_VERSION} from https://ziglang.org/download/, or set {CARGO_ZIGBUILD_ZIG_PATH_VAR} to a Zig {ZIG_VERSION} binary"
+        )),
+    }
+}
+
+fn installed_zig_version(executable: &str) -> Result<Option<String>, String> {
+    let output = match std::process::Command::new(executable)
+        .arg("version")
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("failed to run {executable} version: {error}")),
+    };
+
+    if !output.status.success() {
+        return Err(format!(
+            "{executable} version failed with {}",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(zig_version(&stdout).map(str::to_string))
+}
+
+/// Parse `zig version` output, which — unlike `cargo-xwin`/`cargo-zigbuild`
+/// `--version` — prints only the bare version number (e.g. `0.13.0`), with
+/// no leading binary name to strip. Pure so it can be unit-tested directly.
+fn zig_version(output: &str) -> Option<&str> {
+    output.lines().next()?.split_whitespace().next()
+}
+
+/// Pure SDKROOT validation for the `CargoZigbuild` backend, so tests can
+/// exercise every case (missing, empty, non-directory, valid) with mock
+/// inputs instead of mutating the real process environment — `std::env`
+/// mutation is unsafe and races across tests that run in parallel.
+///
+/// Unlike a native macOS toolchain, `cargo zigbuild` neither vendors nor
+/// lazily downloads an Apple SDK: without a real `SDKROOT`, it silently
+/// links against Zig's minimal libc/libSystem stubs instead of failing.
+/// Public PRs validate with a direct `cargo check`/`cargo build`, so
+/// `publish-build` must fail loudly here rather than let that happen.
+/// xtask itself never downloads an SDK; trusted CI sets `SDKROOT` to a
+/// vendored one explicitly. Native macOS hosts don't reach this backend
+/// (see `select_backend_for_host`), so the check only gates the actual
+/// cross case.
+fn validate_sdkroot(
+    host: HostOs,
+    backend: Backend,
+    sdkroot: Option<&str>,
+    is_directory: impl Fn(&str) -> bool,
+) -> Result<(), String> {
+    if backend != Backend::CargoZigbuild || host == HostOs::MacOs {
+        return Ok(());
+    }
+
+    match sdkroot {
+        None => Err(
+            "SDKROOT is required to cross-compile Apple targets with cargo zigbuild from a non-macOS host.\n  help: set SDKROOT to an extracted macOS SDK directory, e.g. SDKROOT=/opt/MacOSX14.sdk"
+                .to_string(),
+        ),
+        Some(path) if path.trim().is_empty() => Err(
+            "SDKROOT is set but empty; cargo zigbuild requires it to point at a real macOS SDK directory".to_string(),
+        ),
+        Some(path) if !is_directory(path) => Err(format!(
+            "SDKROOT={path} does not name an existing directory.\n  help: point SDKROOT at an extracted macOS SDK directory"
+        )),
+        Some(_) => Ok(()),
+    }
+}
+
+fn ensure_sdkroot_for_zigbuild(host: HostOs) -> Result<(), String> {
+    let sdkroot = std::env::var("SDKROOT").ok();
+    validate_sdkroot(host, Backend::CargoZigbuild, sdkroot.as_deref(), |path| {
+        Path::new(path).is_dir()
+    })
+}
+
+/// Like [`crate::util::run_command`], but also sets extra environment
+/// variables (e.g. `MACOSX_DEPLOYMENT_TARGET` for the `cargo zigbuild`
+/// backend; see `macos_deployment_target_env`). Every other backend passes
+/// an empty slice and behaves exactly like `run_command`.
+fn run_command_with_env(
+    cmd: &str,
+    args: &[&str],
+    cwd: &Path,
+    env: &[(&str, &str)],
+) -> Result<(), String> {
+    let mut command = build_command(cmd, args);
+    command.current_dir(cwd);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    match command.status() {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(format!("exit code {}", status.code().unwrap_or(1))),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+/// Like [`crate::util::run_command_quiet`], but also sets extra environment
+/// variables. Used for the `maturin --zig` backend; see
+/// `run_command_with_env`.
+fn run_command_quiet_with_env(
+    cmd: &str,
+    args: &[&str],
+    cwd: &Path,
+    env: &[(&str, &str)],
+) -> Result<(), String> {
+    use std::process::Stdio;
+
+    let mut command = build_command(cmd, args);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    command.current_dir(cwd);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    match command.output() {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => {
+            let mut msg = String::new();
+            if let Ok(s) = String::from_utf8(output.stdout) {
+                msg.push_str(&s);
+            }
+            if let Ok(s) = String::from_utf8(output.stderr) {
+                msg.push_str(&s);
+            }
+            if msg.is_empty() {
+                msg = format!("exit code {}", output.status.code().unwrap_or(1));
+            }
+            Err(msg)
+        }
+        Err(error) => Err(error.to_string()),
+    }
 }
 
 /// Copy this target's freshly built artifacts into an external output root.
@@ -1959,7 +2337,7 @@ mod tests {
     #[test]
     fn maturin_build_args_never_name_an_interpreter() {
         for platform in PLATFORMS {
-            let args = maturin_build_args("Cargo.toml", platform.triple, "out");
+            let args = maturin_build_args("Cargo.toml", platform.triple, "out", Backend::Cargo);
 
             assert!(
                 !args.contains(&"--interpreter"),
@@ -2054,7 +2432,7 @@ mod tests {
 
     #[test]
     fn native_build_args_map_debug_to_cargo_dev_profile() {
-        let args = native_build_args("x86_64-unknown-linux-gnu", "debug")
+        let args = native_build_args("x86_64-unknown-linux-gnu", "debug", Backend::Cargo)
             .expect("debug profile should be supported");
 
         assert_eq!(args[0], "build");
@@ -2064,10 +2442,280 @@ mod tests {
 
     #[test]
     fn native_build_args_map_release_to_release_flag() {
-        let args = native_build_args("x86_64-unknown-linux-gnu", "release")
+        let args = native_build_args("x86_64-unknown-linux-gnu", "release", Backend::Cargo)
             .expect("release profile should be supported");
 
         assert!(args.contains(&"--release"));
+    }
+
+    #[test]
+    fn native_build_args_prefix_backend_subcommand() {
+        let cargo = native_build_args("x86_64-unknown-linux-gnu", "release", Backend::Cargo)
+            .expect("cargo backend should be supported");
+        assert_eq!(cargo[0], "build");
+
+        let xwin = native_build_args("x86_64-pc-windows-msvc", "release", Backend::CargoXwin)
+            .expect("xwin backend should be supported");
+        assert_eq!(&xwin[..2], &["xwin", "build"]);
+
+        let zigbuild = native_build_args("aarch64-apple-darwin", "release", Backend::CargoZigbuild)
+            .expect("zigbuild backend should be supported");
+        assert_eq!(&zigbuild[..2], &["zigbuild", "build"]);
+
+        // Every backend still builds the same three native packages.
+        for args in [&cargo, &xwin, &zigbuild] {
+            assert!(args.contains(&"microsoft-webui-cli"));
+            assert!(args.contains(&"microsoft-webui-ffi"));
+            assert!(args.contains(&"microsoft-webui-node"));
+        }
+    }
+
+    #[test]
+    fn select_backend_for_host_uses_native_cargo_for_each_host_family() {
+        for platform in PLATFORMS {
+            let backend = select_backend_for_host(HostOs::Linux, platform.triple);
+            let expected = if platform.triple.ends_with("-linux-gnu") {
+                Backend::Cargo
+            } else if platform.triple.ends_with("-pc-windows-msvc") {
+                Backend::CargoXwin
+            } else {
+                Backend::CargoZigbuild
+            };
+            assert_eq!(
+                backend, expected,
+                "Linux host backend mismatch for {}",
+                platform.triple
+            );
+        }
+    }
+
+    #[test]
+    fn select_backend_for_host_linux_accepts_every_platform_entry() {
+        // A Linux host must have a defined (non-panicking) backend for all
+        // six release targets: this is the primary cross-compilation host.
+        for platform in PLATFORMS {
+            let backend = select_backend_for_host(HostOs::Linux, platform.triple);
+            assert_ne!(
+                format!("{backend:?}"),
+                "",
+                "Linux host should accept {}",
+                platform.triple
+            );
+        }
+    }
+
+    #[test]
+    fn select_backend_for_host_macos_builds_its_own_darwin_targets_natively() {
+        assert_eq!(
+            select_backend_for_host(HostOs::MacOs, "x86_64-apple-darwin"),
+            Backend::Cargo
+        );
+        assert_eq!(
+            select_backend_for_host(HostOs::MacOs, "aarch64-apple-darwin"),
+            Backend::Cargo
+        );
+        // macOS still needs cargo-xwin to reach Windows MSVC.
+        assert_eq!(
+            select_backend_for_host(HostOs::MacOs, "x86_64-pc-windows-msvc"),
+            Backend::CargoXwin
+        );
+    }
+
+    #[test]
+    fn select_backend_for_host_windows_builds_its_own_msvc_targets_natively() {
+        assert_eq!(
+            select_backend_for_host(HostOs::Windows, "x86_64-pc-windows-msvc"),
+            Backend::Cargo
+        );
+        assert_eq!(
+            select_backend_for_host(HostOs::Windows, "aarch64-pc-windows-msvc"),
+            Backend::Cargo
+        );
+    }
+
+    #[test]
+    fn backend_subcommand_matches_expected_cargo_plugin() {
+        assert_eq!(Backend::Cargo.subcommand(), None);
+        assert_eq!(Backend::CargoXwin.subcommand(), Some("xwin"));
+        assert_eq!(Backend::CargoZigbuild.subcommand(), Some("zigbuild"));
+    }
+
+    #[test]
+    fn maturin_build_args_add_backend_flag_only_for_cross_toolchains() {
+        let cargo = maturin_build_args(
+            "Cargo.toml",
+            "x86_64-unknown-linux-gnu",
+            "out",
+            Backend::Cargo,
+        );
+        assert!(!cargo.contains(&"--xwin"));
+        assert!(!cargo.contains(&"--zig"));
+
+        let xwin = maturin_build_args(
+            "Cargo.toml",
+            "x86_64-pc-windows-msvc",
+            "out",
+            Backend::CargoXwin,
+        );
+        assert!(xwin.contains(&"--xwin"));
+        assert!(!xwin.contains(&"--zig"));
+
+        let zigbuild = maturin_build_args(
+            "Cargo.toml",
+            "aarch64-apple-darwin",
+            "out",
+            Backend::CargoZigbuild,
+        );
+        assert!(zigbuild.contains(&"--zig"));
+        assert!(!zigbuild.contains(&"--xwin"));
+    }
+
+    #[test]
+    fn maturin_build_args_preserve_abi3_target_output_and_manylinux() {
+        for platform in PLATFORMS {
+            let backend = select_backend_for_host(HostOs::Linux, platform.triple);
+            let args = maturin_build_args("Cargo.toml", platform.triple, "out", backend);
+
+            // abi3: no --interpreter is ever pinned (see maturin_build_args docs).
+            assert!(!args.contains(&"--interpreter"));
+            assert!(args.contains(&"--target"));
+            assert!(args.contains(&platform.triple));
+            assert!(args.contains(&"--out"));
+            assert!(args.contains(&"out"));
+            assert_eq!(
+                args.contains(&"manylinux_2_17"),
+                platform.triple.ends_with("-linux-gnu")
+            );
+        }
+    }
+
+    #[test]
+    fn macos_deployment_target_env_matches_platform_metadata() {
+        assert_eq!(
+            macos_deployment_target_env("x86_64-apple-darwin"),
+            Some(("MACOSX_DEPLOYMENT_TARGET", "10.12"))
+        );
+        assert_eq!(
+            macos_deployment_target_env("aarch64-apple-darwin"),
+            Some(("MACOSX_DEPLOYMENT_TARGET", "11.0"))
+        );
+        assert_eq!(
+            macos_deployment_target_env("x86_64-unknown-linux-gnu"),
+            None
+        );
+        assert_eq!(macos_deployment_target_env("unknown-target"), None);
+    }
+
+    #[test]
+    fn cargo_zigbuild_version_parses_expected_output() {
+        assert_eq!(
+            cargo_zigbuild_version("cargo-zigbuild 0.23.0\n"),
+            Some(CARGO_ZIGBUILD_VERSION)
+        );
+        assert_eq!(cargo_zigbuild_version("cargo 1.93.0\n"), None);
+    }
+
+    #[test]
+    fn ensure_cargo_zigbuild_error_mentions_pinned_version_when_missing() {
+        // `cargo-zigbuild` is not expected to be on PATH in the test
+        // environment, so this exercises the "not found" branch's message.
+        if crate::util::which_exists("cargo-zigbuild") {
+            return;
+        }
+
+        let error = ensure_cargo_zigbuild().expect_err("cargo-zigbuild should be missing in CI");
+        assert!(error.contains(CARGO_ZIGBUILD_VERSION));
+        assert!(error.contains("cargo install cargo-zigbuild"));
+    }
+
+    #[test]
+    fn resolve_zig_executable_prefers_non_empty_override() {
+        assert_eq!(
+            resolve_zig_executable(Some("/opt/zig-0.13.0/zig")),
+            "/opt/zig-0.13.0/zig"
+        );
+    }
+
+    #[test]
+    fn resolve_zig_executable_falls_back_to_default_when_unset_or_blank() {
+        assert_eq!(resolve_zig_executable(None), "zig");
+        assert_eq!(resolve_zig_executable(Some("")), "zig");
+        assert_eq!(resolve_zig_executable(Some("   ")), "zig");
+    }
+
+    #[test]
+    fn zig_version_parses_bare_version_number() {
+        assert_eq!(zig_version("0.13.0\n"), Some(ZIG_VERSION));
+        assert_eq!(zig_version("0.13.0"), Some("0.13.0"));
+        assert_eq!(zig_version(""), None);
+        assert_eq!(zig_version("\n"), None);
+    }
+
+    #[test]
+    fn ensure_zig_error_mentions_pinned_version_and_override_var_when_missing() {
+        // Zig is not expected to be on PATH in the test environment, so
+        // this exercises the "not found" branch's message.
+        if crate::util::which_exists("zig") {
+            return;
+        }
+
+        let error = ensure_zig().expect_err("zig should be missing in CI");
+        assert!(error.contains(ZIG_VERSION));
+        assert!(error.contains(CARGO_ZIGBUILD_ZIG_PATH_VAR));
+    }
+
+    #[test]
+    fn validate_sdkroot_requires_sdkroot_for_zigbuild_on_non_macos_hosts() {
+        let error = validate_sdkroot(HostOs::Linux, Backend::CargoZigbuild, None, |_| true)
+            .expect_err("missing SDKROOT should fail");
+        assert!(error.contains("SDKROOT"));
+        assert!(error.contains("cargo zigbuild"));
+    }
+
+    #[test]
+    fn validate_sdkroot_rejects_empty_value() {
+        let error = validate_sdkroot(HostOs::Linux, Backend::CargoZigbuild, Some("   "), |_| true)
+            .expect_err("empty SDKROOT should fail");
+        assert!(error.contains("SDKROOT"));
+    }
+
+    #[test]
+    fn validate_sdkroot_rejects_nonexistent_directory() {
+        let error = validate_sdkroot(
+            HostOs::Linux,
+            Backend::CargoZigbuild,
+            Some("/does/not/exist.sdk"),
+            |_| false,
+        )
+        .expect_err("a SDKROOT that is not a real directory should fail");
+        assert!(error.contains("/does/not/exist.sdk"));
+        assert!(error.contains("existing directory"));
+    }
+
+    #[test]
+    fn validate_sdkroot_accepts_a_real_directory() {
+        validate_sdkroot(
+            HostOs::Linux,
+            Backend::CargoZigbuild,
+            Some("/opt/MacOSX14.sdk"),
+            |_| true,
+        )
+        .expect("an existing SDKROOT directory should pass");
+    }
+
+    #[test]
+    fn validate_sdkroot_skips_check_on_macos_host_and_non_zigbuild_backends() {
+        // Native macOS hosts never reach the CargoZigbuild backend (see
+        // select_backend_for_host), so the check is a no-op there even
+        // without SDKROOT.
+        validate_sdkroot(HostOs::MacOs, Backend::CargoZigbuild, None, |_| false)
+            .expect("macOS host should skip the SDKROOT check");
+
+        // Only the CargoZigbuild backend needs an Apple SDK.
+        validate_sdkroot(HostOs::Linux, Backend::Cargo, None, |_| false)
+            .expect("Cargo backend should not require SDKROOT");
+        validate_sdkroot(HostOs::Linux, Backend::CargoXwin, None, |_| false)
+            .expect("CargoXwin backend should not require SDKROOT");
     }
 
     #[test]
@@ -2081,6 +2729,7 @@ mod tests {
             cli_binary: "webui",
             platform_suffix: "darwin-arm64",
             python_platform_tag: "macosx_11_0_arm64",
+            macos_deployment_target: Some("11.0"),
         };
         assert_eq!(native_binary_name(&p), "webui-darwin-arm64");
     }
@@ -2096,6 +2745,7 @@ mod tests {
             cli_binary: "webui.exe",
             platform_suffix: "win32-x64",
             python_platform_tag: "win_amd64",
+            macos_deployment_target: None,
         };
         assert_eq!(native_binary_name(&p), "webui-win32-x64.exe");
     }

--- a/xtask/src/windows_local.rs
+++ b/xtask/src/windows_local.rs
@@ -271,14 +271,15 @@ fn missing_targets_message(missing: &[&str]) -> String {
     message
 }
 
-/// Verify `clang-cl` and LLD are on PATH.
+/// Verify `clang-cl`, `lld-link`, and `llvm-lib` are on PATH.
 ///
 /// Shared with `publish-build`'s `CargoXwin` backend; see `ensure_cargo_xwin`.
 pub(crate) fn ensure_llvm_tools() -> Result<(), String> {
     let has_clang_cl = which_exists("clang-cl");
     let has_lld = which_exists("lld-link") || which_exists("ld.lld") || which_exists("lld");
+    let has_llvm_lib = which_exists("llvm-lib");
 
-    if has_clang_cl && has_lld {
+    if has_clang_cl && has_lld && has_llvm_lib {
         return Ok(());
     }
 
@@ -286,7 +287,7 @@ pub(crate) fn ensure_llvm_tools() -> Result<(), String> {
 }
 
 fn llvm_tools_help() -> &'static str {
-    "clang-cl and LLD are required for cargo-xwin. On macOS: brew install llvm lld; on Linux: install clang and lld from your package manager. Then ensure both are on PATH"
+    "clang-cl, lld-link, and llvm-lib are required for cargo-xwin. On macOS: brew install llvm lld; on Linux: install clang, lld, and llvm from your package manager, then ensure clang-cl, lld-link, and llvm-lib are on PATH"
 }
 
 fn build_target(root: &Path, target: &WindowsTarget, cache_dir: &Path) -> Result<(), String> {
@@ -467,10 +468,12 @@ mod tests {
     }
 
     #[test]
-    fn llvm_tools_help_mentions_clang_cl() {
+    fn llvm_tools_help_mentions_required_tools() {
         let message = llvm_tools_help();
 
         assert!(message.contains("clang-cl"));
+        assert!(message.contains("lld-link"));
+        assert!(message.contains("llvm-lib"));
         assert!(message.contains("brew install llvm lld"));
     }
 

--- a/xtask/src/windows_local.rs
+++ b/xtask/src/windows_local.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Local macOS Windows artifact builds through cargo-xwin.
+//! Local Windows artifact builds through cargo-xwin, for developers on
+//! macOS or Linux who want to reproduce a Windows MSVC release leg without
+//! CI. `publish-build` shares this module's cargo-xwin preflight checks
+//! (`ensure_cargo_xwin`, `ensure_llvm_tools`) when it selects the same
+//! `cargo xwin` backend for a Linux host.
 
 use crate::util::which_exists;
 use std::fmt::Write;
@@ -12,11 +16,6 @@ use std::process::{Command, ExitCode};
 const CARGO_XWIN_VERSION: &str = "0.23.0";
 const PROFILE: &str = "release";
 const XWIN_CACHE_DIR: &str = "target/xwin-cache";
-const NATIVE_PACKAGES: &[&str] = &[
-    "microsoft-webui-cli",
-    "microsoft-webui-ffi",
-    "microsoft-webui-node",
-];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct WindowsTarget {
@@ -69,7 +68,7 @@ fn run_inner(args: &[String]) -> Result<(), String> {
     };
 
     let root = std::env::current_dir().map_err(|e| format!("failed to read current dir: {e}"))?;
-    ensure_macos_host()?;
+    ensure_supported_host()?;
     ensure_cargo_xwin()?;
     ensure_llvm_tools()?;
     ensure_rustup_targets(&targets)?;
@@ -175,27 +174,33 @@ fn find_target(value: &str) -> Option<&'static WindowsTarget> {
 fn print_usage() {
     eprintln!(
         "Usage: cargo xtask build-windows-local [--target all|x64|arm64|<triple>]\n\n\
-         Builds and stages Windows MSVC artifacts locally on macOS using cargo-xwin.\n\
+         Builds and stages Windows MSVC artifacts locally on macOS or Linux using cargo-xwin.\n\
          Defaults to both x86_64-pc-windows-msvc and aarch64-pc-windows-msvc."
     );
 }
 
-fn ensure_macos_host() -> Result<(), String> {
-    if cfg!(target_os = "macos") {
+fn ensure_supported_host() -> Result<(), String> {
+    if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
         return Ok(());
     }
 
-    Err("build-windows-local is intended for local macOS use; CI and release workflows are unchanged".to_string())
+    Err("build-windows-local is intended for local macOS or Linux use only".to_string())
 }
 
-fn ensure_cargo_xwin() -> Result<(), String> {
+/// Verify the pinned `cargo-xwin` is on PATH.
+///
+/// Shared with `publish-build`'s `CargoXwin` backend (see
+/// `publish::preflight_backend`), so a Linux host cross-compiling Windows
+/// MSVC artifacts gets the same actionable version check as this local
+/// command instead of a duplicated one.
+pub(crate) fn ensure_cargo_xwin() -> Result<(), String> {
     match installed_cargo_xwin_version()? {
         Some(found) if found == CARGO_XWIN_VERSION => Ok(()),
         Some(found) => Err(format!(
-            "cargo-xwin {CARGO_XWIN_VERSION} is required, found {found}.\n  help: install the pinned version with: cargo install cargo-xwin --version {CARGO_XWIN_VERSION}"
+            "cargo-xwin {CARGO_XWIN_VERSION} is required, found {found}.\n  help: install the pinned version with: cargo install cargo-xwin --version {CARGO_XWIN_VERSION} --locked"
         )),
         None => Err(format!(
-            "cargo-xwin {CARGO_XWIN_VERSION} is required but was not found on PATH.\n  help: install it with: cargo install cargo-xwin --version {CARGO_XWIN_VERSION}"
+            "cargo-xwin {CARGO_XWIN_VERSION} is required but was not found on PATH.\n  help: install it with: cargo install cargo-xwin --version {CARGO_XWIN_VERSION} --locked"
         )),
     }
 }
@@ -266,7 +271,10 @@ fn missing_targets_message(missing: &[&str]) -> String {
     message
 }
 
-fn ensure_llvm_tools() -> Result<(), String> {
+/// Verify `clang-cl` and LLD are on PATH.
+///
+/// Shared with `publish-build`'s `CargoXwin` backend; see `ensure_cargo_xwin`.
+pub(crate) fn ensure_llvm_tools() -> Result<(), String> {
     let has_clang_cl = which_exists("clang-cl");
     let has_lld = which_exists("lld-link") || which_exists("ld.lld") || which_exists("lld");
 
@@ -278,7 +286,7 @@ fn ensure_llvm_tools() -> Result<(), String> {
 }
 
 fn llvm_tools_help() -> &'static str {
-    "clang-cl and LLD are required for cargo-xwin. On macOS: brew install llvm lld, then ensure both Homebrew bin directories are on PATH"
+    "clang-cl and LLD are required for cargo-xwin. On macOS: brew install llvm lld; on Linux: install clang and lld from your package manager. Then ensure both are on PATH"
 }
 
 fn build_target(root: &Path, target: &WindowsTarget, cache_dir: &Path) -> Result<(), String> {
@@ -288,11 +296,19 @@ fn build_target(root: &Path, target: &WindowsTarget, cache_dir: &Path) -> Result
         console::style(target.triple).bold(),
     );
 
-    let args = cargo_xwin_build_args(target);
-    let mut command = Command::new("cargo-xwin");
-    command.args(&args);
+    let args = crate::publish::native_build_args(
+        target.triple,
+        PROFILE,
+        crate::publish::Backend::CargoXwin,
+    )
+    .map_err(|e| {
+        format!(
+            "failed to assemble cargo-xwin build args for {}: {e}",
+            target.triple
+        )
+    })?;
+    let mut command = crate::util::build_command("cargo", &args);
     command.current_dir(root);
-    command.env("CARGO_INCREMENTAL", "0");
     command.env("XWIN_CACHE_DIR", cache_dir);
 
     match command.status() {
@@ -306,19 +322,6 @@ fn build_target(root: &Path, target: &WindowsTarget, cache_dir: &Path) -> Result
             target.triple
         )),
     }
-}
-
-fn cargo_xwin_build_args(target: &WindowsTarget) -> Vec<String> {
-    let mut args = Vec::with_capacity(4 + (NATIVE_PACKAGES.len() * 2));
-    args.push("build".to_string());
-    args.push("--release".to_string());
-    args.push("--target".to_string());
-    args.push(target.triple.to_string());
-    for package in NATIVE_PACKAGES {
-        args.push("-p".to_string());
-        args.push((*package).to_string());
-    }
-    args
 }
 
 fn validate_staged_artifacts(root: &Path, targets: &[&WindowsTarget]) -> Result<(), String> {
@@ -440,6 +443,17 @@ mod tests {
     }
 
     #[test]
+    fn ensure_supported_host_accepts_macos_and_linux_only() {
+        let result = ensure_supported_host();
+        if cfg!(target_os = "macos") || cfg!(target_os = "linux") {
+            assert!(result.is_ok());
+        } else {
+            let error = result.expect_err("unsupported hosts should fail");
+            assert!(error.contains("macOS or Linux"));
+        }
+    }
+
+    #[test]
     fn missing_targets_message_includes_install_command() {
         let message =
             missing_targets_message(&["x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc"]);
@@ -467,11 +481,19 @@ mod tests {
             None => panic!("x64 target should exist"),
         };
 
-        let args = cargo_xwin_build_args(target);
+        // build_target shares its argument construction with publish-build's
+        // CargoXwin backend; assert on that shared function directly.
+        let args = crate::publish::native_build_args(
+            target.triple,
+            PROFILE,
+            crate::publish::Backend::CargoXwin,
+        )
+        .expect("cargo-xwin build args should be assembled for x64");
 
         assert_eq!(
             args,
             vec![
+                "xwin",
                 "build",
                 "--release",
                 "--target",


### PR DESCRIPTION
## Why

Release artifact production currently depends on separate Linux, macOS, and Windows runners. Consolidating production onto Linux reduces runner complexity and makes the release toolchain reproducible while preserving all six native distributions.

## What changed

- Adds host-aware `publish-build` backends: Cargo for Linux, cargo-xwin for Windows MSVC, and cargo-zigbuild for macOS x64/ARM64.
- Collapses Azure release production into one six-target Linux matrix and moves Windows PR builds onto Linux cross-compilation.
- Preserves native macOS PR builds and x64/ARM64 wheel tests so the macOS packaging path is exercised before release.
- Secures macOS release cross-builds with pinned Rust/Zig/cargo-zigbuild versions, a checksum-verified Apple SDK secure file, link-safe archive extraction, and SDK-aware cache keys.
- Pins nested maturin builds to the release Rust toolchain and propagates `SOURCE_DATE_EPOCH` for reproducible Windows/macOS wheels.

## Operational notes

Azure release builds require secure file `WebUI-MacOSX-SDK.tar.xz` and pipeline/library variable `WEBUI_APPLE_SDK_SHA256`. macOS and Windows release artifacts are cross-linked and packaged on Linux; matching-hardware runtime qualification remains a separate release step.

## Validation

- `cargo xtask check`
- `cargo test -p xtask` (121 tests)
- `dotnet build dotnet/Microsoft.WebUI.sln --configuration Release`
- `pnpm install --frozen-lockfile --registry=https://registry.npmjs.org`
- `pnpm --filter @microsoft/webui build`
- GitHub/Azure YAML parsing and six-target release-contract checks
- Malicious symlink archive rejection through `tarfile.data_filter`