### PR TITLE
feat(press): add compile-time named regions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4566,6 +4566,8 @@ behavior. Dotted names map state beneath the reserved `regions` object, and
 layout-qualified declarations inject only into pages of that layout.
 State-bearing names cannot overlap as dotted prefixes, while HTML-only prefix
 names remain valid. Full template replacement remains an escape hatch.
+The bundled template's `site.*`, `home.*`, `doc.*`, `page.*`, and `full.*`
+region names are stable extension points documented by WebUI Press.
 
 Before the projection barrier releases page rendering, press publishes the
 generated root/page output identities and an exact identity-to-served-URL map.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4555,6 +4555,19 @@ Generated esbuild entries live in a targeted temporary directory beneath the
 site output, keeping projection inputs and outputs on the project volume. The
 directory is removed after that bundle completes.
 
+The WebUI Press template may declare compile-time extension regions with an
+empty `<webui-press-region name="..." layout="..."></webui-press-region>`
+marker. Site configuration supplies inline or file-backed HTML, optional
+page-local state, and an optional script for each named region. The builder
+validates declarations once and substitutes matching region HTML before
+component discovery and protocol compilation, so injected components retain
+ordinary SSR, CSS, projection, and bundling behavior. Dotted region names map
+state beneath the reserved `regions` object, and layout-qualified declarations
+inject only into pages of that layout. State-bearing names cannot overlap as
+dotted prefixes, while HTML-only prefix names remain valid. Full template
+replacement remains an escape hatch rather than the normal customization
+mechanism.
+
 Before the projection barrier releases page rendering, press publishes the
 generated root/page output identities and an exact identity-to-served-URL map.
 The compiler consumes each manifest's already ordered static-import closure and

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4555,18 +4555,17 @@ Generated esbuild entries live in a targeted temporary directory beneath the
 site output, keeping projection inputs and outputs on the project volume. The
 directory is removed after that bundle completes.
 
-The WebUI Press template may declare compile-time extension regions with an
-empty `<webui-press-region name="..." layout="..."></webui-press-region>`
-marker. Site configuration supplies inline or file-backed HTML, optional
-page-local state, and an optional script for each named region. The builder
-validates declarations once and substitutes matching region HTML before
-component discovery and protocol compilation, so injected components retain
-ordinary SSR, CSS, projection, and bundling behavior. Dotted region names map
-state beneath the reserved `regions` object, and layout-qualified declarations
-inject only into pages of that layout. State-bearing names cannot overlap as
-dotted prefixes, while HTML-only prefix names remain valid. Full template
-replacement remains an escape hatch rather than the normal customization
-mechanism.
+The WebUI Press template may declare compile-time extension regions with
+`<webui-press-region name="..." layout="...">fallback HTML</webui-press-region>`.
+Child markup is the default; matching site configuration may replace it with
+inline or file-backed HTML, clear it with an empty inline value, or retain it
+while adding page-local state and an optional script. The builder substitutes
+regions before component discovery and protocol compilation, so default and
+replacement components retain ordinary SSR, CSS, projection, and bundling
+behavior. Dotted names map state beneath the reserved `regions` object, and
+layout-qualified declarations inject only into pages of that layout.
+State-bearing names cannot overlap as dotted prefixes, while HTML-only prefix
+names remain valid. Full template replacement remains an escape hatch.
 
 Before the projection barrier releases page rendering, press publishes the
 generated root/page output identities and an exact identity-to-served-URL map.

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -107,6 +107,8 @@ docs/                          # contentDir (anything you want)
 │   │       ├── my-widget.html
 │   │       ├── my-widget.css
 │   │       └── my-widget.ts
+│   ├── regions/               # optional compile-time template fragments
+│   │   └── home-after-hero.html
 │   ├── public/                # optional static asset passthrough
 │   └── state/                 # optional state JSON for custom pages
 │       └── playground.json
@@ -261,6 +263,13 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
 
   "stateFile": "./state/site.json",
 
+  "regions": {
+    "home.afterHero": {
+      "htmlFile": "./regions/home-after-hero.html",
+      "stateFile": "./state/home-summary.json"
+    }
+  },
+
   "customPages": {
     "/playground/": {
       "layout": "full",
@@ -326,14 +335,61 @@ components and Markdown-authored custom elements can bind to it directly:
 
 Shared state cannot override reserved docs keys such as `site`, `navigation`,
 `sidebar`, `page`, `hero`, `footer`, `prev`, `next`, `pageData`,
-`headTags`, `tokens`, `label`, or `icon`. Global state is applied first. Custom page
-state is applied afterward for that page, so non-reserved custom page keys can
-override global keys.
+`regions`, `headTags`, `tokens`, `label`, or `icon`. Global state is applied
+first. Custom page state is applied afterward for that page, so non-reserved
+custom page keys can override global keys.
 
 The merged render state is embedded into each generated page's `#webui-data`
 hydration block. Do not put secrets in `state` or `stateFile`, and keep shared
 state small. Large global JSON files are duplicated into every output page; use
 custom page state or static JSON assets for large page-specific datasets.
+
+### Compile-time named regions
+
+Templates can expose stable extension points without requiring consumers to
+fork the full page template:
+
+```html
+<webui-press-region
+  name="home.afterHero"
+  layout="home"
+></webui-press-region>
+```
+
+Sites provide the content in `config.json`:
+
+```json
+{
+  "regions": {
+    "home.afterHero": {
+      "htmlFile": "./regions/home-after-hero.html",
+      "stateFile": "./state/home-summary.json"
+    }
+  }
+}
+```
+
+`html` and `htmlFile` are mutually exclusive, as are `state` and `stateFile`.
+An optional `scriptFile` is bundled only on pages where the region is active.
+The marker's optional `layout` attribute limits injection to that page layout;
+without it the region is active on every page.
+
+Region state is namespaced by its dotted name. The example above is available
+as `regions.home.afterHero`:
+
+```html
+<project-summary :data="{{regions.home.afterHero}}"></project-summary>
+```
+
+Every dotted segment must be non-empty. Two prefix-related regions such as
+`summary` and `summary.details` may both supply HTML, but they cannot both supply
+state because one JSON value cannot safely own both paths.
+
+WebUI Press replaces region markers before component discovery and protocol
+compilation. Injected components therefore participate in SSR, CSS ordering,
+projection, and script bundling exactly like components authored directly in
+the template. Missing region config renders an empty extension point; configured
+names that the template does not declare fail the build.
 
 ### `head` injection
 

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -376,6 +376,32 @@ and bundling. A self-closing unconfigured marker is empty; a configured but
 undeclared name fails the build. State-bearing dotted names cannot overlap as
 prefixes.
 
+The bundled template exposes these stable regions:
+
+| Region | Layout | Default |
+| --- | --- | --- |
+| `site.navigation` | all | Logo and site navigation |
+| `site.announcement` | all | Empty announcement/banner slot |
+| `home.hero` | `home` | Hero, actions, and manifesto |
+| `home.afterHero` | `home` | Empty slot after the hero |
+| `home.features` | `home` | Feature card grid |
+| `home.footer` | `home` | Site footer |
+| `doc.sidebar` | `doc` | Documentation sidebar |
+| `doc.context` | `doc` | Mobile current-location context |
+| `doc.beforeContent` | `doc` | Empty slot before the article |
+| `doc.afterContent` | `doc` | Empty slot after the article |
+| `doc.pageNavigation` | `doc` | Previous/next links |
+| `doc.footer` | `doc` | Site footer |
+| `page.beforeContent` | `page` | Empty slot before wide content |
+| `page.afterContent` | `page` | Empty slot after wide content |
+| `page.footer` | `page` | Wide page footer |
+| `full.beforeContent` | `full` | Empty slot before viewport content |
+| `full.afterContent` | `full` | Empty slot after viewport content |
+
+`home.*` regions belong to the generated home page. A `customPages` entry with
+`layout: "home"` keeps the existing non-home shell and therefore uses `doc.*`
+regions.
+
 ### `head` injection
 
 Every entry in `head[]` is rendered into `<head>` with attributes sorted alphabetically (deterministic output for reproducible builds). Use it for favicons, analytics tags, preloads, OpenGraph overrides, anything `<head>`-shaped.

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -343,7 +343,9 @@ Templates expose stable extension points without requiring a full template fork:
 <webui-press-region
   name="home.afterHero"
   layout="home"
-></webui-press-region>
+>
+  <h2>After the hero</h2>
+</webui-press-region>
 ```
 
 Sites provide the content in `config.json`:
@@ -359,17 +361,20 @@ Sites provide the content in `config.json`:
 }
 ```
 
-Use either `html` or `htmlFile`, and either `state` or `stateFile`. An optional
-`scriptFile` is bundled only on active pages. `layout` limits the marker to one
-page layout; omit it for every layout. Dotted names create nested state:
+Child markup is the default. A matching `regions` entry can replace it with
+`html` or `htmlFile`; omit both to keep the default while adding `state`,
+`stateFile`, or `scriptFile`. Use `html: ""` to clear it. `layout` limits the
+marker to one page layout; omit it for every layout. Dotted names create nested
+state:
 
 ```html
 <project-summary :data="{{regions.home.afterHero}}"></project-summary>
 ```
 
-Injected components participate normally in SSR, CSS, projection, and bundling.
-An unconfigured marker is empty; a configured but undeclared name fails the
-build. State-bearing dotted names cannot overlap as prefixes.
+Default and replacement components participate normally in SSR, CSS, projection,
+and bundling. A self-closing unconfigured marker is empty; a configured but
+undeclared name fails the build. State-bearing dotted names cannot overlap as
+prefixes.
 
 ### `head` injection
 

--- a/crates/webui-press/README.md
+++ b/crates/webui-press/README.md
@@ -107,8 +107,6 @@ docs/                          # contentDir (anything you want)
 │   │       ├── my-widget.html
 │   │       ├── my-widget.css
 │   │       └── my-widget.ts
-│   ├── regions/               # optional compile-time template fragments
-│   │   └── home-after-hero.html
 │   ├── public/                # optional static asset passthrough
 │   └── state/                 # optional state JSON for custom pages
 │       └── playground.json
@@ -263,13 +261,6 @@ Shadow DOM components can react to the layout via `:host-context([data-layout="f
 
   "stateFile": "./state/site.json",
 
-  "regions": {
-    "home.afterHero": {
-      "htmlFile": "./regions/home-after-hero.html",
-      "stateFile": "./state/home-summary.json"
-    }
-  },
-
   "customPages": {
     "/playground/": {
       "layout": "full",
@@ -346,8 +337,7 @@ custom page state or static JSON assets for large page-specific datasets.
 
 ### Compile-time named regions
 
-Templates can expose stable extension points without requiring consumers to
-fork the full page template:
+Templates expose stable extension points without requiring a full template fork:
 
 ```html
 <webui-press-region
@@ -369,27 +359,17 @@ Sites provide the content in `config.json`:
 }
 ```
 
-`html` and `htmlFile` are mutually exclusive, as are `state` and `stateFile`.
-An optional `scriptFile` is bundled only on pages where the region is active.
-The marker's optional `layout` attribute limits injection to that page layout;
-without it the region is active on every page.
-
-Region state is namespaced by its dotted name. The example above is available
-as `regions.home.afterHero`:
+Use either `html` or `htmlFile`, and either `state` or `stateFile`. An optional
+`scriptFile` is bundled only on active pages. `layout` limits the marker to one
+page layout; omit it for every layout. Dotted names create nested state:
 
 ```html
 <project-summary :data="{{regions.home.afterHero}}"></project-summary>
 ```
 
-Every dotted segment must be non-empty. Two prefix-related regions such as
-`summary` and `summary.details` may both supply HTML, but they cannot both supply
-state because one JSON value cannot safely own both paths.
-
-WebUI Press replaces region markers before component discovery and protocol
-compilation. Injected components therefore participate in SSR, CSS ordering,
-projection, and script bundling exactly like components authored directly in
-the template. Missing region config renders an empty extension point; configured
-names that the template does not declare fail the build.
+Injected components participate normally in SSR, CSS, projection, and bundling.
+An unconfigured marker is empty; a configured but undeclared name fails the
+build. State-bearing dotted names cannot overlap as prefixes.
 
 ### `head` injection
 

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -26,10 +26,15 @@ use crate::bundler::{
 use crate::content::process_content_with_states;
 use crate::error::{Error, Result};
 use crate::markdown::Highlighter;
+use crate::regions::RegionSet;
 use crate::state::{load_render_states, merge_page_state};
-use crate::types::{BuildStats, DocsConfig};
+use crate::types::{BuildStats, DocsConfig, PageDescriptor};
 
 webui_handler::define_string_response_writer!(StringWriter, buf);
+
+fn page_layout(page: &PageDescriptor) -> &str {
+    page.state["page"]["layout"].as_str().unwrap_or("doc")
+}
 
 /// Persistent state held by the dev server across rebuilds. The dev
 /// server always performs a full rebuild on every watcher tick — the
@@ -320,7 +325,8 @@ pub fn build_docs_with_cache(
     // to pay every keystroke.
     let render_states = load_render_states(config, config_dir)?;
     let highlighter = cache.highlighter.take().unwrap_or_default();
-    let pages = process_content_with_states(config, &highlighter, &head_injection, &render_states)?;
+    let mut pages =
+        process_content_with_states(config, &highlighter, &head_injection, &render_states)?;
 
     // Restore the highlighter for the next rebuild.
     cache.highlighter = Some(highlighter);
@@ -349,6 +355,7 @@ pub fn build_docs_with_cache(
 
     let template_html = fs::read_to_string(template_dir.join("index.html"))
         .map_err(|e| Error::Build(format!("Failed to read template: {e}")))?;
+    let regions = RegionSet::load(&config.regions, config_dir, template_html.clone())?;
     let component_script_index = discover_component_scripts(&component_sources)?;
 
     // Step 3: Wipe the previous output and recreate the site root.
@@ -408,6 +415,12 @@ pub fn build_docs_with_cache(
                     .extend(scripts);
             }
         }
+        for script_file in regions.script_files(page_layout(page)) {
+            explicit_page_scripts
+                .entry(page.path.clone())
+                .or_default()
+                .push(ScriptSource::File(script_file.to_string()));
+        }
     }
 
     // Collect scriptFile from customPages config.
@@ -466,8 +479,12 @@ pub fn build_docs_with_cache(
             .get(&page.path)
             .map(String::as_str)
             .unwrap_or_else(|| page.state["page"]["content"].as_str().unwrap_or(""));
+        let region_fragments = regions.html_fragments(page_layout(page));
+        let mut html_sources = Vec::with_capacity(region_fragments.len() + 1);
+        html_sources.push(content);
+        html_sources.extend(region_fragments);
         let mut component_scripts =
-            collect_component_scripts_for_html(&[content], &component_script_index)?;
+            collect_component_scripts_for_html(&html_sources, &component_script_index)?;
         if let Some(root) = &root_bundle {
             component_scripts.retain(|path| !root.component_scripts.contains(path));
         }
@@ -475,7 +492,6 @@ pub fn build_docs_with_cache(
         if component_scripts.is_empty() && explicit_scripts.is_empty() {
             continue;
         }
-
         let signature = page_bundle_signature(&component_scripts, &explicit_scripts, config_dir);
         if let Some(&id) = page_bundle_signatures.get(&signature) {
             page_bundle_ids.insert(page.path.clone(), id);
@@ -493,26 +509,40 @@ pub fn build_docs_with_cache(
         });
     }
 
-    let not_found_component_scripts =
-        collect_component_scripts_for_html(&[not_found_content.as_str()], &component_script_index)?;
-    let not_found_bundle_id = if not_found_component_scripts.is_empty() {
-        None
-    } else {
-        let signature = page_bundle_signature(&not_found_component_scripts, &[], config_dir);
-        if let Some(&id) = page_bundle_signatures.get(&signature) {
-            Some(id)
+    let not_found_region_fragments = regions.html_fragments("doc");
+    let mut not_found_sources = Vec::with_capacity(not_found_region_fragments.len() + 1);
+    not_found_sources.push(not_found_content.as_str());
+    not_found_sources.extend(not_found_region_fragments);
+    let mut not_found_component_scripts =
+        collect_component_scripts_for_html(&not_found_sources, &component_script_index)?;
+    if let Some(root) = &root_bundle {
+        not_found_component_scripts.retain(|path| !root.component_scripts.contains(path));
+    }
+    let not_found_scripts: Vec<ScriptSource> = regions
+        .script_files("doc")
+        .into_iter()
+        .map(|path| ScriptSource::File(path.to_string()))
+        .collect();
+    let not_found_bundle_id =
+        if not_found_component_scripts.is_empty() && not_found_scripts.is_empty() {
+            None
         } else {
-            let id = page_bundles.len();
-            page_bundle_signatures.insert(signature, id);
-            page_bundles.push(PageBundleEntry {
-                id,
-                page_path: format!("{base_path}404/"),
-                component_scripts: not_found_component_scripts,
-                explicit_scripts: Vec::new(),
-            });
-            Some(id)
-        }
-    };
+            let signature =
+                page_bundle_signature(&not_found_component_scripts, &not_found_scripts, config_dir);
+            if let Some(&id) = page_bundle_signatures.get(&signature) {
+                Some(id)
+            } else {
+                let id = page_bundles.len();
+                page_bundle_signatures.insert(signature, id);
+                page_bundles.push(PageBundleEntry {
+                    id,
+                    page_path: format!("{base_path}404/"),
+                    component_scripts: not_found_component_scripts,
+                    explicit_scripts: not_found_scripts,
+                });
+                Some(id)
+            }
+        };
 
     // Start the one client bundle in parallel with per-page template parsing.
     // Each page blocks only when it reaches projection finalization.
@@ -580,7 +610,7 @@ pub fn build_docs_with_cache(
         std::sync::Mutex::new(HashMap::new());
 
     let page_start = Instant::now();
-    pages.par_iter().try_for_each(|page| -> Result<()> {
+    pages.par_iter_mut().try_for_each(|page| -> Result<()> {
         let page_dir = site_dir.join(page.path.strip_prefix(base_path).unwrap_or(&page.path));
         let target = page_dir.join("index.html");
 
@@ -590,11 +620,13 @@ pub fn build_docs_with_cache(
             .map(|s| s.as_str())
             .unwrap_or_else(|| page.state["page"]["content"].as_str().unwrap_or(""));
 
-        // Protect <pre> blocks from HTML parser whitespace normalization.
-        let (protected, pre_blocks) = protect_pre_blocks(content);
-
-        // Substitute the raw signal in the template with the literal HTML.
-        let page_html = template_html.replace("{{{page.content}}}", &protected);
+        // Resolve site-owned regions before compiling the page so injected
+        // components participate in discovery, SSR, CSS, and hydration.
+        let page_html = regions
+            .render(page_layout(page))
+            .replace("{{{page.content}}}", content);
+        // Protect all preformatted content after region and page injection.
+        let (page_html, pre_blocks) = protect_pre_blocks(&page_html);
 
         // Per-page temp dir holding only this page's index.html — components
         // come exclusively from `component_sources`, which already includes
@@ -656,21 +688,20 @@ pub fn build_docs_with_cache(
             }
         }
 
-        let mut themed_state;
-        let render_state = if let Some(token_file) = token_file.as_ref() {
-            themed_state = page.state.clone();
-            inject_theme_tokens(&mut themed_state, token_file, &build_result.protocol.tokens)?;
-            &themed_state
-        } else {
-            &page.state
-        };
+        let layout = page_layout(page).to_string();
+        if regions.has_state(&layout) {
+            regions.apply_state(&layout, &mut page.state)?;
+        }
+        if let Some(token_file) = token_file.as_ref() {
+            inject_theme_tokens(&mut page.state, token_file, &build_result.protocol.tokens)?;
+        }
 
         let protocol = Protocol::new(build_result.protocol);
         let mut writer = StringWriter::with_capacity(8192);
         handler
             .render(
                 &protocol,
-                render_state,
+                &page.state,
                 &RenderOptions::new("index.html", &page.path),
                 &mut writer,
             )
@@ -748,8 +779,12 @@ pub fn build_docs_with_cache(
         head_injection: &head_injection,
         global_state: render_states.global(),
     });
+    regions.apply_state("doc", &mut not_found_state)?;
 
-    let not_found_html = template_html.replace("{{{page.content}}}", &not_found_content);
+    let not_found_html = regions
+        .render("doc")
+        .replace("{{{page.content}}}", &not_found_content);
+    let (not_found_html, not_found_pre_blocks) = protect_pre_blocks(&not_found_html);
     let nf_tmp = std::env::temp_dir().join(format!(
         "webui-press-404-{}-{:x}",
         std::process::id(),
@@ -809,7 +844,8 @@ pub fn build_docs_with_cache(
         )
         .map_err(|e| Error::Render(format!("404: {e}")))?;
 
-    fs::write(site_dir.join("404.html"), writer_404.buf).map_err(|e| Error::Io(e.to_string()))?;
+    let not_found_output = restore_pre_blocks(&writer_404.buf, &not_found_pre_blocks);
+    fs::write(site_dir.join("404.html"), not_found_output).map_err(|e| Error::Io(e.to_string()))?;
     fs::remove_dir_all(&nf_tmp).ok();
     print_success(cache, "Generated 404 page");
 
@@ -1337,6 +1373,12 @@ fn protect_pre_blocks(content: &str) -> (String, Vec<String>) {
         let start = cursor + rel_start;
         if let Some(rel_end) = content[start..].find("</pre>") {
             let end = start + rel_end + "</pre>".len();
+            let block = &content[start..end];
+            if pre_block_requires_compilation(block) {
+                out.push_str(&content[cursor..end]);
+                cursor = end;
+                continue;
+            }
             out.push_str(&content[cursor..start]);
             out.push_str(PRE_BLOCK_MARKER_PREFIX);
             // write! into existing buffer — avoids `format!` allocation per block.
@@ -1350,6 +1392,70 @@ fn protect_pre_blocks(content: &str) -> (String, Vec<String>) {
     }
     out.push_str(&content[cursor..]);
     (out, blocks)
+}
+
+fn pre_block_requires_compilation(block: &str) -> bool {
+    if block.contains("{{") {
+        return true;
+    }
+
+    let mut cursor = 0;
+    while let Some(offset) = block[cursor..].find('<') {
+        let tag_start = cursor + offset + 1;
+        let Some(tag_offset) = block[tag_start..].find('>') else {
+            break;
+        };
+        let tag_end = tag_start + tag_offset;
+        let raw_tag = &block[tag_start..tag_end];
+        if let Some(tag) = parse_html_tag(raw_tag) {
+            if !tag.is_end
+                && (tag.name.contains('-')
+                    || is_webui_directive(tag.name)
+                    || has_compiler_owned_attribute(raw_tag, tag.name.len()))
+            {
+                return true;
+            }
+        }
+        cursor = tag_end + 1;
+    }
+    false
+}
+
+fn is_webui_directive(name: &str) -> bool {
+    name.eq_ignore_ascii_case("if")
+        || name.eq_ignore_ascii_case("for")
+        || name.eq_ignore_ascii_case("outlet")
+        || name.eq_ignore_ascii_case("boundary")
+}
+
+fn has_compiler_owned_attribute(raw_tag: &str, mut cursor: usize) -> bool {
+    let bytes = raw_tag.as_bytes();
+    while cursor < bytes.len() {
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        let start = cursor;
+        while bytes.get(cursor).is_some_and(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'@' | b':' | b'?')
+        }) {
+            cursor += 1;
+        }
+        if start == cursor {
+            cursor += 1;
+            continue;
+        }
+        let attribute = &raw_tag[start..cursor];
+        if attribute
+            .as_bytes()
+            .first()
+            .is_some_and(|byte| matches!(byte, b'@' | b':' | b'?'))
+            || attribute.starts_with("w-")
+            || attribute == "key"
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Find the next opening `<pre` tag where the next byte is one of `>`, ` `,
@@ -1532,6 +1638,27 @@ mod tests {
         let (protected, blocks) = protect_pre_blocks(input);
         let restored = restore_pre_blocks(&protected, &blocks);
         assert_eq!(restored, input);
+    }
+
+    #[test]
+    fn protect_pre_blocks_keeps_dynamic_blocks_compilable() {
+        let input = "<pre>{{regions.home.panel.message}}</pre>";
+        let (protected, blocks) = protect_pre_blocks(input);
+        assert_eq!(protected, input);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn protect_pre_blocks_keeps_events_and_components_compilable() {
+        for input in [
+            r#"<pre @click="{copy()}">Copy</pre>"#,
+            "<pre><example-widget></example-widget></pre>",
+            r#"<pre w-ref="{code}">Code</pre>"#,
+        ] {
+            let (protected, blocks) = protect_pre_blocks(input);
+            assert_eq!(protected, input);
+            assert!(blocks.is_empty());
+        }
     }
 
     #[test]

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -457,8 +457,9 @@ pub fn build_docs_with_cache(
     } else {
         None
     };
+    let template_shell = regions.template_shell();
     let root_component_scripts =
-        collect_component_scripts_for_html(&[template_html.as_str()], &component_script_index)?;
+        collect_component_scripts_for_html(&[template_shell.as_str()], &component_script_index)?;
     let root_bundle = if template_script.is_some() || !root_component_scripts.is_empty() {
         Some(RootBundleEntry {
             script_path: template_script,

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -32,8 +32,13 @@ use crate::types::{BuildStats, DocsConfig, PageDescriptor};
 
 webui_handler::define_string_response_writer!(StringWriter, buf);
 
-fn page_layout(page: &PageDescriptor) -> &str {
-    page.state["page"]["layout"].as_str().unwrap_or("doc")
+fn region_layout(page: &PageDescriptor) -> &str {
+    let layout = page.state["page"]["layout"].as_str().unwrap_or("doc");
+    if layout == "home" && !page.is_home {
+        "doc"
+    } else {
+        layout
+    }
 }
 
 /// Persistent state held by the dev server across rebuilds. The dev
@@ -415,7 +420,7 @@ pub fn build_docs_with_cache(
                     .extend(scripts);
             }
         }
-        for script_file in regions.script_files(page_layout(page)) {
+        for script_file in regions.script_files(region_layout(page)) {
             explicit_page_scripts
                 .entry(page.path.clone())
                 .or_default()
@@ -480,7 +485,7 @@ pub fn build_docs_with_cache(
             .get(&page.path)
             .map(String::as_str)
             .unwrap_or_else(|| page.state["page"]["content"].as_str().unwrap_or(""));
-        let region_fragments = regions.html_fragments(page_layout(page));
+        let region_fragments = regions.html_fragments(region_layout(page));
         let mut html_sources = Vec::with_capacity(region_fragments.len() + 1);
         html_sources.push(content);
         html_sources.extend(region_fragments);
@@ -624,7 +629,7 @@ pub fn build_docs_with_cache(
         // region-resolved template.
         let (protected, pre_blocks) = protect_pre_blocks(content);
         let page_html = regions
-            .render(page_layout(page))
+            .render(region_layout(page))
             .replace("{{{page.content}}}", &protected);
 
         // Per-page temp dir holding only this page's index.html — components
@@ -687,7 +692,7 @@ pub fn build_docs_with_cache(
             }
         }
 
-        let layout = page_layout(page).to_string();
+        let layout = region_layout(page).to_string();
         regions.apply_state(&layout, &mut page.state)?;
         if let Some(token_file) = token_file.as_ref() {
             inject_theme_tokens(&mut page.state, token_file, &build_result.protocol.tokens)?;
@@ -1500,6 +1505,24 @@ mod tests {
         assert_eq!(state["pageData"], Value::Null);
         assert_eq!(state["headTags"], "<meta name=\"docs\">");
         Ok(())
+    }
+
+    #[test]
+    fn custom_home_layout_uses_non_home_regions() {
+        let state = test_obj([("page", test_obj([("layout", string_value("home"))]))]);
+        let custom_page = PageDescriptor {
+            path: "/custom/".to_string(),
+            is_home: false,
+            state: state.clone(),
+        };
+        let home_page = PageDescriptor {
+            path: "/".to_string(),
+            is_home: true,
+            state,
+        };
+
+        assert_eq!(region_layout(&custom_page), "doc");
+        assert_eq!(region_layout(&home_page), "home");
     }
 
     // --- truncate_utf8 ---------------------------------------------------

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -520,7 +520,6 @@ pub fn build_docs_with_cache(
     }
     let not_found_scripts: Vec<ScriptSource> = regions
         .script_files("doc")
-        .into_iter()
         .map(|path| ScriptSource::File(path.to_string()))
         .collect();
     let not_found_bundle_id =
@@ -620,13 +619,12 @@ pub fn build_docs_with_cache(
             .map(|s| s.as_str())
             .unwrap_or_else(|| page.state["page"]["content"].as_str().unwrap_or(""));
 
-        // Resolve site-owned regions before compiling the page so injected
-        // components participate in discovery, SSR, CSS, and hydration.
+        // Protect markdown code blocks before injecting content into the
+        // region-resolved template.
+        let (protected, pre_blocks) = protect_pre_blocks(content);
         let page_html = regions
             .render(page_layout(page))
-            .replace("{{{page.content}}}", content);
-        // Protect all preformatted content after region and page injection.
-        let (page_html, pre_blocks) = protect_pre_blocks(&page_html);
+            .replace("{{{page.content}}}", &protected);
 
         // Per-page temp dir holding only this page's index.html — components
         // come exclusively from `component_sources`, which already includes
@@ -689,9 +687,7 @@ pub fn build_docs_with_cache(
         }
 
         let layout = page_layout(page).to_string();
-        if regions.has_state(&layout) {
-            regions.apply_state(&layout, &mut page.state)?;
-        }
+        regions.apply_state(&layout, &mut page.state)?;
         if let Some(token_file) = token_file.as_ref() {
             inject_theme_tokens(&mut page.state, token_file, &build_result.protocol.tokens)?;
         }
@@ -781,10 +777,10 @@ pub fn build_docs_with_cache(
     });
     regions.apply_state("doc", &mut not_found_state)?;
 
+    let (protected_not_found, not_found_pre_blocks) = protect_pre_blocks(&not_found_content);
     let not_found_html = regions
         .render("doc")
-        .replace("{{{page.content}}}", &not_found_content);
-    let (not_found_html, not_found_pre_blocks) = protect_pre_blocks(&not_found_html);
+        .replace("{{{page.content}}}", &protected_not_found);
     let nf_tmp = std::env::temp_dir().join(format!(
         "webui-press-404-{}-{:x}",
         std::process::id(),
@@ -1373,12 +1369,6 @@ fn protect_pre_blocks(content: &str) -> (String, Vec<String>) {
         let start = cursor + rel_start;
         if let Some(rel_end) = content[start..].find("</pre>") {
             let end = start + rel_end + "</pre>".len();
-            let block = &content[start..end];
-            if pre_block_requires_compilation(block) {
-                out.push_str(&content[cursor..end]);
-                cursor = end;
-                continue;
-            }
             out.push_str(&content[cursor..start]);
             out.push_str(PRE_BLOCK_MARKER_PREFIX);
             // write! into existing buffer — avoids `format!` allocation per block.
@@ -1392,70 +1382,6 @@ fn protect_pre_blocks(content: &str) -> (String, Vec<String>) {
     }
     out.push_str(&content[cursor..]);
     (out, blocks)
-}
-
-fn pre_block_requires_compilation(block: &str) -> bool {
-    if block.contains("{{") {
-        return true;
-    }
-
-    let mut cursor = 0;
-    while let Some(offset) = block[cursor..].find('<') {
-        let tag_start = cursor + offset + 1;
-        let Some(tag_offset) = block[tag_start..].find('>') else {
-            break;
-        };
-        let tag_end = tag_start + tag_offset;
-        let raw_tag = &block[tag_start..tag_end];
-        if let Some(tag) = parse_html_tag(raw_tag) {
-            if !tag.is_end
-                && (tag.name.contains('-')
-                    || is_webui_directive(tag.name)
-                    || has_compiler_owned_attribute(raw_tag, tag.name.len()))
-            {
-                return true;
-            }
-        }
-        cursor = tag_end + 1;
-    }
-    false
-}
-
-fn is_webui_directive(name: &str) -> bool {
-    name.eq_ignore_ascii_case("if")
-        || name.eq_ignore_ascii_case("for")
-        || name.eq_ignore_ascii_case("outlet")
-        || name.eq_ignore_ascii_case("boundary")
-}
-
-fn has_compiler_owned_attribute(raw_tag: &str, mut cursor: usize) -> bool {
-    let bytes = raw_tag.as_bytes();
-    while cursor < bytes.len() {
-        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
-            cursor += 1;
-        }
-        let start = cursor;
-        while bytes.get(cursor).is_some_and(|byte| {
-            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'@' | b':' | b'?')
-        }) {
-            cursor += 1;
-        }
-        if start == cursor {
-            cursor += 1;
-            continue;
-        }
-        let attribute = &raw_tag[start..cursor];
-        if attribute
-            .as_bytes()
-            .first()
-            .is_some_and(|byte| matches!(byte, b'@' | b':' | b'?'))
-            || attribute.starts_with("w-")
-            || attribute == "key"
-        {
-            return true;
-        }
-    }
-    false
 }
 
 /// Find the next opening `<pre` tag where the next byte is one of `>`, ` `,
@@ -1638,27 +1564,6 @@ mod tests {
         let (protected, blocks) = protect_pre_blocks(input);
         let restored = restore_pre_blocks(&protected, &blocks);
         assert_eq!(restored, input);
-    }
-
-    #[test]
-    fn protect_pre_blocks_keeps_dynamic_blocks_compilable() {
-        let input = "<pre>{{regions.home.panel.message}}</pre>";
-        let (protected, blocks) = protect_pre_blocks(input);
-        assert_eq!(protected, input);
-        assert!(blocks.is_empty());
-    }
-
-    #[test]
-    fn protect_pre_blocks_keeps_events_and_components_compilable() {
-        for input in [
-            r#"<pre @click="{copy()}">Copy</pre>"#,
-            "<pre><example-widget></example-widget></pre>",
-            r#"<pre w-ref="{code}">Code</pre>"#,
-        ] {
-            let (protected, blocks) = protect_pre_blocks(input);
-            assert_eq!(protected, input);
-            assert!(blocks.is_empty());
-        }
     }
 
     #[test]

--- a/crates/webui-press/src/build.rs
+++ b/crates/webui-press/src/build.rs
@@ -360,7 +360,7 @@ pub fn build_docs_with_cache(
 
     let template_html = fs::read_to_string(template_dir.join("index.html"))
         .map_err(|e| Error::Build(format!("Failed to read template: {e}")))?;
-    let regions = RegionSet::load(&config.regions, config_dir, template_html.clone())?;
+    let regions = RegionSet::load(&config.regions, config_dir, template_html)?;
     let component_script_index = discover_component_scripts(&component_sources)?;
 
     // Step 3: Wipe the previous output and recreate the site root.

--- a/crates/webui-press/src/lib.rs
+++ b/crates/webui-press/src/lib.rs
@@ -11,6 +11,7 @@ mod bundler;
 pub mod content;
 pub mod error;
 pub mod markdown;
+mod regions;
 pub mod serve;
 mod state;
 pub mod types;

--- a/crates/webui-press/src/main.rs
+++ b/crates/webui-press/src/main.rs
@@ -16,6 +16,7 @@ mod bundler;
 mod content;
 mod error;
 mod markdown;
+mod regions;
 mod serve;
 mod state;
 mod types;

--- a/crates/webui-press/src/regions.rs
+++ b/crates/webui-press/src/regions.rs
@@ -3,25 +3,30 @@
 
 //! Compile-time named template regions.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
+use crate::state::StateLoader;
 use crate::types::RegionConfig;
 
 mod parser;
 
-use parser::{parse_declarations, RegionDeclaration};
+use parser::parse_declarations;
 
 const REGION_TAG: &str = "webui-press-region";
 const REGION_STATE_ROOT: &str = "regions";
 
 #[derive(Debug)]
-struct LoadedRegion {
-    html: String,
+struct Region {
+    start: usize,
+    end: usize,
+    name: String,
+    layout: Option<String>,
+    html: Option<String>,
     state: Option<Value>,
     script_file: Option<String>,
 }
@@ -30,8 +35,7 @@ struct LoadedRegion {
 #[derive(Debug)]
 pub(crate) struct RegionSet {
     template: String,
-    declarations: Vec<RegionDeclaration>,
-    regions: BTreeMap<String, LoadedRegion>,
+    regions: Vec<Region>,
 }
 
 impl RegionSet {
@@ -40,10 +44,9 @@ impl RegionSet {
         config_dir: &Path,
         template: String,
     ) -> Result<Self> {
-        let declarations = parse_declarations(&template)?;
-        let declared: HashSet<&str> = declarations.iter().map(|item| item.name.as_str()).collect();
+        let mut regions = parse_declarations(&template)?;
         for name in configs.keys() {
-            if !declared.contains(name.as_str()) {
+            if !regions.iter().any(|item| item.name == *name) {
                 return Err(Error::Build(format!(
                     "Region '{name}' is configured but the template does not declare it. \
                      Add <{REGION_TAG} name=\"{name}\"></{REGION_TAG}> or remove the config entry."
@@ -51,112 +54,80 @@ impl RegionSet {
             }
         }
 
-        let mut state_cache = HashMap::new();
-        let mut regions = BTreeMap::new();
-        for (name, config) in configs {
-            let html = load_html(name, config, config_dir)?;
-            let state = load_state(name, config, config_dir, &mut state_cache)?;
-            regions.insert(
-                name.clone(),
-                LoadedRegion {
-                    html,
-                    state,
-                    script_file: config.script_file.clone(),
-                },
-            );
+        let mut state_loader = StateLoader::new();
+        for region in &mut regions {
+            let Some(config) = configs.get(&region.name) else {
+                continue;
+            };
+            region.html = Some(load_html(&region.name, config, config_dir)?);
+            region.state = load_state(&region.name, config, config_dir, &mut state_loader)?;
+            region.script_file.clone_from(&config.script_file);
         }
-
         validate_state_paths(&regions)?;
 
-        Ok(Self {
-            template,
-            declarations,
-            regions,
-        })
+        Ok(Self { template, regions })
     }
 
     pub(crate) fn render(&self, layout: &str) -> String {
-        if self.declarations.is_empty() {
+        if self.regions.is_empty() {
             return self.template.clone();
         }
 
         let extra = self
-            .declarations
-            .iter()
-            .filter(|declaration| declaration_applies(declaration, layout))
-            .filter_map(|declaration| self.regions.get(&declaration.name))
-            .map(|region| region.html.len())
+            .active_regions(layout)
+            .filter_map(|region| region.html.as_ref())
+            .map(String::len)
             .sum();
         let mut output = String::with_capacity(self.template.len().saturating_add(extra));
         let mut cursor = 0;
-        for declaration in &self.declarations {
-            output.push_str(&self.template[cursor..declaration.start]);
-            if declaration_applies(declaration, layout) {
-                if let Some(region) = self.regions.get(&declaration.name) {
-                    output.push_str(&region.html);
+        for region in &self.regions {
+            output.push_str(&self.template[cursor..region.start]);
+            if region_applies(region, layout) {
+                if let Some(html) = &region.html {
+                    output.push_str(html);
                 }
             }
-            cursor = declaration.end;
+            cursor = region.end;
         }
         output.push_str(&self.template[cursor..]);
         output
     }
 
-    pub(crate) fn html_fragments(&self, layout: &str) -> Vec<&str> {
+    pub(crate) fn html_fragments<'a>(&'a self, layout: &'a str) -> Vec<&'a str> {
         self.active_regions(layout)
-            .into_iter()
-            .map(|region| region.html.as_str())
+            .filter_map(|region| region.html.as_deref())
             .collect()
     }
 
-    pub(crate) fn script_files(&self, layout: &str) -> Vec<&str> {
+    pub(crate) fn script_files<'a>(
+        &'a self,
+        layout: &'a str,
+    ) -> impl Iterator<Item = &'a str> + 'a {
         self.active_regions(layout)
-            .into_iter()
             .filter_map(|region| region.script_file.as_deref())
-            .collect()
-    }
-
-    pub(crate) fn has_state(&self, layout: &str) -> bool {
-        self.declarations.iter().any(|declaration| {
-            declaration_applies(declaration, layout)
-                && self
-                    .regions
-                    .get(&declaration.name)
-                    .is_some_and(|region| region.state.is_some())
-        })
     }
 
     pub(crate) fn apply_state(&self, layout: &str, state: &mut Value) -> Result<()> {
-        for declaration in &self.declarations {
-            if !declaration_applies(declaration, layout) {
+        for region in &self.regions {
+            if !region_applies(region, layout) {
                 continue;
             }
-            let Some(region_state) = self
-                .regions
-                .get(&declaration.name)
-                .and_then(|region| region.state.as_ref())
-            else {
-                continue;
-            };
-            insert_region_state(state, &declaration.name, region_state.clone())?;
+            if let Some(region_state) = &region.state {
+                insert_region_state(state, &region.name, region_state.clone())?;
+            }
         }
         Ok(())
     }
 
-    fn active_regions<'a>(&'a self, layout: &str) -> Vec<&'a LoadedRegion> {
-        self.declarations
+    fn active_regions<'a>(&'a self, layout: &'a str) -> impl Iterator<Item = &'a Region> + 'a {
+        self.regions
             .iter()
-            .filter(move |declaration| declaration_applies(declaration, layout))
-            .filter_map(|declaration| self.regions.get(&declaration.name))
-            .collect()
+            .filter(move |region| region_applies(region, layout))
     }
 }
 
-fn declaration_applies(declaration: &RegionDeclaration, layout: &str) -> bool {
-    declaration
-        .layout
-        .as_deref()
-        .is_none_or(|value| value == layout)
+fn region_applies(region: &Region, layout: &str) -> bool {
+    region.layout.as_deref().is_none_or(|value| value == layout)
 }
 
 fn load_html(name: &str, config: &RegionConfig, config_dir: &Path) -> Result<String> {
@@ -178,23 +149,17 @@ fn load_state(
     name: &str,
     config: &RegionConfig,
     config_dir: &Path,
-    cache: &mut HashMap<PathBuf, Value>,
+    loader: &mut StateLoader,
 ) -> Result<Option<Value>> {
-    let value = match (&config.state, &config.state_file) {
-        (Some(_), Some(_)) => {
-            return Err(Error::Build(format!(
-                "Region '{name}': 'state' and 'stateFile' are mutually exclusive - pick one."
-            )));
-        }
-        (Some(value), None) => Some(value.clone()),
-        (None, Some(path)) => Some(read_json_file(
-            &format!("Region '{name}' stateFile"),
-            path,
-            config_dir,
-            cache,
-        )?),
-        (None, None) => None,
-    };
+    let value = loader.load_state_value(
+        &format!("Region '{name}'"),
+        config.state.as_ref(),
+        config.state_file.as_deref(),
+        config_dir,
+    )?;
+    if value.as_ref().is_some_and(Value::is_null) {
+        return Ok(None);
+    }
     if value.as_ref().is_some_and(|item| !item.is_object()) {
         return Err(Error::Build(format!(
             "Region '{name}': state/stateFile must be a JSON object."
@@ -220,51 +185,19 @@ fn read_relative_file(label: &str, path: &str, config_dir: &Path) -> Result<Stri
     })
 }
 
-fn read_json_file(
-    label: &str,
-    path: &str,
-    config_dir: &Path,
-    cache: &mut HashMap<PathBuf, Value>,
-) -> Result<Value> {
-    let relative = Path::new(path);
-    if relative.is_absolute() {
-        return Err(Error::Build(format!(
-            "{label} must be relative to config.json, got {}",
-            relative.display()
-        )));
-    }
-    let absolute = config_dir.join(relative);
-    let key = fs::canonicalize(&absolute).unwrap_or_else(|_| absolute.clone());
-    if let Some(value) = cache.get(&key) {
-        return Ok(value.clone());
-    }
-    let raw = fs::read_to_string(&absolute).map_err(|error| {
-        Error::Build(format!(
-            "{label} {} cannot be read: {error}",
-            absolute.display()
-        ))
-    })?;
-    let value: Value = serde_json::from_str(&raw).map_err(|error| {
-        Error::Build(format!(
-            "{label} {} is not valid JSON: {error}",
-            absolute.display()
-        ))
-    })?;
-    cache.insert(key, value.clone());
-    Ok(value)
-}
-
-fn validate_state_paths(regions: &BTreeMap<String, LoadedRegion>) -> Result<()> {
-    for (ancestor_name, ancestor) in regions {
+fn validate_state_paths(regions: &[Region]) -> Result<()> {
+    for ancestor in regions {
         if ancestor.state.is_none() {
             continue;
         }
-        for (descendant_name, descendant) in regions {
-            if descendant.state.is_some() && is_dotted_path_prefix(ancestor_name, descendant_name) {
+        for descendant in regions {
+            if descendant.state.is_some() && is_dotted_path_prefix(&ancestor.name, &descendant.name)
+            {
                 return Err(Error::Build(format!(
-                    "Region state paths '{ancestor_name}' and '{descendant_name}' conflict. \
+                    "Region state paths '{}' and '{}' conflict. \
                      Rename one region or remove its state/stateFile so each state-bearing region \
-                     owns a distinct path."
+                     owns a distinct path.",
+                    ancestor.name, descendant.name
                 )));
             }
         }

--- a/crates/webui-press/src/regions.rs
+++ b/crates/webui-press/src/regions.rs
@@ -59,7 +59,9 @@ impl RegionSet {
             let Some(config) = configs.get(&region.name) else {
                 continue;
             };
-            region.html = Some(load_html(&region.name, config, config_dir)?);
+            if let Some(html) = load_html(&region.name, config, config_dir)? {
+                region.html = Some(html);
+            }
             region.state = load_state(&region.name, config, config_dir, &mut state_loader)?;
             region.script_file.clone_from(&config.script_file);
         }
@@ -87,6 +89,17 @@ impl RegionSet {
                     output.push_str(html);
                 }
             }
+            cursor = region.end;
+        }
+        output.push_str(&self.template[cursor..]);
+        output
+    }
+
+    pub(crate) fn template_shell(&self) -> String {
+        let mut output = String::with_capacity(self.template.len());
+        let mut cursor = 0;
+        for region in &self.regions {
+            output.push_str(&self.template[cursor..region.start]);
             cursor = region.end;
         }
         output.push_str(&self.template[cursor..]);
@@ -130,18 +143,16 @@ fn region_applies(region: &Region, layout: &str) -> bool {
     region.layout.as_deref().is_none_or(|value| value == layout)
 }
 
-fn load_html(name: &str, config: &RegionConfig, config_dir: &Path) -> Result<String> {
+fn load_html(name: &str, config: &RegionConfig, config_dir: &Path) -> Result<Option<String>> {
     match (&config.html, &config.html_file) {
         (Some(_), Some(_)) => Err(Error::Build(format!(
             "Region '{name}': 'html' and 'htmlFile' are mutually exclusive - pick one."
         ))),
-        (Some(html), None) => Ok(html.clone()),
+        (Some(html), None) => Ok(Some(html.clone())),
         (None, Some(path)) => {
-            read_relative_file(&format!("Region '{name}' htmlFile"), path, config_dir)
+            read_relative_file(&format!("Region '{name}' htmlFile"), path, config_dir).map(Some)
         }
-        (None, None) => Err(Error::Build(format!(
-            "Region '{name}' must define either 'html' or 'htmlFile'."
-        ))),
+        (None, None) => Ok(None),
     }
 }
 

--- a/crates/webui-press/src/regions.rs
+++ b/crates/webui-press/src/regions.rs
@@ -49,7 +49,9 @@ impl RegionSet {
             if !regions.iter().any(|item| item.name == *name) {
                 return Err(Error::Build(format!(
                     "Region '{name}' is configured but the template does not declare it. \
-                     Add <{REGION_TAG} name=\"{name}\"></{REGION_TAG}> or remove the config entry."
+                     Add <{REGION_TAG} name=\"{name}\" /> or \
+                     <{REGION_TAG} name=\"{name}\">fallback HTML</{REGION_TAG}>, \
+                     or remove the config entry."
                 )));
             }
         }

--- a/crates/webui-press/src/regions.rs
+++ b/crates/webui-press/src/regions.rs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Compile-time named template regions.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::error::{Error, Result};
+use crate::types::RegionConfig;
+
+mod parser;
+
+use parser::{parse_declarations, RegionDeclaration};
+
+const REGION_TAG: &str = "webui-press-region";
+const REGION_STATE_ROOT: &str = "regions";
+
+#[derive(Debug)]
+struct LoadedRegion {
+    html: String,
+    state: Option<Value>,
+    script_file: Option<String>,
+}
+
+/// Parsed template declarations plus site-owned region content.
+#[derive(Debug)]
+pub(crate) struct RegionSet {
+    template: String,
+    declarations: Vec<RegionDeclaration>,
+    regions: BTreeMap<String, LoadedRegion>,
+}
+
+impl RegionSet {
+    pub(crate) fn load(
+        configs: &BTreeMap<String, RegionConfig>,
+        config_dir: &Path,
+        template: String,
+    ) -> Result<Self> {
+        let declarations = parse_declarations(&template)?;
+        let declared: HashSet<&str> = declarations.iter().map(|item| item.name.as_str()).collect();
+        for name in configs.keys() {
+            if !declared.contains(name.as_str()) {
+                return Err(Error::Build(format!(
+                    "Region '{name}' is configured but the template does not declare it. \
+                     Add <{REGION_TAG} name=\"{name}\"></{REGION_TAG}> or remove the config entry."
+                )));
+            }
+        }
+
+        let mut state_cache = HashMap::new();
+        let mut regions = BTreeMap::new();
+        for (name, config) in configs {
+            let html = load_html(name, config, config_dir)?;
+            let state = load_state(name, config, config_dir, &mut state_cache)?;
+            regions.insert(
+                name.clone(),
+                LoadedRegion {
+                    html,
+                    state,
+                    script_file: config.script_file.clone(),
+                },
+            );
+        }
+
+        validate_state_paths(&regions)?;
+
+        Ok(Self {
+            template,
+            declarations,
+            regions,
+        })
+    }
+
+    pub(crate) fn render(&self, layout: &str) -> String {
+        if self.declarations.is_empty() {
+            return self.template.clone();
+        }
+
+        let extra = self
+            .declarations
+            .iter()
+            .filter(|declaration| declaration_applies(declaration, layout))
+            .filter_map(|declaration| self.regions.get(&declaration.name))
+            .map(|region| region.html.len())
+            .sum();
+        let mut output = String::with_capacity(self.template.len().saturating_add(extra));
+        let mut cursor = 0;
+        for declaration in &self.declarations {
+            output.push_str(&self.template[cursor..declaration.start]);
+            if declaration_applies(declaration, layout) {
+                if let Some(region) = self.regions.get(&declaration.name) {
+                    output.push_str(&region.html);
+                }
+            }
+            cursor = declaration.end;
+        }
+        output.push_str(&self.template[cursor..]);
+        output
+    }
+
+    pub(crate) fn html_fragments(&self, layout: &str) -> Vec<&str> {
+        self.active_regions(layout)
+            .into_iter()
+            .map(|region| region.html.as_str())
+            .collect()
+    }
+
+    pub(crate) fn script_files(&self, layout: &str) -> Vec<&str> {
+        self.active_regions(layout)
+            .into_iter()
+            .filter_map(|region| region.script_file.as_deref())
+            .collect()
+    }
+
+    pub(crate) fn has_state(&self, layout: &str) -> bool {
+        self.declarations.iter().any(|declaration| {
+            declaration_applies(declaration, layout)
+                && self
+                    .regions
+                    .get(&declaration.name)
+                    .is_some_and(|region| region.state.is_some())
+        })
+    }
+
+    pub(crate) fn apply_state(&self, layout: &str, state: &mut Value) -> Result<()> {
+        for declaration in &self.declarations {
+            if !declaration_applies(declaration, layout) {
+                continue;
+            }
+            let Some(region_state) = self
+                .regions
+                .get(&declaration.name)
+                .and_then(|region| region.state.as_ref())
+            else {
+                continue;
+            };
+            insert_region_state(state, &declaration.name, region_state.clone())?;
+        }
+        Ok(())
+    }
+
+    fn active_regions<'a>(&'a self, layout: &str) -> Vec<&'a LoadedRegion> {
+        self.declarations
+            .iter()
+            .filter(move |declaration| declaration_applies(declaration, layout))
+            .filter_map(|declaration| self.regions.get(&declaration.name))
+            .collect()
+    }
+}
+
+fn declaration_applies(declaration: &RegionDeclaration, layout: &str) -> bool {
+    declaration
+        .layout
+        .as_deref()
+        .is_none_or(|value| value == layout)
+}
+
+fn load_html(name: &str, config: &RegionConfig, config_dir: &Path) -> Result<String> {
+    match (&config.html, &config.html_file) {
+        (Some(_), Some(_)) => Err(Error::Build(format!(
+            "Region '{name}': 'html' and 'htmlFile' are mutually exclusive - pick one."
+        ))),
+        (Some(html), None) => Ok(html.clone()),
+        (None, Some(path)) => {
+            read_relative_file(&format!("Region '{name}' htmlFile"), path, config_dir)
+        }
+        (None, None) => Err(Error::Build(format!(
+            "Region '{name}' must define either 'html' or 'htmlFile'."
+        ))),
+    }
+}
+
+fn load_state(
+    name: &str,
+    config: &RegionConfig,
+    config_dir: &Path,
+    cache: &mut HashMap<PathBuf, Value>,
+) -> Result<Option<Value>> {
+    let value = match (&config.state, &config.state_file) {
+        (Some(_), Some(_)) => {
+            return Err(Error::Build(format!(
+                "Region '{name}': 'state' and 'stateFile' are mutually exclusive - pick one."
+            )));
+        }
+        (Some(value), None) => Some(value.clone()),
+        (None, Some(path)) => Some(read_json_file(
+            &format!("Region '{name}' stateFile"),
+            path,
+            config_dir,
+            cache,
+        )?),
+        (None, None) => None,
+    };
+    if value.as_ref().is_some_and(|item| !item.is_object()) {
+        return Err(Error::Build(format!(
+            "Region '{name}': state/stateFile must be a JSON object."
+        )));
+    }
+    Ok(value)
+}
+
+fn read_relative_file(label: &str, path: &str, config_dir: &Path) -> Result<String> {
+    let relative = Path::new(path);
+    if relative.is_absolute() {
+        return Err(Error::Build(format!(
+            "{label} must be relative to config.json, got {}",
+            relative.display()
+        )));
+    }
+    let absolute = config_dir.join(relative);
+    fs::read_to_string(&absolute).map_err(|error| {
+        Error::Build(format!(
+            "{label} {} cannot be read: {error}",
+            absolute.display()
+        ))
+    })
+}
+
+fn read_json_file(
+    label: &str,
+    path: &str,
+    config_dir: &Path,
+    cache: &mut HashMap<PathBuf, Value>,
+) -> Result<Value> {
+    let relative = Path::new(path);
+    if relative.is_absolute() {
+        return Err(Error::Build(format!(
+            "{label} must be relative to config.json, got {}",
+            relative.display()
+        )));
+    }
+    let absolute = config_dir.join(relative);
+    let key = fs::canonicalize(&absolute).unwrap_or_else(|_| absolute.clone());
+    if let Some(value) = cache.get(&key) {
+        return Ok(value.clone());
+    }
+    let raw = fs::read_to_string(&absolute).map_err(|error| {
+        Error::Build(format!(
+            "{label} {} cannot be read: {error}",
+            absolute.display()
+        ))
+    })?;
+    let value: Value = serde_json::from_str(&raw).map_err(|error| {
+        Error::Build(format!(
+            "{label} {} is not valid JSON: {error}",
+            absolute.display()
+        ))
+    })?;
+    cache.insert(key, value.clone());
+    Ok(value)
+}
+
+fn validate_state_paths(regions: &BTreeMap<String, LoadedRegion>) -> Result<()> {
+    for (ancestor_name, ancestor) in regions {
+        if ancestor.state.is_none() {
+            continue;
+        }
+        for (descendant_name, descendant) in regions {
+            if descendant.state.is_some() && is_dotted_path_prefix(ancestor_name, descendant_name) {
+                return Err(Error::Build(format!(
+                    "Region state paths '{ancestor_name}' and '{descendant_name}' conflict. \
+                     Rename one region or remove its state/stateFile so each state-bearing region \
+                     owns a distinct path."
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_dotted_path_prefix(ancestor: &str, descendant: &str) -> bool {
+    descendant.len() > ancestor.len()
+        && descendant.starts_with(ancestor)
+        && descendant.as_bytes().get(ancestor.len()) == Some(&b'.')
+}
+
+fn insert_region_state(state: &mut Value, name: &str, value: Value) -> Result<()> {
+    let root = state
+        .as_object_mut()
+        .ok_or_else(|| Error::Build("Page render state must be a JSON object.".to_string()))?;
+    let regions = root
+        .entry(REGION_STATE_ROOT)
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .ok_or_else(|| Error::Build("Reserved 'regions' state must be an object.".to_string()))?;
+
+    let mut current = regions;
+    let mut segments = name.split('.').peekable();
+    while let Some(segment) = segments.next() {
+        if segments.peek().is_none() {
+            current.insert(segment.to_string(), value);
+            return Ok(());
+        }
+        current = current
+            .entry(segment)
+            .or_insert_with(|| Value::Object(Map::new()))
+            .as_object_mut()
+            .ok_or_else(|| {
+                Error::Build(format!(
+                    "Region state path '{name}' conflicts with another region."
+                ))
+            })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -54,6 +54,11 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
                     Error::Build(format!("Template region '{name}' has no closing tag."))
                 })?;
             let close_start = content_start + close_offset;
+            if template[content_start..close_start].contains(REGION_OPEN) {
+                return Err(Error::Build(format!(
+                    "Template region '{name}' contains a nested region; region declarations cannot be nested."
+                )));
+            }
             (
                 close_start + REGION_CLOSE.len(),
                 Some(template[content_start..close_start].to_string()),

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -27,6 +27,10 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
             cursor = name_end;
             continue;
         }
+        if inside_comment(template, start) {
+            cursor = name_end;
+            continue;
+        }
         let open_end = name_end
             + template[name_end..]
                 .find('>')
@@ -68,6 +72,13 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
     }
 
     Ok(declarations)
+}
+
+fn inside_comment(template: &str, offset: usize) -> bool {
+    let prefix = &template[..offset];
+    prefix
+        .rfind("<!--")
+        .is_some_and(|open| prefix.rfind("-->").is_none_or(|close| open > close))
 }
 
 fn parse_attributes(raw: &str, self_closing: bool) -> Result<(String, Option<String>)> {

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -40,8 +40,8 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
             )));
         }
 
-        let end = if self_closing {
-            open_end + 1
+        let (end, html) = if self_closing {
+            (open_end + 1, None)
         } else {
             let content_start = open_end + 1;
             let close_offset = template[content_start..]
@@ -50,19 +50,17 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
                     Error::Build(format!("Template region '{name}' has no closing tag."))
                 })?;
             let close_start = content_start + close_offset;
-            if !template[content_start..close_start].trim().is_empty() {
-                return Err(Error::Build(format!(
-                    "Template region '{name}' must be empty; configure its content in config.json."
-                )));
-            }
-            close_start + REGION_CLOSE.len()
+            (
+                close_start + REGION_CLOSE.len(),
+                Some(template[content_start..close_start].to_string()),
+            )
         };
         declarations.push(Region {
             start,
             end,
             name,
             layout,
-            html: None,
+            html,
             state: None,
             script_file: None,
         });

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -1,117 +1,70 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Deterministic scanner for compile-time region declarations.
+//! Strict scanner for trusted template region markers.
 
 use std::collections::HashSet;
 
 use crate::error::{Error, Result};
 
-use super::REGION_TAG;
+use super::{Region, REGION_TAG};
 
-const HTML_COMMENT_OPEN: &str = "<!--";
-const HTML_COMMENT_CLOSE: &str = "-->";
+const REGION_OPEN: &str = "<webui-press-region";
+const REGION_CLOSE: &str = "</webui-press-region>";
 
-#[derive(Debug)]
-pub(super) struct RegionDeclaration {
-    pub(super) start: usize,
-    pub(super) end: usize,
-    pub(super) name: String,
-    pub(super) layout: Option<String>,
-}
-
-pub(super) fn parse_declarations(template: &str) -> Result<Vec<RegionDeclaration>> {
+pub(super) fn parse_declarations(template: &str) -> Result<Vec<Region>> {
     let mut declarations = Vec::new();
     let mut names = HashSet::new();
     let mut cursor = 0;
 
-    while let Some(offset) = template[cursor..].find('<') {
+    while let Some(offset) = template[cursor..].find(REGION_OPEN) {
         let start = cursor + offset;
-        if template[start..].starts_with(HTML_COMMENT_OPEN) {
-            let comment_start = start + HTML_COMMENT_OPEN.len();
-            let Some(close_offset) = template[comment_start..].find(HTML_COMMENT_CLOSE) else {
-                break;
-            };
-            cursor = comment_start + close_offset + HTML_COMMENT_CLOSE.len();
-            continue;
-        }
-
-        let bytes = template.as_bytes();
-        let mut name_start = start + 1;
-        let is_end = bytes.get(name_start) == Some(&b'/');
-        if is_end {
-            name_start += 1;
-        }
-        let Some(first) = bytes.get(name_start).copied() else {
-            break;
+        let name_end = start + REGION_OPEN.len();
+        let Some(next) = template.as_bytes().get(name_end).copied() else {
+            return Err(invalid_declaration("region start tag is incomplete"));
         };
-        if matches!(first, b'!' | b'?') {
-            cursor = find_tag_end(template, start).map_or(template.len(), |end| end + 1);
+        if !next.is_ascii_whitespace() && !matches!(next, b'/' | b'>') {
+            cursor = name_end;
             continue;
         }
-
-        let mut name_end = name_start;
-        while bytes
-            .get(name_end)
-            .is_some_and(|byte| is_tag_name_byte(*byte))
-        {
-            name_end += 1;
-        }
-        if name_end == name_start {
-            cursor = template[name_start..]
-                .chars()
-                .next()
-                .map_or(template.len(), |ch| name_start + ch.len_utf8());
-            continue;
-        }
-
-        let tag_name = &template[name_start..name_end];
-        let is_region = tag_name.eq_ignore_ascii_case(REGION_TAG);
-        let open_end =
-            find_tag_end(template, start).ok_or_else(|| invalid_unclosed_tag(is_region))?;
-        let self_closing = template[name_end..open_end].trim_end().ends_with('/');
-
-        if !is_end && !self_closing && is_raw_text_tag(tag_name) {
-            cursor = if tag_name.eq_ignore_ascii_case("plaintext") {
-                template.len()
-            } else {
-                find_closing_tag(template, open_end + 1, tag_name)
-                    .map_or(template.len(), |(_, end)| end)
-            };
-            continue;
-        }
-        if is_end || !is_region {
-            cursor = open_end + 1;
-            continue;
-        }
-
-        let attributes = parse_region_attributes(&template[name_end..open_end])?;
-        let name = attributes.name;
+        let open_end = name_end
+            + template[name_end..]
+                .find('>')
+                .ok_or_else(|| invalid_declaration("region start tag is not closed"))?;
+        let raw_attributes = &template[name_end..open_end];
+        let self_closing = raw_attributes.trim_end().ends_with('/');
+        let (name, layout) = parse_attributes(raw_attributes, self_closing)?;
         if !names.insert(name.clone()) {
             return Err(Error::Build(format!(
                 "Template region '{name}' is declared more than once."
             )));
         }
+
         let end = if self_closing {
             open_end + 1
         } else {
             let content_start = open_end + 1;
-            let (close_start, close_end) = find_closing_tag(template, content_start, REGION_TAG)
+            let close_offset = template[content_start..]
+                .find(REGION_CLOSE)
                 .ok_or_else(|| {
                     Error::Build(format!("Template region '{name}' has no closing tag."))
                 })?;
+            let close_start = content_start + close_offset;
             if !template[content_start..close_start].trim().is_empty() {
                 return Err(Error::Build(format!(
                     "Template region '{name}' must be empty; configure its content in config.json."
                 )));
             }
-            close_end
+            close_start + REGION_CLOSE.len()
         };
-        declarations.push(RegionDeclaration {
+        declarations.push(Region {
             start,
             end,
             name,
-            layout: attributes.layout,
+            layout,
+            html: None,
+            state: None,
+            script_file: None,
         });
         cursor = end;
     }
@@ -119,75 +72,45 @@ pub(super) fn parse_declarations(template: &str) -> Result<Vec<RegionDeclaration
     Ok(declarations)
 }
 
-struct RegionAttributes {
-    name: String,
-    layout: Option<String>,
-}
-
-fn parse_region_attributes(raw: &str) -> Result<RegionAttributes> {
-    let bytes = raw.as_bytes();
-    let mut cursor = 0;
+fn parse_attributes(raw: &str, self_closing: bool) -> Result<(String, Option<String>)> {
+    let mut remaining = raw.trim();
+    if self_closing {
+        remaining = remaining
+            .strip_suffix('/')
+            .map(str::trim_end)
+            .unwrap_or(remaining);
+    }
     let mut name = None;
     let mut layout = None;
 
-    while cursor < bytes.len() {
-        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
-            cursor += 1;
-        }
-        if cursor == bytes.len() {
-            break;
-        }
-        if bytes.get(cursor) == Some(&b'/') && raw[cursor + 1..].trim().is_empty() {
-            break;
-        }
-
-        let attribute_start = cursor;
-        while bytes
-            .get(cursor)
-            .is_some_and(|byte| is_attribute_name_byte(*byte))
-        {
-            cursor += 1;
-        }
-        if attribute_start == cursor {
-            return Err(invalid_declaration("attributes are malformed"));
-        }
-        let attribute = &raw[attribute_start..cursor];
-        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
-            cursor += 1;
-        }
-        if bytes.get(cursor) != Some(&b'=') {
-            return Err(invalid_declaration(&format!(
-                "attribute '{attribute}' requires a non-empty value"
-            )));
-        }
-        cursor += 1;
-        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
-            cursor += 1;
-        }
-        let (value, next) = parse_attribute_value(raw, cursor)?;
-        cursor = next;
+    for token in remaining.split_ascii_whitespace() {
+        let Some((attribute, quoted)) = token.split_once('=') else {
+            return Err(attribute_error(token, "requires a quoted value"));
+        };
+        let value = quoted
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .or_else(|| {
+                quoted
+                    .strip_prefix('\'')
+                    .and_then(|value| value.strip_suffix('\''))
+            })
+            .ok_or_else(|| attribute_error(attribute, "requires a quoted value"))?;
         if value.is_empty() {
-            return Err(invalid_declaration(&format!(
-                "attribute '{attribute}' requires a non-empty value"
-            )));
+            return Err(attribute_error(attribute, "requires a non-empty value"));
         }
 
-        if attribute.eq_ignore_ascii_case("name") {
-            if name.replace(value).is_some() {
-                return Err(invalid_declaration(&format!(
-                    "attribute '{attribute}' is declared more than once"
-                )));
-            }
+        let slot = if attribute.eq_ignore_ascii_case("name") {
+            &mut name
         } else if attribute.eq_ignore_ascii_case("layout") {
-            if layout.replace(value).is_some() {
-                return Err(invalid_declaration(&format!(
-                    "attribute '{attribute}' is declared more than once"
-                )));
-            }
+            &mut layout
         } else {
             return Err(invalid_declaration(&format!(
                 "unsupported attribute '{attribute}'; use only 'name' and optional 'layout'"
             )));
+        };
+        if slot.replace(value.to_string()).is_some() {
+            return Err(attribute_error(attribute, "is declared more than once"));
         }
     }
 
@@ -196,99 +119,7 @@ fn parse_region_attributes(raw: &str) -> Result<RegionAttributes> {
         .ok_or_else(|| {
             invalid_declaration("region name is missing or contains invalid characters")
         })?;
-    Ok(RegionAttributes { name, layout })
-}
-
-fn parse_attribute_value(raw: &str, cursor: usize) -> Result<(String, usize)> {
-    let bytes = raw.as_bytes();
-    match bytes.get(cursor).copied() {
-        Some(quote @ (b'"' | b'\'')) => {
-            let value_start = cursor + 1;
-            let Some(close_offset) = raw[value_start..].find(char::from(quote)) else {
-                return Err(invalid_declaration("quoted attribute value is not closed"));
-            };
-            let value_end = value_start + close_offset;
-            Ok((raw[value_start..value_end].to_string(), value_end + 1))
-        }
-        Some(_) => {
-            let value_start = cursor;
-            let mut value_end = cursor;
-            while bytes
-                .get(value_end)
-                .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b'/')
-            {
-                value_end += 1;
-            }
-            Ok((raw[value_start..value_end].to_string(), value_end))
-        }
-        None => Err(invalid_declaration("attribute value is missing")),
-    }
-}
-
-fn find_tag_end(source: &str, start: usize) -> Option<usize> {
-    let bytes = source.as_bytes();
-    let mut quote = None;
-    let mut cursor = start;
-    while let Some(byte) = bytes.get(cursor).copied() {
-        match (quote, byte) {
-            (Some(active), current) if active == current => quote = None,
-            (None, b'"' | b'\'') => quote = Some(byte),
-            (None, b'>') => return Some(cursor),
-            _ => {}
-        }
-        cursor += 1;
-    }
-    None
-}
-
-fn find_closing_tag(source: &str, start: usize, target: &str) -> Option<(usize, usize)> {
-    let bytes = source.as_bytes();
-    let mut cursor = start;
-    while let Some(offset) = source[cursor..].find('<') {
-        let tag_start = cursor + offset;
-        let name_start = tag_start + 2;
-        if bytes.get(tag_start + 1) != Some(&b'/') {
-            cursor = tag_start + 1;
-            continue;
-        }
-        let mut name_end = name_start;
-        while bytes
-            .get(name_end)
-            .is_some_and(|byte| is_tag_name_byte(*byte))
-        {
-            name_end += 1;
-        }
-        let has_tag_name_delimiter = bytes
-            .get(name_end)
-            .is_some_and(|byte| byte.is_ascii_whitespace() || matches!(byte, b'/' | b'>'));
-        if has_tag_name_delimiter && source[name_start..name_end].eq_ignore_ascii_case(target) {
-            let end = find_tag_end(source, tag_start)?;
-            return Some((tag_start, end + 1));
-        }
-        cursor = name_end.max(tag_start + 1);
-    }
-    None
-}
-
-fn is_raw_text_tag(name: &str) -> bool {
-    name.eq_ignore_ascii_case("script")
-        || name.eq_ignore_ascii_case("style")
-        || name.eq_ignore_ascii_case("textarea")
-        || name.eq_ignore_ascii_case("title")
-        || name.eq_ignore_ascii_case("xmp")
-        || name.eq_ignore_ascii_case("iframe")
-        || name.eq_ignore_ascii_case("noembed")
-        || name.eq_ignore_ascii_case("noframes")
-        || name.eq_ignore_ascii_case("noscript")
-        || name.eq_ignore_ascii_case("plaintext")
-}
-
-fn is_tag_name_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'-'
-}
-
-fn is_attribute_name_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+    Ok((name, layout))
 }
 
 fn valid_region_name(name: &str) -> bool {
@@ -302,16 +133,12 @@ fn valid_region_name(name: &str) -> bool {
 
 #[cold]
 #[inline(never)]
-fn invalid_declaration(message: &str) -> Error {
-    Error::Build(format!("Invalid <{REGION_TAG}> declaration: {message}."))
+fn attribute_error(attribute: &str, message: &str) -> Error {
+    invalid_declaration(&format!("attribute '{attribute}' {message}"))
 }
 
 #[cold]
 #[inline(never)]
-fn invalid_unclosed_tag(is_region: bool) -> Error {
-    if is_region {
-        invalid_declaration("region start tag is not closed")
-    } else {
-        Error::Build("Template contains an unclosed HTML start tag.".to_string())
-    }
+fn invalid_declaration(message: &str) -> Error {
+    Error::Build(format!("Invalid <{REGION_TAG}> declaration: {message}."))
 }

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -81,22 +81,31 @@ fn parse_attributes(raw: &str, self_closing: bool) -> Result<(String, Option<Str
     let mut name = None;
     let mut layout = None;
 
-    for token in remaining.split_ascii_whitespace() {
-        let Some((attribute, quoted)) = token.split_once('=') else {
-            return Err(attribute_error(token, "requires a quoted value"));
+    while !remaining.is_empty() {
+        let name_end = remaining
+            .find(|ch: char| ch.is_ascii_whitespace() || ch == '=')
+            .unwrap_or(remaining.len());
+        if name_end == 0 {
+            return Err(invalid_declaration("attributes are malformed"));
+        }
+        let attribute = &remaining[..name_end];
+        remaining = remaining[name_end..].trim_start();
+        let Some(after_equals) = remaining.strip_prefix('=') else {
+            return Err(attribute_error(attribute, "requires a quoted value"));
         };
-        let value = quoted
-            .strip_prefix('"')
-            .and_then(|value| value.strip_suffix('"'))
-            .or_else(|| {
-                quoted
-                    .strip_prefix('\'')
-                    .and_then(|value| value.strip_suffix('\''))
-            })
-            .ok_or_else(|| attribute_error(attribute, "requires a quoted value"))?;
+        remaining = after_equals.trim_start();
+        let Some(quote @ ('"' | '\'')) = remaining.chars().next() else {
+            return Err(attribute_error(attribute, "requires a quoted value"));
+        };
+        let value_start = quote.len_utf8();
+        let Some(value_end) = remaining[value_start..].find(quote) else {
+            return Err(attribute_error(attribute, "has an unclosed quoted value"));
+        };
+        let value = &remaining[value_start..value_start + value_end];
         if value.is_empty() {
             return Err(attribute_error(attribute, "requires a non-empty value"));
         }
+        remaining = remaining[value_start + value_end + quote.len_utf8()..].trim_start();
 
         let slot = if attribute.eq_ignore_ascii_case("name") {
             &mut name

--- a/crates/webui-press/src/regions/parser.rs
+++ b/crates/webui-press/src/regions/parser.rs
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Deterministic scanner for compile-time region declarations.
+
+use std::collections::HashSet;
+
+use crate::error::{Error, Result};
+
+use super::REGION_TAG;
+
+const HTML_COMMENT_OPEN: &str = "<!--";
+const HTML_COMMENT_CLOSE: &str = "-->";
+
+#[derive(Debug)]
+pub(super) struct RegionDeclaration {
+    pub(super) start: usize,
+    pub(super) end: usize,
+    pub(super) name: String,
+    pub(super) layout: Option<String>,
+}
+
+pub(super) fn parse_declarations(template: &str) -> Result<Vec<RegionDeclaration>> {
+    let mut declarations = Vec::new();
+    let mut names = HashSet::new();
+    let mut cursor = 0;
+
+    while let Some(offset) = template[cursor..].find('<') {
+        let start = cursor + offset;
+        if template[start..].starts_with(HTML_COMMENT_OPEN) {
+            let comment_start = start + HTML_COMMENT_OPEN.len();
+            let Some(close_offset) = template[comment_start..].find(HTML_COMMENT_CLOSE) else {
+                break;
+            };
+            cursor = comment_start + close_offset + HTML_COMMENT_CLOSE.len();
+            continue;
+        }
+
+        let bytes = template.as_bytes();
+        let mut name_start = start + 1;
+        let is_end = bytes.get(name_start) == Some(&b'/');
+        if is_end {
+            name_start += 1;
+        }
+        let Some(first) = bytes.get(name_start).copied() else {
+            break;
+        };
+        if matches!(first, b'!' | b'?') {
+            cursor = find_tag_end(template, start).map_or(template.len(), |end| end + 1);
+            continue;
+        }
+
+        let mut name_end = name_start;
+        while bytes
+            .get(name_end)
+            .is_some_and(|byte| is_tag_name_byte(*byte))
+        {
+            name_end += 1;
+        }
+        if name_end == name_start {
+            cursor = template[name_start..]
+                .chars()
+                .next()
+                .map_or(template.len(), |ch| name_start + ch.len_utf8());
+            continue;
+        }
+
+        let tag_name = &template[name_start..name_end];
+        let is_region = tag_name.eq_ignore_ascii_case(REGION_TAG);
+        let open_end =
+            find_tag_end(template, start).ok_or_else(|| invalid_unclosed_tag(is_region))?;
+        let self_closing = template[name_end..open_end].trim_end().ends_with('/');
+
+        if !is_end && !self_closing && is_raw_text_tag(tag_name) {
+            cursor = if tag_name.eq_ignore_ascii_case("plaintext") {
+                template.len()
+            } else {
+                find_closing_tag(template, open_end + 1, tag_name)
+                    .map_or(template.len(), |(_, end)| end)
+            };
+            continue;
+        }
+        if is_end || !is_region {
+            cursor = open_end + 1;
+            continue;
+        }
+
+        let attributes = parse_region_attributes(&template[name_end..open_end])?;
+        let name = attributes.name;
+        if !names.insert(name.clone()) {
+            return Err(Error::Build(format!(
+                "Template region '{name}' is declared more than once."
+            )));
+        }
+        let end = if self_closing {
+            open_end + 1
+        } else {
+            let content_start = open_end + 1;
+            let (close_start, close_end) = find_closing_tag(template, content_start, REGION_TAG)
+                .ok_or_else(|| {
+                    Error::Build(format!("Template region '{name}' has no closing tag."))
+                })?;
+            if !template[content_start..close_start].trim().is_empty() {
+                return Err(Error::Build(format!(
+                    "Template region '{name}' must be empty; configure its content in config.json."
+                )));
+            }
+            close_end
+        };
+        declarations.push(RegionDeclaration {
+            start,
+            end,
+            name,
+            layout: attributes.layout,
+        });
+        cursor = end;
+    }
+
+    Ok(declarations)
+}
+
+struct RegionAttributes {
+    name: String,
+    layout: Option<String>,
+}
+
+fn parse_region_attributes(raw: &str) -> Result<RegionAttributes> {
+    let bytes = raw.as_bytes();
+    let mut cursor = 0;
+    let mut name = None;
+    let mut layout = None;
+
+    while cursor < bytes.len() {
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if cursor == bytes.len() {
+            break;
+        }
+        if bytes.get(cursor) == Some(&b'/') && raw[cursor + 1..].trim().is_empty() {
+            break;
+        }
+
+        let attribute_start = cursor;
+        while bytes
+            .get(cursor)
+            .is_some_and(|byte| is_attribute_name_byte(*byte))
+        {
+            cursor += 1;
+        }
+        if attribute_start == cursor {
+            return Err(invalid_declaration("attributes are malformed"));
+        }
+        let attribute = &raw[attribute_start..cursor];
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'=') {
+            return Err(invalid_declaration(&format!(
+                "attribute '{attribute}' requires a non-empty value"
+            )));
+        }
+        cursor += 1;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        let (value, next) = parse_attribute_value(raw, cursor)?;
+        cursor = next;
+        if value.is_empty() {
+            return Err(invalid_declaration(&format!(
+                "attribute '{attribute}' requires a non-empty value"
+            )));
+        }
+
+        if attribute.eq_ignore_ascii_case("name") {
+            if name.replace(value).is_some() {
+                return Err(invalid_declaration(&format!(
+                    "attribute '{attribute}' is declared more than once"
+                )));
+            }
+        } else if attribute.eq_ignore_ascii_case("layout") {
+            if layout.replace(value).is_some() {
+                return Err(invalid_declaration(&format!(
+                    "attribute '{attribute}' is declared more than once"
+                )));
+            }
+        } else {
+            return Err(invalid_declaration(&format!(
+                "unsupported attribute '{attribute}'; use only 'name' and optional 'layout'"
+            )));
+        }
+    }
+
+    let name = name
+        .filter(|value| valid_region_name(value))
+        .ok_or_else(|| {
+            invalid_declaration("region name is missing or contains invalid characters")
+        })?;
+    Ok(RegionAttributes { name, layout })
+}
+
+fn parse_attribute_value(raw: &str, cursor: usize) -> Result<(String, usize)> {
+    let bytes = raw.as_bytes();
+    match bytes.get(cursor).copied() {
+        Some(quote @ (b'"' | b'\'')) => {
+            let value_start = cursor + 1;
+            let Some(close_offset) = raw[value_start..].find(char::from(quote)) else {
+                return Err(invalid_declaration("quoted attribute value is not closed"));
+            };
+            let value_end = value_start + close_offset;
+            Ok((raw[value_start..value_end].to_string(), value_end + 1))
+        }
+        Some(_) => {
+            let value_start = cursor;
+            let mut value_end = cursor;
+            while bytes
+                .get(value_end)
+                .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b'/')
+            {
+                value_end += 1;
+            }
+            Ok((raw[value_start..value_end].to_string(), value_end))
+        }
+        None => Err(invalid_declaration("attribute value is missing")),
+    }
+}
+
+fn find_tag_end(source: &str, start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut quote = None;
+    let mut cursor = start;
+    while let Some(byte) = bytes.get(cursor).copied() {
+        match (quote, byte) {
+            (Some(active), current) if active == current => quote = None,
+            (None, b'"' | b'\'') => quote = Some(byte),
+            (None, b'>') => return Some(cursor),
+            _ => {}
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn find_closing_tag(source: &str, start: usize, target: &str) -> Option<(usize, usize)> {
+    let bytes = source.as_bytes();
+    let mut cursor = start;
+    while let Some(offset) = source[cursor..].find('<') {
+        let tag_start = cursor + offset;
+        let name_start = tag_start + 2;
+        if bytes.get(tag_start + 1) != Some(&b'/') {
+            cursor = tag_start + 1;
+            continue;
+        }
+        let mut name_end = name_start;
+        while bytes
+            .get(name_end)
+            .is_some_and(|byte| is_tag_name_byte(*byte))
+        {
+            name_end += 1;
+        }
+        let has_tag_name_delimiter = bytes
+            .get(name_end)
+            .is_some_and(|byte| byte.is_ascii_whitespace() || matches!(byte, b'/' | b'>'));
+        if has_tag_name_delimiter && source[name_start..name_end].eq_ignore_ascii_case(target) {
+            let end = find_tag_end(source, tag_start)?;
+            return Some((tag_start, end + 1));
+        }
+        cursor = name_end.max(tag_start + 1);
+    }
+    None
+}
+
+fn is_raw_text_tag(name: &str) -> bool {
+    name.eq_ignore_ascii_case("script")
+        || name.eq_ignore_ascii_case("style")
+        || name.eq_ignore_ascii_case("textarea")
+        || name.eq_ignore_ascii_case("title")
+        || name.eq_ignore_ascii_case("xmp")
+        || name.eq_ignore_ascii_case("iframe")
+        || name.eq_ignore_ascii_case("noembed")
+        || name.eq_ignore_ascii_case("noframes")
+        || name.eq_ignore_ascii_case("noscript")
+        || name.eq_ignore_ascii_case("plaintext")
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'-'
+}
+
+fn is_attribute_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+}
+
+fn valid_region_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        && name.split('.').all(|segment| !segment.is_empty())
+}
+
+#[cold]
+#[inline(never)]
+fn invalid_declaration(message: &str) -> Error {
+    Error::Build(format!("Invalid <{REGION_TAG}> declaration: {message}."))
+}
+
+#[cold]
+#[inline(never)]
+fn invalid_unclosed_tag(is_region: bool) -> Error {
+    if is_region {
+        invalid_declaration("region start tag is not closed")
+    } else {
+        Error::Build("Template contains an unclosed HTML start tag.".to_string())
+    }
+}

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -191,6 +191,21 @@ fn rejects_invalid_declarations() {
 }
 
 #[test]
+fn ignores_commented_markers() -> TestResult {
+    let template = concat!(
+        "<!-- <webui-press-region name=\"ignored\" /> -->",
+        "<webui-press-region name=\"active\">Active</webui-press-region>"
+    );
+    let regions = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string())?;
+
+    assert_eq!(
+        regions.render("doc"),
+        "<!-- <webui-press-region name=\"ignored\" /> -->Active"
+    );
+    Ok(())
+}
+
+#[test]
 fn rejects_undeclared_config_and_invalid_names() {
     let configs = BTreeMap::from([("missing".to_string(), region("<p>x</p>"))]);
     assert!(matches!(

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -30,7 +30,7 @@ fn temp_dir() -> Result<PathBuf> {
 fn renders_layout_scoped_and_global_regions() -> TestResult {
     let template = concat!(
         "<main>",
-        "<webui-press-region name=\"home.panel\" layout=\"home\"><p>Default</p></webui-press-region>",
+        "<webui-press-region name = \"home.panel\" layout = \"home\"><p>Default</p></webui-press-region>",
         "<webui-press-region name=\"home.default\" layout=\"home\"><h1>After Hero</h1></webui-press-region>",
         "<webui-press-region name=\"shared.footer\" />",
         "<webui-press-region name=\"optional\" />",

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -2,56 +2,46 @@
 // Licensed under the MIT license.
 
 use super::*;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
-
 type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-fn region(
-    html: Option<&str>,
-    html_file: Option<&str>,
-    state: Option<Value>,
-    state_file: Option<&str>,
-) -> RegionConfig {
+fn region(html: &str) -> RegionConfig {
     RegionConfig {
-        html: html.map(str::to_string),
-        html_file: html_file.map(str::to_string),
-        state,
-        state_file: state_file.map(str::to_string),
+        html: Some(html.to_string()),
+        html_file: None,
+        state: None,
+        state_file: None,
         script_file: None,
     }
 }
 
-fn temp_dir(label: &str) -> Result<PathBuf> {
+fn temp_dir() -> Result<PathBuf> {
     let id = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!(
-        "webui-press-region-{label}-{}-{id}",
-        std::process::id()
-    ));
+    let path = std::env::temp_dir().join(format!("webui-press-region-{}-{id}", std::process::id()));
     fs::remove_dir_all(&path).ok();
     fs::create_dir_all(&path).map_err(|error| Error::Io(error.to_string()))?;
     Ok(path)
 }
 
 #[test]
-fn renders_only_regions_for_the_active_layout() -> TestResult {
+fn renders_layout_scoped_and_global_regions() -> TestResult {
     let template = concat!(
         "<main>",
-        "<webui-press-region name=\"home.afterHero\" layout=\"home\">",
-        "</webui-press-region>",
+        "<webui-press-region name=\"home.panel\" layout=\"home\"></webui-press-region>",
         "<webui-press-region name=\"shared.footer\" />",
+        "<webui-press-region name=\"optional\" />",
         "</main>"
     );
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "home.afterHero".to_string(),
-        region(Some("<home-card></home-card>"), None, None, None),
-    );
-    configs.insert(
-        "shared.footer".to_string(),
-        region(Some("<site-note></site-note>"), None, None, None),
-    );
+    let configs = BTreeMap::from([
+        ("home.panel".to_string(), region("<home-card></home-card>")),
+        (
+            "shared.footer".to_string(),
+            region("<site-note></site-note>"),
+        ),
+    ]);
     let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
 
     assert_eq!(
@@ -66,220 +56,95 @@ fn renders_only_regions_for_the_active_layout() -> TestResult {
 }
 
 #[test]
-fn loads_file_content_and_namespaces_region_state() -> TestResult {
-    let dir = temp_dir("files")?;
+fn loads_files_and_namespaces_state() -> TestResult {
+    let dir = temp_dir()?;
     fs::write(dir.join("region.html"), "<summary-card></summary-card>")?;
-    fs::write(dir.join("state.json"), r#"{"summary":{"title":"Status"}}"#)?;
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "home.afterHero".to_string(),
-        region(None, Some("region.html"), None, Some("state.json")),
-    );
-    let template = concat!(
-        "<webui-press-region name=\"home.afterHero\" layout=\"home\">",
-        "</webui-press-region>"
-    );
+    fs::write(dir.join("state.json"), r#"{"title":"Status"}"#)?;
+    let configs = BTreeMap::from([(
+        "home.panel".to_string(),
+        RegionConfig {
+            html: None,
+            html_file: Some("region.html".to_string()),
+            state: None,
+            state_file: Some("state.json".to_string()),
+            script_file: Some("region.ts".to_string()),
+        },
+    )]);
+    let template = "<webui-press-region name=\"home.panel\" layout=\"home\"></webui-press-region>";
     let regions = RegionSet::load(&configs, &dir, template.to_string())?;
     let mut state = Value::Object(Map::new());
     regions.apply_state("home", &mut state)?;
 
     assert_eq!(regions.render("home"), "<summary-card></summary-card>");
+    assert_eq!(state["regions"]["home"]["panel"]["title"], "Status");
     assert_eq!(
-        state["regions"]["home"]["afterHero"]["summary"]["title"],
-        "Status"
+        regions.script_files("home").collect::<Vec<_>>(),
+        ["region.ts"]
     );
-    assert_eq!(regions.render("doc"), "");
-    assert!(state["regions"]["home"].is_object());
+    assert_eq!(regions.script_files("doc").count(), 0);
 
     fs::remove_dir_all(dir).ok();
     Ok(())
 }
 
 #[test]
-fn rejects_unknown_duplicate_and_nonempty_declarations() {
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "missing".to_string(),
-        region(Some("<p>x</p>"), None, None, None),
-    );
-    let unknown = RegionSet::load(&configs, Path::new("."), "<main></main>".to_string());
+fn rejects_invalid_declarations() {
+    let cases = [
+        (
+            concat!(
+                "<webui-press-region name=\"same\" />",
+                "<webui-press-region name=\"same\" />"
+            ),
+            "more than once",
+        ),
+        (
+            "<webui-press-region name=\"x\"><p>owned</p></webui-press-region>",
+            "must be empty",
+        ),
+        (
+            "<webui-press-region name=\"x\" layout />",
+            "requires a quoted value",
+        ),
+        (
+            "<webui-press-region name=\"x\" layout=home />",
+            "requires a quoted value",
+        ),
+        (
+            "<webui-press-region name=\"x\" layout=\"\" />",
+            "requires a non-empty value",
+        ),
+        (
+            "<webui-press-region name=\"x\" layout=\"home\" layout=\"doc\" />",
+            "declared more than once",
+        ),
+        (
+            "<webui-press-region name=\"x\" unexpected=\"value\" />",
+            "unsupported attribute",
+        ),
+    ];
+    for (template, expected) in cases {
+        let result = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string());
+        assert!(
+            matches!(result, Err(Error::Build(message)) if message.contains(expected)),
+            "expected {expected:?} for {template:?}"
+        );
+    }
+}
+
+#[test]
+fn rejects_undeclared_config_and_invalid_names() {
+    let configs = BTreeMap::from([("missing".to_string(), region("<p>x</p>"))]);
     assert!(matches!(
-        unknown,
+        RegionSet::load(&configs, Path::new("."), "<main></main>".to_string()),
         Err(Error::Build(message)) if message.contains("does not declare")
     ));
 
-    let duplicate = RegionSet::load(
-        &BTreeMap::new(),
-        Path::new("."),
-        concat!(
-            "<webui-press-region name=\"same\" />",
-            "<webui-press-region name=\"same\" />"
-        )
-        .to_string(),
-    );
-    assert!(matches!(
-        duplicate,
-        Err(Error::Build(message)) if message.contains("more than once")
-    ));
-
-    let nonempty = RegionSet::load(
-        &BTreeMap::new(),
-        Path::new("."),
-        "<webui-press-region name=\"x\"><p>owned</p></webui-press-region>".to_string(),
-    );
-    assert!(matches!(
-        nonempty,
-        Err(Error::Build(message)) if message.contains("must be empty")
-    ));
-}
-
-#[test]
-fn ignores_region_text_outside_html_element_contexts() -> TestResult {
-    let template = concat!(
-        "<!-- <webui-press-region name=\"commented\" /> -->",
-        "<script>const marker = '<webui-press-region name=\"scripted\" />';</script>",
-        "<style>/* <webui-press-region name=\"styled\" /> */</style>",
-        "<div data-marker=\"<webui-press-region name='attribute' />\"></div>",
-        "<webui-press-region name=\"active\" />"
-    );
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "active".to_string(),
-        region(Some("<p>Active</p>"), None, None, None),
-    );
-    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
-    let rendered = regions.render("doc");
-
-    assert!(rendered.contains("name=\"commented\""));
-    assert!(rendered.contains("name=\"scripted\""));
-    assert!(rendered.contains("name=\"styled\""));
-    assert!(rendered.contains("name='attribute'"));
-    assert!(rendered.ends_with("<p>Active</p>"));
-    Ok(())
-}
-
-#[test]
-fn handles_non_ascii_tag_text_without_losing_utf8_boundaries() -> TestResult {
-    let template = "<é-tag></é-tag><webui-press-region name=\"active\" />".to_string();
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "active".to_string(),
-        region(Some("<p>Active</p>"), None, None, None),
-    );
-
-    let regions = RegionSet::load(&configs, Path::new("."), template)?;
-    assert_eq!(regions.render("doc"), "<é-tag></é-tag><p>Active</p>");
-    Ok(())
-}
-
-#[test]
-fn raw_text_scanning_requires_an_exact_closing_tag() -> TestResult {
-    let template = concat!(
-        "<script>",
-        "const falseClose = '</script:x>';",
-        "const marker = '<webui-press-region name=\"ignored\" />';",
-        "</script>",
-        "<webui-press-region name=\"active\" />"
-    );
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "active".to_string(),
-        region(Some("<p>Active</p>"), None, None, None),
-    );
-
-    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
-    let rendered = regions.render("doc");
-    assert!(rendered.contains("name=\"ignored\""));
-    assert!(rendered.ends_with("<p>Active</p>"));
-    Ok(())
-}
-
-#[test]
-fn ignores_markers_in_all_html_raw_text_contexts() -> TestResult {
-    let mut template = String::new();
-    for tag in [
-        "script", "style", "textarea", "title", "xmp", "iframe", "noembed", "noframes", "noscript",
-    ] {
-        template.push('<');
-        template.push_str(tag);
-        template.push('>');
-        template.push_str("<webui-press-region name=\"ignored\" />");
-        template.push_str("</");
-        template.push_str(tag);
-        template.push('>');
-    }
-    template.push_str("<webui-press-region name=\"active\" />");
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "active".to_string(),
-        region(Some("<p>Active</p>"), None, None, None),
-    );
-
-    let regions = RegionSet::load(&configs, Path::new("."), template)?;
-    let rendered = regions.render("doc");
-    assert_eq!(rendered.matches("name=\"ignored\"").count(), 9);
-    assert!(rendered.ends_with("<p>Active</p>"));
-    Ok(())
-}
-
-#[test]
-fn plaintext_consumes_marker_text_to_end_of_template() -> TestResult {
-    let template = concat!(
-        "<plaintext>",
-        "<webui-press-region name=\"ignored\" />",
-        "<webui-press-region name=\"alsoIgnored\" />"
-    );
-    let regions = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string())?;
-    assert_eq!(regions.render("doc"), template);
-    Ok(())
-}
-
-#[test]
-fn rejects_missing_empty_and_duplicate_layout_values() {
-    for template in [
-        "<webui-press-region name=\"x\" layout />",
-        "<webui-press-region name=\"x\" layout=\"\" />",
-        "<webui-press-region name=\"x\" layout=\"home\" layout=\"doc\" />",
-    ] {
-        let result = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string());
-        assert!(
-            matches!(result, Err(Error::Build(message)) if message.contains("layout")),
-            "template should reject malformed layout: {template}"
-        );
-    }
-}
-
-#[test]
-fn accepts_multiline_declarations_with_trailing_whitespace() -> TestResult {
-    let template = concat!(
-        "<webui-press-region\n",
-        "  name=\"home.panel\"\n",
-        "  layout=\"home\"\n",
-        "></webui-press-region>"
-    );
-    let mut configs = BTreeMap::new();
-    configs.insert(
-        "home.panel".to_string(),
-        region(Some("<p>Panel</p>"), None, None, None),
-    );
-
-    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
-    assert_eq!(regions.render("home"), "<p>Panel</p>");
-    Ok(())
-}
-
-#[test]
-fn rejects_region_names_with_empty_dotted_segments() {
-    for name in ["home..afterHero", "home."] {
-        let result = RegionSet::load(
-            &BTreeMap::new(),
-            Path::new("."),
-            format!("<webui-press-region name=\"{name}\" />"),
-        );
-        assert!(
-            matches!(result, Err(Error::Build(message)) if message.contains("invalid characters")),
-            "name {name:?} should be rejected"
-        );
+    for name in ["home..panel", "home."] {
+        let template = format!("<webui-press-region name=\"{name}\" />");
+        assert!(matches!(
+            RegionSet::load(&BTreeMap::new(), Path::new("."), template),
+            Err(Error::Build(message)) if message.contains("invalid characters")
+        ));
     }
 }
 
@@ -290,65 +155,48 @@ fn rejects_state_prefix_collisions_but_allows_html_only_prefixes() {
         "<webui-press-region name=\"summary.details\" />"
     )
     .to_string();
-    let mut stateful = BTreeMap::new();
-    stateful.insert(
-        "summary".to_string(),
-        region(
-            Some("<p>Summary</p>"),
-            None,
-            Some(Value::Object(Map::new())),
-            None,
-        ),
-    );
-    stateful.insert(
-        "summary.details".to_string(),
-        region(
-            Some("<p>Details</p>"),
-            None,
-            Some(Value::Object(Map::new())),
-            None,
-        ),
-    );
-    let conflict = RegionSet::load(&stateful, Path::new("."), template.clone());
+    let mut parent = region("<p>Summary</p>");
+    parent.state = Some(Value::Object(Map::new()));
+    let mut child = region("<p>Details</p>");
+    child.state = Some(Value::Object(Map::new()));
+    let stateful = BTreeMap::from([
+        ("summary".to_string(), parent),
+        ("summary.details".to_string(), child),
+    ]);
     assert!(matches!(
-        conflict,
+        RegionSet::load(&stateful, Path::new("."), template.clone()),
         Err(Error::Build(message)) if message.contains("distinct path")
     ));
 
-    let mut html_only = BTreeMap::new();
-    html_only.insert(
-        "summary".to_string(),
-        region(Some("<p>Summary</p>"), None, None, None),
-    );
-    html_only.insert(
-        "summary.details".to_string(),
-        region(Some("<p>Details</p>"), None, None, None),
-    );
+    let html_only = BTreeMap::from([
+        ("summary".to_string(), region("<p>Summary</p>")),
+        ("summary.details".to_string(), region("<p>Details</p>")),
+    ]);
     assert!(RegionSet::load(&html_only, Path::new("."), template).is_ok());
 }
 
 #[test]
-fn rejects_conflicting_region_sources_and_non_object_state() {
+fn rejects_conflicting_sources_and_non_object_state() {
     let template = "<webui-press-region name=\"x\" />".to_string();
-    let mut conflicting = BTreeMap::new();
-    conflicting.insert(
-        "x".to_string(),
-        region(Some("<p>x</p>"), Some("x.html"), None, None),
-    );
-    let conflict = RegionSet::load(&conflicting, Path::new("."), template.clone());
+    let mut conflicting = region("<p>x</p>");
+    conflicting.html_file = Some("x.html".to_string());
     assert!(matches!(
-        conflict,
+        RegionSet::load(
+            &BTreeMap::from([("x".to_string(), conflicting)]),
+            Path::new("."),
+            template.clone()
+        ),
         Err(Error::Build(message)) if message.contains("mutually exclusive")
     ));
 
-    let mut invalid_state = BTreeMap::new();
-    invalid_state.insert(
-        "x".to_string(),
-        region(Some("<p>x</p>"), None, Some(Value::Array(Vec::new())), None),
-    );
-    let invalid = RegionSet::load(&invalid_state, Path::new("."), template);
+    let mut invalid_state = region("<p>x</p>");
+    invalid_state.state = Some(Value::Array(Vec::new()));
     assert!(matches!(
-        invalid,
+        RegionSet::load(
+            &BTreeMap::from([("x".to_string(), invalid_state)]),
+            Path::new("."),
+            template
+        ),
         Err(Error::Build(message)) if message.contains("must be a JSON object")
     ));
 }

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static NEXT_DIR: AtomicUsize = AtomicUsize::new(0);
+
+type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+fn region(
+    html: Option<&str>,
+    html_file: Option<&str>,
+    state: Option<Value>,
+    state_file: Option<&str>,
+) -> RegionConfig {
+    RegionConfig {
+        html: html.map(str::to_string),
+        html_file: html_file.map(str::to_string),
+        state,
+        state_file: state_file.map(str::to_string),
+        script_file: None,
+    }
+}
+
+fn temp_dir(label: &str) -> Result<PathBuf> {
+    let id = NEXT_DIR.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "webui-press-region-{label}-{}-{id}",
+        std::process::id()
+    ));
+    fs::remove_dir_all(&path).ok();
+    fs::create_dir_all(&path).map_err(|error| Error::Io(error.to_string()))?;
+    Ok(path)
+}
+
+#[test]
+fn renders_only_regions_for_the_active_layout() -> TestResult {
+    let template = concat!(
+        "<main>",
+        "<webui-press-region name=\"home.afterHero\" layout=\"home\">",
+        "</webui-press-region>",
+        "<webui-press-region name=\"shared.footer\" />",
+        "</main>"
+    );
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "home.afterHero".to_string(),
+        region(Some("<home-card></home-card>"), None, None, None),
+    );
+    configs.insert(
+        "shared.footer".to_string(),
+        region(Some("<site-note></site-note>"), None, None, None),
+    );
+    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
+
+    assert_eq!(
+        regions.render("home"),
+        "<main><home-card></home-card><site-note></site-note></main>"
+    );
+    assert_eq!(
+        regions.render("doc"),
+        "<main><site-note></site-note></main>"
+    );
+    Ok(())
+}
+
+#[test]
+fn loads_file_content_and_namespaces_region_state() -> TestResult {
+    let dir = temp_dir("files")?;
+    fs::write(dir.join("region.html"), "<summary-card></summary-card>")?;
+    fs::write(dir.join("state.json"), r#"{"summary":{"title":"Status"}}"#)?;
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "home.afterHero".to_string(),
+        region(None, Some("region.html"), None, Some("state.json")),
+    );
+    let template = concat!(
+        "<webui-press-region name=\"home.afterHero\" layout=\"home\">",
+        "</webui-press-region>"
+    );
+    let regions = RegionSet::load(&configs, &dir, template.to_string())?;
+    let mut state = Value::Object(Map::new());
+    regions.apply_state("home", &mut state)?;
+
+    assert_eq!(regions.render("home"), "<summary-card></summary-card>");
+    assert_eq!(
+        state["regions"]["home"]["afterHero"]["summary"]["title"],
+        "Status"
+    );
+    assert_eq!(regions.render("doc"), "");
+    assert!(state["regions"]["home"].is_object());
+
+    fs::remove_dir_all(dir).ok();
+    Ok(())
+}
+
+#[test]
+fn rejects_unknown_duplicate_and_nonempty_declarations() {
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "missing".to_string(),
+        region(Some("<p>x</p>"), None, None, None),
+    );
+    let unknown = RegionSet::load(&configs, Path::new("."), "<main></main>".to_string());
+    assert!(matches!(
+        unknown,
+        Err(Error::Build(message)) if message.contains("does not declare")
+    ));
+
+    let duplicate = RegionSet::load(
+        &BTreeMap::new(),
+        Path::new("."),
+        concat!(
+            "<webui-press-region name=\"same\" />",
+            "<webui-press-region name=\"same\" />"
+        )
+        .to_string(),
+    );
+    assert!(matches!(
+        duplicate,
+        Err(Error::Build(message)) if message.contains("more than once")
+    ));
+
+    let nonempty = RegionSet::load(
+        &BTreeMap::new(),
+        Path::new("."),
+        "<webui-press-region name=\"x\"><p>owned</p></webui-press-region>".to_string(),
+    );
+    assert!(matches!(
+        nonempty,
+        Err(Error::Build(message)) if message.contains("must be empty")
+    ));
+}
+
+#[test]
+fn ignores_region_text_outside_html_element_contexts() -> TestResult {
+    let template = concat!(
+        "<!-- <webui-press-region name=\"commented\" /> -->",
+        "<script>const marker = '<webui-press-region name=\"scripted\" />';</script>",
+        "<style>/* <webui-press-region name=\"styled\" /> */</style>",
+        "<div data-marker=\"<webui-press-region name='attribute' />\"></div>",
+        "<webui-press-region name=\"active\" />"
+    );
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "active".to_string(),
+        region(Some("<p>Active</p>"), None, None, None),
+    );
+    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
+    let rendered = regions.render("doc");
+
+    assert!(rendered.contains("name=\"commented\""));
+    assert!(rendered.contains("name=\"scripted\""));
+    assert!(rendered.contains("name=\"styled\""));
+    assert!(rendered.contains("name='attribute'"));
+    assert!(rendered.ends_with("<p>Active</p>"));
+    Ok(())
+}
+
+#[test]
+fn handles_non_ascii_tag_text_without_losing_utf8_boundaries() -> TestResult {
+    let template = "<é-tag></é-tag><webui-press-region name=\"active\" />".to_string();
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "active".to_string(),
+        region(Some("<p>Active</p>"), None, None, None),
+    );
+
+    let regions = RegionSet::load(&configs, Path::new("."), template)?;
+    assert_eq!(regions.render("doc"), "<é-tag></é-tag><p>Active</p>");
+    Ok(())
+}
+
+#[test]
+fn raw_text_scanning_requires_an_exact_closing_tag() -> TestResult {
+    let template = concat!(
+        "<script>",
+        "const falseClose = '</script:x>';",
+        "const marker = '<webui-press-region name=\"ignored\" />';",
+        "</script>",
+        "<webui-press-region name=\"active\" />"
+    );
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "active".to_string(),
+        region(Some("<p>Active</p>"), None, None, None),
+    );
+
+    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
+    let rendered = regions.render("doc");
+    assert!(rendered.contains("name=\"ignored\""));
+    assert!(rendered.ends_with("<p>Active</p>"));
+    Ok(())
+}
+
+#[test]
+fn ignores_markers_in_all_html_raw_text_contexts() -> TestResult {
+    let mut template = String::new();
+    for tag in [
+        "script", "style", "textarea", "title", "xmp", "iframe", "noembed", "noframes", "noscript",
+    ] {
+        template.push('<');
+        template.push_str(tag);
+        template.push('>');
+        template.push_str("<webui-press-region name=\"ignored\" />");
+        template.push_str("</");
+        template.push_str(tag);
+        template.push('>');
+    }
+    template.push_str("<webui-press-region name=\"active\" />");
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "active".to_string(),
+        region(Some("<p>Active</p>"), None, None, None),
+    );
+
+    let regions = RegionSet::load(&configs, Path::new("."), template)?;
+    let rendered = regions.render("doc");
+    assert_eq!(rendered.matches("name=\"ignored\"").count(), 9);
+    assert!(rendered.ends_with("<p>Active</p>"));
+    Ok(())
+}
+
+#[test]
+fn plaintext_consumes_marker_text_to_end_of_template() -> TestResult {
+    let template = concat!(
+        "<plaintext>",
+        "<webui-press-region name=\"ignored\" />",
+        "<webui-press-region name=\"alsoIgnored\" />"
+    );
+    let regions = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string())?;
+    assert_eq!(regions.render("doc"), template);
+    Ok(())
+}
+
+#[test]
+fn rejects_missing_empty_and_duplicate_layout_values() {
+    for template in [
+        "<webui-press-region name=\"x\" layout />",
+        "<webui-press-region name=\"x\" layout=\"\" />",
+        "<webui-press-region name=\"x\" layout=\"home\" layout=\"doc\" />",
+    ] {
+        let result = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string());
+        assert!(
+            matches!(result, Err(Error::Build(message)) if message.contains("layout")),
+            "template should reject malformed layout: {template}"
+        );
+    }
+}
+
+#[test]
+fn accepts_multiline_declarations_with_trailing_whitespace() -> TestResult {
+    let template = concat!(
+        "<webui-press-region\n",
+        "  name=\"home.panel\"\n",
+        "  layout=\"home\"\n",
+        "></webui-press-region>"
+    );
+    let mut configs = BTreeMap::new();
+    configs.insert(
+        "home.panel".to_string(),
+        region(Some("<p>Panel</p>"), None, None, None),
+    );
+
+    let regions = RegionSet::load(&configs, Path::new("."), template.to_string())?;
+    assert_eq!(regions.render("home"), "<p>Panel</p>");
+    Ok(())
+}
+
+#[test]
+fn rejects_region_names_with_empty_dotted_segments() {
+    for name in ["home..afterHero", "home."] {
+        let result = RegionSet::load(
+            &BTreeMap::new(),
+            Path::new("."),
+            format!("<webui-press-region name=\"{name}\" />"),
+        );
+        assert!(
+            matches!(result, Err(Error::Build(message)) if message.contains("invalid characters")),
+            "name {name:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn rejects_state_prefix_collisions_but_allows_html_only_prefixes() {
+    let template = concat!(
+        "<webui-press-region name=\"summary\" />",
+        "<webui-press-region name=\"summary.details\" />"
+    )
+    .to_string();
+    let mut stateful = BTreeMap::new();
+    stateful.insert(
+        "summary".to_string(),
+        region(
+            Some("<p>Summary</p>"),
+            None,
+            Some(Value::Object(Map::new())),
+            None,
+        ),
+    );
+    stateful.insert(
+        "summary.details".to_string(),
+        region(
+            Some("<p>Details</p>"),
+            None,
+            Some(Value::Object(Map::new())),
+            None,
+        ),
+    );
+    let conflict = RegionSet::load(&stateful, Path::new("."), template.clone());
+    assert!(matches!(
+        conflict,
+        Err(Error::Build(message)) if message.contains("distinct path")
+    ));
+
+    let mut html_only = BTreeMap::new();
+    html_only.insert(
+        "summary".to_string(),
+        region(Some("<p>Summary</p>"), None, None, None),
+    );
+    html_only.insert(
+        "summary.details".to_string(),
+        region(Some("<p>Details</p>"), None, None, None),
+    );
+    assert!(RegionSet::load(&html_only, Path::new("."), template).is_ok());
+}
+
+#[test]
+fn rejects_conflicting_region_sources_and_non_object_state() {
+    let template = "<webui-press-region name=\"x\" />".to_string();
+    let mut conflicting = BTreeMap::new();
+    conflicting.insert(
+        "x".to_string(),
+        region(Some("<p>x</p>"), Some("x.html"), None, None),
+    );
+    let conflict = RegionSet::load(&conflicting, Path::new("."), template.clone());
+    assert!(matches!(
+        conflict,
+        Err(Error::Build(message)) if message.contains("mutually exclusive")
+    ));
+
+    let mut invalid_state = BTreeMap::new();
+    invalid_state.insert(
+        "x".to_string(),
+        region(Some("<p>x</p>"), None, Some(Value::Array(Vec::new())), None),
+    );
+    let invalid = RegionSet::load(&invalid_state, Path::new("."), template);
+    assert!(matches!(
+        invalid,
+        Err(Error::Build(message)) if message.contains("must be a JSON object")
+    ));
+}

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -30,7 +30,8 @@ fn temp_dir() -> Result<PathBuf> {
 fn renders_layout_scoped_and_global_regions() -> TestResult {
     let template = concat!(
         "<main>",
-        "<webui-press-region name=\"home.panel\" layout=\"home\"></webui-press-region>",
+        "<webui-press-region name=\"home.panel\" layout=\"home\"><p>Default</p></webui-press-region>",
+        "<webui-press-region name=\"home.default\" layout=\"home\"><h1>After Hero</h1></webui-press-region>",
         "<webui-press-region name=\"shared.footer\" />",
         "<webui-press-region name=\"optional\" />",
         "</main>"
@@ -46,12 +47,13 @@ fn renders_layout_scoped_and_global_regions() -> TestResult {
 
     assert_eq!(
         regions.render("home"),
-        "<main><home-card></home-card><site-note></site-note></main>"
+        "<main><home-card></home-card><h1>After Hero</h1><site-note></site-note></main>"
     );
     assert_eq!(
         regions.render("doc"),
         "<main><site-note></site-note></main>"
     );
+    assert_eq!(regions.template_shell(), "<main></main>");
     Ok(())
 }
 
@@ -88,6 +90,26 @@ fn loads_files_and_namespaces_state() -> TestResult {
 }
 
 #[test]
+fn state_only_config_keeps_default_html() -> TestResult {
+    let template =
+        "<webui-press-region name=\"summary\"><summary-card></summary-card></webui-press-region>";
+    let mut config = region("");
+    config.html = None;
+    config.state = Some(Value::Object(Map::from_iter([(
+        "title".to_string(),
+        Value::String("Status".to_string()),
+    )])));
+    let regions = RegionSet::load(
+        &BTreeMap::from([("summary".to_string(), config)]),
+        Path::new("."),
+        template.to_string(),
+    )?;
+
+    assert_eq!(regions.render("doc"), "<summary-card></summary-card>");
+    Ok(())
+}
+
+#[test]
 fn rejects_invalid_declarations() {
     let cases = [
         (
@@ -96,10 +118,6 @@ fn rejects_invalid_declarations() {
                 "<webui-press-region name=\"same\" />"
             ),
             "more than once",
-        ),
-        (
-            "<webui-press-region name=\"x\"><p>owned</p></webui-press-region>",
-            "must be empty",
         ),
         (
             "<webui-press-region name=\"x\" layout />",

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -180,6 +180,14 @@ fn rejects_invalid_declarations() {
             "<webui-press-region name=\"x\" unexpected=\"value\" />",
             "unsupported attribute",
         ),
+        (
+            concat!(
+                "<webui-press-region name=\"outer\">",
+                "<webui-press-region name=\"inner\"></webui-press-region>",
+                "</webui-press-region>"
+            ),
+            "cannot be nested",
+        ),
     ];
     for (template, expected) in cases {
         let result = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string());

--- a/crates/webui-press/src/regions/tests.rs
+++ b/crates/webui-press/src/regions/tests.rs
@@ -58,6 +58,47 @@ fn renders_layout_scoped_and_global_regions() -> TestResult {
 }
 
 #[test]
+fn bundled_template_exposes_stable_regions() -> TestResult {
+    let template = include_str!("../../template/index.html");
+    let regions = RegionSet::load(&BTreeMap::new(), Path::new("."), template.to_string())?;
+    let names: Vec<&str> = regions
+        .regions
+        .iter()
+        .map(|region| region.name.as_str())
+        .collect();
+
+    assert_eq!(
+        names,
+        [
+            "site.navigation",
+            "site.announcement",
+            "home.hero",
+            "home.afterHero",
+            "home.features",
+            "home.footer",
+            "doc.sidebar",
+            "doc.context",
+            "doc.beforeContent",
+            "page.beforeContent",
+            "full.beforeContent",
+            "doc.afterContent",
+            "page.afterContent",
+            "full.afterContent",
+            "doc.pageNavigation",
+            "doc.footer",
+            "page.footer",
+        ]
+    );
+    assert!(regions
+        .regions
+        .iter()
+        .find(|region| region.name == "home.hero")
+        .and_then(|region| region.html.as_deref())
+        .is_some_and(|html| html.contains("home-hero")));
+    Ok(())
+}
+
+#[test]
 fn loads_files_and_namespaces_state() -> TestResult {
     let dir = temp_dir()?;
     fs::write(dir.join("region.html"), "<summary-card></summary-card>")?;

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -54,6 +54,7 @@ const RESERVED_STATE_KEYS: &[&str] = &[
     "prev",
     "next",
     "pageData",
+    "regions",
     "headTags",
     "tokens",
     "label",
@@ -241,6 +242,7 @@ mod tests {
             sidebar: Vec::new(),
             sidebar_groups: std::collections::BTreeMap::new(),
             custom_pages: HashMap::new(),
+            regions: std::collections::BTreeMap::new(),
             state: None,
             state_file: None,
             hero: None,
@@ -394,11 +396,13 @@ mod tests {
             ("site", test_obj([("title", string_value("Override"))])),
             ("headTags", string_value("<script>bad()</script>")),
             ("tokens", string_value("not-token-css")),
+            ("regions", test_obj([("bad", string_value("override"))])),
         ]);
 
         let merged = merge_page_state(base, None, Some(&custom));
         assert_eq!(merged["site"]["title"], "Docs");
         assert_eq!(merged["headTags"], "<meta name=\"docs\">");
         assert_eq!(merged.get("tokens"), None);
+        assert_eq!(merged.get("regions"), None);
     }
 }

--- a/crates/webui-press/src/state.rs
+++ b/crates/webui-press/src/state.rs
@@ -61,18 +61,18 @@ const RESERVED_STATE_KEYS: &[&str] = &[
     "icon",
 ];
 
-struct StateLoader {
+pub(crate) struct StateLoader {
     cache: HashMap<PathBuf, Value>,
 }
 
 impl StateLoader {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             cache: HashMap::new(),
         }
     }
 
-    fn load_state_value(
+    pub(crate) fn load_state_value(
         &mut self,
         label: &str,
         inline: Option<&Value>,

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use serde::{de::Error as _, Deserialize, Deserializer};
+use serde::Deserialize;
 
 /// Documentation site configuration (read from config.json).
 #[derive(Debug, Deserialize)]
@@ -52,7 +52,6 @@ pub struct RegionConfig {
     pub html_file: Option<String>,
     /// Inline JSON object exposed beneath the region's dotted state path.
     /// Mutually exclusive with `state_file`.
-    #[serde(default, deserialize_with = "deserialize_region_state")]
     pub state: Option<serde_json::Value>,
     /// JSON object path relative to `config.json`. Mutually exclusive with
     /// `state`.
@@ -60,21 +59,6 @@ pub struct RegionConfig {
     /// Optional JavaScript/TypeScript file bundled only on pages where the
     /// region is active.
     pub script_file: Option<String>,
-}
-
-fn deserialize_region_state<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<serde_json::Value>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = serde_json::Value::deserialize(deserializer)?;
-    if value.is_null() {
-        return Err(D::Error::custom(
-            "region state must be a JSON object; omit 'state' when no state is needed",
-        ));
-    }
-    Ok(Some(value))
 }
 
 fn default_out_dir() -> String {
@@ -452,13 +436,5 @@ mod tests {
         assert_eq!(config.html_file.as_deref(), Some("./regions/summary.html"));
         assert_eq!(config.state_file.as_deref(), Some("./state/summary.json"));
         assert_eq!(config.script_file.as_deref(), Some("./regions/summary.ts"));
-    }
-
-    #[test]
-    fn region_config_rejects_explicit_null_state() {
-        let error =
-            serde_json::from_str::<RegionConfig>(r#"{ "html": "<p>x</p>", "state": null }"#)
-                .unwrap_err();
-        assert!(error.to_string().contains("must be a JSON object"));
     }
 }

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -45,13 +45,13 @@ pub struct DocsConfig {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegionConfig {
-    /// Inline HTML fragment. Mutually exclusive with `html_file`.
+    /// Inline HTML fragment. Mutually exclusive with `htmlFile`.
     pub html: Option<String>,
     /// HTML fragment path relative to `config.json`. Mutually exclusive with
     /// `html`.
     pub html_file: Option<String>,
     /// Inline JSON object exposed beneath the region's dotted state path.
-    /// Mutually exclusive with `state_file`.
+    /// Mutually exclusive with `stateFile`.
     pub state: Option<serde_json::Value>,
     /// JSON object path relative to `config.json`. Mutually exclusive with
     /// `state`.

--- a/crates/webui-press/src/types.rs
+++ b/crates/webui-press/src/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use serde::Deserialize;
+use serde::{de::Error as _, Deserialize, Deserializer};
 
 /// Documentation site configuration (read from config.json).
 #[derive(Debug, Deserialize)]
@@ -25,6 +25,10 @@ pub struct DocsConfig {
     pub sidebar_groups: std::collections::BTreeMap<String, Vec<SidebarSection>>,
     #[serde(default)]
     pub custom_pages: std::collections::HashMap<String, CustomPage>,
+    /// Site-owned HTML fragments injected into named template regions before
+    /// component discovery and protocol compilation.
+    #[serde(default)]
+    pub regions: std::collections::BTreeMap<String, RegionConfig>,
     /// Inline JSON object merged into every page's render state. Mutually
     /// exclusive with `stateFile`.
     pub state: Option<serde_json::Value>,
@@ -35,6 +39,42 @@ pub struct DocsConfig {
     pub footer: Option<FooterConfig>,
     /// Optional JavaScript bundler configuration (overrides defaults).
     pub bundler: Option<BundlerConfig>,
+}
+
+/// Site-owned content for one compile-time template region.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegionConfig {
+    /// Inline HTML fragment. Mutually exclusive with `html_file`.
+    pub html: Option<String>,
+    /// HTML fragment path relative to `config.json`. Mutually exclusive with
+    /// `html`.
+    pub html_file: Option<String>,
+    /// Inline JSON object exposed beneath the region's dotted state path.
+    /// Mutually exclusive with `state_file`.
+    #[serde(default, deserialize_with = "deserialize_region_state")]
+    pub state: Option<serde_json::Value>,
+    /// JSON object path relative to `config.json`. Mutually exclusive with
+    /// `state`.
+    pub state_file: Option<String>,
+    /// Optional JavaScript/TypeScript file bundled only on pages where the
+    /// region is active.
+    pub script_file: Option<String>,
+}
+
+fn deserialize_region_state<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Err(D::Error::custom(
+            "region state must be a JSON object; omit 'state' when no state is needed",
+        ));
+    }
+    Ok(Some(value))
 }
 
 fn default_out_dir() -> String {
@@ -396,5 +436,29 @@ mod tests {
         let json = r#"{ "layout": "full", "html": "<p>hi</p>" }"#;
         let page: CustomPage = serde_json::from_str(json).unwrap();
         assert!(page.script_file().is_none());
+    }
+
+    #[test]
+    fn region_config_deserializes_file_backed_content() {
+        let config: RegionConfig = serde_json::from_str(
+            r#"{
+                "htmlFile": "./regions/summary.html",
+                "stateFile": "./state/summary.json",
+                "scriptFile": "./regions/summary.ts"
+            }"#,
+        )
+        .unwrap();
+        assert!(config.html.is_none());
+        assert_eq!(config.html_file.as_deref(), Some("./regions/summary.html"));
+        assert_eq!(config.state_file.as_deref(), Some("./state/summary.json"));
+        assert_eq!(config.script_file.as_deref(), Some("./regions/summary.ts"));
+    }
+
+    #[test]
+    fn region_config_rejects_explicit_null_state() {
+        let error =
+            serde_json::from_str::<RegionConfig>(r#"{ "html": "<p>x</p>", "state": null }"#)
+                .unwrap_err();
+        assert!(error.to_string().contains("must be a JSON object"));
     }
 }

--- a/crates/webui-press/template/docs.css
+++ b/crates/webui-press/template/docs.css
@@ -190,6 +190,8 @@ html {
 }
 
 body {
+  display: flex;
+  flex-direction: column;
   height: 100%;
   margin: 0;
   overflow: hidden;
@@ -261,6 +263,7 @@ body {
   justify-content: space-between;
   padding: 0 var(--docs-space-l);
   height: var(--docs-nav-height);
+  flex: 0 0 var(--docs-nav-height);
   border-bottom: 1px solid var(--docs-color-border);
   background: var(--docs-nav-bg);
   backdrop-filter: var(--docs-nav-backdrop);
@@ -286,9 +289,10 @@ body {
 
 .layout {
   display: flex;
+  flex: 1;
+  width: 100%;
   max-width: var(--docs-max-width);
   margin: 0 auto;
-  height: calc(100vh - var(--docs-nav-height));
   min-height: 0;
 }
 
@@ -311,7 +315,7 @@ body {
   flex: 1;
   min-width: 0;
   min-height: 0;
-  height: calc(100vh - var(--docs-nav-height));
+  height: 100%;
   overflow-y: auto;
   padding: var(--docs-space-xl) var(--docs-space-2xl) var(--docs-space-3xl);
 }
@@ -804,8 +808,8 @@ body[data-layout="full"] {
 
 body[data-layout="full"] .layout {
   max-width: none;
-  min-height: calc(100vh - var(--docs-nav-height));
-  height: calc(100vh - var(--docs-nav-height));
+  min-height: 0;
+  height: auto;
 }
 
 body[data-layout="full"] .sidebar,

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -128,6 +128,10 @@
           <if condition="hero.manifesto">
             <p class="hero-manifesto">{{hero.manifesto}}</p>
           </if>
+          <webui-press-region
+            name="home.afterHero"
+            layout="home"
+          ></webui-press-region>
           <div class="features-grid">
             <for each="feature in hero.features">
               <div class="feature-card">

--- a/crates/webui-press/template/index.html
+++ b/crates/webui-press/template/index.html
@@ -89,106 +89,134 @@
 
 <body data-layout="{{page.layout}}">
   <a class="skip-link" href="#main-content">Skip to content</a>
-  <header class="nav-bar">
-    <a href="{{site.base}}" class="logo">
-      <img src="{{site.base}}logo.svg" alt="{{site.title}}" />
-      <span>{{site.title}}</span>
-    </a>
-    <docs-site-navigation
-      :navigation="{{navigation}}"
-      :sections="{{sidebar.sections}}"
-      section="{{page.section}}"
-      ?home="{{page.isHome}}"
-      ?full-layout="{{page.layout == 'full'}}"
-      :open="{{page.mobileNavigationOpen}}"
-    ></docs-site-navigation>
-  </header>
+  <webui-press-region name="site.navigation">
+    <header class="nav-bar">
+      <a href="{{site.base}}" class="logo">
+        <img src="{{site.base}}logo.svg" alt="{{site.title}}" />
+        <span>{{site.title}}</span>
+      </a>
+      <docs-site-navigation
+        :navigation="{{navigation}}"
+        :sections="{{sidebar.sections}}"
+        section="{{page.section}}"
+        ?home="{{page.isHome}}"
+        ?full-layout="{{page.layout == 'full'}}"
+        :open="{{page.mobileNavigationOpen}}"
+      ></docs-site-navigation>
+    </header>
+  </webui-press-region>
+  <webui-press-region name="site.announcement" />
 
   <if condition="page.isHome">
     <main class="main-content" id="main-content" tabindex="-1">
       <div class="home-container">
-        <if condition="hero">
-          <div class="home-hero">
-            <h1>{{site.title}}</h1>
-            <if condition="hero.text">
-              <p class="hero-text">{{hero.text}}</p>
+        <webui-press-region name="home.hero" layout="home">
+          <if condition="hero">
+            <div class="home-hero">
+              <h1>{{site.title}}</h1>
+              <if condition="hero.text">
+                <p class="hero-text">{{hero.text}}</p>
+              </if>
+              <p class="tagline">{{hero.tagline}}</p>
+              <div class="home-actions">
+                <for each="action in hero.actions">
+                  <if condition="action.brand">
+                    <a href="{{action.link}}" class="btn-brand">{{action.text}}</a>
+                  </if>
+                  <if condition="!action.brand">
+                    <a href="{{action.link}}" class="btn-alt">{{action.text}}</a>
+                  </if>
+                </for>
+              </div>
+            </div>
+            <if condition="hero.manifesto">
+              <p class="hero-manifesto">{{hero.manifesto}}</p>
             </if>
-            <p class="tagline">{{hero.tagline}}</p>
-            <div class="home-actions">
-              <for each="action in hero.actions">
-                <if condition="action.brand">
-                  <a href="{{action.link}}" class="btn-brand">{{action.text}}</a>
-                </if>
-                <if condition="!action.brand">
-                  <a href="{{action.link}}" class="btn-alt">{{action.text}}</a>
-                </if>
+          </if>
+        </webui-press-region>
+        <webui-press-region name="home.afterHero" layout="home" />
+        <webui-press-region name="home.features" layout="home">
+          <if condition="hero">
+            <div class="features-grid">
+              <for each="feature in hero.features">
+                <div class="feature-card">
+                  <div class="feature-card-header">
+                    <div class="feature-icon">{{feature.icon}}</div>
+                    <h2>{{feature.title}}</h2>
+                  </div>
+                  <p>{{feature.description}}</p>
+                </div>
               </for>
             </div>
-          </div>
-          <if condition="hero.manifesto">
-            <p class="hero-manifesto">{{hero.manifesto}}</p>
           </if>
-          <webui-press-region
-            name="home.afterHero"
-            layout="home"
-          ></webui-press-region>
-          <div class="features-grid">
-            <for each="feature in hero.features">
-              <div class="feature-card">
-                <div class="feature-card-header">
-                  <div class="feature-icon">{{feature.icon}}</div>
-                  <h2>{{feature.title}}</h2>
-                </div>
-                <p>{{feature.description}}</p>
-              </div>
-            </for>
-          </div>
-        </if>
-        <if condition="footer">
-          <footer class="site-footer">
-            {{{footer.html}}}
-          </footer>
-        </if>
+        </webui-press-region>
+        <webui-press-region name="home.footer" layout="home">
+          <if condition="footer">
+            <footer class="site-footer">
+              {{{footer.html}}}
+            </footer>
+          </if>
+        </webui-press-region>
       </div>
     </main>
   </if>
 
   <if condition="!page.isHome">
     <div class="layout">
-    <aside class="sidebar" aria-label="Documentation sections">
-      <docs-sidebar-navigation
-        :sections="{{sidebar.sections}}"
-      ></docs-sidebar-navigation>
-    </aside>
+    <webui-press-region name="doc.sidebar" layout="doc">
+      <aside class="sidebar" aria-label="Documentation sections">
+        <docs-sidebar-navigation
+          :sections="{{sidebar.sections}}"
+        ></docs-sidebar-navigation>
+      </aside>
+    </webui-press-region>
 
     <main class="main-content" id="main-content" tabindex="-1">
-      <if condition="sidebar.currentSection">
-        <div class="mobile-page-context" aria-label="Current location">
-          <span>{{sidebar.currentSection}}</span>
-          <span aria-hidden="true">/</span>
-          <strong>{{page.title}}</strong>
-        </div>
-      </if>
+      <webui-press-region name="doc.context" layout="doc">
+        <if condition="sidebar.currentSection">
+          <div class="mobile-page-context" aria-label="Current location">
+            <span>{{sidebar.currentSection}}</span>
+            <span aria-hidden="true">/</span>
+            <strong>{{page.title}}</strong>
+          </div>
+        </if>
+      </webui-press-region>
+      <webui-press-region name="doc.beforeContent" layout="doc" />
+      <webui-press-region name="page.beforeContent" layout="page" />
+      <webui-press-region name="full.beforeContent" layout="full" />
       <article class="doc-content">
         {{{page.content}}}
       </article>
-
-      <nav class="page-nav">
-        <if condition="prev">
-          <a href="{{prev.link}}">← {{prev.text}}</a>
+      <webui-press-region name="doc.afterContent" layout="doc" />
+      <webui-press-region name="page.afterContent" layout="page" />
+      <webui-press-region name="full.afterContent" layout="full" />
+      <webui-press-region name="doc.pageNavigation" layout="doc">
+        <nav class="page-nav">
+          <if condition="prev">
+            <a href="{{prev.link}}">← {{prev.text}}</a>
+          </if>
+          <if condition="!prev">
+            <span></span>
+          </if>
+          <if condition="next">
+            <a href="{{next.link}}">{{next.text}} →</a>
+          </if>
+        </nav>
+      </webui-press-region>
+      <webui-press-region name="doc.footer" layout="doc">
+        <if condition="footer">
+          <footer class="site-footer">
+            {{{footer.html}}}
+          </footer>
         </if>
-        <if condition="!prev">
-          <span></span>
+      </webui-press-region>
+      <webui-press-region name="page.footer" layout="page">
+        <if condition="footer">
+          <footer class="site-footer">
+            {{{footer.html}}}
+          </footer>
         </if>
-        <if condition="next">
-          <a href="{{next.link}}">{{next.text}} →</a>
-        </if>
-      </nav>
-      <if condition="footer">
-        <footer class="site-footer">
-          {{{footer.html}}}
-        </footer>
-      </if>
+      </webui-press-region>
     </main>
   </div>
   </if>

--- a/crates/webui-press/template/index.ts
+++ b/crates/webui-press/template/index.ts
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 
 // WebUI Docs — hydration entry point.
-// Imports interactive components for client-side behavior.
-
-import "./docs-site-navigation/docs-site-navigation.js";
+// Interactive components are discovered from the active template regions.
 
 // Hash anchor scrolling
 if (window.location.hash) {

--- a/crates/webui-press/tests/regions_build.rs
+++ b/crates/webui-press/tests/regions_build.rs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::{Map, Value};
+use webui_docs::{build_docs, DocsConfig};
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn builds_layout_scoped_regions_for_pages_and_404() -> TestResult {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace = manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .ok_or("workspace root is missing")?;
+    ensure_projection_package(workspace)?;
+
+    let root = manifest_dir
+        .join("target")
+        .join(format!("regions-build-{}", std::process::id()));
+    fs::remove_dir_all(&root).ok();
+    let template_dir = root.join("template");
+    let components_dir = root.join("components");
+    let content_dir = root.join("content");
+    let scripts_dir = root.join("scripts");
+    let public_dir = root.join("public");
+    let out_dir = root.join("dist");
+    for path in [
+        &template_dir,
+        &components_dir,
+        &content_dir,
+        &scripts_dir,
+        &public_dir,
+    ] {
+        fs::create_dir_all(path)?;
+    }
+
+    fs::write(
+        template_dir.join("index.html"),
+        concat!(
+            "<!DOCTYPE html><html><head><base href=\"{{site.base}}\">",
+            "{{{headTags}}}</head><body data-layout=\"{{page.layout}}\">",
+            "<webui-press-region name=\"home.panel\" layout=\"home\">",
+            "<home-region label=\"{{regions.home.panel.label}}\"></home-region>",
+            "</webui-press-region>",
+            "<webui-press-region name=\"doc.panel\" layout=\"doc\">",
+            "<replaced-region></replaced-region>",
+            "</webui-press-region>",
+            "<main>{{{page.content}}}</main></body></html>"
+        ),
+    )?;
+    write_component(&components_dir, "home-region", "<strong>{{label}}</strong>")?;
+    write_component(&components_dir, "doc-region", "<strong>{{label}}</strong>")?;
+    write_component(
+        &components_dir,
+        "replaced-region",
+        "<strong>must not render</strong>",
+    )?;
+    fs::write(
+        content_dir.join("index.md"),
+        "---\nlayout: home\ntitle: Home\n---\n\n# Home",
+    )?;
+    fs::write(content_dir.join("guide.md"), "# Guide")?;
+    fs::write(
+        scripts_dir.join("home.ts"),
+        "globalThis.__homeRegionScript = true;",
+    )?;
+    fs::write(
+        scripts_dir.join("doc.ts"),
+        "globalThis.__docRegionScript = true;",
+    )?;
+
+    let config: DocsConfig = serde_json::from_value(object([
+        ("site", object([("title", string("Regions"))])),
+        ("basePath", string("/fixture/")),
+        ("contentDir", path_value(&content_dir)),
+        ("outDir", path_value(&out_dir)),
+        ("publicDir", path_value(&public_dir)),
+        ("nav", Value::Array(Vec::new())),
+        ("sidebar", Value::Array(Vec::new())),
+        (
+            "regions",
+            object([
+                (
+                    "home.panel",
+                    object([
+                        ("state", object([("label", string("Home fallback"))])),
+                        ("scriptFile", string("scripts/home.ts")),
+                    ]),
+                ),
+                (
+                    "doc.panel",
+                    object([
+                        (
+                            "html",
+                            string(
+                                "<doc-region label=\"{{regions.doc.panel.label}}\"></doc-region>",
+                            ),
+                        ),
+                        ("state", object([("label", string("Doc override"))])),
+                        ("scriptFile", string("scripts/doc.ts")),
+                    ]),
+                ),
+            ]),
+        ),
+    ]))?;
+
+    build_docs(&config, &root, &template_dir)?;
+
+    let home = fs::read_to_string(out_dir.join("index.html"))?;
+    let doc = fs::read_to_string(out_dir.join("guide/index.html"))?;
+    let not_found = fs::read_to_string(out_dir.join("404.html"))?;
+    assert_page(&home, "home-region", "Home fallback", "replaced-region");
+    assert_page(&doc, "doc-region", "Doc override", "replaced-region");
+    assert_page(&not_found, "doc-region", "Doc override", "replaced-region");
+
+    let home_script = read_page_script(&home, &out_dir)?;
+    let doc_script = read_page_script(&doc, &out_dir)?;
+    let not_found_script = read_page_script(&not_found, &out_dir)?;
+    assert!(home_script.contains("__homeRegionScript"));
+    assert!(!home_script.contains("__docRegionScript"));
+    assert!(doc_script.contains("__docRegionScript"));
+    assert!(!doc_script.contains("__homeRegionScript"));
+    assert!(not_found_script.contains("__docRegionScript"));
+
+    fs::remove_dir_all(root).ok();
+    Ok(())
+}
+
+fn ensure_projection_package(workspace: &Path) -> TestResult {
+    let entry = workspace.join("packages/webui/dist/projection/index.js");
+    if entry.exists() {
+        return Ok(());
+    }
+    let program = if cfg!(windows) { "pnpm.cmd" } else { "pnpm" };
+    let status = Command::new(program)
+        .args(["--filter", "@microsoft/webui", "build"])
+        .current_dir(workspace)
+        .status()?;
+    if !status.success() {
+        return Err("failed to build @microsoft/webui projection package".into());
+    }
+    Ok(())
+}
+
+fn write_component(root: &Path, name: &str, html: &str) -> TestResult {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir)?;
+    fs::write(dir.join(format!("{name}.html")), html)?;
+    Ok(())
+}
+
+fn assert_page(html: &str, component: &str, text: &str, absent: &str) {
+    assert!(html.contains(&format!("<{component}")));
+    assert!(html.contains(text));
+    assert!(!html.contains(&format!("<{absent}")));
+}
+
+fn read_page_script(html: &str, out_dir: &Path) -> TestResult<String> {
+    let marker = "<script type=\"module\" src=\"";
+    let start = html.find(marker).ok_or("module script is missing")? + marker.len();
+    let end = html[start..]
+        .find('"')
+        .ok_or("module script is malformed")?
+        + start;
+    let relative = html[start..end]
+        .split('?')
+        .next()
+        .ok_or("module script path is missing")?
+        .strip_prefix("/fixture/")
+        .ok_or("module script has the wrong base path")?;
+    Ok(fs::read_to_string(out_dir.join(relative))?)
+}
+
+fn path_value(path: &Path) -> Value {
+    Value::String(path.to_string_lossy().into_owned())
+}
+
+fn string(value: &str) -> Value {
+    Value::String(value.to_string())
+}
+
+fn object<const N: usize>(entries: [(&str, Value); N]) -> Value {
+    let mut map = Map::with_capacity(N);
+    for (key, value) in entries {
+        map.insert(key.to_string(), value);
+    }
+    Value::Object(map)
+}

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1222,6 +1222,24 @@ x error: invalid <for> each expression [invalid-for-each]
 Full flag tables, exit codes, and the error-code list:
 [CLI Reference](/guide/cli/).
 
+### WebUI Press named regions
+
+In a WebUI Press template, use paired regions for fallback markup and
+self-closing regions for empty insertion points:
+
+```html
+<webui-press-region name="home.afterHero" layout="home">
+  <project-summary></project-summary>
+</webui-press-region>
+```
+
+A matching `regions` entry in `.webui-press/config.json` may replace or clear
+the HTML, add object state beneath the dotted `regions.*` path, and add a
+page-scoped `scriptFile`. Omit `html`/`htmlFile` to retain the fallback. Regions
+resolve before component discovery and compilation; do not manually register
+their components elsewhere. See [WebUI Press named regions](/guide/webui-press)
+for the stable built-in region list and full configuration contract.
+
 ```json
 {
   "scripts": {
@@ -1317,6 +1335,7 @@ Full detail: [Integrations](/guide/integrations/).
 | Routing, loaders, actions, caching | [/guide/concepts/routing](/guide/concepts/routing) |
 | Design tokens and theming | [/guide/concepts/css-tokens](/guide/concepts/css-tokens) |
 | CLI flags, diagnostics, exit codes | [/guide/cli/](/guide/cli/) |
+| WebUI Press named regions | [/guide/webui-press](/guide/webui-press) |
 | Rust, Node, Python, WASM, FFI, Electron | [/guide/integrations/](/guide/integrations/) |
 | Performance characteristics | [/guide/concepts/performance](/guide/concepts/performance) |
 | Build a first app | [/tutorials/hello-world/](/tutorials/hello-world/) |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -70,4 +70,5 @@ those 2. The other 8 remain server-rendered HTML with zero client-side cost.
 - **[Playground](/playground/)** - Experiment in the browser with zero setup.
 - **[Installation Guide](./installation)** - Set up WebUI locally.
 - **[Hello World Tutorial](/tutorials/hello-world)** - Build your first WebUI app step by step.
+- **[WebUI Press named regions](./webui-press)** - Customize documentation layouts without forking the template.
 - **[Why WebUI?](./why)** - Understand the architecture and performance benefits in depth.

--- a/docs/guide/webui-press.md
+++ b/docs/guide/webui-press.md
@@ -75,4 +75,6 @@ overlap as dotted prefixes, because one JSON value cannot own both `summary` and
 
 `home.*` applies to the generated home page. A custom page with
 `layout: "home"` retains the non-home shell and therefore uses `doc.*` regions.
-For complete template replacement, keep using `webui-press --template`.
+For complete template replacement, use
+`webui-press build --template <TEMPLATE_DIR>` or the equivalent `serve`
+subcommand.

--- a/docs/guide/webui-press.md
+++ b/docs/guide/webui-press.md
@@ -1,0 +1,78 @@
+# WebUI Press named regions
+
+WebUI Press templates expose compile-time named regions that a site can keep,
+replace, clear, or augment with state and browser code. Regions are resolved
+before component discovery and protocol compilation, so their components receive
+normal SSR, CSS, projection, and script bundling.
+
+## Declare fallback content
+
+A paired marker renders its child markup when the site has no matching
+configuration:
+
+```html
+<webui-press-region name="home.afterHero" layout="home">
+  <project-summary></project-summary>
+</webui-press-region>
+```
+
+Use a self-closing marker for an empty insertion point:
+
+```html
+<webui-press-region name="site.announcement" />
+```
+
+`layout` is optional. Without it, the region is active on every layout.
+
+## Configure a region
+
+Add `regions` to `.webui-press/config.json`:
+
+```json
+{
+  "regions": {
+    "home.afterHero": {
+      "htmlFile": "./regions/home-after-hero.html",
+      "stateFile": "./state/home-summary.json",
+      "scriptFile": "./scripts/home-summary.ts"
+    }
+  }
+}
+```
+
+- `html` or `htmlFile` replaces the fallback markup. Set `html` to `""` to
+  clear it.
+- Omit both HTML fields to retain the fallback while adding state or a script.
+- `state` or `stateFile` must be a JSON object and is exposed beneath the
+  dotted region name, such as `regions.home.afterHero`.
+- `scriptFile` is bundled only on pages where the region is active.
+
+Configured names must exist in the active template. State-bearing names cannot
+overlap as dotted prefixes, because one JSON value cannot own both `summary` and
+`summary.details`.
+
+## Bundled template regions
+
+| Region | Layout | Default |
+| --- | --- | --- |
+| `site.navigation` | all | Logo and site navigation |
+| `site.announcement` | all | Empty announcement/banner slot |
+| `home.hero` | `home` | Hero, actions, and manifesto |
+| `home.afterHero` | `home` | Empty slot after the hero |
+| `home.features` | `home` | Feature card grid |
+| `home.footer` | `home` | Site footer |
+| `doc.sidebar` | `doc` | Documentation sidebar |
+| `doc.context` | `doc` | Mobile current-location context |
+| `doc.beforeContent` | `doc` | Empty slot before the article |
+| `doc.afterContent` | `doc` | Empty slot after the article |
+| `doc.pageNavigation` | `doc` | Previous/next links |
+| `doc.footer` | `doc` | Site footer |
+| `page.beforeContent` | `page` | Empty slot before wide content |
+| `page.afterContent` | `page` | Empty slot after wide content |
+| `page.footer` | `page` | Wide page footer |
+| `full.beforeContent` | `full` | Empty slot before viewport content |
+| `full.afterContent` | `full` | Empty slot after viewport content |
+
+`home.*` applies to the generated home page. A custom page with
+`layout: "home"` retains the non-home shell and therefore uses `doc.*` regions.
+For complete template replacement, keep using `webui-press --template`.


### PR DESCRIPTION
## Summary

- add reusable compile-time `<webui-press-region>` extension points with template fallback content and optional config overrides
- expose 17 stable built-in regions across site navigation, home, documentation, wide-page, and full layouts
- inject layout-scoped HTML, namespaced state, discovered components, and explicit scripts before protocol compilation, including doc-scoped 404 handling
- document the `regions` configuration contract while preserving `--template` as the full-replacement escape hatch

## Scope

This PR exposes only the generalized WebUI Press region architecture. It intentionally excludes consumer-specific docs wiring, Benchmark Explorer content/state, benchmark publication, `ssr-framework-bench`, framework/router performance work, and manifest or lockfile changes.

## Validation

- `cargo test -p microsoft-webui-press`
- real scratch Press builds proving layout-scoped fallback and override HTML, SSR components, namespaced state, scoped scripts, and doc-scoped 404 output
- real docs build plus Playwright geometry checks for home/doc/full layouts, announcement height, and replacement navigation height
- `cargo xtask check`