### PR TITLE
perf: reduce framework hydration allocations

### DIFF
--- a/packages/webui-framework/src/template-element.ts
+++ b/packages/webui-framework/src/template-element.ts
@@ -303,6 +303,10 @@ interface PendingParentState {
 
 const pendingParentStateByElement = new WeakMap<Element, PendingParentState>();
 
+function bindingArray<T>(count: number): T[] {
+  return count > 0 ? [] : EMPTY_ARR as unknown as T[];
+}
+
 function queuePendingParentState(
   element: Element,
   name: string,
@@ -492,8 +496,10 @@ export class TemplateElement extends HTMLElement {
   /** Keep unavailable template-only roots from being replaced by empty values
    *  after a deferred SSR activation. */
   declare private $guardUnknownState: boolean | undefined;
-  /** Cached condition resolver — avoids allocating a closure per evaluation. */
-  private $resolver = (p: string, s?: unknown): unknown => this.$resolveValue(p, s as ScopeFrame | undefined);
+  /** Allocated only for components that evaluate a runtime condition. */
+  declare private $resolver:
+    | ((path: string, scope?: unknown) => unknown)
+    | undefined;
   private $pathIndex?: Map<string, {
     texts: TextBinding[];
     attrs: AttrBinding[];
@@ -1019,10 +1025,10 @@ export class TemplateElement extends HTMLElement {
     instance.parent = undefined;
     instance.container = null;
     instance.nodes.length = 0;
-    instance.texts.length = 0;
-    instance.attrs.length = 0;
-    instance.conds.length = 0;
-    instance.repeats.length = 0;
+    if (instance.texts.length > 0) instance.texts.length = 0;
+    if (instance.attrs.length > 0) instance.attrs.length = 0;
+    if (instance.conds.length > 0) instance.conds.length = 0;
+    if (instance.repeats.length > 0) instance.repeats.length = 0;
   }
 
   attributeChangedCallback(
@@ -1696,7 +1702,7 @@ export class TemplateElement extends HTMLElement {
     const index = this.$pathIndex;
     if (!index) return;
     const ctx: MismatchContext = {
-      resolver: this.$resolver,
+      resolver: this.$conditionResolver(),
       resolveParts: (parts, scope) => this.$resolveParts(parts, scope),
       resolveValue: (path, scope) => this.$resolveValue(path, scope),
     };
@@ -1776,7 +1782,10 @@ export class TemplateElement extends HTMLElement {
   private $wire(root: Node, meta: TemplateBlockMeta, scope?: ScopeFrame): TemplateInstance {
     const instance: TemplateInstance = {
       scope, container: root as ParentNode & Node, nodes: childNodesArray(root),
-      texts: [], attrs: [], conds: [], repeats: [],
+      texts: bindingArray<TextBinding>(meta.tx?.length ?? 0),
+      attrs: bindingArray<AttrBinding>(meta.a?.length ?? 0),
+      conds: bindingArray<CondBinding>(meta.c?.length ?? 0),
+      repeats: bindingArray<RepeatBinding>(meta.r?.length ?? 0),
     };
 
     // Resolve every static insertion reference before inserting dynamic nodes.
@@ -1930,7 +1939,10 @@ export class TemplateElement extends HTMLElement {
       scope,
       container: (pathStart > 0 ? ssrRoot.parentNode : ssrRoot) as (ParentNode & Node) | null,
       nodes: pathStart > 0 ? [ssrRoot] : childNodesArray(ssrRoot),
-      texts: [], attrs: [], conds: [], repeats: [],
+      texts: bindingArray<TextBinding>(meta.tx?.length ?? 0),
+      attrs: bindingArray<AttrBinding>(meta.a?.length ?? 0),
+      conds: bindingArray<CondBinding>(meta.c?.length ?? 0),
+      repeats: bindingArray<RepeatBinding>(meta.r?.length ?? 0),
     };
 
     // Collect SSR markers for deferred removal.  Closing markers
@@ -2740,7 +2752,7 @@ export class TemplateElement extends HTMLElement {
         break;
       }
       case ATTR_KIND_BOOLEAN: {
-        const show = b.condition![0](this.$resolver, b.scope);
+        const show = b.condition![0](this.$conditionResolver(), b.scope);
         if (show) el.setAttribute(b.name, '');
         else el.removeAttribute(b.name);
         // Form control properties must be set via DOM property, not attribute
@@ -2778,7 +2790,7 @@ export class TemplateElement extends HTMLElement {
   }
 
   private $toggleCond(c: CondBinding): void {
-    const show = c.condition[0](this.$resolver, c.scope);
+    const show = c.condition[0](this.$conditionResolver(), c.scope);
     if (show) {
       let created = false;
       const container = c.anchor.parentNode as (ParentNode & Node) | null;
@@ -2820,6 +2832,11 @@ export class TemplateElement extends HTMLElement {
     const dot = path.indexOf('.');
     if (dot === -1) return this.$resolveComponentRoot(path);
     return dotWalk(this.$resolveComponentRoot(path.substring(0, dot)), path, dot + 1);
+  }
+
+  private $conditionResolver(): (path: string, scope?: unknown) => unknown {
+    return this.$resolver ??= (path, scope) =>
+      this.$resolveValue(path, scope as ScopeFrame | undefined);
   }
 
   /** Return whether a binding path's scope or component root is available. */


### PR DESCRIPTION
## Summary

- allocate the condition resolver only for components that evaluate a runtime condition
- share the existing empty-array sentinel for absent text, attribute, condition, and repeat metadata in both client wiring and SSR hydration
- clear populated binding arrays in place while guarding the shared empty sentinel

## Performance

Measured in Chromium with the direct `streaming-browser-bench` lazy-hydration matrix at 10, 100, and 1,000 elements. Each arm ran 60 samples in counterbalanced `baseline → branch → branch → baseline` order with forced-GC CDP heap samples. Both source trees included the same PR #475 runtime fix and differed only in `template-element.ts`.

| Mode | Elements | Baseline retained heap | Branch retained heap | Delta |
| --- | ---: | ---: | ---: | ---: |
| eager | 10 | 214.3 KiB | 214.5 KiB | noise (+0.1%) |
| eager | 100 | 335.5 KiB | 326.8 KiB | **-2.6%** |
| eager | 1,000 | 1,378.0 KiB | 1,244.6 KiB | **-9.7% (-133.4 KiB)** |
| lazy-hydrate | 1,000 | 635.1 KiB | 588.1 KiB | **-7.4% (-47.0 KiB)** |
| lazy-render | 1,000 | 652.0 KiB | 605.3 KiB | **-7.2% (-46.7 KiB)** |

A separate object-identity probe confirmed exactly four avoided allocations per element: one resolver closure and three empty binding arrays, or **40 / 400 / 4,000 allocations** at 10 / 100 / 1,000 elements. Baseline roots retained `N` resolver functions and `3N` unique empty arrays; the branch retained no resolver on condition-free roots and reused one pre-existing empty sentinel.

End-to-end custom-element definition medians remained effectively flat:

- eager 1,000: 26.95 ms → 27.25 ms (+0.30 ms)
- lazy-hydrate 1,000: 21.70 ms → 21.75 ms (+0.05 ms)
- lazy-render 1,000: 21.45 ms → 21.55 ms (+0.10 ms)

Bundle size changes by +83 B gzip for eager and +100 B gzip for lazy modes. Exact `body.innerHTML` SHA-256 values matched between baseline and branch at all three scales.

## Validation

- `pnpm --dir packages/webui-framework test:unit`
- focused Playwright fixtures: 82 passed, 2 skipped
- `cargo xtask check`
