### PR TITLE
fix: forward CSP nonces through serve_request

### DIFF
--- a/.github/skills/perf/SKILL.md
+++ b/.github/skills/perf/SKILL.md
@@ -95,6 +95,7 @@ These apply to `packages/webui-router` (the client-side SPA router).
 ```bash
 cargo bench -p microsoft-webui --bench contact_book_bench          # full run
 cargo bench -p microsoft-webui --bench contact_book_bench -- --test # quick validation
+cargo bench -p microsoft-webui --bench server_request_bench         # high-level request helper
 cargo xtask bench all                                               # all Rust crates
 cargo xtask bench node-addon                                        # Node/V8/N-API boundary
 ```

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -95,6 +95,8 @@ Standard criterion harnesses. Each crate has its own `benches/` dir:
 * `crates/webui-state/benches/state_bench.rs`
 * `crates/webui/benches/contact_book_bench.rs` — end-to-end render
 * `crates/webui/benches/streaming_bench.rs` — writer-path wall-clock + TTFB
+* `crates/webui/benches/component_assets_bench.rs` — static asset graph rendering
+* `crates/webui/benches/server_request_bench.rs` — router-aware full HTML and JSON requests
 
 These integrate with criterion's HTML reports
 (`target/criterion/report/index.html`) and native baseline support

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -907,6 +907,24 @@ impl<'a> RenderOptions<'a> {
     pub fn with_body_inject(self, html: &'a str) -> Self;
 }
 
+/// One router-aware request handled by the high-level Rust server helper.
+pub struct ServeRequest<'a> { /* private fields */ }
+
+impl<'a> ServeRequest<'a> {
+    pub fn new(
+        render_options: RenderOptions<'a>,
+        accept_json: bool,
+        inventory_hex: &'a str,
+    ) -> Self;
+}
+
+pub fn serve_request(
+    protocol: &Protocol,
+    handler: &WebUIHandler,
+    state: Value,
+    request: &ServeRequest<'_>,
+) -> std::result::Result<ServeResponse, String>;
+
 impl WebUIHandler {
     pub fn new() -> Self;
     pub fn with_plugin(factory: fn() -> Box<dyn HandlerPlugin>) -> Self;
@@ -920,6 +938,13 @@ impl WebUIHandler {
     ) -> Result<()>;
 }
 ```
+
+`ServeRequest` owns the complete borrowed `RenderOptions` value. Full-document
+requests pass that exact value to `WebUIHandler::render`, so the request nonce
+and all other per-render controls cannot diverge from the lower-level handler
+API. JSON partial requests use its entry and request path together with the
+client inventory. Constructing the request performs no heap allocation, and the
+helper never scans or rewrites rendered HTML.
 
 #### Runtime Protocol
 

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -62,6 +62,10 @@ harness = false
 name = "component_assets_bench"
 harness = false
 
+[[bench]]
+name = "server_request_bench"
+harness = false
+
 [[example]]
 name = "streaming_resource_bench"
 path = "examples/streaming_resource_bench.rs"

--- a/crates/webui/benches/README.md
+++ b/crates/webui/benches/README.md
@@ -1,6 +1,6 @@
 # `microsoft-webui` benches
 
-Two criterion benches in this directory:
+Four criterion benches in this directory:
 
 * **`contact_book_bench.rs`** — end-to-end render of the
   contact-book-manager template at 10 / 100 / 1 000 contacts. Measures
@@ -12,6 +12,11 @@ Two criterion benches in this directory:
   hook) vs `String + post-injection` (the legacy livereload path the
   streaming module replaces). Includes a separate `ttfb` group that
   measures time-to-first-chunk for the streaming path.
+* **`component_assets_bench.rs`** — static component asset graph
+  generation and chunk rendering.
+* **`server_request_bench.rs`** — high-level router-aware request
+  handling for full documents with and without a CSP nonce, plus JSON
+  partial responses.
 
 Two **examples** (in `crates/webui/examples/`) round out the suite:
 

--- a/crates/webui/benches/server_request_bench.rs
+++ b/crates/webui/benches/server_request_bench.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Benchmarks the high-level Rust server helper for full-document rendering.
+
+use std::collections::HashMap;
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use webui::server::{serve_request, ServeRequest, ServeResponse};
+use webui::{Protocol, RenderOptions, WebUIHandler};
+use webui_handler::plugin::webui::WebUIHydrationPlugin;
+use webui_protocol::{ComponentData, FragmentList, WebUIFragment, WebUIProtocol};
+
+const ENTRY_ID: &str = "index.html";
+const REQUEST_PATH: &str = "/";
+
+fn structural_fragment(value: &str) -> WebUIFragment {
+    let mut signal = String::with_capacity("}}}webui:".len() + value.len());
+    signal.push_str("}}}webui:");
+    signal.push_str(value);
+    WebUIFragment::signal(signal, true)
+}
+
+fn benchmark_protocol() -> Protocol {
+    let fragments = HashMap::from([
+        (
+            ENTRY_ID.to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<!doctype html><html><head>"),
+                    structural_fragment("head_end"),
+                    WebUIFragment::raw("</head><body>"),
+                    WebUIFragment::component("bench-page"),
+                    structural_fragment("body_end"),
+                    WebUIFragment::raw("</body></html>"),
+                ],
+                contains_boundary: false,
+            },
+        ),
+        (
+            "bench-page".to_string(),
+            FragmentList {
+                fragments: vec![WebUIFragment::raw("<main>ready</main>")],
+                contains_boundary: false,
+            },
+        ),
+    ]);
+    let mut protocol = WebUIProtocol::new(fragments);
+    protocol.components.insert(
+        "bench-page".to_string(),
+        ComponentData {
+            template_json: r#"{"h":"<main>ready</main>","th":1}"#.to_string(),
+            template_functions: "[function(){return true}]".to_string(),
+            ..Default::default()
+        },
+    );
+    Protocol::new(protocol)
+}
+
+fn server_request_bench(c: &mut Criterion) {
+    let protocol = benchmark_protocol();
+    let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
+    let html_request = ServeRequest::new(RenderOptions::new(ENTRY_ID, REQUEST_PATH), false, "");
+    let nonce_request = ServeRequest::new(
+        RenderOptions::new(ENTRY_ID, REQUEST_PATH).with_nonce("request-nonce"),
+        false,
+        "",
+    );
+    let partial_request = ServeRequest::new(RenderOptions::new(ENTRY_ID, REQUEST_PATH), true, "");
+
+    c.bench_function("server_request/full_html_without_nonce", |b| {
+        b.iter(|| {
+            let response = serve_request(
+                black_box(&protocol),
+                black_box(&handler),
+                serde_json::Value::Null,
+                black_box(&html_request),
+            )
+            .unwrap_or_else(|error| panic!("server request render failed: {error}"));
+            match response {
+                ServeResponse::Html(html) => black_box(html.len()),
+                ServeResponse::Json(_) => panic!("full-document request returned JSON"),
+            }
+        });
+    });
+
+    c.bench_function("server_request/full_html_with_nonce", |b| {
+        b.iter(|| {
+            let response = serve_request(
+                black_box(&protocol),
+                black_box(&handler),
+                serde_json::Value::Null,
+                black_box(&nonce_request),
+            )
+            .unwrap_or_else(|error| panic!("server request render failed: {error}"));
+            match response {
+                ServeResponse::Html(html) => black_box(html.len()),
+                ServeResponse::Json(_) => panic!("full-document request returned JSON"),
+            }
+        });
+    });
+
+    c.bench_function("server_request/json_partial", |b| {
+        b.iter(|| {
+            let response = serve_request(
+                black_box(&protocol),
+                black_box(&handler),
+                serde_json::Value::Null,
+                black_box(&partial_request),
+            )
+            .unwrap_or_else(|error| panic!("server request render failed: {error}"));
+            match response {
+                ServeResponse::Json(json) => black_box(json.len()),
+                ServeResponse::Html(_) => panic!("partial request returned HTML"),
+            }
+        });
+    });
+}
+
+criterion_group!(benches, server_request_bench);
+criterion_main!(benches);

--- a/crates/webui/src/server.rs
+++ b/crates/webui/src/server.rs
@@ -12,15 +12,16 @@
 //! # Example
 //!
 //! ```rust,ignore
-//! use webui::server::{serve_request, ServeRequest, ServeResponse};
-//!
-//! let request = ServeRequest {
-//!     path: "/email/thread-5",
-//!     accept_json: false,
-//!     inventory_hex: "",
+//! use webui::{
+//!     server::{serve_request, ServeRequest, ServeResponse},
+//!     RenderOptions,
 //! };
 //!
-//! match serve_request(&protocol, &handler, &state, "index.html", &request) {
+//! let options = RenderOptions::new("index.html", "/email/thread-5")
+//!     .with_nonce("request-csp-nonce");
+//! let request = ServeRequest::new(options, false, "");
+//!
+//! match serve_request(&protocol, &handler, state, &request) {
 //!     Ok(ServeResponse::Html(html)) => { /* serve HTML */ }
 //!     Ok(ServeResponse::Json(json)) => { /* serve JSON */ }
 //!     Err(e) => { /* handle error */ }
@@ -35,14 +36,30 @@ webui_handler::define_string_response_writer!(MemWriter, buf);
 
 /// A server request to be handled by [`serve_request`].
 pub struct ServeRequest<'a> {
-    /// The URL path (e.g., `"/email/thread-5"`, `"/folder/sent"`).
-    pub path: &'a str,
-    /// Whether the client accepts JSON (for partial navigation).
-    /// Check `Accept: application/json` in request headers.
-    pub accept_json: bool,
-    /// The client's current template inventory (hex bitmask).
-    /// Read from `X-WebUI-Inventory` request header. Empty string if not present.
-    pub inventory_hex: &'a str,
+    render_options: RenderOptions<'a>,
+    accept_json: bool,
+    inventory_hex: &'a str,
+}
+
+impl<'a> ServeRequest<'a> {
+    /// Create a server request from the complete per-render configuration.
+    ///
+    /// Set `accept_json` when the request accepts a partial-navigation response.
+    /// `inventory_hex` is the client's `X-WebUI-Inventory` value, or an empty
+    /// string when the header is absent.
+    #[must_use]
+    #[inline]
+    pub fn new(
+        render_options: RenderOptions<'a>,
+        accept_json: bool,
+        inventory_hex: &'a str,
+    ) -> Self {
+        Self {
+            render_options,
+            accept_json,
+            inventory_hex,
+        }
+    }
 }
 
 /// The response from [`serve_request`].
@@ -68,20 +85,30 @@ pub enum ServeResponse {
 /// - `state` — The state JSON to render. For HTML requests, this should be
 ///   the full app state. For JSON requests, the caller should provide
 ///   route-scoped state (only what the target page component needs).
-/// - `request` — The incoming request details
+/// - `request` — The incoming request details and complete [`RenderOptions`]
 ///
 /// # Route Parameters
 /// Route parameters (`:param` in route paths) are automatically extracted
 /// and injected into the state object.
+///
+/// # Content Security Policy
+/// Set the response nonce with [`RenderOptions::with_nonce`]. Full-document
+/// rendering forwards the options unchanged so every generated inline script
+/// and the `webui-nonce` metadata receive the request nonce.
 pub fn serve_request(
     protocol: &Protocol,
     handler: &WebUIHandler,
     state: serde_json::Value,
-    entry: &str,
     request: &ServeRequest<'_>,
 ) -> Result<ServeResponse, String> {
+    let options = &request.render_options;
+
     // Extract route params and inject into state
-    let params = route_handler::collect_nested_route_params(protocol, entry, request.path);
+    let params = route_handler::collect_nested_route_params(
+        protocol,
+        options.entry_id,
+        options.request_path,
+    );
     let mut data = state;
     if let Some(map) = data.as_object_mut() {
         for (k, v) in &params {
@@ -94,16 +121,20 @@ pub fn serve_request(
         let state_json =
             serde_json::to_string(&data).map_err(|e| format!("state serialization failed: {e}"))?;
         let partial = protocol
-            .render_partial(&state_json, entry, request.path, request.inventory_hex)
+            .render_partial(
+                &state_json,
+                options.entry_id,
+                options.request_path,
+                request.inventory_hex,
+            )
             .map_err(|e| format!("render_partial failed: {e}"))?;
         Ok(ServeResponse::Json(partial))
     } else {
         // Full HTML SSR — handler emits the consolidated window.__webui
         // script block (state, chain, inventory, templates) automatically.
         let mut writer = MemWriter::with_capacity(131_072);
-        let opts = RenderOptions::new(entry, request.path);
         handler
-            .render(protocol, &data, &opts, &mut writer)
+            .render(protocol, &data, options, &mut writer)
             .map_err(|e| format!("render failed: {e}"))?;
 
         Ok(ServeResponse::Html(writer.buf))
@@ -115,9 +146,18 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;
+    use webui_handler::plugin::webui::WebUIHydrationPlugin;
     use webui_protocol::{
-        ComponentStyleClosure, CssStrategy, FragmentList, WebUIFragment, WebUIProtocol,
+        ComponentData, ComponentStyleClosure, CssStrategy, FragmentList, WebUIFragment,
+        WebUIProtocol,
     };
+
+    fn structural_fragment(value: &str) -> WebUIFragment {
+        let mut signal = String::with_capacity("}}}webui:".len() + value.len());
+        signal.push_str("}}}webui:");
+        signal.push_str(value);
+        WebUIFragment::signal(signal, true)
+    }
 
     fn add_page_style_closures(protocol: &mut WebUIProtocol) {
         let closure = ComponentStyleClosure {
@@ -139,6 +179,74 @@ mod tests {
             }
             ServeResponse::Html(_) => panic!("expected JSON partial response"),
         }
+    }
+
+    fn full_document_protocol() -> Protocol {
+        let fragments = HashMap::from([
+            (
+                "index.html".to_string(),
+                FragmentList {
+                    fragments: vec![
+                        WebUIFragment::raw("<!doctype html><html><head>"),
+                        structural_fragment("head_end"),
+                        WebUIFragment::raw("</head><body>"),
+                        WebUIFragment::component("my-page"),
+                        structural_fragment("body_end"),
+                        WebUIFragment::raw("</body></html>"),
+                    ],
+                    contains_boundary: false,
+                },
+            ),
+            (
+                "my-page".to_string(),
+                FragmentList {
+                    fragments: vec![WebUIFragment::raw("<main>ready</main>")],
+                    contains_boundary: false,
+                },
+            ),
+        ]);
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol.components.insert(
+            "my-page".to_string(),
+            ComponentData {
+                template_json: r#"{"h":"<main>ready</main>","th":1}"#.to_string(),
+                template_functions: "[function(){return true}]".to_string(),
+                ..Default::default()
+            },
+        );
+        Protocol::new(protocol)
+    }
+
+    #[test]
+    fn serve_request_html_forwards_complete_render_options() {
+        let protocol = full_document_protocol();
+        let handler = WebUIHandler::with_plugin(|| Box::new(WebUIHydrationPlugin::new()));
+        let request = ServeRequest::new(
+            RenderOptions::new("index.html", "/")
+                .with_nonce("request-nonce")
+                .with_head_inject("<meta name=\"host-head\">")
+                .with_body_inject("<script src=\"host.js\"></script>"),
+            false,
+            "",
+        );
+
+        let response = serve_request(&protocol, &handler, json!({}), &request)
+            .expect("full-document response should succeed");
+        let html = match response {
+            ServeResponse::Html(html) => html,
+            ServeResponse::Json(_) => panic!("expected full-document response"),
+        };
+
+        let mut direct = MemWriter::with_capacity(131_072);
+        handler
+            .render(&protocol, &json!({}), &request.render_options, &mut direct)
+            .expect("direct render should succeed");
+
+        assert_eq!(html, direct.buf);
+        assert!(html.contains(r#"<meta name="webui-nonce" content="request-nonce">"#));
+        assert!(html.contains(r#"<script nonce="request-nonce">(function(){var w=window.__webui"#));
+        assert!(html.contains(r#"<meta name="host-head">"#));
+        assert!(html.contains(r#"<script src="host.js"></script>"#));
     }
 
     #[test]
@@ -171,13 +279,9 @@ mod tests {
         let protocol = Protocol::new(protocol);
 
         let handler = WebUIHandler::new();
-        let request = ServeRequest {
-            path: "/",
-            accept_json: true,
-            inventory_hex: "",
-        };
+        let request = ServeRequest::new(RenderOptions::new("index.html", "/"), true, "");
 
-        let response = serve_request(&protocol, &handler, json!({}), "index.html", &request)
+        let response = serve_request(&protocol, &handler, json!({}), &request)
             .expect("partial response should succeed");
 
         let json = response_json(response);
@@ -229,13 +333,9 @@ mod tests {
         let protocol = Protocol::new(protocol);
 
         let handler = WebUIHandler::new();
-        let request = ServeRequest {
-            path: "/",
-            accept_json: true,
-            inventory_hex: "",
-        };
+        let request = ServeRequest::new(RenderOptions::new("index.html", "/"), true, "");
 
-        let response = serve_request(&protocol, &handler, json!({}), "index.html", &request)
+        let response = serve_request(&protocol, &handler, json!({}), &request)
             .expect("partial response should succeed");
 
         let json = response_json(response);
@@ -280,13 +380,9 @@ mod tests {
         let protocol = Protocol::new(protocol);
 
         let handler = WebUIHandler::new();
-        let request = ServeRequest {
-            path: "/",
-            accept_json: true,
-            inventory_hex: "",
-        };
+        let request = ServeRequest::new(RenderOptions::new("index.html", "/"), true, "");
 
-        let response = serve_request(&protocol, &handler, json!({}), "index.html", &request)
+        let response = serve_request(&protocol, &handler, json!({}), &request)
             .expect("partial response should succeed");
 
         let json = response_json(response);

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -1354,6 +1354,17 @@ let handler = WebUIHandler::new();
 handler.render(&protocol, &state, &options, &mut writer)?;
 ```
 
+For one Rust endpoint that serves both initial documents and router partials,
+pass the complete per-response options through `ServeRequest`. Always attach a
+fresh document CSP nonce before calling the helper:
+
+```rust
+let options = RenderOptions::new("index.html", request_path)
+    .with_nonce(csp_nonce);
+let request = ServeRequest::new(options, accepts_json, inventory_header);
+let response = serve_request(&protocol, &handler, state, &request)?;
+```
+
 ```javascript
 const protocol = new Protocol(result.protocol, { plugin: 'webui' });
 const html = protocol.render(state, { entry: 'index.html', requestPath: req.url });

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -153,6 +153,40 @@ async fn main() {
 </webui-press-tab-panel>
 </webui-press-tabs>
 
+## Router-aware request helper
+
+Use `webui::server::serve_request` when one endpoint serves both initial HTML
+documents and `webui-router` JSON partials. Build the `ServeRequest` with the
+complete `RenderOptions` value for that HTTP response:
+
+```rust
+use webui::{
+    server::{serve_request, ServeRequest, ServeResponse},
+    RenderOptions,
+};
+
+let options = RenderOptions::new("index.html", request_path)
+    .with_nonce(csp_nonce);
+let request = ServeRequest::new(
+    options,
+    accepts_json,
+    inventory_header,
+);
+
+match serve_request(&protocol, &handler, state, &request)? {
+    ServeResponse::Html(html) => send_html(html),
+    ServeResponse::Json(json) => send_json(json),
+}
+```
+
+For a full document, the helper passes the complete options directly to
+`WebUIHandler::render`. The nonce therefore reaches the generated
+`templateFns` bootstrap, every other inline script, and
+`<meta name="webui-nonce">` without scanning or rewriting the rendered HTML.
+Use a fresh nonce for each document response and send the same value in the
+Content Security Policy header. JSON partial responses use the options' entry
+and request path plus the client inventory; they do not emit document scripts.
+
 ## Streaming SSR
 
 `webui::streaming::StreamingWriter` coalesces small writes, sends them over a
@@ -482,6 +516,13 @@ component.
 | `with_nonce(&str)` | builder | CSP nonce reflected onto inline `<script>` tags (including the `<script type="importmap">` tags that register Module-strategy CSS). Empty string normalises to `None`. |
 | `with_head_inject(&str)` | builder | Raw HTML emitted immediately before `</head>` at the parser's structural boundary (see [Streaming SSR](#streaming-ssr)). |
 | `with_body_inject(&str)` | builder | Raw HTML emitted immediately before `</body>`. Same structural-boundary contract. |
+
+### Router-aware server requests
+
+| API | Description |
+|---|---|
+| `ServeRequest::new(render_options, accept_json, inventory_hex)` | Store the complete borrowed render configuration and the client's partial-navigation metadata without a heap allocation |
+| `serve_request(protocol, handler, state, request)` | Inject route parameters, then return either a full `ServeResponse::Html` document rendered with the supplied options or a `ServeResponse::Json` partial |
 
 ### Host-driven streaming
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -329,6 +329,7 @@ const CRITERION_BENCHES: &[(&str, &str)] = &[
     ("microsoft-webui", "contact_book_bench"),
     ("microsoft-webui", "streaming_bench"),
     ("microsoft-webui", "component_assets_bench"),
+    ("microsoft-webui", "server_request_bench"),
 ];
 
 fn bench_all_criterion(


### PR DESCRIPTION
Strict CSP currently blocks the executable `templateFns` bootstrap when applications use the high-level Rust `serve_request` helper, because that helper reconstructs `RenderOptions` and drops the request nonce.

This change makes `ServeRequest` own the complete borrowed `RenderOptions` value and removes the duplicate `entry` argument from `serve_request`. Full-document responses now pass those exact options to `WebUIHandler::render`, while JSON partials use the same entry and request path with the client inventory. This keeps route behavior aligned and forwards current and future per-render controls without scanning or rewriting generated HTML.

### Breaking change

Callers now construct requests with `ServeRequest::new(RenderOptions::new(entry, path).with_nonce(nonce), accepts_json, inventory)` and call `serve_request(protocol, handler, state, request)` without a separate entry argument.

### Performance

- The request constructor remains allocation-free and stores only borrowed render configuration.
- Full HTML without a nonce showed no statistically significant change: Criterion's comparison interval was -1.26% to +1.03%.
- JSON partial rendering stayed within the repository's noise threshold.
- Full HTML with nonce measured approximately 2.32 us on the focused fixture; its additional work is limited to the required nonce-bearing output bytes.

### Validation

- Added byte-for-byte regression coverage against direct handler rendering, including nonce metadata, executable `templateFns`, and head/body injection.
- Added and registered a dedicated Criterion benchmark for full HTML with and without a nonce and JSON partials.
- Updated `DESIGN.md`, Rust integration docs, the AI reference, and benchmark documentation.
- `cargo xtask check` passes.