### PR TITLE
fix: allow SSR bootstrap without component styles

### DIFF
--- a/packages/webui-framework/src/template.test.ts
+++ b/packages/webui-framework/src/template.test.ts
@@ -153,7 +153,7 @@ describe('template registry helpers', () => {
     }
   });
 
-  test('getTemplate lazily loads webui-data and preserves eager runtime metadata', () => {
+  test('getTemplate loads webui-data without componentStyles and preserves eager runtime metadata', () => {
     const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
     const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
     const fn = (): boolean => true;
@@ -175,7 +175,7 @@ describe('template registry helpers', () => {
           getElementById(id: string) {
             if (id !== 'webui-data') return null;
             return {
-              textContent: '{"inventory":"0c","state":{"title":"Hello"},"componentStyles":{"version":1,"strategy":"style","resources":{},"closures":{}},"templates":{"greeting":{"h":"<p></p>","b":[{"h":"<span></span>"}],"c":[[[0,["ready"]],0,[[],0]]]}}}',
+              textContent: '{"inventory":"0c","state":{"title":"Hello"},"templates":{"greeting":{"h":"<p></p>","b":[{"h":"<span></span>"}],"c":[[[0,["ready"]],0,[[],0]]]}}}',
               remove() { removed = true; },
             };
           },
@@ -188,6 +188,7 @@ describe('template registry helpers', () => {
       assert.equal((registered.c![0][0][0] as unknown), fn);
       assert.equal(window.__webui!.inventory, '0c');
       assert.deepEqual(window.__webui!.state, { title: 'Hello' });
+      assert.equal(window.__webui!.componentStyles, undefined);
       assert.deepEqual(
         window.__webui!.componentAssetStyles,
         { 'lazy-panel': ['/lazy-panel.css'] },

--- a/packages/webui-framework/src/template.ts
+++ b/packages/webui-framework/src/template.ts
@@ -264,14 +264,16 @@ function loadWebUIDataBlock(): void {
     const parsed = JSON.parse(text) as NonNullable<Window['__webui']>;
     if (templateFns) parsed.templateFns = templateFns;
     if (componentAssetStyles) parsed.componentAssetStyles = componentAssetStyles;
-    // Publish before registering styles. A malformed `componentStyles` throws,
+    // Publish before registering styles. A malformed present `componentStyles` throws,
     // and doing it the other way round loses the templates and state that
     // parsed fine — then re-parses the whole block on the next lookup, because
     // nothing recorded that the work was already done.
     window.__webui = parsed;
     el.remove();
     webuiDataLoaded = true;
-    registerComponentStyles(parsed.componentStyles);
+    if (parsed.componentStyles !== undefined) {
+      registerComponentStyles(parsed.componentStyles);
+    }
     return;
   }
   el.remove();


### PR DESCRIPTION
## Summary

- allow inert `#webui-data` startup blocks to omit `componentStyles`
- preserve strict validation for malformed `componentStyles` values when the field is present
- cover the templates/state-only bootstrap regression introduced by #429

## Validation

- regression-red proof produced `[WebUI] componentStyles is required.` with the pre-fix loader
- `pnpm --dir packages/webui-framework test:unit`
- `pnpm --dir packages/webui-framework typecheck:e2e`
- `pnpm --dir packages/webui-framework exec playwright test lazy-hydration.spec.ts light-shadow-policy.spec.ts` (37 passed)
- `WEBUI_LAZY_HYDRATION_RUNS=1 WEBUI_LAZY_HYDRATION_TRACE_RUNS=0 pnpm --dir examples/integration/streaming-browser-bench test:lazy-hydration` (1 passed)
- `cargo xtask check`