### PR TITLE
chore: bump version to 0.0.26

### DIFF
--- a/.github/skills/bump-version/SKILL.md
+++ b/.github/skills/bump-version/SKILL.md
@@ -52,7 +52,7 @@ Use `v<version>` only when comparing or creating Git tags.
    git --no-pager log --reverse --format='%s%x09%H' "${previous_tag}..HEAD"
    ```
 
-7. Build the PR release notes by grouping all commits into user-facing buckets.
+7. Build the PR release notes by grouping all commits into user-facing buckets and attributing every supporting PR to its contributor.
 8. Commit the version bump with an imperative message:
 
    ```text
@@ -80,13 +80,15 @@ Use these buckets, omitting empty buckets:
 
 Prefer concise, user-facing summaries over raw commit subjects. Combine related commits into one bullet when they describe the same release-note item.
 
-For each bullet, include the supporting PR title and number in parentheses:
+For each bullet, include the supporting PR title, number, and contributor handle in parentheses. Put the contributor immediately after the PR reference:
 
 ```text
-- summary sentence (PR title #number).
+- summary sentence (PR title #number by @contributor).
 ```
 
-Do not include commit SHAs in the PR release notes. If a commit subject already contains a PR number, use it. Otherwise, use `gh` to inspect the commit or associated PR when possible.
+Use the PR author's GitHub login as the contributor, not the commit author or a co-author. When one bullet combines multiple PRs, repeat `#number by @contributor` for each supporting PR.
+
+Do not include commit SHAs in the PR release notes. If a commit subject already contains a PR number, use it, then use `gh` to retrieve the PR title and `author.login`. Otherwise, use `gh` to inspect the commit or associated PR when possible.
 
 ## PR body template
 
@@ -101,19 +103,19 @@ Previous release tag: `<previous_tag>`
 
 Features:
 
-- <feature summary> (<PR title> #<number>).
+- <feature summary> (<PR title> #<number> by @<contributor>).
 
 Fixes:
 
-- <fix summary> (<PR title> #<number>).
+- <fix summary> (<PR title> #<number> by @<contributor>).
 
 Docs:
 
-- <docs summary> (<PR title> #<number>).
+- <docs summary> (<PR title> #<number> by @<contributor>).
 
 Maintenance:
 
-- <maintenance summary> (<PR title> #<number>).
+- <maintenance summary> (<PR title> #<number> by @<contributor>).
 
 ## Validation
 
@@ -127,16 +129,16 @@ Remove empty buckets before opening or updating the PR.
 ```markdown
 Features:
 
-- parser comment policy strips template/style comments while preserving legal comments, with CLI, Node, docs, and benchmark coverage (feat: strip template and style comments in parser and support legal comments #326).
-- CSS module delivery now emits import-map data URI modules and the commerce demo defaults to module styles (Emit style modules via importmap + dataURI instead of <style type="module"> #325, Switch default styles to module for commerce demo #327).
+- parser comment policy strips template/style comments while preserving legal comments, with CLI, Node, docs, and benchmark coverage (feat: strip template and style comments in parser and support legal comments #326 by @mohamedmansour).
+- CSS module delivery now emits import-map data URI modules and the commerce demo defaults to module styles (Emit style modules via importmap + dataURI instead of <style type="module"> #325 by @KurtCattiSchmidt, Switch default styles to module for commerce demo #327 by @KurtCattiSchmidt).
 
 Fixes:
 
-- repeat-scope event arguments hydrate correctly for framework bindings, including strict argument handling (Fix event handler args in repeat scopes #317, fix: hydrate strict event arguments in repeat scopes #322).
-- client binding lifecycle ordering preserves child updates across conditional and repeated DOM paths (fix: initialize child bindings before connection #329).
-- compiled templates preserve raw style text instead of altering author-provided CSS content (fix: preserve raw style text in compiled templates #330).
+- repeat-scope event arguments hydrate correctly for framework bindings, including strict argument handling (Fix event handler args in repeat scopes #317 by @jibin7jose, fix: hydrate strict event arguments in repeat scopes #322 by @mohamedmansour).
+- client binding lifecycle ordering preserves child updates across conditional and repeated DOM paths (fix: initialize child bindings before connection #329 by @mohamedmansour).
+- compiled templates preserve raw style text instead of altering author-provided CSS content (fix: preserve raw style text in compiled templates #330 by @mohamedmansour).
 
 Docs:
 
-- issue forms, contribution/support policy, framework rendering docs, CLI docs, and integration guides were refreshed (chore: clarify contribution and support policy #321, chore: add GitHub issue forms #328, plus docs in fix: hydrate strict event arguments in repeat scopes #322/Emit style modules via importmap + dataURI instead of <style type="module"> #325/feat: strip template and style comments in parser and support legal comments #326/fix: initialize child bindings before connection #329).
+- issue forms, contribution/support policy, framework rendering docs, CLI docs, and integration guides were refreshed (chore: clarify contribution and support policy #321 by @mohamedmansour, chore: add GitHub issue forms #328 by @mohamedmansour, plus docs in fix: hydrate strict event arguments in repeat scopes #322 by @mohamedmansour/Emit style modules via importmap + dataURI instead of <style type="module"> #325 by @KurtCattiSchmidt/feat: strip template and style comments in parser and support legal comments #326 by @mohamedmansour/fix: initialize child bindings before connection #329 by @mohamedmansour).
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "actix-web",
  "awc",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "cbindgen",
  "criterion",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "criterion",
  "memchr",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "clap",
  "criterion",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "criterion",
  "prost",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-python"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "microsoft-webui-handler",
  "pyo3",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.25"
+version = "0.0.26"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.25", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.25" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.25" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.25" }
+microsoft-webui = { path = "../webui", version = "0.0.26", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.26" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -43,7 +43,7 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.26" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.25" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -30,7 +30,7 @@ cbindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
 
 [[bench]]
 name = "protocol_bench"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,17 +15,17 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.25" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.26" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.26" }
 memchr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.25" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.25" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.25" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25", features = ["projection-manifest"] }
+microsoft-webui = { path = "../webui", version = "0.0.26" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.25", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,8 +26,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.25" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,10 +19,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.25", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.25" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.25" }
+microsoft-webui = { path = "../webui", version = "0.0.26", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.25" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.26" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-python/Cargo.toml
+++ b/crates/webui-python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
 pyo3 = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.25" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.25", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,11 +18,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.25" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25", features = ["projection-manifest"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.25" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.25" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -44,8 +44,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.25" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.25", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.25</Version>
+    <Version>0.0.26</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration and compiled-template path mapping.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -40,5 +40,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.25"
+  "version": "0.0.26"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.26`.

Previous release tag: `v0.0.25`

## Changes since `v0.0.25`

Features:

- Python hosts now have an official typed PyO3 renderer package with buffered, partial, template, token, and host-driven streaming APIs (feat: add official Python renderer package #453 by @mohamedmansour).
- Progressive SSR can place transport-flushed streaming boundaries inside reusable components while preserving component ownership and continuation state (feat: support component-local streaming boundaries #460 by @mohamedmansour).
- Components can defer compiler-owned hydration until interaction, with router preload handoff and a combined lazy-render policy (feat: add compiler-driven interaction hydration #485 by @mohamedmansour).
- Builds can opt into global Light DOM CSS while preserving explicit authored Shadow roots and deterministic style closures (feat: make Light DOM a global CSS opt-in #429 by @mohamedmansour).
- State projection supports application-owned TypeScript 7.0.2 while retaining the TypeScript 6 migration path (feat: support TypeScript 7 projection compilation #452 by @mohamedmansour).
- WebUI Press supports layout-scoped compile-time named regions with fallback HTML, state, components, and scripts (feat(press): add compile-time named regions #484 by @mohamedmansour).
- FAST v2 and v3 gain plugin-owned local and npm component discovery with validated FAST template transformation (feat: add plugin-owned FAST component discovery #378 by @janechu).

Fixes:

- Missing condition identifiers are treated as falsy before negation and logical evaluation, aligning SSR with the browser runtime (fix: negate missing condition paths correctly #449 by @mohamedmansour).
- FAST route state now scales through escaped scalar kebab-case attributes shared by FAST v2 and v3 (fix: scale FAST route state with scalar attributes #450 by @janechu).
- Dynamic Link-mode components wait for native stylesheet readiness across navigation and component assets, preventing unstyled flashes (fix: prevent dynamic component stylesheet flashes #454 by @mohamedmansour).
- Authored component definitions defer whenever compiled template metadata has not arrived, including ordinary router navigation (fix: defer authored define() whenever template metadata is missing #461 by @mohamedmansour).
- Client structural updates preserve authored order and sibling ownership for shared slots and raw HTML ranges (fix: preserve source order for shared structural slots #465 by @mohamedmansour, fix: preserve siblings around raw HTML updates #466 by @mohamedmansour).
- Native-element attributes no longer leak into the local state of a later component (perf(handler): stop native attributes leaking into component state #469 by @mohamedmansour).
- Templates-and-state-only SSR bootstrap payloads no longer require component style metadata (fix: allow SSR bootstrap without component styles #475 by @mohamedmansour).
- The high-level Rust `serve_request` path now preserves complete render options, including CSP nonces, while sharing the same entry and request path with partial rendering (fix: forward CSP nonces through serve_request #488 by @mohamedmansour).
- Projection compilation bounds source reads, excludes binary and unsupported-loader inputs from semantic analysis, and preserves deterministic cleanup under large esbuild graphs (fix: bound projection adapter source reads #489 by @mohamedmansour).
- Router pending UI remains mounted through pre-commit work and settles at the synchronous DOM commit, with stale, aborted, and re-entrant navigation cleanup kept generation-safe (fix: settle router pending UI during navigation commits #491 by @mohamedmansour).

Docs:

- The documentation site adds accessible responsive navigation, improved reading layouts, stronger search behavior, and Playground recovery states (feat: polish WebUI documentation experience #459 by @mohamedmansour).
- Slot-resolution implementation guidance now documents pre-order lookup, pending placement ownership, and marker handling (chore: clarify slot resolution comments #471 by @mohamedmansour).
- Repeated `w-ref` behavior is now explicit: refs are scalar and the last wired occurrence wins, while stable authored IDs or item components provide identity-based lookup (chore: clarify repeated w-ref behavior #490 by @mohamedmansour).

Maintenance:

- Release and package policy metadata now constrains the transitive h2 advisory, uses SPDX NuGet licensing, and classifies publishing jobs correctly (chore: allow constrained h2 advisory #451 by @janechu, fix: use modern NuGet license metadata #457 by @janechu, chore: mark publishing jobs as release jobs #458 by @janechu).
- The development and CI Rust toolchain is updated to 1.98 with the resulting warnings resolved (Update rust toolchain version and fix clippy warning #462 by @telecos).
- Release builds use Thin LTO to retain cross-crate optimization with faster linking (perf: switch release builds to Thin LTO #464 by @mohamedmansour).
- Handler and expression hot paths reduce attribute vtable calls, render lookup and scope allocations, and single-term condition overhead (perf(handler): centralize HTML attribute writing in ResponseWriter #467 by @mohamedmansour, perf(expressions): fast-path single-term conditions #470 by @mohamedmansour, perf(handler): reduce render lookup and scope allocations #472 by @mohamedmansour).
- Node rendering can reuse immutable prepared-state snapshots and bounded per-route output capacity hints (perf(node): reuse prepared state across renders #477 by @mohamedmansour, perf: reuse Node render output capacity #478 by @mohamedmansour).
- Framework hydration releases bootstrap data sooner and reduces allocations for bindings, empty hosts, and visible conditionals (perf: reduce framework hydration allocations #479 by @mohamedmansour, perf: release SSR bootstrap memory after hydration #480 by @mohamedmansour, perf: reduce empty template host overhead #482 by @mohamedmansour, perf: remove visible conditional anchors #483 by @mohamedmansour).
- Benchmark tooling now renders the full contact workload, runs Criterion baselines per target, and restores the streaming hydration fixture (fix(bench): render contacts in contact-book benchmark #468 by @mohamedmansour, fix(xtask): run Criterion benchmarks per target #473 by @mohamedmansour, fix: repair streaming hydration benchmark fixture #476 by @mohamedmansour).

## Validation

- `cargo xtask check`