### PR TITLE
fix: keep effective style guards out of host markup

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1771,11 +1771,13 @@ native request instead of exposing the component.
 Preload CORS, integrity, CSP `style-src`, or timeout failures likewise do not
 authorize CSS and do not weaken the authoritative native path. MIME enforcement
 belongs to the native stylesheet link because preload exposes no response
-headers. The framework
-installs an anonymous first-layer shadow guard with an inline backup before
-appending client content. The guard disables host transitions before forcing
-hidden visibility, then restores both inline properties only after every
-applicable native link fires `load`. If CSP blocks the temporary shadow guard,
+headers. The framework installs an anonymous first-layer shadow guard before
+appending client content. When CSSOM confirms that guard parsed, it is the sole
+guard and the framework does not mutate author-facing host inline styles. Only
+when the shadow guard is unavailable does an inline backup preserve and later
+restore both property values and priorities. The guard disables host transitions
+before forcing hidden visibility and is released only after every applicable
+native link fires `load`. If CSP blocks the temporary shadow guard,
 non-style content stays detached and `$ready` remains false. Immediately before
 append, the framework reconciles the staging instance from current reactive
 state; it then transfers structural containers to the live root and invokes

--- a/packages/webui-framework/src/element/link-styles.ts
+++ b/packages/webui-framework/src/element/link-styles.ts
@@ -1048,6 +1048,23 @@ function installGuard(host: HTMLElement, root: ShadowRoot): InstalledGuard {
   } catch {
     effective = false;
   }
+  // Keep framework-owned declarations out of author-facing host markup when
+  // the stronger first-layer shadow rule is available.
+  const releaseInlineGuard = effective
+    ? undefined
+    : installInlineGuard(host);
+  return {
+    effective,
+    release: () => {
+      style.remove();
+      releaseInlineGuard?.();
+    },
+    style,
+  };
+}
+
+function installInlineGuard(host: HTMLElement): () => void {
+  const hadStyleAttribute = host.hasAttribute('style');
   const previousTransitionValue =
     host.style.getPropertyValue('transition-property');
   const previousTransitionPriority =
@@ -1056,36 +1073,34 @@ function installGuard(host: HTMLElement, root: ShadowRoot): InstalledGuard {
   const previousPriority = host.style.getPropertyPriority('visibility');
   host.style.setProperty('transition-property', 'none', 'important');
   host.style.setProperty('visibility', 'hidden', 'important');
-  return {
-    effective,
-    release: () => {
-      style.remove();
-      if (
-        host.style.getPropertyValue('visibility') === 'hidden' &&
-        host.style.getPropertyPriority('visibility') === 'important'
-      ) {
-        if (previousValue) {
-          host.style.setProperty('visibility', previousValue, previousPriority);
-        } else {
-          host.style.removeProperty('visibility');
-        }
+  return () => {
+    if (
+      host.style.getPropertyValue('visibility') === 'hidden' &&
+      host.style.getPropertyPriority('visibility') === 'important'
+    ) {
+      if (previousValue) {
+        host.style.setProperty('visibility', previousValue, previousPriority);
+      } else {
+        host.style.removeProperty('visibility');
       }
-      if (
-        host.style.getPropertyValue('transition-property') === 'none' &&
-        host.style.getPropertyPriority('transition-property') === 'important'
-      ) {
-        if (previousTransitionValue) {
-          host.style.setProperty(
-            'transition-property',
-            previousTransitionValue,
-            previousTransitionPriority,
-          );
-        } else {
-          host.style.removeProperty('transition-property');
-        }
+    }
+    if (
+      host.style.getPropertyValue('transition-property') === 'none' &&
+      host.style.getPropertyPriority('transition-property') === 'important'
+    ) {
+      if (previousTransitionValue) {
+        host.style.setProperty(
+          'transition-property',
+          previousTransitionValue,
+          previousTransitionPriority,
+        );
+      } else {
+        host.style.removeProperty('transition-property');
       }
-    },
-    style,
+    }
+    if (!hadStyleAttribute && host.getAttribute('style') === '') {
+      host.removeAttribute('style');
+    }
   };
 }
 

--- a/packages/webui-framework/tests/fixtures/css-link/css-link.spec.ts
+++ b/packages/webui-framework/tests/fixtures/css-link/css-link.spec.ts
@@ -300,6 +300,66 @@ test.describe('css link fixture', () => {
     expect(visibilityDuringPromotion?.every(value => value === '')).toBe(true);
   });
 
+  test('does not expose an effective shadow guard through host markup', async ({
+    page,
+  }) => {
+    let releaseLinks!: () => void;
+    let linkRequested!: () => void;
+    const linkGate = new Promise<void>(resolve => {
+      releaseLinks = resolve;
+    });
+    const requestSeen = new Promise<void>(resolve => {
+      linkRequested = resolve;
+    });
+    await page.route('**/*.css', async route => {
+      if (
+        route.request().resourceType() === 'stylesheet' &&
+        (route.request().url().endsWith('/child.css') ||
+          route.request().url().endsWith('/styles/relative.css'))
+      ) {
+        linkRequested();
+        await linkGate;
+      }
+      await route.continue();
+    });
+    await openFixture(page);
+
+    const authoredMarkup = await page.locator('test-link-host').evaluate((host) => {
+      const child = document.createElement('test-link-child');
+      child.id = 'serialized-link-child';
+      child.style.color = 'red';
+      child.style.transitionDuration = '10s';
+      const markup = child.outerHTML;
+      (host.shadowRoot ?? host).querySelector('.slot')?.appendChild(child);
+      return markup;
+    });
+    await requestSeen;
+
+    await expect(page.locator('#serialized-link-child').evaluate(async child => {
+      await new Promise<void>(resolve =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      );
+      return {
+        markup: child.outerHTML,
+        visibility: getComputedStyle(child).visibility,
+      };
+    })).resolves.toEqual({
+      markup: authoredMarkup,
+      visibility: 'hidden',
+    });
+
+    releaseLinks();
+    await expect.poll(async () =>
+      page.locator('#serialized-link-child').evaluate(child => ({
+        markup: child.outerHTML,
+        ready: (child as HTMLElement & { $ready?: boolean }).$ready ?? false,
+      }))
+    ).toEqual({
+      markup: authoredMarkup,
+      ready: true,
+    });
+  });
+
   test('keeps the guard isolated from authored cascade layers', async ({ page }) => {
     let releaseRelative!: () => void;
     const relativeGate = new Promise<void>(resolve => {
@@ -383,10 +443,32 @@ test.describe('css link fixture', () => {
       const child = (host.shadowRoot ?? host).querySelector('test-link-child');
       const style = child ? getComputedStyle(child) : null;
       return {
-        transition: style?.transitionProperty ?? null,
-        visibility: style?.visibility ?? null,
+        computedTransition: style?.transitionProperty ?? null,
+        computedVisibility: style?.visibility ?? null,
+        inlineTransition:
+          (child as HTMLElement | null)?.style.getPropertyValue(
+            'transition-property',
+          ) ?? null,
+        inlineTransitionPriority:
+          (child as HTMLElement | null)?.style.getPropertyPriority(
+            'transition-property',
+          ) ?? null,
+        inlineVisibility:
+          (child as HTMLElement | null)?.style.getPropertyValue('visibility') ??
+          null,
+        inlineVisibilityPriority:
+          (child as HTMLElement | null)?.style.getPropertyPriority(
+            'visibility',
+          ) ?? null,
       };
-    })).resolves.toEqual({ transition: 'none', visibility: 'hidden' });
+    })).resolves.toEqual({
+      computedTransition: 'none',
+      computedVisibility: 'hidden',
+      inlineTransition: 'visibility',
+      inlineTransitionPriority: 'important',
+      inlineVisibility: 'visible',
+      inlineVisibilityPriority: 'important',
+    });
 
     releaseLinks();
     await expect.poll(async () => page.locator('test-link-host').evaluate((host) => {
@@ -400,12 +482,15 @@ test.describe('css link fixture', () => {
         transition:
           child?.style.getPropertyValue('transition-property') ?? null,
         visibility: child?.style.getPropertyValue('visibility') ?? null,
+        visibilityPriority:
+          child?.style.getPropertyPriority('visibility') ?? null,
       };
     })).toEqual({
       duration: '10s',
       priority: 'important',
       transition: 'visibility',
       visibility: 'visible',
+      visibilityPriority: 'important',
     });
   });
 
@@ -583,7 +668,16 @@ test.describe('css link fixture', () => {
     });
     await openFixture(page);
 
-    await page.locator('test-link-host .spawn').click();
+    await page.locator('test-link-host').evaluate((host) => {
+      const child = document.createElement('test-link-child');
+      child.style.setProperty(
+        'transition-property',
+        'opacity',
+        'important',
+      );
+      child.style.setProperty('visibility', 'visible', 'important');
+      (host.shadowRoot ?? host).querySelector('.slot')?.appendChild(child);
+    });
     await requestSeen;
     await page.locator('test-link-host').evaluate((host) => {
       const child = (host.shadowRoot ?? host).querySelector('test-link-child') as
@@ -601,12 +695,31 @@ test.describe('css link fixture', () => {
         links: child?.shadowRoot?.querySelectorAll('link[rel~="stylesheet"]').length ?? 0,
         ready:
           (child as HTMLElement & { $ready?: boolean } | null)?.$ready ?? false,
+        transition:
+          (child as HTMLElement | null)?.style.getPropertyValue(
+            'transition-property',
+          ) ?? null,
+        transitionPriority:
+          (child as HTMLElement | null)?.style.getPropertyPriority(
+            'transition-property',
+          ) ?? null,
+        visibility:
+          (child as HTMLElement | null)?.style.getPropertyValue('visibility') ??
+          null,
+        visibilityPriority:
+          (child as HTMLElement | null)?.style.getPropertyPriority(
+            'visibility',
+          ) ?? null,
       };
     })).resolves.toEqual({
       hasContent: false,
       hydratedCount: 0,
       links: 2,
       ready: false,
+      transition: 'none',
+      transitionPriority: 'important',
+      visibility: 'hidden',
+      visibilityPriority: 'important',
     });
 
     releaseLink();
@@ -625,6 +738,21 @@ test.describe('css link fixture', () => {
           hydratedHadContent: instance?.hydratedHadContent ?? false,
           ready: instance?.$ready ?? false,
           text: label?.textContent ?? null,
+          transition:
+            (child as HTMLElement | null)?.style.getPropertyValue(
+              'transition-property',
+            ) ?? null,
+          transitionPriority:
+            (child as HTMLElement | null)?.style.getPropertyPriority(
+              'transition-property',
+            ) ?? null,
+          visibility:
+            (child as HTMLElement | null)?.style.getPropertyValue('visibility') ??
+            null,
+          visibilityPriority:
+            (child as HTMLElement | null)?.style.getPropertyPriority(
+              'visibility',
+            ) ?? null,
         };
       });
     }).toEqual({
@@ -633,6 +761,10 @@ test.describe('css link fixture', () => {
       hydratedHadContent: true,
       ready: true,
       text: 'Child updated',
+      transition: 'opacity',
+      transitionPriority: 'important',
+      visibility: 'visible',
+      visibilityPriority: 'important',
     });
   });
 
@@ -783,12 +915,14 @@ test.describe('css link fixture', () => {
       return {
         content: child?.shadowRoot?.querySelectorAll('.child-label').length ?? 0,
         hydratedCount: child?.hydratedCount ?? 0,
+        style: child?.getAttribute('style') ?? null,
         text: label?.textContent ?? null,
         tracked: !!label && child?.$root?.nodes.includes(label),
       };
     })).toEqual({
       content: 1,
       hydratedCount: 1,
+      style: null,
       text: 'Child reconnected',
       tracked: true,
     });

--- a/packages/webui-framework/tests/fixtures/css-link/css-link.spec.ts
+++ b/packages/webui-framework/tests/fixtures/css-link/css-link.spec.ts
@@ -475,7 +475,10 @@ test.describe('css link fixture', () => {
       const child = (host.shadowRoot ?? host).querySelector(
         'test-link-child',
       ) as HTMLElement | null;
+      const computed = child ? getComputedStyle(child) : null;
       return {
+        computedTransition: computed?.transitionProperty ?? null,
+        computedVisibility: computed?.visibility ?? null,
         duration: child?.style.getPropertyValue('transition-duration') ?? null,
         priority:
           child?.style.getPropertyPriority('transition-property') ?? null,
@@ -486,6 +489,8 @@ test.describe('css link fixture', () => {
           child?.style.getPropertyPriority('visibility') ?? null,
       };
     })).toEqual({
+      computedTransition: 'visibility',
+      computedVisibility: 'visible',
       duration: '10s',
       priority: 'important',
       transition: 'visibility',


### PR DESCRIPTION
## Summary
- use the parsed anonymous shadow guard as the sole no-FOUC guard when CSSOM confirms it is active
- reserve inline host mutation for the unavailable-shadow-guard fallback and restore authored values, priorities, and style-attribute presence
- cover host serialization during linked stylesheet mounting, authored important styles, CSP fallback, release transitions, cancellation, and cleanup

## Root cause
The 0.0.26 mount guard always wrote temporary `transition-property` and `visibility` declarations to the custom-element host even when its stronger first-layer shadow rule had parsed successfully. Author code serializing live DOM during the pending mount could persist those framework-owned declarations as input.

## Design rationale
CSS cascading rules give important declarations from the inner shadow context precedence over outer author declarations, including inline important styles. Important declarations also reverse cascade-layer order, so the prepended anonymous first layer wins over later component layers. Chromium, Firefox, and WebKit all confirmed the guard computes `transition-property: none` and `visibility: hidden` without changing host markup.

A CSSOM parse check is preferable to a computed-style probe: the guard CSS and selector are framework constants, while `getComputedStyle()` would force style resolution on every mount and cannot distinguish the guard from authored hidden styles. If CSP or parsing prevents the sheet from becoming available, the existing inline fallback remains and content stays detached until linked styles settle.

## Regression evidence
Before the production fix, the new browser test failed because `outerHTML` changed from the authored style to include `transition-property: none !important; visibility: hidden !important` while the external stylesheets were pending.

## Performance
Chromium microbenchmarks alternated the pre-fix and fixed implementations and included a pending-style flush plus guard release:

| Effective guard workload | Before | After | Median change |
| --- | ---: | ---: | ---: |
| 2,000 mounts, no authored inline style | 7.9 ms | 5.4 ms | -31.6% |
| 2,000 mounts, authored important values | 9.3 ms | 6.5 ms | -30.1% |

P95 improved from 12.1 ms to 6.4 ms and from 11.2 ms to 7.7 ms respectively. The common path removes four inline-style reads, two writes, restoration reads/writes, mutation-observer visibility, and host capture from the pending release closure.

The rare unavailable-shadow-guard fallback adds exact style-attribute restoration. An isolated 5,000-fallback microbenchmark added 0.5 ms with no authored style and 1.2 ms with authored values, about 0.10-0.24 microseconds per fallback. A 3,000-pending-mount CDP sample reduced median V8 heap by about 33 bytes per mount and kept the DOM node count identical; native/embedder heap readings were noisy and are not used as a claim.

The minified production framework bundle changes from 78,447 to 78,588 bytes, or 24,533 to 24,573 bytes gzip: +141 raw / +40 gzip bytes.

## Validation
- framework TypeScript and E2E typechecks
- targeted guard lifecycle tests in Chromium, Firefox, and WebKit: 4/4 per engine
- full CSS-link suite: 18/18
- full framework suite: 275 passed, 2 skipped
- `cargo xtask check`
- all GitHub PR checks