### PR TITLE
fix(bench): render contacts in contact-book benchmark

### DIFF
--- a/crates/webui/benches/contact_book_bench.rs
+++ b/crates/webui/benches/contact_book_bench.rs
@@ -21,6 +21,14 @@ use webui_protocol::WebUIProtocol;
 /// Contact counts to benchmark.
 const CONTACT_COUNTS: &[usize] = &[10, 100, 1000];
 
+/// Request path rendered by every benchmark.
+///
+/// The `/contacts` route renders `cb-page-contacts`, which loops over the full
+/// `filteredContacts` array. The root `/` route renders `cb-page-dashboard`,
+/// which only ever emits the five most recent contacts, so its output does not
+/// scale with [`CONTACT_COUNTS`] and cannot measure list rendering.
+const REQUEST_PATH: &str = "/contacts";
+
 /// Measurement time per benchmark — 30 s gives criterion enough samples for
 /// stable statistics even at the 1,000-contact scale.
 const MEASUREMENT_TIME: Duration = Duration::from_secs(30);
@@ -28,30 +36,49 @@ const MEASUREMENT_TIME: Duration = Duration::from_secs(30);
 /// Minimum time to spend collecting samples for the summary table.
 const SUMMARY_MIN_TIME: Duration = Duration::from_secs(3);
 
-/// Estimated bytes of HTML output per contact (without plugin).
+/// Measured bytes of HTML output per contact on [`REQUEST_PATH`] (no plugin).
 /// Used to pre-allocate the writer buffer: `count * BYTES_PER_CONTACT + BASE_HTML_BYTES`.
-const BYTES_PER_CONTACT: usize = 512;
+///
+/// `cb-page-contacts` renders one `cb-contact-card` per contact with 12 dynamic
+/// attributes each, measuring ~2,422 B/contact; rounded up for headroom.
+const BYTES_PER_CONTACT: usize = 2_432;
 
-/// Estimated bytes of HTML output per contact with the hydration plugin.
-/// Plugin adds binding markers per signal/loop, increasing output ~50%.
-const BYTES_PER_CONTACT_WITH_PLUGIN: usize = 768;
+/// Same as [`BYTES_PER_CONTACT`] but with the hydration plugin, which adds
+/// binding markers per signal and loop. Measured ~3,651 B/contact.
+const BYTES_PER_CONTACT_WITH_PLUGIN: usize = 3_712;
 
 /// Approximate size of the static HTML shell (head, header, sidebar, chrome)
-/// that is independent of the contact count.
-const BASE_HTML_BYTES: usize = 8_192;
+/// that is independent of the contact count. Measured ~9,787 B.
+const BASE_HTML_BYTES: usize = 12_288;
 
 /// Same as [`BASE_HTML_BYTES`] but for plugin output which includes extra
-/// hydration scaffolding in the shell.
-const BASE_HTML_BYTES_WITH_PLUGIN: usize = 16_384;
+/// hydration scaffolding in the shell. Measured ~21,314 B.
+const BASE_HTML_BYTES_WITH_PLUGIN: usize = 24_576;
 
 /// Extra headroom added to the bench writer beyond the warmup-measured size,
-/// so the buffer is never reallocated during timed iterations.
+/// so the buffer is never reallocated during timed iterations. Rendering is
+/// deterministic, so the timed output matches the warmup byte-for-byte and this
+/// headroom only absorbs incidental drift.
 const WRITER_HEADROOM: usize = 1_024;
 
-/// Initial capacity for the summary writer. 64 KiB is enough for the largest
-/// render (1,000 contacts with plugin produces ~443 KiB, but the summary pass
-/// reuses the same writer via `clear()`).
-const SUMMARY_WRITER_CAPACITY: usize = 64 * 1024;
+/// Largest scale in [`CONTACT_COUNTS`], used to size the summary writer.
+const MAX_CONTACT_COUNT: usize = {
+    let mut max = 0;
+    let mut idx = 0;
+    while idx < CONTACT_COUNTS.len() {
+        if CONTACT_COUNTS[idx] > max {
+            max = CONTACT_COUNTS[idx];
+        }
+        idx += 1;
+    }
+    max
+};
+
+/// Initial capacity for the summary writer, sized for the largest render the
+/// summary pass performs (1,000 contacts with the plugin, ~3.5 MiB). The writer
+/// is reused across scenarios via `clear()`, so one allocation covers them all.
+const SUMMARY_WRITER_CAPACITY: usize =
+    MAX_CONTACT_COUNT * BYTES_PER_CONTACT_WITH_PLUGIN + BASE_HTML_BYTES_WITH_PLUGIN;
 
 /// Expected upper bound of samples collected per summary scenario.
 /// Used only for `Vec::with_capacity` — does not limit collection.
@@ -204,7 +231,7 @@ fn build_contact_state(contact_count: usize) -> Value {
     let recent: Vec<Value> = contacts[contact_count.saturating_sub(recent_count)..].to_vec();
 
     json!({
-        "page": "dashboard",
+        "page": "contacts",
         "searchQuery": "",
         "activeGroup": "all",
         "groups": GROUPS,
@@ -311,7 +338,7 @@ fn protocol_deserialization_bench(c: &mut Criterion) {
 
 fn handler_rendering_bench(c: &mut Criterion) {
     let fixture = setup();
-    let mut group = c.benchmark_group("contact_book_render");
+    let mut group = c.benchmark_group("contact_book_contacts_render");
     group.measurement_time(MEASUREMENT_TIME);
 
     for (count, state) in &fixture.states {
@@ -322,7 +349,7 @@ fn handler_rendering_bench(c: &mut Criterion) {
             .render(
                 &fixture.protocol,
                 state,
-                &RenderOptions::new("index.html", "/"),
+                &RenderOptions::new("index.html", REQUEST_PATH),
                 &mut warmup_writer,
             )
             .unwrap_or_else(|e| panic!("warmup render failed for {count} contacts: {e}"));
@@ -337,7 +364,7 @@ fn handler_rendering_bench(c: &mut Criterion) {
                 h.render(
                     black_box(&fixture.protocol),
                     black_box(state),
-                    &RenderOptions::new("index.html", "/"),
+                    &RenderOptions::new("index.html", REQUEST_PATH),
                     &mut w,
                 )
                 .unwrap_or_else(|e| panic!("render failed for {count} contacts: {e}"));
@@ -354,7 +381,7 @@ fn handler_rendering_bench(c: &mut Criterion) {
 
 fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
     let fixture = setup();
-    let mut group = c.benchmark_group("contact_book_render_fast_plugin");
+    let mut group = c.benchmark_group("contact_book_contacts_render_fast_plugin");
     group.measurement_time(MEASUREMENT_TIME);
 
     for (count, state) in &fixture.states {
@@ -365,7 +392,7 @@ fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
             .render(
                 &fixture.protocol,
                 state,
-                &RenderOptions::new("index.html", "/"),
+                &RenderOptions::new("index.html", REQUEST_PATH),
                 &mut warmup_writer,
             )
             .unwrap_or_else(|e| {
@@ -382,7 +409,7 @@ fn handler_rendering_with_plugin_bench(c: &mut Criterion) {
                 h.render(
                     black_box(&fixture.protocol),
                     black_box(state),
-                    &RenderOptions::new("index.html", "/"),
+                    &RenderOptions::new("index.html", REQUEST_PATH),
                     &mut w,
                 )
                 .unwrap_or_else(|e| panic!("render with plugin failed for {count} contacts: {e}"));
@@ -516,7 +543,7 @@ fn collect_render_samples(
             .render(
                 protocol,
                 state,
-                &RenderOptions::new("index.html", "/"),
+                &RenderOptions::new("index.html", REQUEST_PATH),
                 &mut writer,
             )
             .expect("warmup failed in summary pass");
@@ -534,7 +561,7 @@ fn collect_render_samples(
             .render(
                 black_box(protocol),
                 black_box(state),
-                &RenderOptions::new("index.html", "/"),
+                &RenderOptions::new("index.html", REQUEST_PATH),
                 &mut writer,
             )
             .expect("render failed in summary pass");
@@ -618,11 +645,48 @@ fn run_summary_pass(fixture: &BenchFixture) {
     print_summary(&rows);
 }
 
+/// Fails fast when the benchmark renders a route whose output does not grow
+/// with the contact count.
+///
+/// Renders [`CONTACT_COUNTS`] in ascending order and requires strictly
+/// increasing output. A route that ignores `contacts`/`filteredContacts` —
+/// such as the dashboard, which caps its list at [`MAX_RECENT_CONTACTS`] —
+/// produces a flat byte count and is rejected here instead of silently
+/// reporting meaningless scaling numbers.
+fn validate_output_scales_with_contacts(fixture: &BenchFixture) {
+    let handler = WebUIHandler::new();
+    let mut previous_bytes = 0;
+
+    for (count, state) in &fixture.states {
+        let mut writer = BenchWriter::new(count * BYTES_PER_CONTACT + BASE_HTML_BYTES);
+        handler
+            .render(
+                &fixture.protocol,
+                state,
+                &RenderOptions::new("index.html", REQUEST_PATH),
+                &mut writer,
+            )
+            .unwrap_or_else(|e| panic!("validation render failed for {count} contacts: {e}"));
+
+        assert!(
+            writer.len() > previous_bytes,
+            "benchmark route {REQUEST_PATH} does not scale with the contact count: \
+             {count} contacts produced {} bytes, which is not more than the {previous_bytes} \
+             bytes produced by the previous, smaller scale",
+            writer.len(),
+        );
+        previous_bytes = writer.len();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Custom main — runs criterion then prints the summary table
 // ---------------------------------------------------------------------------
 
 fn main() {
+    let fixture = setup();
+    validate_output_scales_with_contacts(&fixture);
+
     // Run criterion benchmarks (handles --test, filters, etc.)
     benches();
 


### PR DESCRIPTION
## Problem

`crates/webui/benches/contact_book_bench.rs` scales `contacts` / `filteredContacts` to 10 / 100 / 1,000 entries, but every render call used `RenderOptions::new("index.html", "/")`.

Route selection is **request-path driven** — the state `page` field only controls sidebar highlighting. `/` resolves to `cb-page-dashboard`, which renders `recentContacts` capped at `MAX_RECENT_CONTACTS` (5). The scaled arrays were never traversed, so output stayed flat at ~24 KB at every scale and the reported throughput measured nothing about list rendering.

Measured on `main` (no plugin):

| Contacts | `/` output bytes |
| --- | --- |
| 10 | 24,237 |
| 100 | 24,210 |
| 1,000 | 24,253 |

The Node addon benchmark already uses `requestPath: "/contacts"`; the Rust benchmark had drifted.

## Fix

Render `/contacts`, which resolves to `cb-page-contacts` and loops the full contact list, emitting one `cb-contact-card` per contact with 12 dynamic attributes each.

| Contacts | `/contacts` output bytes | with FAST plugin |
| --- | --- | --- |
| 10 | 34,007 | 57,874 |
| 100 | 251,727 | 385,566 |
| 1,000 | 2,431,665 | 3,671,155 |

Changes, all in the one benchmark file:

- **`REQUEST_PATH` constant** (`/contacts`) threaded through all six `RenderOptions` sites — three benchmark groups plus the summary pass.
- **Fixture `page` → `"contacts"`** so sidebar state matches the rendered route.
- **Criterion groups renamed** `contact_book_render*` → `contact_book_contacts_render*`, so stale dashboard baselines cannot be compared against the new workload.
- **Startup guard** `validate_output_scales_with_contacts` renders `CONTACT_COUNTS` in ascending order and fails unless output strictly increases. It fails on the old route with an actionable message, so this regression cannot silently return.
- **Recalibrated buffer constants** against the measured `/contacts` workload (see below).

## Guard proof

Temporarily pointing `REQUEST_PATH` at `/` — the pre-fix behavior — fails immediately:

```
thread 'main' panicked at crates\webui\benches\contact_book_bench.rs:671:9:
benchmark route / does not scale with the contact count: 100 contacts produced
24209 bytes, which is not more than the 24236 bytes produced by the previous,
smaller scale
error: bench failed
```

With `/contacts` restored, `cargo bench -p microsoft-webui --bench contact_book_bench -- --test` passes.

## Buffer sizing

The old constants were calibrated for the dashboard route and under-allocated the real workload by 4–5×, forcing repeated reallocation inside the warmup render.

| Constant | Before | Measured | After | Rationale |
| --- | --- | --- | --- | --- |
| `BYTES_PER_CONTACT` | 512 | ~2,422 B | 2,432 | Marginal cost per contact: (2,431,665 − 251,727) / 900 |
| `BYTES_PER_CONTACT_WITH_PLUGIN` | 768 | ~3,651 B | 3,712 | (3,671,155 − 385,566) / 900 |
| `BASE_HTML_BYTES` | 8,192 | ~9,787 B | 12,288 | 34,007 − 10 × 2,422 |
| `BASE_HTML_BYTES_WITH_PLUGIN` | 16,384 | ~21,314 B | 24,576 | 57,874 − 10 × 3,651 |

Resulting slack is 0.5–7.6% — enough that no scale reallocates, without retaining excessive memory.

- `WRITER_HEADROOM` (1,024) is **unchanged**. Rendering is deterministic, so the timed output matches the warmup byte-for-byte; the headroom only absorbs incidental drift and 1 KiB is adequate.
- `SUMMARY_WRITER_CAPACITY` was 64 KiB with a stale comment claiming a ~443 KiB peak. The real peak is ~3.5 MiB. It is now **derived** from `MAX_CONTACT_COUNT × BYTES_PER_CONTACT_WITH_PLUGIN + BASE_HTML_BYTES_WITH_PLUGIN` (a `const` block, no recursion), so it stays in sync if `CONTACT_COUNTS` changes.

## Validation

```
cargo bench -p microsoft-webui --bench contact_book_bench -- --test          # passes
cargo bench -p microsoft-webui --bench contact_book_bench -- contact_book_contacts_render --quick
cargo xtask check
```

New group IDs, now scaling as expected:

```
contact_book_contacts_render/contacts/10                time: 54.234 µs
contact_book_contacts_render/contacts/100               time: 466.73 µs
contact_book_contacts_render/contacts/1000              time: 4.9881 ms
contact_book_contacts_render_fast_plugin/contacts/10    time: 86.826 µs
contact_book_contacts_render_fast_plugin/contacts/100   time: 570.53 µs
contact_book_contacts_render_fast_plugin/contacts/1000  time: 6.8939 ms
```

`cargo xtask check`: license-headers, fmt, clippy, deny, test, build, build (wasm), build (examples), and **bench (validate)** all pass. The `docs` phase fails locally with `PROJ-C013: Adapter module graph is incomplete or inconsistent`; this reproduces identically on pristine `main` with this change stashed, so it is a pre-existing local baseline failure and is not addressed here.

## Scope

Benchmark correctness only — one file, no lockfile drift, no product code. This makes no performance claim about the framework; it repairs the workload that later benchmarking work depends on.