### PR TITLE
fix: bound projection adapter source reads

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3911,11 +3911,14 @@ export interface AdapterContext {
   A specifier is treated as WebUI framework semantics only when the adapter
   proves `packageName: "@microsoft/webui-framework"`. Literal source text does
   not override adapter resolution.
+- The normalized graph contains only JavaScript/TypeScript modules that can
+  participate in projection semantics. Bundler inputs such as images, fonts,
+  and CSS are omitted; their incoming edges are external to this semantic graph.
 - Every physical module has raw source and every physical output has exact
   bytes. Disk outputs can never be represented as `"virtual"` to skip stale
   validation.
-- `rootDir` contains the manifest and every physical input/output. The compiler
-  rejects graph members outside it.
+- `rootDir` contains the manifest and every physical normalized input/output.
+  The compiler rejects graph members outside it.
 
 The compiler parses source lazily. It seeds modules containing a supported
 literal `.define(...)`/`customElements.define(...)` candidate (or a framework
@@ -4133,7 +4136,8 @@ export interface ProjectionManifest {
   readonly outputs: Record<string, string>;
 
   /**
-   * Every module in the adapter graph, including tree-shaken modules.
+   * Every module in the normalized adapter graph, including tree-shaken
+   * modules.
    * Key: canonical build-root-relative path, or `virtual:<hex-id>`.
    * Value: exact UTF-8 source SHA-256, or "virtual" only for a virtual key.
    */
@@ -4735,14 +4739,22 @@ The esbuild adapter:
    cannot substitute unrelated disk bytes. Other non-file namespace inputs are
    also represented as virtual graph nodes. A WebUI component whose defining
    source is unavailable fails strict coverage instead of being guessed.
-7. Hashes exact `result.outputFiles` bytes for `write: false`, or reads emitted
+7. Filters the metafile to supported JavaScript/TypeScript source extensions
+   that esbuild classified as ESM or CommonJS, then reads those sources through
+   a fixed 64-worker pool. This follows configured and plugin-provided loader
+   decisions, including longest-suffix loader overrides. Non-source bundler
+   inputs are omitted from the semantic graph and output membership; imports to
+   them are represented as external semantic edges. Their bytes remain covered
+   by emitted-output hashes without being read a second time as projection
+   inputs.
+8. Hashes exact `result.outputFiles` bytes for `write: false`, or reads emitted
    files during `onEnd` for `write: true` (esbuild has completed writes before
    `onEnd`).
-8. Chooses the common ancestor of the manifest, physical inputs, and outputs
+9. Chooses the common ancestor of the manifest, physical inputs, and outputs
    as `rootDir`, constructs `AdapterContext`, and calls the shared compiler.
-9. Writes canonical compact JSON to a same-directory temporary file, flushes
+10. Writes canonical compact JSON to a same-directory temporary file, flushes
    it, and atomically renames it over the manifest.
-10. If the build or projection compiler has errors, the manifest is **not**
+11. If the build or projection compiler has errors, the manifest is **not**
    written. An existing stale
    manifest from a prior run is left in place (not deleted).
 

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -512,10 +512,13 @@ The generated file has this shape (hashes abbreviated):
 Do not hand-author this file. It is a deterministic record of the completed
 bundle and becomes stale as soon as a declared input or output changes.
 
-The manifest records exact input hashes, emitted output hashes, code-split
-membership, component ownership, and sorted `@observable` plus `@attr` property
-names. WebUI validates those hashes and embeds only the resulting key surfaces
-in `protocol.bin`. Runtime handlers do not load the manifest, TypeScript, or a
+The manifest records exact analyzable-source hashes, emitted output hashes,
+code-split membership, component ownership, and sorted `@observable` plus
+`@attr` property names. Non-source inputs remain in esbuild's native graph but
+stay outside the normalized projection graph; their emitted outputs provide the
+byte proof instead of a duplicate input hash. WebUI validates the declared
+hashes and embeds only the resulting key surfaces in
+`protocol.bin`. Runtime handlers do not load the manifest, TypeScript, or a
 bundler.
 
 Behavior is intentionally strict:
@@ -528,8 +531,8 @@ Behavior is intentionally strict:
 - Shared controls supplied through `--components` remain application-owned
   bundles. If they are external to the main bundle, build them separately and
   pass each manifest fragment with another `--projection-manifest`.
-- Stale inputs or outputs fail the WebUI build. Re-run the client bundler before
-  rebuilding the protocol.
+- Stale source inputs or outputs fail the WebUI build. Re-run the client
+  bundler before rebuilding the protocol.
 - `@attr` entries use JavaScript property names. During hydration, an existing
   SSR host attribute wins; projected state seeds the property only when that
   attribute is absent.
@@ -541,7 +544,10 @@ imports, external modules, or output naming.
 Other bundlers are not coupled to esbuild. A Vite, Rollup, Rolldown, webpack,
 Rspack, or other adapter can construct the exported `AdapterContext`, call
 `compileProjection()`, and run the exported conformance suite. The official
-package currently ships and supports the esbuild adapter.
+package currently ships and supports the esbuild adapter. Custom adapters must
+provide a normalized JavaScript/TypeScript source graph and exact
+emitted-output bytes. Non-source bundler inputs stay outside the semantic
+graph, so projection does not decode or hash their input bodies.
 
 ## State Sent to the Browser
 

--- a/packages/webui/README.md
+++ b/packages/webui/README.md
@@ -113,13 +113,16 @@ const result = build({
 esbuild runs once and emits both browser chunks and
 `webui-projection.json`; WebUI then embeds the exact initial/navigation
 surfaces into `protocol.bin`. The adapter uses esbuild's resolved graph and
-emitted output membership, so code splitting, dynamic imports, output hashes,
-and external bundles remain application-owned.
+emitted output membership. Source inputs and outputs receive exact hashes;
+opaque inputs rely on their emitted output proof. Code splitting, dynamic
+imports, output hashes, and external bundles remain application-owned.
 
 Other bundler adapters can use the exported `AdapterContext`,
 `compileProjection()`, and conformance fixtures without importing esbuild. The
 package currently ships and supports `esbuildProjection()` as its official
-adapter.
+adapter. Custom adapters provide a normalized JavaScript/TypeScript source
+graph and exact emitted output bytes. Non-source bundler inputs stay outside
+the semantic graph, so projection does not decode or hash their input bodies.
 
 With no manifest, WebUI performs no JavaScript analysis and preserves full
 state. Once any manifest is supplied, coverage is strict: every scripted

--- a/packages/webui/src/projection/adapters/esbuild.ts
+++ b/packages/webui/src/projection/adapters/esbuild.ts
@@ -29,6 +29,7 @@ import type {
   ModuleNode,
   ResolvedImport,
 } from "../graph.js";
+import { mapConcurrent } from "../concurrency.js";
 import {
   ProjectionError,
   createDiagnostic,
@@ -62,6 +63,17 @@ interface InputRecord {
   readonly packageName: string | undefined;
 }
 
+const MAX_CONCURRENT_SOURCE_READS = 64;
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
 let temporaryFileSequence = 0;
 
 /** Create the official esbuild projection plugin. */
@@ -242,9 +254,16 @@ async function loadInputRecords(
   metafile: Metafile,
   packageCache: Map<string, string | undefined>
 ): Promise<InputRecord[]> {
-  const entries = Object.keys(metafile.inputs);
-  const records = await Promise.all(
-    entries.map(async (metafileId) => {
+  const entries = Object.keys(metafile.inputs).filter(
+    (metafileId) =>
+      metafile.inputs[metafileId]?.format !== undefined &&
+      (isStdinMetafileId(metafileId, build) ||
+        isProjectionSourceId(metafileId))
+  );
+  const records = await mapConcurrent(
+    entries,
+    MAX_CONCURRENT_SOURCE_READS,
+    async (metafileId) => {
       const stdinSource = sourceForStdin(
         metafileId,
         build
@@ -278,7 +297,7 @@ async function loadInputRecords(
         source: undefined,
         packageName: undefined,
       };
-    })
+    }
   );
   const resolved: InputRecord[] = [];
   for (const record of records) {
@@ -315,13 +334,20 @@ function sourceForStdin(
 ): string | undefined {
   const stdin = build.initialOptions.stdin;
   if (!stdin) return undefined;
-  const sourcefile = stdin.sourcefile ?? "<stdin>";
-  if (metafileId !== sourcefile && metafileId !== "<stdin>") {
-    return undefined;
-  }
+  if (!isStdinMetafileId(metafileId, build)) return undefined;
   return typeof stdin.contents === "string"
     ? stdin.contents
     : Buffer.from(stdin.contents).toString("utf8");
+}
+
+function isStdinMetafileId(
+  metafileId: string,
+  build: PluginBuild
+): boolean {
+  const stdin = build.initialOptions.stdin;
+  if (!stdin) return false;
+  const sourcefile = stdin.sourcefile ?? "<stdin>";
+  return metafileId === sourcefile || metafileId === "<stdin>";
 }
 
 function buildModuleGraph(
@@ -363,10 +389,13 @@ function resolvedImport(
   const target = entry.external
     ? undefined
     : recordByMetafileId.get(entry.path);
+  // Non-source inputs stay in esbuild's graph but are external to projection's
+  // JavaScript/TypeScript symbol graph.
+  const external = entry.external === true || target === undefined;
   return {
     specifier: entry.original ?? entry.path,
-    resolvedId: target?.moduleId,
-    external: entry.external === true,
+    resolvedId: external ? undefined : target.moduleId,
+    external,
     kind:
       entry.kind === "dynamic-import" ? "dynamic" : "static",
     ...packageNameProperty(
@@ -374,6 +403,12 @@ function resolvedImport(
         (entry.external ? packageNameFromSpecifier(entry.path) : undefined)
     ),
   };
+}
+
+function isProjectionSourceId(
+  moduleId: string
+): boolean {
+  return SOURCE_EXTENSIONS.has(path.extname(moduleId));
 }
 
 function packageNameProperty(

--- a/packages/webui/src/projection/concurrency.ts
+++ b/packages/webui/src/projection/concurrency.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Map values with a fixed worker count while preserving input order.
+ *
+ * Workers stop taking new work after the first failure, then allow already
+ * active operations to settle before the error is propagated.
+ */
+export async function mapConcurrent<T, U>(
+  values: ReadonlyArray<T>,
+  maxConcurrency: number,
+  operation: (value: T, index: number, workerIndex: number) => Promise<U>
+): Promise<U[]> {
+  if (!Number.isSafeInteger(maxConcurrency) || maxConcurrency < 1) {
+    throw new RangeError("maxConcurrency must be a positive safe integer");
+  }
+
+  const results = new Array<U>(values.length);
+  const workerCount = Math.min(values.length, maxConcurrency);
+  const workers = new Array<Promise<void>>(workerCount);
+  let nextIndex = 0;
+  let didFail = false;
+  let failure: unknown;
+
+  for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+    workers[workerIndex] = (async () => {
+      while (!didFail) {
+        const index = nextIndex;
+        if (index >= values.length) return;
+        nextIndex++;
+        try {
+          results[index] = await operation(
+            values[index]!,
+            index,
+            workerIndex
+          );
+        } catch (error: unknown) {
+          if (!didFail) {
+            didFail = true;
+            failure = error;
+          }
+          return;
+        }
+      }
+    })();
+  }
+
+  await Promise.all(workers);
+  if (didFail) throw failure;
+  return results;
+}

--- a/packages/webui/test/projection-esbuild.test.ts
+++ b/packages/webui/test/projection-esbuild.test.ts
@@ -30,6 +30,14 @@ const FRAMEWORK_ENTRY = path.resolve(
   "index.ts"
 );
 
+interface ConcurrencyModule {
+  mapConcurrent<T, U>(
+    values: ReadonlyArray<T>,
+    maxConcurrency: number,
+    operation: (value: T, index: number, workerIndex: number) => Promise<U>
+  ): Promise<U[]>;
+}
+
 async function fixtureRoot(): Promise<string> {
   const root = await mkdtemp(
     path.join(process.cwd(), ".tmp-esbuild-projection-")
@@ -120,6 +128,260 @@ export const used = padding.length;
 }
 
 describe("esbuildProjection", () => {
+  test("bounds projection I/O concurrency and preserves order", async () => {
+    const moduleUrl = new URL(
+      "../projection/concurrency.js",
+      import.meta.url
+    );
+    const { mapConcurrent } = (await import(
+      moduleUrl.href
+    )) as ConcurrencyModule;
+    const values = Array.from({ length: 20 }, (_, index) => index);
+    let active = 0;
+    let peak = 0;
+
+    const results = await mapConcurrent(
+      values,
+      4,
+      async (value) => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        active--;
+        return value * 2;
+      }
+    );
+
+    assert.equal(peak, 4);
+    assert.deepEqual(
+      results,
+      values.map((value) => value * 2)
+    );
+  });
+
+  test("settles active projection I/O before propagating errors", async () => {
+    const moduleUrl = new URL(
+      "../projection/concurrency.js",
+      import.meta.url
+    );
+    const { mapConcurrent } = (await import(
+      moduleUrl.href
+    )) as ConcurrencyModule;
+    const started: number[] = [];
+    let active = 0;
+
+    await assert.rejects(
+      mapConcurrent([0, 1, 2], 2, async (value) => {
+        started.push(value);
+        if (value === 1) throw new Error("read failed");
+        active++;
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        active--;
+        return value;
+      }),
+      /read failed/
+    );
+
+    assert.equal(active, 0);
+    assert.deepEqual(started, [0, 1]);
+  });
+
+  test("proves opaque assets through emitted bytes", async (t) => {
+    const root = await fixtureRoot();
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const weatherBytes = Uint8Array.from([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+    ]);
+    await writeFile(path.join(root, "src", "weather.jpg"), weatherBytes);
+    await writeFile(
+      path.join(root, "src", "entry.ts"),
+      "import weather from './weather.jpg';\nexport { weather };\n"
+    );
+
+    await esbuild.build({
+      absWorkingDir: root,
+      entryPoints: ["src/entry.ts"],
+      outdir: "dist",
+      bundle: true,
+      format: "esm",
+      write: true,
+      loader: { ".jpg": "file" },
+      plugins: [esbuildProjection()],
+    });
+
+    const manifest = await readManifest(root);
+    assert.equal(
+      Object.keys(manifest.inputs).some((key) =>
+        key.endsWith("src/weather.jpg")
+      ),
+      false
+    );
+    assert.ok(
+      Object.keys(manifest.inputs).some((key) =>
+        key.endsWith("src/entry.ts")
+      )
+    );
+
+    const outputKey = Object.keys(manifest.outputs).find((key) =>
+      key.endsWith(".jpg")
+    );
+    assert.ok(outputKey);
+    assert.equal(
+      manifest.outputs[outputKey],
+      hashContent(await readFile(resolvedArtifact(root, manifest, outputKey)))
+    );
+  });
+
+  test("honors non-source loader overrides on source extensions", async (t) => {
+    const root = await fixtureRoot();
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const assetBytes = Uint8Array.from([0xff, 0x00, 0xfe, 0x01]);
+    await writeFile(path.join(root, "src", "asset.ts"), assetBytes);
+    await writeFile(
+      path.join(root, "src", "entry.js"),
+      "import asset from './asset.ts';\nexport { asset };\n"
+    );
+
+    await esbuild.build({
+      absWorkingDir: root,
+      entryPoints: ["src/entry.js"],
+      outdir: "dist",
+      bundle: true,
+      format: "esm",
+      write: true,
+      loader: { ".ts": "file" },
+      plugins: [esbuildProjection()],
+    });
+
+    const manifest = await readManifest(root);
+    assert.equal(
+      Object.keys(manifest.inputs).some((key) =>
+        key.endsWith("src/asset.ts")
+      ),
+      false
+    );
+    assert.ok(
+      Object.keys(manifest.inputs).some((key) =>
+        key.endsWith("src/entry.js")
+      )
+    );
+  });
+
+  test("follows esbuild loader plugins and longest suffixes", async (t) => {
+    const root = await fixtureRoot();
+    t.after(() => rm(root, { recursive: true, force: true }));
+    await writeFile(
+      path.join(root, "src", "card.component.ts"),
+      `
+import { WebUIElement } from '@microsoft/webui-framework';
+class Card extends WebUIElement {}
+Card.define('suffix-card');
+`
+    );
+    await writeFile(
+      path.join(root, "src", "suffix-entry.js"),
+      "import './card.component.ts';\n"
+    );
+
+    await esbuild.build({
+      absWorkingDir: root,
+      entryPoints: ["src/suffix-entry.js"],
+      outdir: "suffix-dist",
+      bundle: true,
+      format: "esm",
+      write: true,
+      loader: { ".ts": "file", ".component.ts": "ts" },
+      external: ["@microsoft/webui-framework"],
+      plugins: [esbuildProjection()],
+    });
+    assert.ok(
+      (await readManifest(root, "suffix-dist")).components["suffix-card"]
+    );
+
+    await writeFile(
+      path.join(root, "src", "plugin-asset.ts"),
+      Uint8Array.from([0xff, 0x00, 0xfe, 0x01])
+    );
+    await writeFile(
+      path.join(root, "src", "plugin-entry.js"),
+      "import asset from './plugin-asset.ts';\nexport { asset };\n"
+    );
+    await esbuild.build({
+      absWorkingDir: root,
+      entryPoints: ["src/plugin-entry.js"],
+      outdir: "plugin-dist",
+      bundle: true,
+      format: "esm",
+      write: true,
+      plugins: [
+        {
+          name: "binary-ts-loader",
+          setup(build) {
+            build.onLoad(
+              { filter: /plugin-asset\.ts$/ },
+              async (args) => ({
+                contents: await readFile(args.path),
+                loader: "file",
+              })
+            );
+          },
+        },
+        esbuildProjection(),
+      ],
+    });
+    assert.equal(
+      Object.keys(
+        (await readManifest(root, "plugin-dist")).inputs
+      ).some((key) => key.endsWith("src/plugin-asset.ts")),
+      false
+    );
+  });
+
+  test("resolves the default stdin loader from its sourcefile", async (t) => {
+    const root = await fixtureRoot();
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const source = "const value: number = 1;\nexport { value };\n";
+
+    await esbuild.build({
+      absWorkingDir: root,
+      stdin: {
+        contents: source,
+        sourcefile: "src/entry.ts",
+        loader: "default",
+        resolveDir: root,
+      },
+      outfile: "dist/index.js",
+      bundle: true,
+      format: "esm",
+      write: true,
+      plugins: [esbuildProjection()],
+    });
+    assert.equal(
+      Object.keys((await readManifest(root)).inputs).length,
+      1
+    );
+
+    await esbuild.build({
+      absWorkingDir: root,
+      stdin: {
+        contents: source,
+        sourcefile: "src/asset.ts",
+        loader: "default",
+        resolveDir: root,
+      },
+      outdir: "opaque-dist",
+      bundle: true,
+      format: "esm",
+      write: true,
+      loader: { ".ts": "file" },
+      plugins: [esbuildProjection()],
+    });
+    assert.deepEqual(
+      (await readManifest(root, "opaque-dist")).inputs,
+      {}
+    );
+  });
+
   test("treats stdin as virtual even when sourcefile exists on disk", async (t) => {
     const root = await fixtureRoot();
     t.after(() => rm(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Why

The esbuild projection adapter read every metafile input through one unbounded `Promise.all`. Large browser graphs could exhaust Windows file handles and fail with `PROJ-C013`, while binary inputs were UTF-8 decoded and could later fail Rust stale validation with `PROJ-M003`.

## What changed

- limit projection source reads to 64 concurrent operations with deterministic result ordering and complete active-work cleanup on error
- normalize only supported JavaScript/TypeScript inputs that esbuild classified as ESM or CommonJS
- follow configured, longest-suffix, plugin-provided, and stdin loader decisions through esbuild's metafile format signal
- keep non-source inputs outside the semantic projection graph and treat their incoming edges as external there; existing emitted output bytes continue to provide their exact stale-data proof
- leave the compiler, output SPI, and runtime bundles unchanged

## Performance

- 512-source build median: 149.7 ms before, 147.6 ms after
- 64 MiB binary-asset graph: 1165.8 ms before, 460.3 ms after
- binary-asset peak RSS: 264.6 MiB before, 12.0 MiB after
- emitted runtime bytes are unchanged

## Validation

- added esbuild adapter regressions for bounded concurrency, error settling, binary assets, configured loader overrides, longest-suffix loaders, plugin-provided loaders, and stdin loader resolution
- `cargo xtask check` passes, including lint, tests, builds, examples, WASM, benchmarks, and docs