### PR TITLE
perf: switch release builds to Thin LTO

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -220,7 +220,7 @@ The workspace ships with an aggressive release profile (`Cargo.toml`):
 
 ```toml
 [profile.release]
-lto = true            # Full link-time optimization
+lto = "thin"          # Thin link-time optimization
 codegen-units = 1     # Maximum optimization (slower compile)
 panic = "abort"       # No unwinding - smaller binary, but panics terminate immediately
 strip = true          # Strip debug symbols
@@ -228,7 +228,7 @@ strip = true          # Strip debug symbols
 
 - **`panic = "abort"` means panics kill the process instantly** - reinforcing why `unwrap`/`expect` are banned in library code.
 - Always validate performance claims in `--release` mode. Debug builds are not representative.
-- Be aware that LTO + single codegen unit makes release builds slow. Use `cargo test` (debug) for iteration, `cargo build --release` for final validation.
+- Thin LTO with a single codegen unit keeps cross-crate optimization while reducing release build time compared with full LTO. Use `cargo test` (debug) for iteration, `cargo build --release` for final validation.
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ unnecessary_box_returns = "deny"
 unsafe_code = "deny"
 
 [profile.release]
-lto = true
+lto = "thin"
 codegen-units = 1
 panic = "abort"
 strip = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -669,12 +669,12 @@ impl Step {
         run: || {
             // Use the dev profile (not the default bench profile) for the
             // criterion `--test` smoke run. The bench profile inherits the
-            // release profile's `lto = true, codegen-units = 1`, which spends
-            // ~40s compiling the full graph just to assert criterion's
+            // release profile's `lto = "thin", codegen-units = 1`, which still
+            // compiles the full optimized graph just to assert criterion's
             // `--test` entry point runs once. The dev profile reuses the
             // already-built unit-test artifacts and finishes in seconds. Real
             // benchmark measurements (via `cargo xtask bench`) continue to
-            // use the unchanged bench profile so their numbers stay accurate.
+            // use the release-derived bench profile so their numbers stay accurate.
             run_command_quiet(
                 "cargo",
                 &[


### PR DESCRIPTION
## Motivation

Full LTO (`lto = true`) in the release profile delivers maximum cross-crate optimization but at a steep cold-build-time cost. This PR switches the release profile to Thin LTO (`lto = "thin"`), which still performs cross-crate LTO (unlike `lto = false`/no LTO, or per-codegen-unit "thin local" LTO) but with a faster, more parallelizable linking pipeline. `codegen-units = 1` is retained so cross-crate inlining and optimization opportunities are not reduced by unit fragmentation.

This is a standalone follow-up scoped strictly to the LTO mode itself — no CI matrix, SDK, platform-support, packaging, macOS/Windows, README, or DESIGN.md changes are included.

## Changes

1. `Cargo.toml`: `[profile.release] lto = true` -> `lto = "thin"` (keeps `codegen-units = 1`, `panic = "abort"`, `strip = true` unchanged).
2. `.github/copilot-instructions.md`: updated the release-profile code snippet and surrounding prose to accurately describe Thin LTO instead of full LTO.
3. `xtask/src/main.rs`: updated the benchmark-validation step's comment referencing `lto = true` to `lto = "thin"`, and adjusted the accompanying explanation of why the bench-profile smoke test is skipped in favor of the dev profile.

## Measured results (release build, this environment)

| Metric | Full LTO (`true`) | Thin LTO (`"thin"`) | Delta |
|---|---|---|---|
| Cold release build time | 123.789s | 67.479s | **-45.5%** |
| Canonical `Render/1000` (criterion) | 31.218us | 27.075us | **-13.3%** |
| `RenderFAST/1000` (criterion) | 1.2949ms | 0.9803ms | **-24.3%** |
| Rendered output bytes | unchanged | unchanged | 0% |
| CLI binary size | 5,717,504 B | 6,585,344 B | **+15.2%** |
| Node addon size | 1,873,408 B | 1,984,512 B | **+5.9%** |
| FFI binary size | 641,536 B | 641,536 B | unchanged |
| Python extension size | 771,072 B | 771,072 B | unchanged |

Takeaways:
- Cold release build time is nearly halved, which meaningfully speeds up local `--release` iteration and CI release builds.
- Runtime performance in the canonical render and fast-render benchmarks actually **improved** with Thin LTO in this measurement, rather than regressing — Thin LTO is not simply "less optimization," and cross-crate inlining decisions can differ in ways that help these particular hot paths.
- Rendered output bytes are unchanged, confirming no behavioral/output difference from the LTO mode change.
- Binary size grows modestly for the CLI (+15.2%) and Node addon (+5.9%), likely from different inlining/code-layout decisions under Thin LTO; FFI and Python artifact sizes are unaffected.

## Validation

- `cargo xtask check` (license-headers, fmt, clippy, deny, test, build, build (wasm), build (examples), bench (validate), docs) passes cleanly on this branch.
- Confirmed the branch is rebased on latest `origin/main` with 0 commits ahead/behind at the merge-base, and contains no cross-compilation-related changes.
- Confirmed the diff touches exactly the three files described above (`Cargo.toml`, `.github/copilot-instructions.md`, `xtask/src/main.rs`) — no CI matrix, SDK, platform-support, packaging, macOS/Windows, README, or DESIGN.md changes.