### PR TITLE
perf(expressions): fast-path single-term conditions

### DIFF
--- a/crates/webui-expressions/src/lib.rs
+++ b/crates/webui-expressions/src/lib.rs
@@ -57,6 +57,16 @@ pub fn evaluate_with_resolver<'a, F>(condition: &ConditionExpr, resolver: F) -> 
 where
     F: Fn(&str) -> Option<Cow<'a, Value>>,
 {
+    // Single-term conditions carry no logical operators, so the traversal in
+    // `count_logical_operators` (and the allocation backing its stack) is pure
+    // overhead for the most common template conditions.
+    if matches!(
+        condition.expr,
+        Some(condition_expr::Expr::Identifier(_)) | Some(condition_expr::Expr::Predicate(_))
+    ) {
+        return evaluate_expr(condition, &resolver);
+    }
+
     let (logical_op_count, has_mixed_ops) = count_logical_operators(condition);
 
     if logical_op_count > 5 {
@@ -939,6 +949,125 @@ mod tests {
             matches!(result, Ok(true)),
             "Expected Ok(true), got {:?}",
             result
+        );
+    }
+
+    // === Single-term fast path ===
+
+    #[test]
+    fn test_single_term_matches_operator_guard_semantics() {
+        let state = test_json!({
+            "flag": true,
+            "off": false,
+            "count": 0,
+            "name": "Alice",
+            "user": { "age": 25 }
+        });
+
+        // Single identifiers and predicates carry no logical operators, so they
+        // must evaluate normally and never surface an operator-limit error.
+        let cases: [(ConditionExpr, bool); 6] = [
+            (ConditionExpr::identifier("flag"), true),
+            (ConditionExpr::identifier("off"), false),
+            (ConditionExpr::identifier("count"), false),
+            (ConditionExpr::identifier("name"), true),
+            (
+                ConditionExpr::predicate("user.age", ComparisonOperator::GreaterThan, "18"),
+                true,
+            ),
+            (
+                ConditionExpr::predicate("name", ComparisonOperator::Equal, "'Bob'"),
+                false,
+            ),
+        ];
+
+        for (condition, expected) in cases {
+            assert_eq!(
+                evaluate(&condition, &state).ok(),
+                Some(expected),
+                "single-term condition {:?} must evaluate to {}",
+                condition,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_single_term_predicate_still_reports_missing_value() {
+        let state = test_json!({ "user": { "name": "John" } });
+        let condition = ConditionExpr::predicate("user.age", ComparisonOperator::LessThan, "18");
+
+        assert!(matches!(
+            evaluate(&condition, &state),
+            Err(ExpressionError::MissingValue(_))
+        ));
+    }
+
+    #[test]
+    fn test_negated_tree_still_enforces_operator_limit() {
+        // A `Not` wrapper must not be mistaken for a single term: the operator
+        // guard has to keep walking the tree underneath it.
+        let mut inner = ConditionExpr::identifier("a");
+        for i in 0..6 {
+            inner = ConditionExpr::compound(
+                inner,
+                LogicalOperator::And,
+                ConditionExpr::identifier(format!("var{}", i)),
+            );
+        }
+        let condition = ConditionExpr::negated(inner);
+
+        let state = test_json!({
+            "a": true, "var0": true, "var1": true,
+            "var2": true, "var3": true, "var4": true, "var5": true
+        });
+
+        assert!(matches!(
+            evaluate(&condition, &state),
+            Err(ExpressionError::TooManyOperators(6))
+        ));
+    }
+
+    #[test]
+    fn test_negated_tree_still_rejects_mixed_operators() {
+        let condition = ConditionExpr::negated(ConditionExpr::compound(
+            ConditionExpr::compound(
+                ConditionExpr::identifier("a"),
+                LogicalOperator::And,
+                ConditionExpr::identifier("b"),
+            ),
+            LogicalOperator::Or,
+            ConditionExpr::identifier("c"),
+        ));
+
+        let state = test_json!({ "a": true, "b": true, "c": true });
+
+        assert!(matches!(
+            evaluate(&condition, &state),
+            Err(ExpressionError::MixedOperators)
+        ));
+    }
+
+    #[test]
+    fn test_single_term_fast_path_uses_same_resolver_contract() {
+        let value = Value::String("active".to_string());
+        let lookups = std::cell::Cell::new(0usize);
+
+        let condition = ConditionExpr::predicate("status", ComparisonOperator::Equal, "'active'");
+        let result = evaluate_with_resolver(&condition, |path| {
+            lookups.set(lookups.get() + 1);
+            if path == "status" {
+                Some(Cow::Borrowed(&value))
+            } else {
+                None
+            }
+        });
+
+        assert!(matches!(result, Ok(true)));
+        assert_eq!(
+            lookups.get(),
+            1,
+            "a single-term predicate must resolve exactly one path"
         );
     }
 }


### PR DESCRIPTION
## Summary

`evaluate_with_resolver` always ran `count_logical_operators` before evaluating, even for a bare `Identifier` or `Predicate`. Those expressions cannot contain a logical operator, so the walk is guaranteed to return `(0, false)` — but it still allocates the `Vec` backing its traversal stack on every evaluation. Since single-term conditions are the overwhelmingly common shape in real templates (`{#if isAdmin}`, `{#if item.state == 'done'}`), that allocation sat directly in the hottest render path.

This short-circuits those two variants straight to `evaluate_expr`.

## Semantics

Unchanged. `count_logical_operators` returns `(0, false)` for a single term today, so the fast path is provably equivalent:

- The max-logical-operator guard and the mixed-operator guard still run for **every** `Not` and `Compound` tree — `Not` is deliberately *not* fast-pathed, so a `Not`-wrapped compound is still fully walked.
- Predicate coercion, missing-path falsiness for identifiers, `MissingValue` errors for comparison predicates, and every error variant are untouched.
- The `None` expr case still falls through to the existing path.

## Performance

Measured with the existing `expressions_bench`, interleaved pristine/patched runs (pristine → patched → pristine → patched) because the machine showed drift. Criterion medians:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `expr_identifier/boolean` | 32.16 ns | 13.21 ns | **−57.2%** |
| `expr_identifier/number` | 31.77 ns | 8.73 ns | **−72.8%** |
| `expr_identifier/string` | 32.84 ns | 14.00 ns | **−56.8%** |
| `expr_identifier/deep_path` | 47.90 ns | 35.07 ns | **−22.1%** |
| `expr_predicate/string_eq` | 70.81 ns | 43.82 ns | **−38.7%** |
| `expr_predicate/string_neq` | 73.59 ns | 44.22 ns | **−38.0%** |
| `expr_predicate/numeric_gt` | 50.62 ns | 23.95 ns | **−51.9%** |
| `expr_predicate/numeric_lte` | 51.35 ns | 25.88 ns | **−50.0%** |
| `expr_predicate/var_vs_var` | 51.42 ns | 25.43 ns | **−50.6%** |
| `expr_realistic/state_check` | 77.24 ns | 49.36 ns | **−36.0%** |

Controls (untouched code paths) — all inside the noise floor:

| Control | Δ | Verdict |
|---|---|---|
| `expr_compound/and_2_terms` | −1.6% | No change |
| `expr_compound/and_3_terms` | +2.2% | No change |
| `expr_compound/or_short_circuit` | −0.1% | No change |
| `expr_compound/or_full_eval` | +0.2% | No change |
| `expr_compound/and_short_circuit` | −4.3% | Within noise |
| `expr_negation/simple` | −2.1% | No change |
| `expr_negation/predicate` | +4.7% | Within noise |
| `expr_realistic/admin_check` | +4.2% | Within noise |
| `expr_realistic/auth_guard` | −1.4% | No change |

**Noise assessment:** a pristine-vs-pristine run (identical code, no patch) was used to establish the floor and showed swings of up to ±5% typically, with one outlier case at ~19%. The single-term improvements (22–73%) are an order of magnitude above that floor and reproduced consistently across two independent patched runs. The small positive deltas on the compound/negation controls sit inside the measured floor and touch no modified code.

## Tests

Five focused tests added alongside the existing 31:

- `test_single_term_matches_operator_guard_semantics` — single identifiers and predicates evaluate correctly across bool/zero/empty-string/truthy shapes and never surface an operator error.
- `test_single_term_predicate_still_reports_missing_value` — the fast path still returns `MissingValue`.
- `test_negated_tree_still_enforces_operator_limit` — a `Not`-wrapped 6-operator tree still returns `TooManyOperators(6)`, proving `Not` was not swept into the fast path.
- `test_negated_tree_still_rejects_mixed_operators` — a `Not`-wrapped mixed tree still returns `MixedOperators`.
- `test_single_term_fast_path_uses_same_resolver_contract` — the resolver is invoked exactly once, unchanged.

`cargo test -p microsoft-webui-expressions`: 36 passed, 0 failed. Benchmark smoke (`--test`): all cases pass.

## Gate

`cargo xtask check`: `license-headers`, `fmt`, `clippy`, `proto` drift, `deny`, `test`, `build`, `build (wasm)`, `build (examples)`, and `bench (validate)` all pass.

The `docs` phase fails locally with `PROJ-C013: Adapter module graph is incomplete or inconsistent` (esbuild). This is a **pre-existing baseline failure**: it was re-verified on a clean tree at the merge base `2efb60e4` with this change stashed, and reproduces identically. Not addressed here — out of scope.

## Scope

One file, `crates/webui-expressions/src/lib.rs`. No dependency or lockfile changes; no handler, node, framework, router, docs, `DESIGN.md`, benchmark fixture, or example changes.