### PR TITLE
perf: release SSR bootstrap memory after hydration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -436,8 +436,15 @@ non-executable SSR metadata:
 </script>
 ```
 
-This is the single metadata startup contract. The client packages first read any existing `window.__webui`, then
-lazily parse and remove `#webui-data` into `window.__webui` when metadata is needed. Note that
+This is the single metadata startup contract. The client packages first read any
+existing `window.__webui`, then lazily parse and remove `#webui-data` into
+`window.__webui` when metadata is needed. The projected `state` object is a
+one-shot handoff: eager components consume it synchronously, lazy roots copy
+their owned roots before deferral, and the framework deletes it when the startup
+`webui:hydration-complete` cohort settles on a page without a route chain. Pages
+with a route chain retain the handoff for router-owned lazy startup instead.
+Template closure entries are likewise removed from `templateFns` after
+normalization embeds each function into its template metadata. Note that
 **CSS module definitions** are emitted for all **reachable** components (including those in false
 `<if>` blocks), not just rendered ones.
 

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -254,13 +254,6 @@ WebUI dispatches these events on `window`:
   barrier remains pending. It means the complete response lifecycle is done,
   not merely that the first interactive child is ready.
 
-For a non-routed ordinary response, `window.__webui.state` is a one-shot
-projected handoff rather than a retained client store. Eager roots consume it
-during hydration, visibility-deferred roots copy the keys they own before
-sleeping, and the framework releases the global state when the startup
-`webui:hydration-complete` cohort settles. When a route chain exists, the state
-remains available for router-owned lazy startup.
-
 ### Measuring commits in production
 
 Events require a listener installed before the first commit, which is often

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -254,6 +254,13 @@ WebUI dispatches these events on `window`:
   barrier remains pending. It means the complete response lifecycle is done,
   not merely that the first interactive child is ready.
 
+For a non-routed ordinary response, `window.__webui.state` is a one-shot
+projected handoff rather than a retained client store. Eager roots consume it
+during hydration, visibility-deferred roots copy the keys they own before
+sleeping, and the framework releases the global state when the startup
+`webui:hydration-complete` cohort settles. When a route chain exists, the state
+remains available for router-owned lazy startup.
+
 ### Measuring commits in production
 
 Events require a listener installed before the first commit, which is often

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -828,7 +828,13 @@ State seeding uses `window.__webui.state` loaded from the server-emitted
 `@observable` and `@attr` keys from reachable authored components select
 initial state; HTML-only dormant components and authored template-only roots
 contribute no startup keys. Without projection metadata, the server preserves
-full state. During `$mount()`, `$applySSRState()` writes matching decorated keys
+full state. The startup state is not a permanent application store. Eager
+components consume it during hydration, lazy components copy their projected
+roots before deferral, and the framework releases the global handoff when
+`webui:hydration-complete` fires on a page without a route chain. Routed pages
+retain it for router-owned lazy startup. Normalized template closure entries are
+released as soon as their functions are embedded in template metadata. During
+`$mount()`, `$applySSRState()` writes matching decorated keys
 directly to observable backing fields before any bindings are wired:
 
 ```mermaid

--- a/packages/webui-framework/src/component-asset.test.ts
+++ b/packages/webui-framework/src/component-asset.test.ts
@@ -500,7 +500,7 @@ describe('component asset helpers', () => {
     }
   });
 
-  test('manifest preload registers template functions from the asset module', async () => {
+  test('manifest preload embeds template functions without retaining the closure array', async () => {
     const previousWindow = setGlobal('window', { __webui: {} });
     const previousDocument = setGlobal('document', {
       baseURI: 'https://example.test/app/',
@@ -525,7 +525,13 @@ describe('component asset helpers', () => {
             externalComponents: [],
             imports: [],
             componentStyles: { version: 1, strategy: 'style', resources: {}, closures: {} },
-            templates: { 'fn-card': { h: '<p>Fn</p>' } },
+            templates: {
+              'fn-card': {
+                h: '<!--wc:0--><!--/wc-->',
+                b: [{ h: '<p>Fn</p>' }],
+                c: [[[0, ['ready']], 0, [[], 0]]]
+              }
+            },
             templateFunctions: { 'fn-card': [function(v,s){return !!v('ready',s);}] }
           }`),
         },
@@ -533,9 +539,9 @@ describe('component asset helpers', () => {
 
       await assets.preload('fn-card').asset;
 
-      const fns = window.__webui?.templateFns?.['fn-card'];
-      assert.equal(typeof fns?.[0], 'function');
-      assert.equal(getTemplate('fn-card')?.h, '<p>Fn</p>');
+      const template = getTemplate('fn-card');
+      assert.equal(typeof template?.c?.[0][0][0], 'function');
+      assert.equal(window.__webui?.templateFns, undefined);
     } finally {
       restoreGlobal('window', previousWindow);
       restoreGlobal('document', previousDocument);

--- a/packages/webui-framework/src/template-bootstrap-release.test.ts
+++ b/packages/webui-framework/src/template-bootstrap-release.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+test('hydration completion releases the non-routed bootstrap handoff once', async () => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const template = { h: '<p>Hello</p>' };
+  const listeners = new Map<string, {
+    listener: EventListener;
+    options?: boolean | AddEventListenerOptions;
+  }>();
+  const fakeWindow = {
+    __webui: {
+      state: { title: 'Hello' },
+      templates: { greeting: template },
+    },
+    addEventListener(
+      type: string,
+      listener: EventListener,
+      options?: boolean | AddEventListenerOptions,
+    ): void {
+      listeners.set(type, { listener, options });
+    },
+  };
+
+  try {
+    Object.defineProperty(globalThis, 'window', {
+      value: fakeWindow,
+      configurable: true,
+      writable: true,
+    });
+
+    await import('./template.js');
+
+    const registration = listeners.get('webui:hydration-complete');
+    assert.ok(registration);
+    assert.deepEqual(registration.options, { once: true });
+    registration.listener.call(
+      fakeWindow,
+      new Event('webui:hydration-complete'),
+    );
+    assert.equal(fakeWindow.__webui.state, undefined);
+    assert.equal(fakeWindow.__webui.templates.greeting, template);
+  } finally {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  }
+});

--- a/packages/webui-framework/src/template.test.ts
+++ b/packages/webui-framework/src/template.test.ts
@@ -4,7 +4,13 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
 
-import { getTemplate, registerTemplateData, type TemplateMeta } from './template.js';
+import {
+  getTemplate,
+  registerTemplateData,
+  releaseNonRoutedSSRBootstrapState,
+  releaseSSRBootstrapState,
+  type TemplateMeta,
+} from './template.js';
 
 describe('template registry helpers', () => {
   test('getTemplate returns registered metadata from window', () => {
@@ -55,6 +61,7 @@ describe('template registry helpers', () => {
       const registered = getTemplate('greeting')!;
       assert.equal((registered.c![0][0][0] as unknown), fn);
       assert.deepEqual(registered.c![0][0][1], ['ready']);
+      assert.equal(window.__webui!.templateFns, undefined);
     } finally {
       if (previousWindow) {
         Object.defineProperty(globalThis, 'window', previousWindow);
@@ -144,6 +151,53 @@ describe('template registry helpers', () => {
       assert.equal((registered.c![0][0][0] as unknown), fn);
       assert.equal(window.__webui!.inventory, '0c');
       assert.deepEqual(window.__webui!.state, { title: 'Hello' });
+      assert.equal(window.__webui!.templateFns, undefined);
+    } finally {
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  });
+
+  test('reconciles standalone closures added after the initial count', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const firstFn = (): boolean => true;
+    const secondFn = (): boolean => false;
+    const lateFn = (): boolean => true;
+    const template = (): TemplateMeta => ({
+      h: '<p></p>',
+      b: [{ h: '<span></span>' }],
+      c: [[[0, ['ready']], 0, [[], 0]]],
+    } as unknown as TemplateMeta);
+    const first = template();
+    const second = template();
+    const late = template();
+
+    try {
+      Object.defineProperty(globalThis, 'window', {
+        value: {
+          __webui: {
+            templates: { first, second, late },
+            templateFns: { first: [firstFn], second: [secondFn] },
+          },
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      assert.equal(getTemplate('first'), first);
+      assert.deepEqual(Object.keys(window.__webui!.templateFns!), ['second']);
+      window.__webui!.templateFns!.late = [lateFn];
+      assert.equal(getTemplate('late'), late);
+      assert.deepEqual(
+        Object.keys(window.__webui!.templateFns!),
+        ['second'],
+        'a late direct registration must not make the count drop the remaining closure',
+      );
+      assert.equal(getTemplate('second'), second);
+      assert.equal(window.__webui!.templateFns, undefined);
     } finally {
       if (previousWindow) {
         Object.defineProperty(globalThis, 'window', previousWindow);
@@ -203,6 +257,70 @@ describe('template registry helpers', () => {
         Object.defineProperty(globalThis, 'document', previousDocument);
       } else {
         Reflect.deleteProperty(globalThis, 'document');
+      }
+    }
+  });
+
+  test('releases one-shot SSR state without dropping template metadata', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const template: TemplateMeta = { h: '<p>Hello</p>' };
+    try {
+      Object.defineProperty(globalThis, 'window', {
+        value: {
+          __webui: {
+            state: { title: 'Hello' },
+            templates: { greeting: template },
+          },
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      releaseSSRBootstrapState();
+
+      assert.equal(window.__webui!.state, undefined);
+      assert.equal(window.__webui!.templates!.greeting, template);
+    } finally {
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  });
+
+  test('keeps one-shot state while the router owns startup', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    try {
+      Object.defineProperty(globalThis, 'window', {
+        value: {
+          __webui: {
+            chain: [{ component: 'lazy-route' }],
+            state: { title: 'Server title' },
+            templateHostExclusions: new Set(['lazy-route']),
+          },
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      releaseNonRoutedSSRBootstrapState();
+      assert.deepEqual(window.__webui!.state, { title: 'Server title' });
+      delete window.__webui!.chain;
+      releaseNonRoutedSSRBootstrapState();
+      assert.deepEqual(
+        window.__webui!.state,
+        { title: 'Server title' },
+        'the durable router marker must outlive its one-shot chain snapshot',
+      );
+      delete window.__webui!.templateHostExclusions;
+      releaseNonRoutedSSRBootstrapState();
+      assert.equal(window.__webui!.state, undefined);
+    } finally {
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
       }
     }
   });

--- a/packages/webui-framework/src/template.ts
+++ b/packages/webui-framework/src/template.ts
@@ -69,9 +69,22 @@ import type {
 } from './template-types.js';
 
 const WEBUI_DATA_ID = 'webui-data';
+const HYDRATION_COMPLETE_EVENT = 'webui:hydration-complete';
+const TEMPLATE_FN_COUNT = Symbol.for('microsoft.webui.templateFnCount');
 const normalizedTemplates = new WeakSet<TemplateMeta>();
 const assetNormalizedTemplates = new WeakSet<TemplateMeta>();
 let webuiDataLoaded = false;
+
+type RuntimeTemplateFns = Record<string, CompiledConditionFn[]>
+  & Record<symbol, number | undefined>;
+
+function runtimeTemplateFnCount(registry: RuntimeTemplateFns): number {
+  const count = registry[TEMPLATE_FN_COUNT];
+  if (typeof count === 'number') return count;
+  const initialized = Object.keys(registry).length;
+  registry[TEMPLATE_FN_COUNT] = initialized;
+  return initialized;
+}
 
 interface PendingTemplateDefinition {
   readonly ctor: Function;
@@ -94,14 +107,6 @@ function acceptTemplateData(
   const w = window as Window;
   if (!w.__webui) w.__webui = {};
   if (!w.__webui.templates) w.__webui.templates = {};
-  if (templateFns) {
-    if (!w.__webui.templateFns) w.__webui.templateFns = {};
-    const fnNames = Object.keys(templateFns);
-    for (let i = 0; i < fnNames.length; i++) {
-      const tag = fnNames[i];
-      w.__webui.templateFns[tag] = templateFns[tag];
-    }
-  }
   const names = Object.keys(templates);
   for (let i = 0; i < names.length; i++) {
     const tag = names[i];
@@ -136,6 +141,11 @@ if (typeof window !== 'undefined' && typeof window.addEventListener === 'functio
     const ready = prepareRegisteredLinkStyles(detail.templates);
     if (ready) detail.waitUntil?.(ready);
   });
+  window.addEventListener(
+    HYDRATION_COMPLETE_EVENT,
+    releaseNonRoutedSSRBootstrapState,
+    { once: true },
+  );
 }
 
 declare global {
@@ -278,15 +288,57 @@ function loadWebUIDataBlock(): void {
   webuiDataLoaded = true;
 }
 
+/**
+ * Release the one-shot page state after every startup hydration consumer has
+ * copied the roots it owns. Template metadata remains available for future
+ * client-created blocks and route navigation.
+ *
+ * @internal
+ */
+export function releaseSSRBootstrapState(): void {
+  const runtime = window.__webui;
+  if (runtime?.state !== undefined) {
+    delete runtime.state;
+  }
+}
+
+/** Release only on non-routed pages; the router owns routed startup state. */
+export function releaseNonRoutedSSRBootstrapState(): void {
+  const runtime = window.__webui;
+  if (
+    runtime?.chain === undefined &&
+    runtime?.templateHostExclusions === undefined
+  ) {
+    releaseSSRBootstrapState();
+  }
+}
+
 function normalizeTemplate(
   name: string,
   meta: TemplateMeta,
   suppliedFns?: CompiledConditionFn[],
 ): void {
   if (normalizedTemplates.has(meta)) return;
-  const fns = suppliedFns ?? window.__webui?.templateFns?.[name] ?? [];
+  const runtimeFns = window.__webui?.templateFns as
+    | RuntimeTemplateFns
+    | undefined;
+  const fns = suppliedFns ?? runtimeFns?.[name] ?? [];
   normalizeTemplateConditions(name, meta, fns);
   normalizedTemplates.add(meta);
+  if (suppliedFns === undefined && runtimeFns?.[name] === fns) {
+    let remaining = runtimeTemplateFnCount(runtimeFns);
+    delete runtimeFns[name];
+    remaining--;
+    runtimeFns[TEMPLATE_FN_COUNT] = remaining;
+    if (remaining === 0 && window.__webui) {
+      const liveCount = Object.keys(runtimeFns).length;
+      if (liveCount === 0) {
+        delete window.__webui.templateFns;
+      } else {
+        runtimeFns[TEMPLATE_FN_COUNT] = liveCount;
+      }
+    }
+  }
 }
 
 function normalizeTemplateConditions(


### PR DESCRIPTION
## Summary
- release the non-routed `window.__webui.state` handoff after the startup hydration cohort settles while preserving router-owned lazy startup state
- embed condition closures into template metadata, evict consumed standalone entries, reconcile late direct writers, and avoid retaining asset closure arrays
- document the startup ownership contract and add focused lifecycle, routing, late-registration, and asset regressions

## Performance
Measured against merge-base `e971c13a` with the real production framework bundle, fresh Chromium pages, 1,500 hydrated/reactive SSR roots, 23 KiB projected startup state, 30 runs per arm, and three forced CDP garbage collections before each pre/post `Runtime.getHeapUsage` sample.

| Ordinary startup metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Post-hydration retained JS heap | 1,844.8 KiB | 1,814.9 KiB | **-29.9 KiB (-1.6%)** |
| Peak JS heap | 2,208.3 KiB | 2,149.8 KiB | **-58.5 KiB (-2.6%)** |
| Hydration CPU median | 7.9 ms | 7.3 ms | **-7.6%** |
| Hydration elapsed median | 31.2 ms | 31.2 ms | 0.0% |
| Ordinary bundle | 74,969 B / 23,603 B gzip | 75,384 B / 23,736 B gzip | +415 B / +133 B gzip |

An independent 30-run three-GC pair measured **-28.6 KiB** retained heap. Routed/streaming arms remained effectively flat; the repeat pair ranged from -0.4 KiB to +1.3 KiB retained heap across 1, 3, 10, and 100 boundaries. Every arm hydrated and reactively updated all 1,500 roots.

Exact ownership checks lock down state `1 -> 0` while templates remain, standalone closure keys `2 -> 1 -> 2 (late writer) -> 1 -> 0`, no retained component-asset closure registry, and routed state retention after the router consumes and deletes its one-shot chain snapshot.

## Validation
- `pnpm --dir packages\webui-framework test:unit`
- `pnpm --dir packages\webui-framework exec playwright test hydration-bench`
- `pnpm --dir docs build`
- `cargo xtask check`