### PR TITLE
perf(handler): stop native attributes leaking into component state

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -283,6 +283,13 @@ pub struct WebUIFragmentAttribute {
 }
 ```
 
+`attr_start` opens the component attribute collection window and `attr_skip`
+excludes individual attributes from it. The window closes when the matching
+component fragment is entered. Attributes on native elements never carry
+`attr_start`, so they render directly to HTML and never enter component
+attribute state — a native attribute cannot become a local variable of a
+later component.
+
 ##### Attribute Name Mapping
 
 Some HTML attributes use concatenated lowercase names that do not follow

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -417,6 +417,10 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     pub(crate) local_vars: HashMap<String, Value>,
     /// Accumulates component attribute values between attrStart and the component fragment.
     pub(crate) component_attrs: HashMap<String, Value>,
+    /// True only while parser-produced component opening-tag attributes are
+    /// being accumulated. Native element attributes render directly and never
+    /// enter `component_attrs`.
+    collecting_component_attrs: bool,
     /// URL path for server-side route matching. Borrowed from
     /// `RenderOptions<'a>::request_path` — zero-copy.
     pub(crate) request_path: &'protocol str,
@@ -2078,6 +2082,7 @@ impl WebUIHandler {
             take_scope_map(&mut context.scope_pool),
         );
         context.local_vars = saved_component_attrs;
+        context.collecting_component_attrs = false;
 
         if let Some(p) = &mut context.plugin {
             p.push_scope();
@@ -2688,16 +2693,18 @@ impl WebUIHandler {
         attr: &webui_protocol::WebUIFragmentAttribute,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
-        // Initialize component attribute accumulator on attrStart
+        // Initialize component attribute accumulator on attrStart. Clearing the
+        // pooled map keeps its bucket capacity instead of allocating a fresh one.
         if attr.attr_start {
-            context.component_attrs = HashMap::new();
+            context.component_attrs.clear();
+            context.collecting_component_attrs = true;
         }
 
         // Boolean attribute with condition tree
         if let Some(condition) = &attr.condition_tree {
             let condition_met = self.evaluate_condition(condition, context)?;
 
-            if !attr.attr_skip {
+            if context.collecting_component_attrs && !attr.attr_skip {
                 let name = component_attr_name(&attr.name);
                 context
                     .component_attrs
@@ -2717,7 +2724,7 @@ impl WebUIHandler {
             let escaped = crate::html_encode::encode_safe(&raw_value);
             write_attr(context.writer, &attr.name, &escaped)?;
 
-            if !attr.attr_skip {
+            if context.collecting_component_attrs && !attr.attr_skip {
                 let name = component_attr_name(&attr.name);
                 context
                     .component_attrs
@@ -2731,7 +2738,7 @@ impl WebUIHandler {
             if attr.raw_value {
                 // Static attribute — value is the literal string
                 write_attr(context.writer, &attr.name, &attr.value)?;
-                if !attr.attr_skip {
+                if context.collecting_component_attrs && !attr.attr_skip {
                     let name = component_attr_name(&attr.name);
                     context
                         .component_attrs
@@ -2740,7 +2747,7 @@ impl WebUIHandler {
             } else if attr.complex {
                 // Complex attribute — resolve value, don't render to HTML, store as state
                 if let Some(value) = self.resolve_value(&attr.value, context) {
-                    if !attr.attr_skip {
+                    if context.collecting_component_attrs && !attr.attr_skip {
                         let stripped = attr.name.strip_prefix(':').unwrap_or(&attr.name);
                         let name = component_attr_name(stripped);
                         context.component_attrs.insert(name, value);
@@ -2772,7 +2779,7 @@ impl WebUIHandler {
                     }
                 }
 
-                if !attr.attr_skip {
+                if context.collecting_component_attrs && !attr.attr_skip {
                     let name = component_attr_name(&attr.name);
                     context
                         .component_attrs
@@ -2860,6 +2867,7 @@ impl WebUIHandler {
             writer,
             local_vars: HashMap::new(),
             component_attrs: HashMap::new(),
+            collecting_component_attrs: false,
             request_path: options.request_path,
             route_base: Cow::Borrowed("/"),
             rendered_components: HashSet::new(),
@@ -3229,6 +3237,56 @@ mod tests {
         assert_eq!(
             writer.get_content(),
             "top-negated<span>Normal</span><mark>Search</mark>"
+        );
+    }
+
+    #[test]
+    fn native_dynamic_attribute_does_not_leak_into_next_component() {
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<div"),
+                    WebUIFragment {
+                        fragment: Some(web_ui_fragment::Fragment::Attribute(
+                            WebUIFragmentAttribute {
+                                name: "title".into(),
+                                value: "nativeTitle".into(),
+                                ..Default::default()
+                            },
+                        )),
+                    },
+                    WebUIFragment::raw("></div><my-comp>"),
+                    WebUIFragment::component("my-comp"),
+                    WebUIFragment::raw("</my-comp>"),
+                ],
+                contains_boundary: false,
+            },
+        );
+        fragments.insert(
+            "my-comp".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::signal("title", false)],
+                contains_boundary: false,
+            },
+        );
+        let protocol = WebUIProtocol::new(fragments);
+        let state = test_json!({
+            "nativeTitle": "native",
+            "title": "global"
+        });
+        let mut writer = TestWriter::new();
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap_or_else(|error| panic!("render failed: {error}"));
+        assert_eq!(
+            writer.get_content(),
+            "<div title=\"native\"></div><my-comp>global</my-comp>"
         );
     }
 

--- a/crates/webui-handler/src/streaming/inventory.rs
+++ b/crates/webui-handler/src/streaming/inventory.rs
@@ -410,6 +410,7 @@ mod tests {
             writer: &mut writer,
             local_vars: HashMap::new(),
             component_attrs: HashMap::new(),
+            collecting_component_attrs: false,
             request_path: "/account/details",
             route_base: std::borrow::Cow::Borrowed("/account"),
             rendered_components: std::collections::HashSet::new(),

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -539,6 +539,7 @@ impl SessionCore {
             writer,
             local_vars: std::mem::take(&mut self.local_vars),
             component_attrs: std::mem::take(&mut self.component_attrs),
+            collecting_component_attrs: false,
             request_path: options.request_path,
             route_base: self
                 .route_base

--- a/crates/webui-handler/src/streaming/vm.rs
+++ b/crates/webui-handler/src/streaming/vm.rs
@@ -725,6 +725,7 @@ impl ContinuationVm {
             crate::take_scope_map(&mut context.scope_pool),
         );
         context.local_vars = saved_component_attrs;
+        context.collecting_component_attrs = false;
         if let Some(plugin) = context.plugin.as_mut() {
             plugin.push_scope();
         }
@@ -749,6 +750,7 @@ impl ContinuationVm {
         let used_locals = std::mem::replace(&mut context.local_vars, frame.saved_local_vars);
         crate::recycle_scope_map(&mut context.scope_pool, used_locals);
         context.component_attrs.clear();
+        context.collecting_component_attrs = false;
         if frame.owns_css_tree {
             let component = protocol
                 .fragment_id(frame.component_slot)

--- a/crates/webui-handler/tests/streaming_v2.rs
+++ b/crates/webui-handler/tests/streaming_v2.rs
@@ -103,6 +103,40 @@ fn component_local_boundary_suspends_and_emits_v2_span_contract() {
 }
 
 #[test]
+fn native_attribute_does_not_leak_into_next_streamed_component() {
+    let protocol = parsed_protocol(
+        &document(concat!(
+            r#"<boundary name="probe">"#,
+            r#"<div title="{{nativeTitle}}"></div>"#,
+            "<leaf-box></leaf-box>",
+            "</boundary>",
+        )),
+        &[("leaf-box", "<span>{{title}}</span>")],
+    );
+    let mut session = new_session(protocol, "/");
+
+    let state = test_json!({ "nativeTitle": "native", "title": "global" });
+    let start = session.start(&state).unwrap();
+    let boundary = start.boundary.unwrap();
+    let committed = session
+        .resume(boundary.instance_id, &state, BoundaryMode::Final)
+        .unwrap();
+    let html = String::from_utf8(committed.bytes).unwrap();
+    assert!(
+        html.contains(r#"<div title="native">"#),
+        "native attribute should still render: {html}"
+    );
+    assert!(
+        html.contains("<span>global</span>"),
+        "component must resolve `title` from global state, not the leaked native attribute: {html}"
+    );
+    assert!(
+        !html.contains("<span>native</span>"),
+        "native attribute leaked into component state: {html}"
+    );
+}
+
+#[test]
 fn resume_writes_only_the_committed_boundary_and_advance_writes_the_tail() {
     let protocol = parsed_protocol(
         &document(concat!(


### PR DESCRIPTION
## Problem

`process_attribute` accumulated **every** non-skipped attribute into `context.component_attrs`, but only component opening tags carry `attr_start`. Attributes on native elements were collected too, and the next component fragment adopted them as local variables.

```html
<div title="{{nativeTitle}}"></div>
<my-comp></my-comp>   <!-- {{title}} resolved to the div's value, not state -->
```

`<my-comp>` declares no attributes at all, yet rendered `native` instead of the global `title`. Native element state silently leaks into the next component's scope.

## Fix

A new `collecting_component_attrs` flag on `WebUIProcessContext` scopes the accumulation window:

- `attr_start` opens the window (only the parser sets it, and only on component elements).
- Entering a component closes it, so trailing native attributes cannot leak into a sibling.
- The streaming VM clears it on component enter *and* exit, so a leak cannot cross a component or a chunk boundary.

Every `component_attrs.insert` is now gated on the flag. `attr_skip` handling is unchanged.

## Allocation effect

`attr_start` previously did `context.component_attrs = HashMap::new()`, discarding the capacity-preserving map that `process_component`/`begin_component` had just pulled from the scope pool. The pooling was defeated on the very next attribute. Clearing instead of replacing restores it.

A deterministic counting-allocator harness over 500 component instances, measuring only the `render` call:

| | allocations | bytes |
|---|---|---|
| main | 2003 | 129,815 |
| this PR | 1505 | 8,303 |
| delta | **-498** (-24.9%) | **-121,512** (-93.6%) |

Exactly one allocation per component instance is avoided.

**No timing claim is made.** Wall-clock spread on this machine exceeds the effect size: running pristine `main` against its *own* saved criterion baseline reproduces the same 3-19% "regressions" on `handler_state_depth`, so those readings are machine noise, not signal. The deterministic allocation counts above are the claim, and there is no measured regression attributable to this change.

## Tests

Two regression tests, both verified **failing on pristine main** and passing here:

- `native_dynamic_attribute_does_not_leak_into_next_component` (direct render). Main produced `<my-comp>native</my-comp>`, expected `global`.
- `native_attribute_does_not_leak_into_next_streamed_component` (streaming VM path). Main produced `<span>native</span>` inside the boundary chunk.

Output is byte-identical to `main` everywhere except the intentionally fixed leak case, and the full workspace suite passes unchanged.

## Gate

`cargo xtask check`: `license-headers`, `fmt`, `clippy`, `proto (drift check)`, `deny`, `test`, `build`, `build (wasm)`, `build (examples)`, `bench (validate)` all pass.

The `docs` phase fails with `PROJ-C013: Adapter module graph is incomplete or inconsistent`. This is **pre-existing and unrelated**. The identical failure was reproduced on pristine `main` (`2efb60e`) before any change here, and is deliberately not addressed in this PR.

## Scope

Touches only the handler attribute-collection gate plus its DESIGN.md contract note. No manifest, lockfile, benchmark, or example changes.
