### PR TITLE
chore: clarify repeated w-ref behavior

### DIFF
--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -296,6 +296,12 @@ Use `w-ref` only for imperative browser APIs - `focus()`, `scrollIntoView()`,
 `showModal()`, `showPopover()`, measurement. Never use it to read or write
 state that a template binding could express.
 
+`w-ref` is scalar. Reusing one ref name inside `<for>` overwrites the same
+property, so the last wired occurrence wins; repeat `key` and position do not
+create an indexed ref collection. For item lookup, use a stable authored `id`
+with `Document.getElementById()` / `ShadowRoot.getElementById()`, or put the ref
+inside an item component.
+
 ### The `<template>` tag
 
 Unwrapped components default to Shadow. In a `--dom light` build they use

--- a/docs/guide/concepts/interactivity.md
+++ b/docs/guide/concepts/interactivity.md
@@ -314,6 +314,12 @@ focusInput(): void {
 (or the unquoted `w-ref={inputEl}`), never `w-ref="inputEl"`. The build fails
 with an actionable error otherwise.
 
+`w-ref` is scalar. Reusing a name inside `<for>` writes the same property, so
+the last wired occurrence wins; repeat keys and positions do not create an
+indexed ref collection. For lookup by item identity, author a stable `id` and
+use the owning document or shadow root's `getElementById()`, or move the ref
+into an item component.
+
 ### Conditional Rendering
 
 Render content based on expressions:


### PR DESCRIPTION
`w-ref` is a scalar component-property binding, but the documentation did not state what happens when the same ref name appears inside `<for>`. This could incorrectly imply that repeat keys or positions create an indexed ref collection.

- Clarify that the last wired occurrence wins.
- State that repeat `key` and position are not imperative lookup contracts.
- Recommend stable authored IDs with `getElementById()` or item components for identity-based lookup.
- Keep the AI authoring reference aligned with the public interactivity guide.