### PR TITLE
fix: settle router pending UI during navigation commits

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -364,7 +364,13 @@ the full invalidation graph - developers cannot forget to invalidate related dat
 
 **Pending component:** Declared via `pending="mail-skeleton"` on `<route>`. The compiler validates
 the component exists at build time. During slow navigations (>150ms), the router mounts this
-component as a loading indicator. Skip for keep-alive and cached routes.
+component as a loading indicator. The indicator remains owned by that navigation through response
+validation, component loading, route loaders, and view-transition preparation. A successful
+navigation removes its tracked pending element inside the synchronous DOM commit before settled
+route content is mutated or `webui:route:navigated` is dispatched. Aborted, superseded, failed,
+and destroyed navigations release pending UI through the same generation-checked O(1) ownership
+path, without scanning the document or authored shadow roots. Skip pending setup entirely for
+keep-alive and cached routes.
 
 **Error component:** Declared via `error="error-page"` on `<route>`. The compiler validates
 the component exists at build time. When a navigation fetch fails, the router mounts this
@@ -717,7 +723,7 @@ overlap with the invalidated tags.
 
 **Mutation actions:** Components can declare `static action(ctx: RouteActionContext)` as the write counterpart to `static loader()`. `Router.start({ actions: true })` opts into the action runtime; otherwise the router core does not import form interception code. When enabled, the router intercepts `<form method="post">` submissions, finds the nearest route component's `static action()`, calls it, and auto-invalidates the cache using both the action's returned tags and the route's build-time `invalidates` attribute. The owning chain entry is resolved by route-element identity, not by component tag, so two declarations that reuse one component cannot consume each other's invalidation metadata. Loader results are keyed by the same concrete chain entries. This ensures the compiler-declared invalidation graph is always respected — developers cannot forget.
 
-**Pending UI:** Routes with a `pending` attribute show a loading component during slow navigations (>150ms). The pending component is a normal WebUI component — SSR'd and build-time validated. Keep-alive and cached routes skip pending (no delay to show).
+**Pending UI:** Routes with a `pending` attribute show a loading component during slow navigations (>150ms). The pending component is a normal WebUI component - SSR'd and build-time validated. It remains visible through all pre-commit work and is removed atomically inside the successful DOM commit. Aborted, superseded, failed, and destroyed navigations remove only their generation-owned pending element in O(1). Keep-alive and cached routes skip pending setup entirely.
 
 **Error boundaries:** Routes with an `error` attribute show an error component when the navigation fetch fails. The error component receives `{ error, status, path }` as state and can call `Router.navigate()` to recover.
 

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -403,9 +403,9 @@ Show a loading component during slow navigations. The component is validated at 
 
 | Behavior | Description |
 |----------|-------------|
-| **Threshold** | Pending component appears after 150ms - fast navigations never flash |
+| **Threshold** | Pending component appears when pre-commit navigation work exceeds 150ms - fast navigations never flash |
 | **Mount** | Rendered in the parent route's outlet area |
-| **Replace** | Real content replaces the skeleton when the fetch completes |
+| **Commit** | Removed atomically when settled route content commits, before `webui:route:navigated` |
 | **Keep-alive** | Skipped - keep-alive routes activate instantly from the DOM |
 | **Cached** | Skipped - cached navigations have no fetch delay |
 

--- a/packages/webui-router/README.md
+++ b/packages/webui-router/README.md
@@ -298,7 +298,9 @@ Show a loading component during slow navigations (>150ms):
 <route path="inbox" component="inbox-page" exact pending="mail-skeleton" />
 ```
 
-The `pending` component is validated at build time. Keep-alive and cached routes skip pending.
+The `pending` component is validated at build time. It remains visible through response
+validation, component loading, and route loaders, then is removed atomically with the settled
+route commit before `webui:route:navigated`. Keep-alive and cached routes skip pending setup.
 
 ### Error Boundaries
 

--- a/packages/webui-router/src/pending.ts
+++ b/packages/webui-router/src/pending.ts
@@ -40,11 +40,7 @@ export class PendingState {
   mountPending(
     componentTag: string,
     container: Element | ShadowRoot,
-    keepAlive: boolean,
   ): void {
-    // Don't show pending for keep-alive routes (they activate instantly)
-    if (keepAlive) return;
-
     if (this.pendingElement?.isConnected) return;
 
     const pending = document.createElement(componentTag);

--- a/packages/webui-router/src/router.test.ts
+++ b/packages/webui-router/src/router.test.ts
@@ -317,6 +317,24 @@ describe('WebUIRouter', () => {
     });
   });
 
+  describe('boundary UI lifecycle', () => {
+    test('rejects a settle that synchronously starts a newer boundary generation', () => {
+      const router = new WebUIRouter();
+      const priv = router as any;
+      priv.pending = {
+        clearElements() {
+          priv.boundaryGeneration++;
+        },
+        destroy() {},
+      };
+
+      const generation = priv.boundaryGeneration as number;
+      assert.equal(priv.invalidateBoundaryState(generation), null);
+      assert.equal(priv.boundaryGeneration, generation + 2);
+      router.destroy();
+    });
+  });
+
   describe('template execution in fetchPartial', () => {
     test('split template registration stores data and condition closures', () => {
       const origCreateElement = (globalThis as any).document.createElement;
@@ -1088,7 +1106,7 @@ describe('WebUIRouter', () => {
       );
     });
 
-    test('handleNavigation checks signal.aborted after fetch and inside preload loop', () => {
+    test('handleNavigation checks signal.aborted after fetch and during commit', () => {
       // Verify the architectural contract: commitWithData has abort gates
       // after fetchPartial and inside the ensureComponentLoaded loop.
       const router = new WebUIRouter();
@@ -1132,11 +1150,41 @@ describe('WebUIRouter', () => {
       const clearIdx = source.indexOf('this.clearSsrPreloads()');
       const fetchIdx = source.indexOf('fetchPartial');
 
-      assert.ok(clearIdx > -1, 'handleNavigation should clear SSR preload links on SPA navigations');
+      assert.ok(clearIdx > -1, 'handleNavigation should clear SSR preload links');
       assert.ok(fetchIdx > -1, 'handleNavigation should fetch partial data');
       assert.ok(
         clearIdx < fetchIdx,
         'SSR preload links should be cleared before fetching the next partial route',
+      );
+    });
+
+    test('commit atomically settles pending UI before mutating route content', () => {
+      const router = new WebUIRouter();
+      const source = (router as any).commitWithData.toString() as string;
+      const commitIdx = source.indexOf('const commitNavigation');
+      const settleIdx = source.indexOf('this.invalidateBoundaryState', commitIdx);
+      const deactivateIdx = source.indexOf('deactivateRoute', commitIdx);
+
+      assert.ok(commitIdx > -1, 'commitWithData should define a synchronous DOM commit');
+      assert.ok(settleIdx > commitIdx, 'the DOM commit should settle its pending boundary');
+      assert.ok(
+        settleIdx < deactivateIdx,
+        'pending UI must be removed before settled route content is mutated',
+      );
+    });
+
+    test('settles pending UI before awaiting deferred stream cancellation', () => {
+      const router = new WebUIRouter();
+      const source = (router as any).handleNavigation.toString() as string;
+      const mismatchIdx = source.indexOf('Response path mismatch');
+      const settleIdx = source.indexOf('this.invalidateBoundaryState', mismatchIdx);
+      const cancelIdx = source.indexOf('cancelDeferredStream', mismatchIdx);
+
+      assert.ok(mismatchIdx > -1, 'handleNavigation should reject mismatched responses');
+      assert.ok(settleIdx > mismatchIdx, 'mismatch cleanup should settle pending UI');
+      assert.ok(
+        settleIdx < cancelIdx,
+        'pending UI must settle before deferred stream cancellation can block',
       );
     });
   });
@@ -1923,6 +1971,9 @@ describe('WebUIRouter', () => {
       const tag = `missing-client-${Date.now()}`;
 
       try {
+        const navigationGeneration = (router as any).navGeneration as number;
+        const boundaryGeneration =
+          (router as any).invalidateBoundaryState() as number;
         await (router as any).commitWithData(
           {
             state: {},
@@ -1930,10 +1981,13 @@ describe('WebUIRouter', () => {
           },
           '/missing-client',
           {},
+          navigationGeneration,
+          boundaryGeneration,
         );
 
         assert.equal(window.location.href, '/missing-client');
       } finally {
+        router.destroy();
         window.location.href = originalHref;
       }
     });

--- a/packages/webui-router/src/router.ts
+++ b/packages/webui-router/src/router.ts
@@ -139,10 +139,6 @@ export class WebUIRouter {
     }
   }
 
-  private clearPendingElements(): void {
-    this.pending?.clearElements();
-  }
-
   private abortPartialRequests(): void {
     for (const controller of this.partialControllers) {
       controller.abort();
@@ -157,11 +153,17 @@ export class WebUIRouter {
     this.partialCleanups.delete(controller);
   }
 
-  private invalidateBoundaryState(): number {
-    this.boundaryGeneration++;
+  private invalidateBoundaryState(expectedGeneration?: number): number | null {
+    if (
+      expectedGeneration !== undefined &&
+      expectedGeneration !== this.boundaryGeneration
+    ) {
+      return null;
+    }
+    const generation = ++this.boundaryGeneration;
     this.clearPendingTimer();
-    this.clearPendingElements();
-    return this.boundaryGeneration;
+    this.pending?.clearElements();
+    return generation === this.boundaryGeneration ? generation : null;
   }
 
   private destroyPending(): void {
@@ -472,123 +474,126 @@ export class WebUIRouter {
       this.actionController = null;
       const thisGen = ++this.navGeneration;
       const boundaryGen = this.invalidateBoundaryState();
-      this.abortPartialRequests();
-      const navCache = this.cacheEnabled ? await this.ensureNavigationCache() : null;
-      if (thisGen !== this.navGeneration) return;
-      navCache?.gc();
+      if (boundaryGen === null) return;
 
-      let partialData: StreamingPartialResponse | null = null;
-      const cached = navCache?.lookup(requestPath) ?? null;
-      if (cached) {
-        partialData = cached;
-      } else {
-        const pendingBoundary = findPendingComponent(this.activeChain, requestPath);
-        if (pendingBoundary) {
-          this.pendingTimer = setTimeout(() => {
-            if (boundaryGen !== this.boundaryGeneration) return;
-            this.pendingTimer = null;
-            void this.pendingState().then((pending) => {
-              if (
-                thisGen === this.navGeneration &&
-                boundaryGen === this.boundaryGeneration
-              ) {
-                pending.mountPending(
-                  pendingBoundary.component,
-                  pendingBoundary.container,
-                  pendingBoundary.keepAlive,
-                );
-              }
-            });
-          }, 150);
-        }
+      try {
+        if (thisGen !== this.navGeneration) return;
+        this.abortPartialRequests();
+        const navCache = this.cacheEnabled ? await this.ensureNavigationCache() : null;
+        if (thisGen !== this.navGeneration) return;
+        navCache?.gc();
 
-        try {
+        let partialData: StreamingPartialResponse | null = null;
+        const cached = navCache?.lookup(requestPath) ?? null;
+        if (cached) {
+          partialData = cached;
+        } else {
+          const pendingBoundary = findPendingComponent(this.activeChain, requestPath);
+          if (pendingBoundary && !pendingBoundary.keepAlive) {
+            this.pendingTimer = setTimeout(() => {
+              if (boundaryGen !== this.boundaryGeneration) return;
+              this.pendingTimer = null;
+              void this.pendingState().then((pending) => {
+                if (
+                  thisGen === this.navGeneration &&
+                  boundaryGen === this.boundaryGeneration
+                ) {
+                  pending.mountPending(
+                    pendingBoundary.component,
+                    pendingBoundary.container,
+                  );
+                }
+              });
+            }, 150);
+          }
+
           partialData =
             await this.takePreparedPartial(requestPath, signal)
             ?? await this.fetchPartial(requestPath, signal);
-        } finally {
-          if (
-            thisGen === this.navGeneration &&
-            boundaryGen === this.boundaryGeneration
-          ) {
-            this.invalidateBoundaryState();
-          }
-        }
 
-        if (!partialData && !signal?.aborted && thisGen === this.navGeneration) {
-          const errorBoundary = findErrorComponent(this.activeChain, requestPath);
-          if (errorBoundary) {
-            const errorBoundaryGen = this.boundaryGeneration;
-            const pending = await this.pendingState();
-            if (
-              thisGen !== this.navGeneration ||
-              errorBoundaryGen !== this.boundaryGeneration
-            ) {
+          if (!partialData && !signal?.aborted && thisGen === this.navGeneration) {
+            const errorBoundary = findErrorComponent(this.activeChain, requestPath);
+            if (errorBoundary) {
+              const errorBoundaryGen = this.invalidateBoundaryState(boundaryGen);
+              if (errorBoundaryGen === null) return;
+              const pending = await this.pendingState();
+              if (
+                thisGen !== this.navGeneration ||
+                errorBoundaryGen !== this.boundaryGeneration
+              ) {
+                return;
+              }
+              pending.mountError(
+                errorBoundary.component,
+                {
+                  error: 'Navigation failed',
+                  status: 0,
+                  path: requestPath,
+                },
+                errorBoundary.container,
+              );
               return;
             }
-            pending.mountError(
-              errorBoundary.component,
-              {
-                error: 'Navigation failed',
-                status: 0,
-                path: requestPath,
-              },
-              errorBoundary.container,
-            );
+            console.warn('[Router] Navigation fetch failed for:', requestPath);
             return;
           }
-          console.warn('[Router] Navigation fetch failed for:', requestPath);
-          return;
         }
-      }
 
-      const streaming = partialData?._deferredStream
-        ? await import('./streaming.js')
-        : undefined;
-      if (!partialData || signal?.aborted || thisGen !== this.navGeneration) {
-        if (partialData && streaming) {
-          await streaming.cancelDeferredStream(partialData);
-        }
-        this.preparedPreload?.release(requestPath);
-        return;
-      }
-
-      if (partialData.path) {
-        const requestPathname = requestPath.split('?')[0];
-        if (partialData.path !== requestPathname && partialData.path !== requestPath) {
-          console.warn(`[Router] Response path mismatch: expected ${requestPathname}, got ${partialData.path}`);
-          await streaming?.cancelDeferredStream(partialData);
+        const streaming = partialData?._deferredStream
+          ? await import('./streaming.js')
+          : undefined;
+        if (!partialData || signal?.aborted || thisGen !== this.navGeneration) {
+          this.invalidateBoundaryState(boundaryGen);
+          if (partialData && streaming) {
+            await streaming.cancelDeferredStream(partialData);
+          }
           this.preparedPreload?.release(requestPath);
           return;
         }
-      }
 
-      if (!cached) {
-        const isStreaming = streaming?.hasDeferredStream(partialData) ?? false;
-        navCache?.store(requestPath, partialData, undefined, isStreaming);
-        this.preparedPreload?.release(requestPath);
-      }
+        if (partialData.path) {
+          const requestPathname = requestPath.split('?')[0];
+          if (partialData.path !== requestPathname && partialData.path !== requestPath) {
+            console.warn(`[Router] Response path mismatch: expected ${requestPathname}, got ${partialData.path}`);
+            this.invalidateBoundaryState(boundaryGen);
+            await streaming?.cancelDeferredStream(partialData);
+            this.preparedPreload?.release(requestPath);
+            return;
+          }
+        }
 
-      let committed = false;
-      try {
-        committed = await this.commitWithData(
-          partialData,
-          requestPath,
-          query,
-          signal,
-          thisGen,
-        );
-      } catch (error) {
-        await streaming?.cancelDeferredStream(partialData);
-        if (!cached) navCache?.evict(requestPath);
-        throw error;
+        if (!cached) {
+          const isStreaming = streaming?.hasDeferredStream(partialData) ?? false;
+          navCache?.store(requestPath, partialData, undefined, isStreaming);
+          this.preparedPreload?.release(requestPath);
+        }
+
+        let committed = false;
+        try {
+          committed = await this.commitWithData(
+            partialData,
+            requestPath,
+            query,
+            thisGen,
+            boundaryGen,
+            signal,
+          );
+        } catch (error) {
+          this.invalidateBoundaryState(boundaryGen);
+          await streaming?.cancelDeferredStream(partialData);
+          if (!cached) navCache?.evict(requestPath);
+          throw error;
+        }
+        if (!committed || signal?.aborted || thisGen !== this.navGeneration) {
+          this.invalidateBoundaryState(boundaryGen);
+          await streaming?.cancelDeferredStream(partialData);
+          if (!cached) navCache?.evict(requestPath);
+          return;
+        }
+        streaming?.startDeferredStream(partialData);
+      } finally {
+        this.invalidateBoundaryState(boundaryGen);
       }
-      if (!committed || signal?.aborted || thisGen !== this.navGeneration) {
-        await streaming?.cancelDeferredStream(partialData);
-        if (!cached) navCache?.evict(requestPath);
-        return;
-      }
-      streaming?.startDeferredStream(partialData);
     }
 
     const leaf = this.activeChain[this.activeChain.length - 1];
@@ -937,8 +942,9 @@ export class WebUIRouter {
     partialData: PartialResponse & { inventory?: string },
     requestPath: string,
     query: Record<string, string>,
+    navigationGeneration: number,
+    boundaryGeneration: number,
     signal?: AbortSignal,
-    generation?: number,
   ): Promise<boolean> {
     const topState = partialData.state ?? null;
     const newChain: RouteChainEntry[] = (partialData.chain ?? []).map(e => ({
@@ -962,7 +968,7 @@ export class WebUIRouter {
     }
 
     // Pre-load component modules
-    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) {
+    if (signal?.aborted || navigationGeneration !== this.navGeneration) {
       return false;
     }
     const preload = Promise.all(
@@ -979,7 +985,7 @@ export class WebUIRouter {
     } else {
       await preload;
     }
-    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) {
+    if (signal?.aborted || navigationGeneration !== this.navGeneration) {
       return false;
     }
 
@@ -993,14 +999,23 @@ export class WebUIRouter {
     // Resolve static loader() methods on component constructors (pre-commit).
     // Loader results replace server state for those components.
     const loaderStates = await resolveLoaders(newChain, query, signal);
-    if (signal?.aborted || (generation !== undefined && generation !== this.navGeneration)) {
+    if (signal?.aborted || navigationGeneration !== this.navGeneration) {
       return false;
     }
 
     const changeLevel = findChangeLevel(this.activeChain, newChain);
     const isQueryOnlyChange = changeLevel === newChain.length && newChain.length > 0;
 
+    let committed = false;
     const commitNavigation = (): void => {
+      if (
+        signal?.aborted ||
+        navigationGeneration !== this.navGeneration ||
+        this.invalidateBoundaryState(boundaryGeneration) === null
+      ) {
+        return;
+      }
+
       // Deactivate old chain from leaf up. Preserve route-owned style markers,
       // but tear down component state when the declaration will not be reused.
       for (let i = this.activeChain.length - 1; i >= changeLevel; i--) {
@@ -1082,6 +1097,7 @@ export class WebUIRouter {
         activateRoute(routeEl, entry.params);
       }
       this.activeChain = newChain;
+      committed = true;
     };
 
     if (document.startViewTransition && !isQueryOnlyChange) {
@@ -1090,7 +1106,7 @@ export class WebUIRouter {
     } else {
       commitNavigation();
     }
-    return true;
+    return committed;
   }
 
 }

--- a/packages/webui-router/tests/router-e2e.spec.ts
+++ b/packages/webui-router/tests/router-e2e.spec.ts
@@ -840,6 +840,94 @@ test.describe('pending UI', () => {
     await expect(page.locator('loading-skeleton')).toHaveCount(0);
   });
 
+  test('atomically settles pending UI across consecutive same-component commits', async ({ page }) => {
+    await page.goto('/items/0');
+    await page.waitForFunction(() => {
+      const shell = document.querySelector('route-shell');
+      return shell && (shell as { $ready?: boolean }).$ready === true;
+    });
+    await expect(page.locator('page-detail h2')).toHaveText('Item 0');
+
+    await page.evaluate(() => {
+      type DetailConstructor = CustomElementConstructor & {
+        loader?: (context: {
+          params: Record<string, string>;
+        }) => Promise<Record<string, unknown>>;
+      };
+      type PendingTestWindow = Window & {
+        __pendingCommitSnapshots?: number[];
+        __releaseDetailLoader?: () => void;
+      };
+
+      const runtime = window as PendingTestWindow;
+      const detail = customElements.get('page-detail') as DetailConstructor | undefined;
+      const startViewTransition = document.startViewTransition?.bind(document);
+      if (!detail || !startViewTransition) {
+        throw new Error('pending lifecycle test requires page-detail and View Transitions');
+      }
+
+      runtime.__pendingCommitSnapshots = [];
+      document.startViewTransition = ((update: () => void) =>
+        startViewTransition(() => {
+          update();
+          const root = document.querySelector('route-shell')?.shadowRoot;
+          runtime.__pendingCommitSnapshots?.push(
+            root?.querySelectorAll('[data-webui-pending]').length ?? -1,
+          );
+        })) as typeof document.startViewTransition;
+
+      detail.loader = ({ params }) => new Promise(resolve => {
+        runtime.__releaseDetailLoader = () => {
+          delete runtime.__releaseDetailLoader;
+          resolve({ itemId: params.itemId });
+        };
+      });
+    });
+
+    for (const itemId of ['1', '2']) {
+      const committed = page.evaluate((nextItemId) => {
+        return new Promise<{ heading: string | null; pendingAtEvent: number }>(resolve => {
+          window.addEventListener('webui:route:navigated', () => {
+            const root = document.querySelector('route-shell')?.shadowRoot;
+            const detail = root?.querySelector<HTMLElement>('page-detail');
+            resolve({
+              heading: detail?.shadowRoot?.querySelector('h2')?.textContent ?? null,
+              pendingAtEvent:
+                root?.querySelectorAll('[data-webui-pending]').length ?? -1,
+            });
+          }, { once: true });
+          window.navigation.navigate(`/items/${nextItemId}`);
+        });
+      }, itemId);
+
+      await page.waitForFunction(
+        () => typeof (window as Window & {
+          __releaseDetailLoader?: () => void;
+        }).__releaseDetailLoader === 'function',
+      );
+      await expect(page.locator('[data-webui-pending]')).toBeVisible();
+      await expect(page.locator('page-detail h2')).not.toHaveText(`Item ${itemId}`);
+
+      await page.evaluate(() => {
+        (window as Window & {
+          __releaseDetailLoader?: () => void;
+        }).__releaseDetailLoader?.();
+      });
+
+      expect(await committed).toEqual({
+        heading: `Item ${itemId}`,
+        pendingAtEvent: 0,
+      });
+      await expect(page.locator('[data-webui-pending]')).toHaveCount(0);
+    }
+
+    expect(await page.evaluate(
+      () => (window as Window & {
+        __pendingCommitSnapshots?: number[];
+      }).__pendingCommitSnapshots,
+    )).toEqual([0, 0]);
+  });
+
   test('shows the destination pending boundary after a prior route is active', async ({ page }) => {
     await page.goto('/alpha');
     await page.waitForFunction(() => {


### PR DESCRIPTION
## Why

Router-owned pending UI was tied to partial-response completion instead of the route DOM commit. That could remove the indicator before component loading and route loaders finished, and it made terminal cleanup ordering vulnerable to stream-cancellation stalls and synchronous custom-element re-entry.

## What changed

- Keep pending UI mounted through all pre-commit work.
- Settle the generation-owned boundary at the start of the synchronous DOM commit, before route mutations and `webui:route:navigated`.
- Clear pending UI before awaiting deferred-stream cancellation on abort and failure paths.
- Reject stale or re-entrant cleanup so an older navigation cannot mutate DOM owned by a newer one.
- Skip pending timer setup for keep-alive destinations.
- Add browser coverage for two consecutive parameter navigations that reuse the same component and assert zero pending nodes inside each commit and navigation event.
- Update the routing specification and developer documentation.

## Performance

Production minified ESM size:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Raw | 37,555 B | 37,800 B | +245 B |
| Gzip | 11,866 B | 11,941 B | +75 B |
| Brotli | 10,692 B | 10,779 B | +87 B |

The boundary lifecycle microbenchmark remained within measurement noise: 1.7562 ns median before and 1.7706 ns after. The implementation adds no DOM scans or per-navigation allocations.

## Validation

- `pnpm --dir packages/webui-router test`
- `cargo xtask check`