### PR TITLE
chore: clarify slot resolution comments

### DIFF
--- a/packages/webui-framework/RENDERING.md
+++ b/packages/webui-framework/RENDERING.md
@@ -220,10 +220,10 @@ Two details shape the walk:
 
 ### Text slot boundaries
 
-Text is the one thing that cannot use the element index directly. The compiler
-emits each dynamic slot as `[parentIndex, beforeIndex, order?]`. `order`
-disambiguates text, conditional, and repeat bindings removed at the same static
-child offset.
+Text bindings cannot use the pre-order element table directly because that
+table contains only elements. The compiler instead emits each dynamic slot as
+`[parentIndex, beforeIndex, order?]`. `order` disambiguates text, conditional,
+and repeat bindings removed at the same static child offset.
 
 During hydration, the runtime finds the slot's right-hand boundary: the next
 co-located structural marker by `order`, or the next static child. A

--- a/packages/webui-framework/src/element/markers.ts
+++ b/packages/webui-framework/src/element/markers.ts
@@ -328,13 +328,15 @@ export function buildSSRIndex(
  * type are handled via depth tracking. Returns the child at the given
  * `ordinal`, or null.
  *
- * Used by static slot fallback to keep SSR node ordinals aligned with the
- * template. Elements are addressed by pre-order index instead (see
- * `buildSSRIndex`); text cannot be, because the renderer strips whitespace
- * that `meta.h` keeps.
+ * Used by static slot fallback to keep SSR nodes aligned with the template.
+ * Element bindings resolve directly from the stable pre-order element table
+ * built by `buildSSRIndex`. Text bindings cannot use that table because SSR
+ * strips formatting-whitespace text nodes that remain in `meta.h`; their
+ * fallback boundaries are therefore located by node type and ordinal.
  *
- * **Requires closing markers to still be in the DOM** — caller must
- * not remove `<!--/wc-->` or `<!--/wr-->` before all resolution is done.
+ * **Requires closing markers to still be in the DOM** - caller must retain
+ * `<!--/wc-->`, `<!--/wr-->`, and paired raw-range end markers until all
+ * resolution is done.
  */
 export function findByOrdinal(parent: Node, nodeType: number, ordinal: number): Node | null {
   let count = 0;

--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -153,8 +153,7 @@ const rootTagCache = new WeakMap<TemplateBlockMeta, string | null>();
 /** Parsed template DOM for SSR path mapping, keyed by TemplateBlockMeta. */
 const templateDOMCache = new WeakMap<TemplateBlockMeta, Element>();
 
-/** Pre-computed ordinals for template nodes: childIndex → [nodeType, ordinal].
- *  Avoids re-counting siblings on every text-slot resolution. */
+/** Per-child node-type ordinals used when a text slot has no dynamic boundary. */
 const tplOrdinalCache = new WeakMap<Node, Map<number, [nodeType: number, ordinal: number]>>();
 /** Encoded next marker boundary per text slot, built once per template. */
 const textMarkerBoundaryCache = new WeakMap<TemplateBlockMeta, Int32Array>();
@@ -169,11 +168,16 @@ const RAW_MARKER_BOUNDARY_BASE = 0x40000000;
  */
 const tplElementCache = new WeakMap<Node, Array<Node | undefined>>();
 
+/**
+ * A dynamic node and the static DOM reference captured before wiring mutates
+ * the cloned template. Raw HTML owns two nodes; every other slot owns one.
+ */
 interface PendingSlot {
   parent: Node;
   before: Node | null;
   order: number;
   node: Node;
+  /** Paired raw-HTML end anchor. */
   end?: Comment;
 }
 
@@ -181,6 +185,13 @@ function comparePendingSlots(left: PendingSlot, right: PendingSlot): number {
   return left.order - right.order;
 }
 
+/**
+ * Insert queued dynamic nodes after all static references have been captured.
+ *
+ * `order` is local to slots sharing one `(parent, before)` reference. Sorting
+ * the complete queue is safe because insertions at different references
+ * commute; only colliding slots need a relative order.
+ */
 function insertPendingSlots(
   slots: PendingSlot[],
   count: number,
@@ -1768,9 +1779,8 @@ export class TemplateElement extends HTMLElement {
       texts: [], attrs: [], conds: [], repeats: [],
     };
 
-    // Resolve ALL slot reference nodes BEFORE inserting any anchors.
-    // Inserting comment anchors shifts childNode indices, so we must
-    // capture target positions from the untouched DOM first.
+    // Resolve every static insertion reference before inserting dynamic nodes.
+    // Any insertion shifts childNodes and invalidates later compiled offsets.
     //
     // Cloned template DOM matches `h` exactly, so numbering its elements in
     // pre-order reproduces the indices the compiler assigned.

--- a/packages/webui-framework/src/template-types.ts
+++ b/packages/webui-framework/src/template-types.ts
@@ -28,7 +28,8 @@ export type TemplateNodeIndex = number;
  *
  * `order` disambiguates text, conditional, and repeat bindings removed at the
  * same static child offset. It starts at zero for each `(parentIndex,
- * beforeIndex)` pair and is omitted for the first binding.
+ * beforeIndex)` pair, is omitted for the first binding, and has no ordering
+ * meaning between different pairs.
  */
 export type TemplateSlot = [
   parentIndex: TemplateNodeIndex,


### PR DESCRIPTION
The slot-resolution comments left important subjects implicit, including what “text cannot be” referred to and why group-local ordering can be applied through one placement queue.

This follow-up clarifies:
- why element bindings use the pre-order element table while text bindings use slot boundaries
- what a `PendingSlot` owns, including paired raw-HTML end anchors
- why sorting the complete queue by group-local order is safe for independent references
- why all static references must be captured before DOM insertion
- which structural and raw-range closing markers must remain during fallback resolution

No runtime behavior changes.

Validation:
- `cargo xtask check`: all phases passed