### PR TITLE
chore: bump version to 0.0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "microsoft-webui"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "actix-web",
  "awc",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-cli"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-dev-server"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-discovery"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "anyhow",
  "expand-tilde",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-expressions"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "criterion",
  "microsoft-webui-protocol",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-ffi"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "cbindgen",
  "criterion",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-handler"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "criterion",
  "memchr",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-node"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "microsoft-webui",
  "microsoft-webui-handler",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-parser"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "clap",
  "criterion",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-press"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-protocol"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "criterion",
  "prost",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-python"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "microsoft-webui-handler",
  "pyo3",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-state"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "criterion",
  "microsoft-webui-test-utils",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-test-utils"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "microsoft-webui-protocol",
  "serde_json",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-tokens"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "microsoft-webui-wasm"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "js-sys",
  "microsoft-webui-handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.26"
+version = "0.0.27"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Microsoft Edge"]

--- a/crates/webui-cli/Cargo.toml
+++ b/crates/webui-cli/Cargo.toml
@@ -16,12 +16,12 @@ name = "webui"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.26", features = ["cli"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.26" }
+microsoft-webui = { path = "../webui", version = "0.0.27", features = ["cli"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.27" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.27" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.27" }
 clap = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -43,7 +43,7 @@ windows-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
 
 [lints]
 workspace = true

--- a/crates/webui-expressions/Cargo.toml
+++ b/crates/webui-expressions/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["web-programming", "parser-implementations"]
 name = "webui_expressions"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.27" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.27" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-ffi/Cargo.toml
+++ b/crates/webui-ffi/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "staticlib", "lib"]
 regenerate-header = ["dep:cbindgen"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -30,7 +30,7 @@ cbindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
 
 [[bench]]
 name = "protocol_bench"

--- a/crates/webui-handler/Cargo.toml
+++ b/crates/webui-handler/Cargo.toml
@@ -15,17 +15,17 @@ categories = ["web-programming", "template-engine"]
 name = "webui_handler"
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
-microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.26" }
-microsoft-webui-state = { path = "../webui-state", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
+microsoft-webui-expressions = { path = "../webui-expressions", version = "0.0.27" }
+microsoft-webui-state = { path = "../webui-state", version = "0.0.27" }
 memchr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.27" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.27" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-node/Cargo.toml
+++ b/crates/webui-node/Cargo.toml
@@ -18,16 +18,16 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { workspace = true }
 napi-derive = { workspace = true }
-microsoft-webui = { path = "../webui", version = "0.0.26" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
+microsoft-webui = { path = "../webui", version = "0.0.27" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27", features = ["projection-manifest"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26", default-features = false }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.27", default-features = false }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/webui-parser/Cargo.toml
+++ b/crates/webui-parser/Cargo.toml
@@ -26,8 +26,8 @@ cli = ["clap"]
 ignored = ["clap"]
 
 [dependencies]
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.27" }
 thiserror = { workspace = true }
 html-escape = { workspace = true }
 walkdir = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ clap = { workspace = true, optional = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.27" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-press/Cargo.toml
+++ b/crates/webui-press/Cargo.toml
@@ -19,10 +19,10 @@ name = "webui-press"
 path = "src/main.rs"
 
 [dependencies]
-microsoft-webui = { path = "../webui", version = "0.0.26", features = ["cli"] }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
+microsoft-webui = { path = "../webui", version = "0.0.27", features = ["cli"] }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.27" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.27" }
 
 # Markdown + syntax highlighting
 comrak = { workspace = true }
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 html-escape = { workspace = true }
 
 # Dev server (`webui-press serve`)
-microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.26" }
+microsoft-webui-dev-server = { path = "../webui-dev-server", version = "0.0.27" }
 actix-web = { workspace = true }
 tokio = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/webui-python/Cargo.toml
+++ b/crates/webui-python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
 pyo3 = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/webui-state/Cargo.toml
+++ b/crates/webui-state/Cargo.toml
@@ -18,7 +18,7 @@ name = "webui_state"
 serde_json = { workspace = true }
 
 [dev-dependencies]
-microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.26" }
+microsoft-webui-test-utils = { path = "../webui-test-utils", version = "0.0.27" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/webui-test-utils/Cargo.toml
+++ b/crates/webui-test-utils/Cargo.toml
@@ -17,7 +17,7 @@ name = "webui_test_utils"
 [dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
 
 [lints]
 workspace = true

--- a/crates/webui-wasm/Cargo.toml
+++ b/crates/webui-wasm/Cargo.toml
@@ -25,9 +25,9 @@ handler = ["dep:microsoft-webui-handler"]
 parser = ["dep:microsoft-webui-parser", "microsoft-webui-protocol/projection-manifest"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26", default-features = false, optional = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26", optional = true }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.27", default-features = false, optional = true }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27", optional = true }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27" }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/webui/Cargo.toml
+++ b/crates/webui/Cargo.toml
@@ -18,11 +18,11 @@ name = "webui"
 cli = ["microsoft-webui-parser/cli"]
 
 [dependencies]
-microsoft-webui-parser = { path = "../webui-parser", version = "0.0.26" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
-microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.26" }
-microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.26" }
+microsoft-webui-parser = { path = "../webui-parser", version = "0.0.27" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
+microsoft-webui-discovery = { path = "../webui-discovery", version = "0.0.27" }
+microsoft-webui-tokens = { path = "../webui-tokens", version = "0.0.27" }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -44,8 +44,8 @@ actix-web = { workspace = true }
 awc = { workspace = true }
 futures-util = { workspace = true }
 libc = { workspace = true }
-microsoft-webui-handler = { path = "../webui-handler", version = "0.0.26" }
-microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.26", features = ["projection-manifest"] }
+microsoft-webui-handler = { path = "../webui-handler", version = "0.0.27" }
+microsoft-webui-protocol = { path = "../webui-protocol", version = "0.0.27", features = ["projection-manifest"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true }

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.26</Version>
+    <Version>0.0.27</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <PackageOwners>Microsoft</PackageOwners>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webui-darwin-arm64/package.json
+++ b/packages/webui-darwin-arm64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-darwin-x64/package.json
+++ b/packages/webui-darwin-x64/package.json
@@ -13,5 +13,5 @@
     "darwin"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-examples-theme/package.json
+++ b/packages/webui-examples-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-examples-theme",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "description": "Shared design token theme for WebUI example applications",
   "license": "MIT",

--- a/packages/webui-framework/package.json
+++ b/packages/webui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-framework",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "description": "WebUI Framework Next — Preact-inspired lightweight Web Component runtime with SSR hydration and compiled-template path mapping.",
   "license": "MIT",

--- a/packages/webui-linux-arm64/package.json
+++ b/packages/webui-linux-arm64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-linux-x64/package.json
+++ b/packages/webui-linux-x64/package.json
@@ -13,5 +13,5 @@
     "linux"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-router/package.json
+++ b/packages/webui-router/package.json
@@ -40,5 +40,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-test-support/package.json
+++ b/packages/webui-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/webui-test-support",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "private": true,
   "description": "Private shared test utilities for WebUI workspace packages.",

--- a/packages/webui-win32-arm64/package.json
+++ b/packages/webui-win32-arm64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui-win32-x64/package.json
+++ b/packages/webui-win32-x64/package.json
@@ -13,5 +13,5 @@
     "win32"
   ],
   "preferUnplugged": true,
-  "version": "0.0.26"
+  "version": "0.0.27"
 }

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/webui",
   "description": "WebUI — high-performance server-side rendering framework. Build-time protocol compiler and streaming renderer.",
   "license": "MIT",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Bumps WebUI to `0.0.27`.

Previous release tag: `v0.0.26`

## Changes since `v0.0.26`

Fixes:

- Release jobs no longer perform forbidden source checkout steps and continue consuming staged pipeline artifacts (fix(cd): remove checkout from release jobs #495 by @janechu).
- Link-mode component mounts keep effective shadow style guards out of host markup while preserving the CSP fallback, preventing framework styles from leaking into serialized DOM (fix: keep effective style guards out of host markup #497 by @mohamedmansour).

Docs:

- The style-mount contract now documents shadow-guard ownership and exact fallback restoration of authored host styles (fix: keep effective style guards out of host markup #497 by @mohamedmansour).

Maintenance:

- Handler rendering classifies inline CSS safety once and reuses resolved component attributes, reducing the 1,000-contact mean render time by 44.5% with byte-identical output (perf(handler): eliminate repeated render scans and lookups #496 by @mohamedmansour).

## Validation

- `cargo xtask check`
