### PR TITLE
perf: keep routed template closure counts exact

### DIFF
--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -353,6 +353,9 @@ export class WebUIRouter {
       for (const tag of Object.keys(functionRegistry)) {
         delete functionRegistry[tag];
       }
+      const counts = functionRegistry as Record<string, unknown>
+        & Record<symbol, number | undefined>;
+      counts[Symbol.for('microsoft.webui.templateFnCount')] = 0;
     }
     if (window.__webui) window.__webui.inventory = '';
   }

--- a/packages/webui-router/src/template-function-count.test.ts
+++ b/packages/webui-router/src/template-function-count.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import './browser-shim.js';
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { WebUIRouter } from './router.js';
+import { registerTemplatesAndStyles } from './templates.js';
+
+const TEMPLATE_FN_COUNT = Symbol.for('microsoft.webui.templateFnCount');
+
+type TemplateFunctionRegistry = Record<string, unknown>
+  & Record<symbol, number | undefined>;
+
+interface TestRuntime {
+  __webui?: {
+    inventory?: string;
+    templates?: Record<string, unknown>;
+    templateFns?: TemplateFunctionRegistry;
+  };
+}
+
+interface ScriptNode {
+  nonce: string;
+  textContent: string;
+}
+
+interface ScriptDocument {
+  createElement(tag: string): ScriptNode;
+  head: {
+    appendChild(script: ScriptNode): ScriptNode;
+    removeChild(script: ScriptNode): ScriptNode;
+  };
+}
+
+function globals(): TestRuntime {
+  return globalThis as unknown as TestRuntime;
+}
+
+function registerFunctions(templateFunctions: Record<string, string>): void {
+  registerTemplatesAndStyles({ templateFunctions }, '', () => {});
+}
+
+function addConditionTemplate(name: string): unknown {
+  const template = {
+    h: '<!--wc:0--><!--/wc-->',
+    b: [{ h: '<p>Ready</p>' }],
+    c: [[[0, ['ready']], 0, [[], 0]]],
+  };
+  const runtime = globals().__webui;
+  assert.ok(runtime);
+  (runtime.templates ??= {})[name] = template;
+  return template;
+}
+
+test('keeps the closure count exact across soft writes, GC, and zero deletion', async () => {
+  const runtime = globals();
+  const savedWebui = runtime.__webui;
+  const scriptDocument = document as unknown as ScriptDocument;
+  const savedCreateElement = scriptDocument.createElement;
+  const savedHead = scriptDocument.head;
+
+  scriptDocument.createElement = () => ({ nonce: '', textContent: '' });
+  scriptDocument.head = {
+    appendChild(script) {
+      // eslint-disable-next-line no-new-func
+      Function(script.textContent)();
+      return script;
+    },
+    removeChild(script) {
+      return script;
+    },
+  };
+
+  try {
+    runtime.__webui = {
+      inventory: 'ff',
+      templates: {},
+      templateFns: {
+        'initial-a': [() => true],
+        'initial-b': [() => false],
+      },
+    };
+    const initialA = addConditionTemplate('initial-a');
+    const initialB = addConditionTemplate('initial-b');
+    const { getTemplate } = await import('@microsoft/webui-framework');
+
+    assert.strictEqual(getTemplate('initial-a'), initialA);
+    let registry = runtime.__webui.templateFns;
+    assert.ok(registry);
+    assert.equal(registry[TEMPLATE_FN_COUNT], 1);
+
+    registerFunctions({ 'initial-b': '[function(){return true}]' });
+    registry = runtime.__webui.templateFns;
+    assert.ok(registry);
+    assert.equal(
+      registry[TEMPLATE_FN_COUNT],
+      1,
+      'replacing a pending closure array must not increment the count',
+    );
+
+    registerFunctions({ 'late-route': '[function(){return true}]' });
+    registry = runtime.__webui.templateFns;
+    assert.ok(registry);
+    assert.equal(
+      registry[TEMPLATE_FN_COUNT],
+      2,
+      'a router write after count initialization must increment the count',
+    );
+
+    const lateRoute = addConditionTemplate('late-route');
+    assert.strictEqual(getTemplate('late-route'), lateRoute);
+    registry = runtime.__webui.templateFns;
+    assert.ok(registry);
+    assert.equal(
+      registry[TEMPLATE_FN_COUNT],
+      1,
+      'the registry must remain while one closure array is pending',
+    );
+    assert.strictEqual(getTemplate('initial-b'), initialB);
+    assert.equal(
+      runtime.__webui.templateFns,
+      undefined,
+      'the registry must be deleted when the exact count reaches zero',
+    );
+
+    for (let i = 0; i < 4; i++) {
+      const tag = `soft-route-${i}`;
+      registerFunctions({ [tag]: '[function(){return true}]' });
+      registry = runtime.__webui.templateFns;
+      assert.ok(registry);
+      assert.equal(registry[TEMPLATE_FN_COUNT], 1);
+      const template = addConditionTemplate(tag);
+      assert.strictEqual(getTemplate(tag), template);
+      assert.equal(runtime.__webui.templateFns, undefined);
+    }
+
+    registerFunctions({
+      'gc-a': '[function(){return true}]',
+      'gc-b': '[function(){return true}]',
+      'gc-c': '[function(){return true}]',
+    });
+    const gcA = addConditionTemplate('gc-a');
+    addConditionTemplate('gc-b');
+    addConditionTemplate('gc-c');
+    assert.strictEqual(getTemplate('gc-a'), gcA);
+    registry = runtime.__webui.templateFns;
+    assert.ok(registry);
+    assert.equal(registry[TEMPLATE_FN_COUNT], 2);
+
+    const registryBeforeGc = registry;
+    new WebUIRouter().gc();
+    assert.strictEqual(runtime.__webui.templateFns, registryBeforeGc);
+    assert.deepEqual(Object.keys(registryBeforeGc), []);
+    assert.equal(
+      registryBeforeGc[TEMPLATE_FN_COUNT],
+      0,
+      'clearing the registry must reset its non-enumerated count',
+    );
+
+    registerFunctions({ 'after-gc': '[function(){return true}]' });
+    registry = runtime.__webui.templateFns;
+    assert.strictEqual(registry, registryBeforeGc);
+    assert.equal(registry?.[TEMPLATE_FN_COUNT], 1);
+    const afterGc = addConditionTemplate('after-gc');
+    assert.strictEqual(getTemplate('after-gc'), afterGc);
+    assert.equal(runtime.__webui.templateFns, undefined);
+  } finally {
+    runtime.__webui = savedWebui;
+    scriptDocument.createElement = savedCreateElement;
+    scriptDocument.head = savedHead;
+  }
+});

--- a/packages/webui-router/src/templates.ts
+++ b/packages/webui-router/src/templates.ts
@@ -17,6 +17,9 @@ const TEMPLATES_REGISTERED_EVENT = 'webui:templates-registered';
 const READINESS_COMPLETE = (): true => true;
 const IGNORE_READINESS_RESULTS = (): void => {};
 
+type RuntimeTemplateFns = Record<string, unknown>
+  & Record<symbol, number | undefined>;
+
 /**
  * Register templates + inject CSS from a server response.
  * Shared by fetchPartial and fetchComponentTemplates.
@@ -82,17 +85,35 @@ export function registerTemplatesAndStyles(
   //    same risk as the existing fetchPartial pipeline.
   if (data.templateFunctions) {
     const tags = Object.keys(data.templateFunctions);
+    const runtimeFns = (window as unknown as {
+      __webui?: { templateFns?: RuntimeTemplateFns };
+    }).__webui?.templateFns;
+    let functionCount = 0;
     if (tags.length > 0) {
+      if (runtimeFns) {
+        const count = runtimeFns[Symbol.for('microsoft.webui.templateFnCount')];
+        functionCount = typeof count === 'number'
+          ? count
+          : Object.keys(runtimeFns).length;
+      }
       executableTemplateBody += 'var w=(window.__webui||(window.__webui={}));var f=w.templateFns||(w.templateFns={});';
     }
     for (let i = 0; i < tags.length; i++) {
       const tag = tags[i];
       const functions = data.templateFunctions[tag];
       if (!functions) continue;
+      if (!runtimeFns || !Object.prototype.hasOwnProperty.call(runtimeFns, tag)) {
+        functionCount++;
+      }
       executableTemplateBody += 'f[';
       executableTemplateBody += JSON.stringify(tag);
       executableTemplateBody += ']=';
       executableTemplateBody += functions;
+      executableTemplateBody += ';';
+    }
+    if (tags.length > 0) {
+      executableTemplateBody += 'f[Symbol.for("microsoft.webui.templateFnCount")]=';
+      executableTemplateBody += functionCount.toString();
       executableTemplateBody += ';';
     }
   }


### PR DESCRIPTION
## Summary

- keep `Symbol.for('microsoft.webui.templateFnCount')` exact when router partials add or replace template closure arrays
- reset the symbol count when `Router.gc()` clears the registry's string keys
- cover late writes, replacement, repeated soft navigation, GC reuse, and deletion exactly at zero

## Why D1 is required

A8 lazily initializes the closure-registry count in the framework. A router partial written after that initialization previously added a string key without incrementing the symbol count (the regression test observes `1` where `2` is required). `Router.gc()` also removed the string keys while leaving the initialized count stale. After a 50-entry registry, one normalization, GC, and 25 soft navigations, A8 retained an empty registry with count `24`; D1 deletes the registry after each consumed post-GC write.

The router computes the next count synchronously before executing its nonce-gated closure script, then adds only the final numeric symbol assignment to the generated script. This avoids the larger per-tag counter code from the initial implementation.

## Measurements

Chromium 149, compared with A8 head `1d12f1b2`. Timing uses 24 measured samples after 4 warmups and 100 partial registrations per sample.

| Metric | A8 | D1 | Delta |
|---|---:|---:|---:|
| Generated script, 1 tag | 147 B | 198 B | +51 B |
| Generated script, 5 tags | 331 B | 382 B | +51 B |
| Generated script, 10 tags | 561 B | 613 B | +52 B |
| Minified browser benchmark bundle | 48,799 B | 49,145 B | +346 B |
| Startup median / p95 | 1.1 / 1.3 ms | 1.0 / 1.3 ms | no regression |
| Registration median, no pending closures | 0.013 ms | 0.014 ms | +0.001 ms |
| Registration median, 50 pending closures | 0.011 ms | 0.012 ms | +0.001 ms |
| Registration p95, 50 pending closures | 0.016 ms | 0.014 ms | -0.002 ms |
| Warmed post-GC retained-heap delta | 43,700 B | 43,940 B | +240 B |

The forced-GC retention scenario seeds 50 closure entries, normalizes one, calls `Router.gc()`, then performs 25 realistic partial registrations. Retained templates stay equal at 25 and retained closure arrays stay at 0; the feature-specific registry-object count improves from 1 to 0 and the stale symbol value changes from 24 to absent. The +240 B total-heap difference is allocator-level overhead for the exact-count path and is bounded, while the stale registry behavior is eliminated.

## Validation

- 94 router unit tests passed
- 31 router browser E2E tests passed; 4 existing Navigation API cases skipped
- framework code review found no significant issues
- `cargo xtask check` passed on current `main`