### PR TITLE
perf: reuse Node render output capacity

### DIFF
--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -27,6 +27,7 @@
 //! protocol.renderStream(state, 'index.html', '/', (chunk) => process.stdout.write(chunk));
 //! ```
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use napi::bindgen_prelude::{Buffer, Either, External, Function};
@@ -45,6 +46,75 @@ use webui_handler::{
 use webui_protocol::WebUIProtocol;
 
 const STREAM_CHUNK_SIZE: usize = 16 * 1024;
+const INITIAL_RENDER_CAPACITY: usize = 4 * 1024;
+const MAX_RENDER_CAPACITY_HINT: usize = 1024 * 1024;
+const RENDER_CAPACITY_BUCKETS: usize = 64;
+const RENDER_CAPACITY_MASK: usize = (1 << 21) - 1;
+const _: () = assert!(RENDER_CAPACITY_BUCKETS.is_power_of_two());
+const _: () = assert!(MAX_RENDER_CAPACITY_HINT <= RENDER_CAPACITY_MASK);
+
+#[cfg(target_pointer_width = "64")]
+const CAPACITY_HASH_OFFSET: usize = 14_695_981_039_346_656_037;
+#[cfg(target_pointer_width = "64")]
+const CAPACITY_HASH_PRIME: usize = 1_099_511_628_211;
+#[cfg(target_pointer_width = "32")]
+const CAPACITY_HASH_OFFSET: usize = 2_166_136_261;
+#[cfg(target_pointer_width = "32")]
+const CAPACITY_HASH_PRIME: usize = 16_777_619;
+
+// A fixed-size direct-mapped cache keeps memory bounded. Each atomic packs the
+// capacity with a fingerprint, so bucket collisions become misses rather than
+// cross-route over-allocation. Races affect only an advisory allocation size.
+struct RenderCapacityHints {
+    buckets: [AtomicUsize; RENDER_CAPACITY_BUCKETS],
+}
+
+impl RenderCapacityHints {
+    fn new() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicUsize::new(0)),
+        }
+    }
+
+    fn load(&self, entry_id: &str, request_path: &str) -> usize {
+        let hash = capacity_hint_hash(entry_id, request_path);
+        let encoded = self.buckets[hash & (RENDER_CAPACITY_BUCKETS - 1)].load(Ordering::Relaxed);
+        if encoded & !RENDER_CAPACITY_MASK == capacity_hint_fingerprint(hash) {
+            encoded & RENDER_CAPACITY_MASK
+        } else {
+            INITIAL_RENDER_CAPACITY
+        }
+    }
+
+    fn store(&self, entry_id: &str, request_path: &str, capacity: usize) {
+        let hash = capacity_hint_hash(entry_id, request_path);
+        let encoded = capacity_hint_fingerprint(hash)
+            | capacity.clamp(INITIAL_RENDER_CAPACITY, MAX_RENDER_CAPACITY_HINT);
+        self.buckets[hash & (RENDER_CAPACITY_BUCKETS - 1)].store(encoded, Ordering::Relaxed);
+    }
+}
+
+fn capacity_hint_hash(entry_id: &str, request_path: &str) -> usize {
+    let mut hash = CAPACITY_HASH_OFFSET;
+    for byte in entry_id
+        .bytes()
+        .chain(std::iter::once(u8::MAX))
+        .chain(request_path.bytes())
+    {
+        hash ^= usize::from(byte);
+        hash = hash.wrapping_mul(CAPACITY_HASH_PRIME);
+    }
+    hash
+}
+
+fn capacity_hint_fingerprint(hash: usize) -> usize {
+    let fingerprint = hash.rotate_left(7) & !RENDER_CAPACITY_MASK;
+    if fingerprint == 0 {
+        RENDER_CAPACITY_MASK + 1
+    } else {
+        fingerprint
+    }
+}
 
 /// Build statistics returned from the build function.
 #[napi(object)]
@@ -260,6 +330,7 @@ pub fn inspect(protocol_data: Buffer) -> napi::Result<String> {
 pub struct Protocol {
     inner: Arc<HandlerProtocol>,
     handler: Arc<WebUIHandler>,
+    output_capacity_hints: RenderCapacityHints,
 }
 
 #[napi]
@@ -269,7 +340,11 @@ impl Protocol {
     pub fn new(protocol_data: Buffer, plugin: Option<String>) -> napi::Result<Self> {
         let inner = Arc::new(decode_protocol(&protocol_data)?);
         let handler = Arc::new(create_handler(plugin)?);
-        Ok(Self { inner, handler })
+        Ok(Self {
+            inner,
+            handler,
+            output_capacity_hints: RenderCapacityHints::new(),
+        })
     }
 
     /// Render from an existing JSON string into a UTF-8 Node.js buffer.
@@ -391,7 +466,16 @@ impl Protocol {
 
 impl Protocol {
     fn render_buffer(&self, state: &Value, options: &RenderOptions<'_>) -> napi::Result<Buffer> {
-        let html = render_to_string(&self.handler, &self.inner, state, options)?;
+        let capacity = self
+            .output_capacity_hints
+            .load(options.entry_id, options.request_path);
+        let mut html = render_to_string(&self.handler, &self.inner, state, options, capacity)?;
+        self.output_capacity_hints
+            .store(options.entry_id, options.request_path, html.len());
+        // Bound a stale same-route hint without reallocating normally sized output.
+        if html.capacity() > html.len().saturating_mul(2) {
+            html.shrink_to_fit();
+        }
         // napi-rs can expose the existing Vec as an external Buffer on Node.
         Ok(Buffer::from(html.into_bytes()))
     }
@@ -595,8 +679,9 @@ fn render_to_string(
     protocol: &HandlerProtocol,
     state: &Value,
     options: &RenderOptions<'_>,
+    capacity: usize,
 ) -> napi::Result<String> {
-    let mut writer = BufferedWriter::with_capacity(4096);
+    let mut writer = BufferedWriter::with_capacity(capacity);
     handler
         .render(protocol, state, options, &mut writer)
         .map_err(|e| NapiError::from_reason(format!("Render error: {e}")))?;
@@ -754,6 +839,120 @@ mod tests {
             )
             .map_err(|e| e.to_string())?;
         Ok(output)
+    }
+
+    #[test]
+    fn render_capacity_hints_isolate_entries_and_routes() {
+        let hints = RenderCapacityHints::new();
+
+        hints.store("index.html", "/contacts", MAX_RENDER_CAPACITY_HINT);
+
+        assert_eq!(
+            hints.load("index.html", "/"),
+            INITIAL_RENDER_CAPACITY,
+            "a small route must not inherit a large route's capacity"
+        );
+        assert_eq!(
+            hints.load("contacts.html", "/contacts"),
+            INITIAL_RENDER_CAPACITY,
+            "another entry must not inherit the large entry's capacity"
+        );
+        assert_eq!(
+            hints.load("index.html", "/contacts"),
+            MAX_RENDER_CAPACITY_HINT
+        );
+    }
+
+    #[test]
+    fn render_capacity_hints_do_not_leak_across_bucket_collisions() {
+        let entry_id = "index.html";
+        let large_path = "/contacts";
+        let large_hash = capacity_hint_hash(entry_id, large_path);
+        let colliding_path = (0..RENDER_CAPACITY_BUCKETS * 16)
+            .map(|index| format!("/route-{index}"))
+            .find(|path| {
+                let hash = capacity_hint_hash(entry_id, path);
+                hash & (RENDER_CAPACITY_BUCKETS - 1) == large_hash & (RENDER_CAPACITY_BUCKETS - 1)
+                    && capacity_hint_fingerprint(hash) != capacity_hint_fingerprint(large_hash)
+            })
+            .unwrap_or_else(|| panic!("a same-bucket route should be found"));
+        let hints = RenderCapacityHints::new();
+
+        hints.store(entry_id, large_path, MAX_RENDER_CAPACITY_HINT);
+        assert_eq!(
+            hints.load(entry_id, &colliding_path),
+            INITIAL_RENDER_CAPACITY
+        );
+
+        hints.store(entry_id, &colliding_path, INITIAL_RENDER_CAPACITY * 2);
+        assert_eq!(
+            hints.load(entry_id, large_path),
+            INITIAL_RENDER_CAPACITY,
+            "an overwritten bucket must miss rather than return another route's hint"
+        );
+        assert_eq!(
+            hints.load(entry_id, &colliding_path),
+            INITIAL_RENDER_CAPACITY * 2
+        );
+    }
+
+    #[test]
+    fn render_capacity_hints_clamp_retained_sizes() {
+        let hints = RenderCapacityHints::new();
+
+        hints.store("index.html", "/", 0);
+        assert_eq!(hints.load("index.html", "/"), INITIAL_RENDER_CAPACITY);
+
+        hints.store("index.html", "/", usize::MAX);
+        assert_eq!(hints.load("index.html", "/"), MAX_RENDER_CAPACITY_HINT);
+    }
+
+    #[test]
+    fn learned_render_capacity_avoids_string_growth_without_changing_bytes() {
+        struct ReallocationWriter {
+            output: String,
+            reallocations: usize,
+        }
+
+        impl ResponseWriter for ReallocationWriter {
+            fn write(&mut self, content: &str) -> webui_handler::Result<()> {
+                let previous_capacity = self.output.capacity();
+                self.output.push_str(content);
+                self.reallocations += usize::from(self.output.capacity() != previous_capacity);
+                Ok(())
+            }
+
+            fn end(&mut self) -> webui_handler::Result<()> {
+                Ok(())
+            }
+        }
+
+        fn render_with_capacity(protocol: &HandlerProtocol, capacity: usize) -> (String, usize) {
+            let mut writer = ReallocationWriter {
+                output: String::with_capacity(capacity),
+                reallocations: 0,
+            };
+            WebUIHandler::new()
+                .render(
+                    protocol,
+                    &Value::Null,
+                    &RenderOptions::new("index.html", "/"),
+                    &mut writer,
+                )
+                .expect("render should succeed");
+            (writer.output, writer.reallocations)
+        }
+
+        let source = format!("<main>{}</main>", "<p>capacity</p>".repeat(1024));
+        let protocol =
+            HandlerProtocol::from_protobuf(&build_protocol(&source)).expect("protocol should load");
+        let (cold_output, cold_reallocations) =
+            render_with_capacity(&protocol, INITIAL_RENDER_CAPACITY);
+        let (warm_output, warm_reallocations) = render_with_capacity(&protocol, cold_output.len());
+
+        assert!(cold_reallocations > 0);
+        assert_eq!(warm_reallocations, 0);
+        assert_eq!(warm_output, cold_output);
     }
 
     #[test]

--- a/examples/integration/node-addon-bench/bench.mjs
+++ b/examples/integration/node-addon-bench/bench.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONTACT_COUNTS = [10, 100, 1000];
 const RENDER_OPTIONS = Object.freeze({ requestPath: "/contacts" });
+const SMALL_ROUTE_OPTIONS = Object.freeze({ requestPath: "/" });
 const SNAPSHOT_SCHEMA = 1;
 const BASELINE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
@@ -700,6 +701,40 @@ async function main() {
       ),
     );
   }
+
+  const largestFixture = fixtures[fixtures.length - 1];
+  const smallRouteBuffer = protocol.renderPrepared(
+    largestFixture.prepared,
+    SMALL_ROUTE_OPTIONS,
+  );
+  assert.ok(
+    smallRouteBuffer.length < largestFixture.outputBytes / 2,
+    "alternating-route benchmark needs materially different output sizes",
+  );
+  results.push(
+    makeResult(
+      `render/prepared/alternating-routes/${largestFixture.contactCount}`,
+      "total",
+      collectSyncSamples(() => {
+        const large = protocol.renderPrepared(
+          largestFixture.prepared,
+          RENDER_OPTIONS,
+        );
+        const small = protocol.renderPrepared(
+          largestFixture.prepared,
+          SMALL_ROUTE_OPTIONS,
+        );
+        return large.length + small.length;
+      }, config),
+      {
+        contacts: largestFixture.contactCount,
+        inputBytes: largestFixture.inputBytes,
+        outputBytes: largestFixture.outputBytes + smallRouteBuffer.length,
+        largeOutputBytes: largestFixture.outputBytes,
+        smallOutputBytes: smallRouteBuffer.length,
+      },
+    ),
+  );
 
   // Keep the raw report data-only so --json and snapshots stay machine-readable.
   const report = {


### PR DESCRIPTION
## Summary

- reuse the last rendered output size for each Node entry/route in a bounded 64-slot relaxed-atomic table
- pack a route fingerprint beside each capacity so bucket collisions miss safely, fall back to 4 KiB, and cap retained hints at 1 MiB
- apply the hint to both `render` and `renderPrepared`, shrinking only when a stale same-route hint leaves more than 2x slack
- add collision, isolation, clamping, reallocation, byte-equivalence tests and an alternating large/small route benchmark

Builds on the prepared-state API merged in #477.

## Performance

Windows x64, Node 24.18.0, release addon, Contact Book `/contacts`; median P50 across five paired full benchmark runs:

| Prepared render | C1 | This PR | Delta |
|---|---:|---:|---:|
| 10 contacts | 58.5 us | 54.2 us | **-7.35%** |
| 100 contacts | 425.9 us | 406.1 us | **-4.65%** |
| 1000 contacts | 4.853 ms | 4.806 ms | **-0.96%** |
| alternating `/contacts` + `/` at 1000 | 5.162 ms | 5.098 ms | **-1.23%** |

HTML output stayed byte-identical at 34,035 / 252,489 / 2,438,775 bytes. A focused writer test changes cold growth from at least one reallocation to zero after learning the output size.

For 128 large/small route alternations while retaining every small buffer (2,438,775-byte large output, 24,331-byte small output), settled RSS deltas were 4.06 MiB for C1 and 3.80 MiB here (three-run medians); native external-memory growth was exactly 3,114,408 bytes for both. Large and small SHA-256 output hashes also matched C1.

A same-route synthetic probe alternating 1,048,607-byte and 18-byte output isolated `shrink_to_fit`: 516.2 us P50 with shrink versus 510.4 us without (+1.1%), while C1 was 525.6 us. The bounded shrink therefore remains net-positive versus C1 and prevents a stale large hint from riding on a tiny response.

## Validation

- `cargo test -p microsoft-webui-node`
- `cargo xtask check`