### PR TITLE
perf(handler): eliminate repeated render scans and lookups

### DIFF
--- a/crates/webui-handler/src/html_encode.rs
+++ b/crates/webui-handler/src/html_encode.rs
@@ -59,6 +59,30 @@ pub fn encode_safe(input: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+#[inline]
+fn is_style_end_tag(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'<'
+        && bytes[index + 1] == b'/'
+        && bytes[index + 2].eq_ignore_ascii_case(&b's')
+        && bytes[index + 3].eq_ignore_ascii_case(&b't')
+        && bytes[index + 4].eq_ignore_ascii_case(&b'y')
+        && bytes[index + 5].eq_ignore_ascii_case(&b'l')
+        && bytes[index + 6].eq_ignore_ascii_case(&b'e')
+}
+
+/// Return whether CSS needs escaping before it is written into a `<style>`.
+pub(crate) fn style_text_needs_escape(css: &str) -> bool {
+    let bytes = css.as_bytes();
+    let mut index = 0usize;
+    while index + 7 <= bytes.len() {
+        if is_style_end_tag(bytes, index) {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
 /// Write CSS into an HTML `<style>` raw-text element without allowing an
 /// authored, case-insensitive `</style` sequence to terminate the element.
 ///
@@ -69,14 +93,7 @@ pub(crate) fn write_style_text(writer: &mut dyn ResponseWriter, css: &str) -> Re
     let mut chunk_start = 0usize;
     let mut index = 0usize;
     while index + 7 <= bytes.len() {
-        if bytes[index] == b'<'
-            && bytes[index + 1] == b'/'
-            && bytes[index + 2].eq_ignore_ascii_case(&b's')
-            && bytes[index + 3].eq_ignore_ascii_case(&b't')
-            && bytes[index + 4].eq_ignore_ascii_case(&b'y')
-            && bytes[index + 5].eq_ignore_ascii_case(&b'l')
-            && bytes[index + 6].eq_ignore_ascii_case(&b'e')
-        {
+        if is_style_end_tag(bytes, index) {
             writer.write(&css[chunk_start..index + 1])?;
             writer.write("\\/")?;
             chunk_start = index + 2;
@@ -249,5 +266,34 @@ mod tests {
             writer.output,
             ".a{content:'<\\/style>'}.b{content:'<\\/StYlE attr>'}"
         );
+    }
+
+    #[test]
+    fn style_text_escape_detection_matches_writer() {
+        let cases = [
+            ("", false),
+            ("</styl", false),
+            ("< /style", false),
+            ("<\\/style", false),
+            ("</style", true),
+            ("prefix</STYLE>suffix", true),
+            ("a</StYlE attr>b", true),
+        ];
+
+        for (css, expected) in cases {
+            assert_eq!(
+                style_text_needs_escape(css),
+                expected,
+                "unexpected detection for {css:?}"
+            );
+
+            let mut writer = StyleWriter::default();
+            write_style_text(&mut writer, css).unwrap();
+            assert_eq!(
+                writer.output != css,
+                expected,
+                "writer and detector diverged for {css:?}"
+            );
+        }
     }
 }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -865,6 +865,11 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     pub(crate) component_index: &'protocol HashMap<String, u32>,
     /// Style-resource ID → request-local dedup bit built with [`Protocol`].
     pub(crate) style_resource_index: &'protocol HashMap<String, u32>,
+    /// Inline style resources whose CSS contains a case-insensitive `</style`.
+    ///
+    /// Computed once when [`Protocol`] loads so repeated component instances can
+    /// write ordinary CSS without rescanning identical bytes on every request.
+    pub(crate) style_resources_requiring_escape: &'protocol HashSet<String>,
     /// Component tag → covering bundle chunk, built once per render.
     ///
     /// Empty (and allocation-free) for unbundled builds. Every style delivery
@@ -2487,7 +2492,11 @@ impl WebUIHandler {
                             "style"
                         })?;
                     context.writer.write("\">")?;
-                    crate::html_encode::write_style_text(context.writer, resource)?;
+                    if context.style_resources_requiring_escape.contains(name) {
+                        crate::html_encode::write_style_text(context.writer, resource)?;
+                    } else {
+                        context.writer.write(resource)?;
+                    }
                     context.writer.write("</style>")?;
                 }
             }
@@ -3827,6 +3836,7 @@ impl WebUIHandler {
             component_asset_styles_emitted: false,
             component_index: protocol.component_index(),
             style_resource_index: protocol.style_resource_index(),
+            style_resources_requiring_escape: protocol.style_resources_requiring_escape(),
             style_chunk_index: protocol.protocol().style_chunk_index(),
             css_strategy: protocol.css_strategy(),
             body_end_emitted: false,

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -3667,16 +3667,21 @@ impl WebUIHandler {
                 } else {
                     None
                 };
-                let value = resolve_value_from_sources(
-                    &attr.value,
-                    &context.loop_vars,
-                    context.visible_loop_scope,
-                    LocalValueSources {
-                        owned: &context.local_vars,
-                        borrowed: &context.local_borrowed_vars,
-                    },
-                    context.state,
-                );
+                // Reuse the immutable-state lookup for both HTML output and the
+                // child scope instead of resolving every component attribute twice.
+                let value = match state_backed_value {
+                    Some(value) => Some(Cow::Borrowed(value)),
+                    None => resolve_value_from_sources(
+                        &attr.value,
+                        &context.loop_vars,
+                        context.visible_loop_scope,
+                        LocalValueSources {
+                            owned: &context.local_vars,
+                            borrowed: &context.local_borrowed_vars,
+                        },
+                        context.state,
+                    ),
+                };
                 // Always emit the attribute so FAST hydration markers
                 // (`data-fe`) match the DOM node structure.
                 match value.as_deref() {
@@ -4096,6 +4101,68 @@ mod tests {
             .as_deref()
             .and_then(Value::as_str),
             Some("global")
+        );
+    }
+
+    #[test]
+    fn state_backed_resolver_matches_general_borrowed_resolution() {
+        let state = test_json!({
+            "global": {"name": "global"},
+            "inner": {"fallback": "global fallback"},
+            "borrowed": {"name": "borrowed"},
+            "items": [1, 2, 3]
+        });
+        let loop_values = test_json!({
+            "outer": {"name": "outer"},
+            "inner": {"name": "inner"}
+        });
+        let loop_vars = vec![
+            LoopBinding {
+                name: "outer",
+                value: &loop_values["outer"],
+            },
+            LoopBinding {
+                name: "inner",
+                value: &loop_values["inner"],
+            },
+        ];
+        let mut local_borrowed_vars = BorrowedScope::default();
+        local_borrowed_vars.insert("borrowed", &state["borrowed"]);
+        let local_vars = HashMap::from([("owned".to_string(), test_json!({"name": "owned"}))]);
+        let sources = LocalValueSources {
+            owned: &local_vars,
+            borrowed: &local_borrowed_vars,
+        };
+        let scope = VisibleLoopScope { start: 0, end: 2 };
+
+        for path in [
+            "global.name",
+            "inner.name",
+            "inner.fallback",
+            "outer.name",
+            "borrowed.name",
+        ] {
+            let state_backed = resolve_state_backed_value(path, &loop_vars, scope, sources, &state)
+                .unwrap_or_else(|| panic!("{path} should resolve from immutable state"));
+            let resolved = resolve_value_from_sources(path, &loop_vars, scope, sources, &state)
+                .unwrap_or_else(|| panic!("{path} should resolve generally"));
+            let Cow::Borrowed(resolved) = resolved else {
+                panic!("{path} should remain borrowed");
+            };
+            assert!(
+                std::ptr::eq(state_backed, resolved),
+                "{path} resolved from different sources"
+            );
+        }
+
+        assert!(
+            resolve_state_backed_value("owned.name", &loop_vars, scope, sources, &state).is_none(),
+            "owned local values must use the general resolver"
+        );
+        assert!(
+            resolve_state_backed_value("items.length", &loop_vars, scope, sources, &state)
+                .is_none(),
+            "synthetic values must use the general resolver"
         );
     }
 
@@ -5775,7 +5842,7 @@ mod tests {
             },
         );
         let protocol = WebUIProtocol::new(fragments);
-        let state = test_json!({"var": "original"});
+        let state = test_json!({"var": "original<&"});
         let mut writer = TestWriter::new();
         handle(
             &protocol,
@@ -5786,7 +5853,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             writer.get_content(),
-            "<parent var=\"original\">Before: original<child foo var=\"replaced\">Label</child>After: original</parent>"
+            "<parent var=\"original&lt;&amp;\">Before: original&lt;&amp;<child foo var=\"replaced\">Label</child>After: original&lt;&amp;</parent>"
         );
     }
 

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -70,6 +70,7 @@ pub struct Protocol {
     component_asset_style_links: String,
     component_index: HashMap<String, u32>,
     style_resource_index: HashMap<String, u32>,
+    style_resources_requiring_escape: HashSet<String>,
     component_reachability: OnceLock<ComponentReachabilityIndex>,
     fragment_ids: Vec<Arc<str>>,
     fragment_slots: HashMap<Arc<str>, u32>,
@@ -132,6 +133,7 @@ impl Protocol {
         };
         let component_index = build_component_index(&protocol);
         let style_resource_index = build_style_resource_index(&protocol);
+        let style_resources_requiring_escape = build_style_escape_resources(&protocol);
         let route_index = CompiledRouteIndex::new(&protocol);
         let mut fragment_ids: Vec<Arc<str>> = protocol
             .fragments
@@ -159,6 +161,7 @@ impl Protocol {
             component_asset_style_links,
             component_index,
             style_resource_index,
+            style_resources_requiring_escape,
             component_reachability: OnceLock::new(),
             fragment_ids,
             fragment_slots,
@@ -209,6 +212,10 @@ impl Protocol {
         } else {
             &self.style_resource_index
         }
+    }
+
+    pub(crate) fn style_resources_requiring_escape(&self) -> &HashSet<String> {
+        &self.style_resources_requiring_escape
     }
 
     pub(crate) fn component_reachability(&self) -> &ComponentReachabilityIndex {
@@ -801,6 +808,25 @@ fn build_style_resource_index(protocol: &WebUIProtocol) -> HashMap<String, u32> 
         index.insert(name.to_string(), position);
     }
     index
+}
+
+fn build_style_escape_resources(protocol: &WebUIProtocol) -> HashSet<String> {
+    if protocol.css_strategy() == CssStrategy::Link {
+        return HashSet::new();
+    }
+
+    let mut resources = HashSet::new();
+    for (name, component) in &protocol.components {
+        if crate::html_encode::style_text_needs_escape(&component.css) {
+            resources.insert(name.clone());
+        }
+    }
+    for chunk in &protocol.style_chunks {
+        if crate::html_encode::style_text_needs_escape(&chunk.css) {
+            resources.insert(chunk.name.clone());
+        }
+    }
+    resources
 }
 
 /// Startup-built direct component dependency graph used by streaming
@@ -3114,6 +3140,43 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
     use webui_protocol::{FragmentList, WebUIFragment, WebUiFragmentRoute};
+
+    #[test]
+    fn protocol_caches_inline_style_resources_requiring_escape() {
+        let mut protocol = WebUIProtocol::new(HashMap::new());
+        protocol.set_css_strategy(CssStrategy::Style);
+        protocol.components.insert(
+            "safe-card".to_string(),
+            webui_protocol::ComponentData {
+                css: ".safe{color:green}".to_string(),
+                ..Default::default()
+            },
+        );
+        protocol.components.insert(
+            "unsafe-card".to_string(),
+            webui_protocol::ComponentData {
+                css: ".unsafe{content:'</StYlE>'}".to_string(),
+                ..Default::default()
+            },
+        );
+        protocol.style_chunks.push(webui_protocol::StyleChunk {
+            name: "_chunk-safe-card-2".to_string(),
+            css: ".safe{color:green}.other{color:blue}".to_string(),
+            ..Default::default()
+        });
+        protocol.style_chunks.push(webui_protocol::StyleChunk {
+            name: "_chunk-unsafe-card-2".to_string(),
+            css: ".unsafe{content:'</style>'}.other{color:blue}".to_string(),
+            ..Default::default()
+        });
+
+        let prepared = Protocol::new(protocol);
+        let resources = prepared.style_resources_requiring_escape();
+
+        assert_eq!(resources.len(), 2);
+        assert!(resources.contains("unsafe-card"));
+        assert!(resources.contains("_chunk-unsafe-card-2"));
+    }
 
     #[test]
     fn protocol_decodes_once_and_exposes_tokens() {

--- a/crates/webui-handler/src/streaming/inventory.rs
+++ b/crates/webui-handler/src/streaming/inventory.rs
@@ -425,6 +425,7 @@ mod tests {
             nonce: None,
             component_index,
             style_resource_index: protocol.style_resource_index(),
+            style_resources_requiring_escape: protocol.style_resources_requiring_escape(),
             style_chunk_index: protocol.protocol().style_chunk_index(),
             css_strategy: protocol.css_strategy(),
             head_inject: None,

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -557,6 +557,7 @@ impl SessionCore {
             nonce: options.nonce.filter(|nonce| !nonce.is_empty()),
             component_index: protocol.component_index(),
             style_resource_index: protocol.style_resource_index(),
+            style_resources_requiring_escape: protocol.style_resources_requiring_escape(),
             style_chunk_index: protocol.protocol().style_chunk_index(),
             css_strategy: protocol.css_strategy(),
             head_inject: options.head_inject.filter(|html| !html.is_empty()),


### PR DESCRIPTION
## Why

Large component-list renders repeated two protocol-invariant or already-completed operations on the request hot path: identical inline CSS was rescanned for `</style` for every instance, and state-backed dynamic component attributes resolved the same path once for HTML output and again for child-scope capture.

## What changed

- Classify component and bundled inline style resources once when the immutable runtime `Protocol` loads.
- Directly write known-safe CSS while preserving the existing escape writer for unsafe CSS.
- Reuse a successful immutable-state attribute lookup for both HTML output and child-scope capture, while retaining the existing resolver fallback for owned, synthetic, missing, and streaming values.
- Share protocol-owned CSS metadata across buffered and streaming render contexts.
- Cover detector/writer parity, component and bundled-chunk cache classification, resolver provenance parity, and escaped borrowed attribute output.

## Architecture

Both optimizations remain inside `webui-handler` and preserve existing ownership boundaries. Runtime-only metadata stays on immutable `Protocol`, not the protobuf wire model. Attribute lookup reuse preserves the established precedence across loop bindings, borrowed locals, owned locals, and global state. No public API, protocol, rendering semantics, or dependencies change.

## Performance

Measured with:

```bash
cargo bench -p microsoft-webui --bench contact_book_bench -- 'contact_book_contacts_render/contacts/1000'
```

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Criterion mean render time | 2.7039 ms | 1.4830 ms | -44.5% |
| Render throughput | 857.66 MiB/s | 1.5271 GiB/s | +80.1% |
| Render/1000 P50 | 2.62 ms | 1.48 ms | -43.5% |
| FAST Render/1000 P50 | 3.66 ms | 2.49 ms | -32.0% |
| Output bytes | 2,431,665 | 2,431,665 | unchanged |

The attribute lookup reuse alone improved the post-CSS-cache contact benchmark by 16.0% and the focused nested-component benchmark by 7.5%.

## Validation

- `cargo xtask check`
- Independent review of cache lifecycle, Style/Module/Link behavior, buffered/streaming parity, resolver precedence, provenance, lifetimes, synthetic values, and escaping