### PR TITLE
perf(node): reuse prepared state across renders

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5009,7 +5009,13 @@ The `@microsoft/webui` npm package follows the esbuild single-package model:
   accept protocol bytes on every call
 - `Protocol.render()` returns the rendered UTF-8 bytes as the canonical Node
   `Buffer` result; callers explicitly decode it when they need a JavaScript
-  string; `Protocol.renderStream()` batches callbacks with a 16 KiB target
+  string
+- `Protocol.prepareState()` creates an immutable, process-local native state
+  snapshot for repeated renders, and `Protocol.renderPrepared()` renders that
+  snapshot without another stringify/parse cycle; snapshots never observe later
+  source object mutations, retain their native state tree until JavaScript
+  garbage collection, and must be recreated when request state changes
+- `Protocol.renderStream()` batches callbacks with a 16 KiB target
   instead of crossing into JavaScript for every internal handler fragment;
   callbacks are synchronous, arbitrary return values are ignored, and thrown
   errors abort rendering immediately; the API cannot await Node transport

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -29,7 +29,7 @@
 
 use std::sync::Arc;
 
-use napi::bindgen_prelude::{Buffer, Either, Function};
+use napi::bindgen_prelude::{Buffer, Either, External, Function};
 use napi::Error as NapiError;
 use napi_derive::napi;
 use serde_json::Value;
@@ -282,9 +282,32 @@ impl Protocol {
     ) -> napi::Result<Buffer> {
         let state = parse_state_json(&state_json)?;
         let options = RenderOptions::new(&entry, &request_path);
-        let html = render_to_string(&self.handler, &self.inner, &state, &options)?;
-        // napi-rs can expose the existing Vec as an external Buffer on Node.
-        Ok(Buffer::from(html.into_bytes()))
+        self.render_buffer(&state, &options)
+    }
+
+    /// Parse and retain an immutable, process-local state snapshot.
+    ///
+    /// The returned N-API external owns the parsed state until its JavaScript
+    /// handle is garbage-collected.
+    #[napi]
+    pub fn prepare_state(&self, state_json: String) -> napi::Result<External<Value>> {
+        let size_hint = state_json.len().saturating_mul(2);
+        Ok(External::new_with_size_hint(
+            parse_state_json(&state_json)?,
+            size_hint,
+        ))
+    }
+
+    /// Render an immutable state snapshot prepared by this process.
+    #[napi]
+    pub fn render_prepared(
+        &self,
+        state: &External<Value>,
+        entry: String,
+        request_path: String,
+    ) -> napi::Result<Buffer> {
+        let options = RenderOptions::new(&entry, &request_path);
+        self.render_buffer(state.as_ref(), &options)
     }
 
     /// Stream an existing JSON string in bounded chunks.
@@ -363,6 +386,14 @@ impl Protocol {
         )
         .map_err(streaming_error)?;
         Ok(StreamingSession { inner })
+    }
+}
+
+impl Protocol {
+    fn render_buffer(&self, state: &Value, options: &RenderOptions<'_>) -> napi::Result<Buffer> {
+        let html = render_to_string(&self.handler, &self.inner, state, options)?;
+        // napi-rs can expose the existing Vec as an external Buffer on Node.
+        Ok(Buffer::from(html.into_bytes()))
     }
 }
 

--- a/docs/guide/integrations/node.md
+++ b/docs/guide/integrations/node.md
@@ -98,6 +98,8 @@ Deno.serve({ port: 3000 }, (req) => {
 | `build(options)` | Build templates into a protocol. Returns `{ protocol, cssFiles, componentAssetFiles, metafile?, warnings, stats }` |
 | `new Protocol(protocol, options?)` | Decode and index protocol bytes once and bind the selected plugin |
 | `protocol.render(state, options?)` | Render into a UTF-8 `Buffer` for direct HTTP writes |
+| `protocol.prepareState(state)` | Parse an immutable, process-local native state snapshot once |
+| `protocol.renderPrepared(state, options?)` | Render a prepared snapshot without serializing or parsing it again |
 | `protocol.renderStream(state, onChunk, options?)` | Render with callbacks coalesced around a 16 KiB target before crossing into JavaScript |
 | `protocol.streamResponse(options?)` | Open a [progressive streaming session](#progressive-streaming) that returns one `Buffer` per host call |
 | `protocol.renderPartial(state, entry, requestPath, inventory)` | Produce a complete partial-navigation JSON response |
@@ -153,6 +155,30 @@ synchronous and its return value is ignored. A `false` result from
 `response.write()` cannot pause native rendering or wait for `drain`, so this
 API does not provide transport backpressure. Callback exceptions abort the
 render immediately and propagate to the caller.
+
+### Reusing immutable state
+
+When one state snapshot is rendered more than once, prepare it alongside the
+protocol:
+
+```js
+const cachedState = protocol.prepareState(await loadCatalogState());
+
+const server = createServer((_req, res) => {
+  res.end(protocol.renderPrepared(cachedState));
+});
+```
+
+Preparation performs serialization and native JSON parsing once.
+`renderPrepared()` reuses the immutable native tree and produces the same bytes
+as `render()` for matching options. Later mutations to the source object are not
+visible; create a new prepared state when request data changes.
+
+The opaque handle is process-local and cannot be serialized. It retains the
+native state tree until JavaScript garbage collection releases the handle, so
+this API trades resident native memory for lower repeated-render CPU and
+allocation pressure. Ordinary per-request state should continue to use
+`render()`.
 
 ### BuildOptions
 

--- a/examples/integration/node-addon-bench/README.md
+++ b/examples/integration/node-addon-bench/README.md
@@ -61,8 +61,10 @@ directly.
 | Case | Boundary included | What it tells you |
 |---|---|---|
 | `protocol/new` | Node `Buffer` -> N-API -> protobuf decode/index | `Protocol` construction after the addon is loaded |
+| `prepare-state/N` | Pre-serialized JSON -> N-API -> JSON parse -> immutable native snapshot | One-time preparation cost for repeated state |
 | `render/json-string/N` | JS string -> N-API -> JSON parse -> Rust render -> external Node `Buffer` | canonical buffered response when state is already serialized |
 | `render/object/N` | `JSON.stringify` plus the JSON-string path | public-package cost for the common object-state API |
+| `render/prepared/N` | Prepared native state -> Rust render -> external Node `Buffer` | repeated render cost without serialization or JSON parsing |
 | `render-stream/...`, `first-callback` | JS string -> N-API -> JSON parse -> render to first 16 KiB -> JS callback | latency until JavaScript receives the first chunk |
 | `render-stream/...`, `total` | the same input path plus all chunks and callbacks | complete streaming callback-path cost |
 
@@ -92,13 +94,23 @@ runner.
 - Warms each operation before collecting samples.
 - Runs garbage collection once before each sample group when Node exposes it;
   GC is not forced between individual operations.
+- Keeps one prepared snapshot per workload live throughout render sampling.
+  Preparation rows allocate fresh snapshots, so their timing includes natural
+  V8 GC pressure after the group-level collection.
 - Collects at least 20 samples per row and targets 750 ms of measurement time.
 - Reports workload sizes/chunk counts plus min, P50, P95, P99, and
   mean-derived ops/s.
-- Verifies object and JSON-string inputs produce byte-identical buffers.
+- Verifies object, JSON-string, and prepared inputs produce byte-identical
+  buffers.
 - Verifies concatenated streaming chunks exactly equal buffered output.
 - Rejects empty protocols, missing chunks, malformed baselines, unsafe baseline
   names, and accidental debug measurements.
+
+Each prepared handle retains a parsed Rust state tree until JavaScript garbage
+collection. The addon reports an approximate external-memory size to V8 so the
+collector can account for that pressure, but this runner does not report native
+allocation counts or RSS. Interpret `render/prepared/N` as the CPU benefit for a
+deliberately retained immutable snapshot, not as a free per-request optimization.
 
 For raw machine-readable output:
 

--- a/examples/integration/node-addon-bench/bench.mjs
+++ b/examples/integration/node-addon-bench/bench.mjs
@@ -577,6 +577,12 @@ async function main() {
       objectBuffer.equals(expectedBuffer),
       `object and JSON-string render differ at ${contactCount} contacts`,
     );
+    const prepared = protocol.prepareState(stateJson);
+    const preparedBuffer = protocol.renderPrepared(prepared, RENDER_OPTIONS);
+    assert.ok(
+      preparedBuffer.equals(expectedBuffer),
+      `prepared-state render differs at ${contactCount} contacts`,
+    );
     const expected = expectedBuffer.toString("utf8");
     const chunks = [];
     protocol.renderStream(
@@ -595,6 +601,7 @@ async function main() {
       contactCount,
       state,
       stateJson,
+      prepared,
       expected,
       inputBytes: Buffer.byteLength(stateJson),
       outputBytes: expectedBuffer.length,
@@ -620,6 +627,28 @@ async function main() {
       outputBytes: fixture.outputBytes,
     };
 
+    results.push(
+      makeResult(
+        `prepare-state/${fixture.contactCount}`,
+        "total",
+        collectSyncSamples(
+          () => protocol.prepareState(fixture.stateJson),
+          config,
+        ),
+        details,
+      ),
+    );
+    results.push(
+      makeResult(
+        `render/prepared/${fixture.contactCount}`,
+        "total",
+        collectSyncSamples(
+          () => protocol.renderPrepared(fixture.prepared, RENDER_OPTIONS),
+          config,
+        ),
+        details,
+      ),
+    );
     results.push(
       makeResult(
         `render/json-string/${fixture.contactCount}`,

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -156,6 +156,26 @@ response.end(protocol.render({ title: "Hello" }));
 Call `.toString("utf8")` explicitly when JavaScript string operations are
 required.
 
+### `protocol.prepareState(state)` / `protocol.renderPrepared(state, options?)`
+
+Use an immutable prepared state only when the same snapshot will be rendered
+repeatedly, such as a cached page shell or fan-out response:
+
+```js
+const state = protocol.prepareState({ title: "Cached" });
+response.end(protocol.renderPrepared(state));
+```
+
+Preparation performs object serialization and native JSON parsing once.
+`renderPrepared()` reuses the parsed native tree and returns bytes identical to
+`render()` for the same state and options. The opaque handle is process-local,
+cannot be serialized, and does not observe later mutations to the source object.
+
+A prepared state retains its native tree until the handle is garbage-collected.
+This trades resident native memory for avoiding repeated stringify/parse work.
+Prepare a new snapshot whenever request state changes, and continue to use
+`render()` for ordinary per-request state.
+
 ### `protocol.renderStream(state, onChunk, options?): void`
 
 Renders with streaming output. Internal handler writes are coalesced around a

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -223,6 +223,8 @@ interface NativeAddon {
 
 interface NativeProtocol {
   render(stateJson: string, entry: string, requestPath: string): Buffer;
+  prepareState(stateJson: string): PreparedState;
+  renderPrepared(state: PreparedState, entry: string, requestPath: string): Buffer;
   renderStream(
     stateJson: string,
     entry: string,
@@ -241,6 +243,18 @@ interface NativeProtocol {
   renderPartial(stateJson: string, entryId: string, requestPath: string, inventoryHex: string): string;
   renderComponentTemplates(componentTags: string[], inventoryHex: string): string;
   tokens(): string[];
+}
+
+declare const preparedStateBrand: unique symbol;
+
+/**
+ * An immutable, process-local native state snapshot.
+ *
+ * The snapshot retains its parsed native state until this handle is garbage
+ * collected. Create snapshots only for state that will be rendered repeatedly.
+ */
+export interface PreparedState {
+  readonly [preparedStateBrand]: never;
 }
 
 interface NativeStreamingSession {
@@ -352,6 +366,27 @@ export class Protocol {
     const stateJson = typeof state === "string" ? state : JSON.stringify(state);
     return this.#native.render(
       stateJson,
+      options?.entry ?? "index.html",
+      options?.requestPath ?? "/",
+    );
+  }
+
+  /**
+   * Parse state once for repeated rendering.
+   *
+   * The returned snapshot is immutable and does not observe later mutations to
+   * the source object. Prepare a new snapshot when request state changes.
+   */
+  prepareState(state: object | string): PreparedState {
+    return this.#native.prepareState(
+      typeof state === "string" ? state : JSON.stringify(state),
+    );
+  }
+
+  /** Render a prepared state snapshot without serializing or parsing it again. */
+  renderPrepared(state: PreparedState, options?: RenderOptions): Buffer {
+    return this.#native.renderPrepared(
+      state,
       options?.entry ?? "index.html",
       options?.requestPath ?? "/",
     );

--- a/packages/webui/test/integration.test.ts
+++ b/packages/webui/test/integration.test.ts
@@ -16,6 +16,7 @@ import {
 import type {
   BoundaryDescriptor,
   ComponentTemplatesResponse,
+  PreparedState,
   StreamStep,
 } from '@microsoft/webui';
 import { existsSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
@@ -234,6 +235,25 @@ describe('render', () => {
       .toString('utf8');
     assert.ok(objectHtml.includes('Hello, Object!'));
     assert.ok(jsonHtml.includes('Hello, JSON!'));
+  });
+
+  test('renders an immutable prepared state repeatedly', () => {
+    const result = build({ appDir });
+    const protocol = new Protocol(result.protocol);
+    const source = { name: 'Prepared', items: ['a', 'b'], show: true };
+    const expected = protocol.render(source);
+    const prepared = protocol.prepareState(source);
+    source.name = 'Mutated';
+    source.items.push('c');
+    source.show = false;
+
+    const first = protocol.renderPrepared(prepared);
+    const second = protocol.renderPrepared(prepared);
+    assert.ok(Buffer.isBuffer(first));
+    assert.deepEqual(first, expected);
+    assert.deepEqual(second, expected);
+    assert.ok(first.toString('utf8').includes('Hello, Prepared!'));
+    assert.throws(() => protocol.renderPrepared({} as PreparedState));
   });
 
   test('owns decoded state independently of source buffer mutations', () => {


### PR DESCRIPTION
## Summary

- add opaque `PreparedState` snapshots backed by N-API `External<Value>`
- add `Protocol.prepareState()` and `Protocol.renderPrepared()` while sharing the existing buffered render path
- document immutable, process-local ownership and retained native-memory tradeoffs
- extend the Node addon benchmark with preparation and prepared-render cases

## Performance

Release Node addon benchmark on Windows x64 with Node 24.18.0. Prepared and JSON-string renders produced byte-identical output at every workload.

| Contacts | JSON-string P50 | Prepared P50 | Delta | Prepare P50 | Amortized after |
|---:|---:|---:|---:|---:|---:|
| 10 | 93.00 us | 60.80 us | -34.6% | 29.10 us | 1 render |
| 100 | 714.10 us | 443.10 us | -37.9% | 396.20 us | 2 renders |
| 1000 | 8.26 ms | 5.19 ms | -37.2% | 3.99 ms | 2 renders |

This is an opt-in repeated-state optimization. It removes per-render JSON parsing and associated allocation/GC churn, but each live prepared handle retains one parsed native `Value` until JavaScript garbage collection. The N-API external reports an approximate external-memory size to V8.

## Validation

- `cargo test -p microsoft-webui-node`
- `pnpm --filter @microsoft/webui test` - 62 passed
- `cargo xtask bench node-addon`
- `cargo xtask check`