### PR TITLE
fix: restore FAST property bindings in SSR

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2101,10 +2101,15 @@ parser view returned as `TransformedComponentSource::parser_content`:
   `unsupported-multiple-f-templates` for multiple wrappers,
   `invalid-fast-template` for unsupported or malformed FAST declarative syntax,
   and the shared `unclosed-html-tag` for unclosed markup.
-- The FAST plugins' `process_attribute` skips `@event`, `:property`, `f-ref`,
-  `f-slotted`, and `f-children` and counts each as a binding, so they are
-  absent from the SSR view while the hydration binding count still reflects
-  them. No parser-core marker or FAST-named branch is involved. FAST idiomatically
+- The FAST plugins' `process_attribute` skips `@event`, FAST single-brace
+  `:property="{expression}"`, `f-ref`, `f-slotted`, and `f-children` and counts
+  each as a binding, so they are absent from the SSR view while the hydration
+  binding count still reflects them. WebUI-owned
+  `:property="{{expression}}"` bypasses plugin classification and remains a
+  normal complex attribute fragment: the handler resolves it into the child
+  component's render scope without emitting an HTML attribute, and parser-core
+  binding accounting counts it once. No parser-core FAST-named branch is
+  involved. FAST idiomatically
   authors host-element bindings directly on the root `<template>` (e.g.
   `<template @click="{…}">`); because their `ComponentProcessing` enables root
   attribute processing, those bindings flow through the same

--- a/crates/webui-parser/src/lib.rs
+++ b/crates/webui-parser/src/lib.rs
@@ -3749,19 +3749,27 @@ impl HtmlParser {
         let mut binding_count: u32 = 0;
         for attr in attrs {
             let attr_name = attr.name;
+            let attr_value = attr.value;
+            let is_property_binding = attr_name.starts_with(':')
+                && attr_value
+                    .and_then(Self::extract_single_handlebars)
+                    .is_some();
 
-            if let Some(ref mut p) = self.plugin {
-                match p.process_attribute(AttributeContext { name: attr_name }) {
-                    AttributeAction::Keep => {}
-                    AttributeAction::Skip => continue,
-                    AttributeAction::SkipAndCountBinding => {
-                        binding_count += 1;
-                        continue;
+            // `:property="{{expr}}"` is WebUI-owned syntax. Plugins may classify
+            // FAST's single-brace `:property="{expr}"`, but cannot discard the
+            // server-side scope transfer before parser-core processes it.
+            if !is_property_binding {
+                if let Some(ref mut p) = self.plugin {
+                    match p.process_attribute(AttributeContext { name: attr_name }) {
+                        AttributeAction::Keep => {}
+                        AttributeAction::Skip => continue,
+                        AttributeAction::SkipAndCountBinding => {
+                            binding_count += 1;
+                            continue;
+                        }
                     }
                 }
             }
-
-            let attr_value = attr.value;
 
             if let Some(bool_name) = attr_name.strip_prefix('?') {
                 if is_component {

--- a/crates/webui-parser/src/plugin/fast/shared.rs
+++ b/crates/webui-parser/src/plugin/fast/shared.rs
@@ -10,7 +10,7 @@ use crate::html_parser::{leading_content, parse_tag};
 use crate::Result;
 use webui_protocol::FastElementData;
 
-// Classify FAST-owned attributes that SSR skips but hydration counts.
+// Classify client-only FAST attributes that SSR skips but hydration counts.
 #[inline]
 pub(crate) fn classify_attribute(attr_name: &str) -> AttributeAction {
     if attr_name.starts_with('@')

--- a/crates/webui-parser/src/plugin/fast/v2.rs
+++ b/crates/webui-parser/src/plugin/fast/v2.rs
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn skip_property_binding() {
+    fn skip_fast_property_binding() {
         let mut plugin = FastV2ParserPlugin::new();
         assert_eq!(
             plugin.classify_attribute(":title"),

--- a/crates/webui-parser/src/plugin/fast/v3.rs
+++ b/crates/webui-parser/src/plugin/fast/v3.rs
@@ -788,7 +788,7 @@ mod tests {
     }
 
     #[test]
-    fn skip_property_binding() {
+    fn skip_fast_property_binding() {
         let mut plugin = FastV3ParserPlugin::new();
         assert_eq!(
             plugin.classify_attribute(":title"),

--- a/crates/webui/src/tests/fast.rs
+++ b/crates/webui/src/tests/fast.rs
@@ -4,6 +4,55 @@
 use super::*;
 
 #[test]
+fn property_bindings_populate_fast_component_render_scope() {
+    let app = create_app_dir(&[
+        (
+            "index.html",
+            r#"<html><body><todo-app :rendertodos="{{todos}}"></todo-app></body></html>"#,
+        ),
+        (
+            "todo-app.template.html",
+            r#"<f-template name="todo-app"><template><ul><f-repeat value="{{todo in rendertodos}}"><todo-item :todo="{{todo}}"></todo-item></f-repeat></ul></template></f-template>"#,
+        ),
+        (
+            "todo-item.template.html",
+            r#"<f-template name="todo-item"><template><li data-id="{{todo.id}}">{{todo.title}}</li></template></f-template>"#,
+        ),
+    ]);
+    let mut options = default_options(app.path());
+    options.plugin = Some(Plugin::FastV3);
+    let result = build(options).unwrap();
+    let protocol = Protocol::new(result.protocol);
+    let handler = WebUIHandler::with_plugin(|| {
+        Box::new(webui_handler::plugin::fast_v3::FastV3HydrationPlugin::new())
+    });
+    let todos: Vec<_> = (0..100)
+        .map(|index| {
+            serde_json::json!({
+                "id": format!("todo-{index}"),
+                "title": format!("Todo {index}"),
+            })
+        })
+        .collect();
+    let state = serde_json::json!({ "todos": todos });
+    let mut writer = StringWriter { buf: String::new() };
+
+    handler
+        .render(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+    let ssr = writer.buf.split("<f-template").next().unwrap_or_default();
+    assert_eq!(ssr.matches(r#"<li data-id="todo-"#).count(), 100);
+    assert!(!ssr.contains(":rendertodos"));
+    assert!(!ssr.contains(":todo"));
+}
+
+#[test]
 fn build_discovers_generated_local_template() {
     let app = create_app_dir(&[
         ("index.html", "<custom-button></custom-button>"),


### PR DESCRIPTION
WebUI 0.0.26 stopped passing FAST `:property="{{expr}}"` values into child component render scope, leaving benchmark todo trees empty during server rendering.

This change reserves valid WebUI double-brace property bindings for parser-core processing before FAST plugin classification. FAST single-brace client bindings remain plugin-owned and continue to be skipped from SSR while contributing to hydration binding counts. The handler therefore receives component scope values without emitting property attributes into HTML.

A FAST V3 end-to-end regression test renders 100 nested todo items and verifies that the property bindings are absent from visible SSR output. `DESIGN.md` documents the distinction between FAST single-brace and WebUI double-brace property syntax.

Validation: `cargo xtask check` passes all lint, test, native/WASM/example build, benchmark validation, and docs phases.