### PR TITLE
fix(cd): remove checkout from release jobs

### DIFF
--- a/.ado/pipelines/azure-pipelines-cd.yml
+++ b/.ado/pipelines/azure-pipelines-cd.yml
@@ -271,9 +271,6 @@ extends:
               artifactName: standalone_release_assets
               targetPath: $(Build.SourcesDirectory)/publish_artifacts_standalone
           steps:
-          - checkout: self
-            clean: true
-
           - task: GitHubRelease@1
             displayName: Create GitHub Release
             inputs:
@@ -310,9 +307,6 @@ extends:
               artifactName: unsigned_npm_packages
               targetPath: $(Build.SourcesDirectory)/publish_artifacts_npm
           steps:
-          - checkout: self
-            clean: true
-
           # The template skips package types whose artifact directory is absent.
           - template: WebUI.Release.PipelineTemplate.yml@webuiPipelines
 
@@ -326,8 +320,5 @@ extends:
               artifactName: unsigned_crate_packages
               targetPath: $(Build.SourcesDirectory)/publish_artifacts_crates
           steps:
-          - checkout: self
-            clean: true
-
           # The template skips package types whose artifact directory is absent.
           - template: WebUI.Release.PipelineTemplate.yml@webuiPipelines


### PR DESCRIPTION
## Summary

- remove forbidden `checkout: self` steps from the GitHub, npm, and crates release jobs
- continue supplying release dependencies through existing `templateContext.inputs` pipeline artifacts
- leave the Web UI - CD Build pipeline unchanged

## Testing

- `cargo xtask check`