### PR TITLE
perf: optimize progressive streaming resumability

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -91,6 +91,8 @@ Standard criterion harnesses. Each crate has its own `benches/` dir:
 * `crates/webui-parser/benches/parser_bench.rs`
 * `crates/webui-protocol/benches/protocol_bench.rs`
 * `crates/webui-handler/benches/handler_bench.rs`
+* `crates/webui-handler/benches/streaming_hydration_bench.rs` - buffered,
+  fused-streaming, and async-resumable split-path comparisons
 * `crates/webui-expressions/benches/expressions_bench.rs`
 * `crates/webui-state/benches/state_bench.rs`
 * `crates/webui/benches/contact_book_bench.rs` — end-to-end render

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1124,10 +1124,22 @@ pub struct StreamStep {
 
 impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
     pub fn start(&mut self, state: &Value) -> Result<StreamStatus>;
+    pub fn start_owned(&mut self, state: Value) -> Result<StreamStatus>;
     pub fn resume(
         &mut self,
         instance_id: BoundaryInstanceId,
         state: &Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStatus>;
+    pub fn resume_owned(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        state: Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStatus>;
+    pub fn resume_current(
+        &mut self,
+        instance_id: BoundaryInstanceId,
         mode: BoundaryMode,
     ) -> Result<StreamStatus>;
     pub fn advance(&mut self) -> Result<StreamStatus>;
@@ -1141,10 +1153,22 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
 
 impl StreamingSession {
     pub fn start(&mut self, state: &Value) -> Result<StreamStep>;
+    pub fn start_owned(&mut self, state: Value) -> Result<StreamStep>;
     pub fn resume(
         &mut self,
         instance_id: BoundaryInstanceId,
         state: &Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStep>;
+    pub fn resume_owned(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        state: Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStep>;
+    pub fn resume_current(
+        &mut self,
+        instance_id: BoundaryInstanceId,
         mode: BoundaryMode,
     ) -> Result<StreamStep>;
     pub fn advance(&mut self) -> Result<StreamStep>;
@@ -1194,8 +1218,14 @@ on the transport flush boundary that closed the step, so a host that writes and
 flushes once per step reproduces the borrowed writer's flush positions byte for
 byte.
 
-`WebUIHandler::render_streaming` drives the whole `start → resume → advance → …`
-cycle internally against one frozen state snapshot.
+`resume_current` preserves the checkpoint-only return and the pause before
+`advance`, but commits against the retained snapshot without comparing another
+state tree. Owned hosts that just decoded or loaded a `Value` use `start_owned`
+and `resume_owned` to move selected top-level values into the session rather
+than cloning them. `WebUIHandler::render_streaming` drives the whole response in
+one prepared render context while borrowing its one state value; it preserves
+the same flush positions without cloning the state or rebuilding that context
+between records.
 
 ### Per-Render HTML Injection
 
@@ -2816,7 +2846,7 @@ into `<f-repeat>` markup.
 
 ## Progressive Streaming Hydration
 
-Progressive streaming is one version-2 contract shared by the compiler, Rust
+Progressive streaming is one version-3 contract shared by the compiler, Rust
 handler, host bindings, CLI proxy, and browser coordinator. It discovers
 boundaries by executing the compiled fragment graph and hydrates complete
 regions while the document is still loading.
@@ -2895,9 +2925,12 @@ regions while the document is still loading.
    retained root activates is shallow-merged and replayed after activation.
 10. **Ordered, self-sufficient wire.** Records use a gapless response-local
     sequence starting at zero. Each checkpoint or span completion carries all
-    template, inventory, CSS, route, nonce, and projected-state deltas needed to
-    commit it after prior records. Global metadata merges additively. Boundary
-    state remains ephemeral and is not published to `window.__webui.state`.
+    template, inventory, CSS, route, nonce, and projected-state data needed to
+    commit it after prior records. A range may reference the exact preceding
+    range record by sequence and carry only a top-level state delta when that
+    prior projection is a proven subset under the same server state revision.
+    Global metadata merges additively. Boundary state remains ephemeral and is
+    not published to `window.__webui.state`.
 11. **Fail closed.** Version, tuple arity, record sequence, occurrence sequence,
     target kind, marker closure, span ancestry, and all configured work and
     retention limits are mandatory. Malformed, truncated, stale, duplicate, or
@@ -2909,11 +2942,12 @@ regions while the document is still loading.
     partial navigation, and component-template operations do not emit streaming
     markers or browser records.
 
-### Stream contract (version 2, normative)
+### Stream contract (version 3, normative)
 
-Version 2 makes `componentStyles` mandatory on every checkpoint. Version 1
-peers are rejected at the envelope gate rather than failing later with an
-apparently valid record whose required style-closure catalog is absent.
+Version 3 adds ordered range-state references and deltas. Version 2 made
+`componentStyles` mandatory on every checkpoint. Version 1 and version 2 peers
+are rejected at the envelope gate rather than interpreting an incompatible
+record.
 
 These invariants are binding. Every one is enforced somewhere — by the
 compiler, by the coordinator, or by a test — and none may be relaxed without a
@@ -2930,7 +2964,7 @@ contract rather than introduce a parallel one.
    is `[version, record_sequence, kind, target, payload]`. `kind` is `0` for a
    final boundary checkpoint, `1` for an updatable boundary checkpoint, `2`
    for a state update, and `4` for the terminal. Every response ends with
-   exactly one markerless `[2, sequence, 4, 0, {}]` after all scriptless tail
+   exactly one markerless `[3, sequence, 4, 0, {}]` after all scriptless tail
    bytes. A record arriving after it is corruption: it is rejected, its
    scaffolding released, and the stream is halted without disturbing the
    successful completion the terminal record already drove. The empty terminal
@@ -2938,18 +2972,26 @@ contract rather than introduce a parallel one.
    fields rather than halting a page that has already fully rendered (rule 21).
 3. **Self-sufficient records.** Given all prior records, a record carries
    everything needed to commit itself: its own template delta, component-style
-   closure delta, inventory delta, and projected state. A record never
-   forward-references a later one, so a truncated response is always a prefix of
-   a valid one.
+   closure delta, inventory delta, and projected state. A range record may carry
+   `stateRef: N` instead of complete `state`, where `N` must identify the exact
+   preceding range record, plus optional `stateDelta` additions/replacements.
+   The server uses this only when the referenced projection is a subset of the
+   current projection and the continuation state revision is unchanged. A
+   record never forward-references a later one, so a truncated response is
+   always a prefix of a valid one.
 4. **Additive global merge; ordered island state.** Global handoff merges
    accumulate only:
    inventory bits are OR-ed, CSS/style lists are appended with deduplication,
    component-style resources and closures are registered once, and templates
    are registered additively. No record may overwrite or invalidate an earlier
-   record's contribution. Boundary state is ephemeral and never published to
-   `window.__webui.state`. A state-update record is a shallow patch applied in
-   record order to one already-committed updatable boundary; repeated writes to
-   the same key are last-writer-wins.
+   record's contribution. The coordinator retains only the last resolved range
+   state as a reference base, creates a new top-level object when applying a
+   delta, and releases that base on terminal, cancellation, reset, or failure.
+   Missing, stale, forward, malformed, or non-object references fail closed.
+   Boundary state is ephemeral and never published to `window.__webui.state`.
+   A state-update record is a shallow patch applied in record order to one
+   already-committed updatable boundary; repeated writes to the same key are
+   last-writer-wins and never mutate the range-state reference base.
 5. **Identity is not placement.** A record never contains a selector, node
    path, or DOM position. Checkpoints carry the compiler-assigned integer
    boundary ID in `target`; state updates carry the same ID. The integer
@@ -3234,18 +3276,18 @@ produce:
 <search-box data-ws data-ws-enclosing="0">...</search-box>
 <!--/wb:0-->
 <script type="application/json" data-webui-boundary>
-  [2,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0,"state":{},"templates":{}}]
+  [3,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0,"state":{"todos":[]},"templates":{}}]
 </script>
 <webui-hydrate></webui-hydrate>
 ...ntp-page tail...
 </ntp-page>
 <!--/ws:0-->
 <script type="application/json" data-webui-boundary>
-  [2,1,3,0,{"state":{},"templates":{}}]
+  [3,1,3,0,{"stateRef":0,"stateDelta":{"toolbar":{}},"templates":{}}]
 </script>
 <webui-hydrate></webui-hydrate>
 <script type="application/json" data-webui-boundary>
-  [2,2,4,0,{}]
+  [3,2,4,0,{}]
 </script>
 <webui-hydrate></webui-hydrate>
 ```
@@ -3256,12 +3298,12 @@ produce:
 - The stream envelope is the script-safe tuple
   `[version, record_sequence, kind, target, payload]`. A boundary checkpoint
   uses kind `0` (final) or `1` (updatable), its compiler-assigned boundary ID as
-  `target`, and the existing bootstrap object as `payload`. `bootstrap`
-  reuses the existing object shape (`state`, `templates`, `inventory`, and
-  optional route/CSS/nonce fields), avoiding a second state-selection or
-  serialization implementation. Every checkpoint carries projected state and
-  template/CSS metadata for the transitive component surface reachable from the
-  tags rendered since the previous checkpoint. `Protocol::new` precomputes a
+  `target`, and a bootstrap object as `payload`. The first reusable projection
+  carries `state`; a later proven superset under the same revision may instead
+  carry `stateRef` and an optional `stateDelta`. Every checkpoint resolves to
+  exact projected state plus template/CSS metadata for the transitive component
+  surface reachable from the tags rendered since the previous checkpoint.
+  `Protocol::new` precomputes a
   compact, integer-indexed entry plan only for entries that declare boundary
   metadata; ordinary entries allocate no streaming plan. Hand-built protocols
   without compiler metadata use a request-local fallback plan. Route-free
@@ -3274,8 +3316,10 @@ produce:
   round-trip. Inventory remains exact and contains only tags with rendered SSR
   DOM. Template/CSS metadata is sent once when first reachable; a later rendered
   instance receives its inventory delta and checkpoint-local state without
-  resending metadata. Per-instance positional state tuples are not part of the
-  wire contract; state is carried as named keys.
+  resending metadata. State references are backward-only and identify the exact
+  preceding range-record sequence; state updates never become reference bases.
+  Per-instance positional state tuples are not part of the wire contract; state
+  is carried as named keys.
 - `data-ws` is a compiler-owned, streaming-only identity inserted into every
   streamed SSR component opening tag before browser upgrade. It is the sole
   parser-time deferral signal when the document also has the streaming mode
@@ -3288,16 +3332,16 @@ produce:
   definitions are loaded (see races below).
 - The handler emits one marker pair, one payload, and one sentinel per boundary,
   then calls `flush()` (see "Flush contract"). State updates are markerless
-  `[2, record_sequence, 2, boundary_id, projected_state]` records followed by
+  `[3, record_sequence, 2, boundary_id, projected_state]` records followed by
   the same sentinel and flush; they resolve only through roots captured by the
   updatable checkpoint. The coordinator removes every payload and sentinel
   after processing and removes checkpoint markers after hydration commits.
 - At `body_end`, the handler writes any host-provided body injection and then
-  emits one empty markerless `[2,next_sequence,4,0,{}]` terminal record. The
+  emits one empty markerless `[3,next_sequence,4,0,{}]` terminal record. The
   terminal flush also commits preceding native/scriptless tail bytes, but those
   bytes never manufacture another state or template projection. A static
   streaming document with no boundaries therefore emits exactly
-  `[2,0,4,0,{}]`. Streaming mode does **not** also emit a page-wide
+  `[3,0,4,0,{}]`. Streaming mode does **not** also emit a page-wide
   `#webui-data` block. Boundary checkpoints share the existing `WebUiBootstrap`
   and `write_selected_state` paths, so there is no second state-selection
   implementation. A request-local key scratch vector is cleared and reused
@@ -3315,7 +3359,7 @@ produce:
   fragment rendering is identical in both modes. Boundary emission is gated on
   session mode and reuses the existing per-signal dedup pattern.
 - Every browser record is the five-element tuple
-  `[2, sequence, kind, target, payload]`.
+  `[3, sequence, kind, target, payload]`.
 - Kinds are `0` final checkpoint, `1` updatable checkpoint, `2` state update,
   `3` generated span completion, and `4` terminal.
 - A checkpoint target is `BoundaryInstanceId`; a span-completion target is
@@ -3330,9 +3374,9 @@ produce:
   `enclosingSpanInstanceId`, projected `state`, and additive template,
   inventory, route, nonce, CSS, and style deltas as needed. Span completion
   payloads use the same bootstrap fields except declaration identity.
-- State updates are markerless `[2, sequence, 2, instanceId, patch]` records.
+- State updates are markerless `[3, sequence, 2, instanceId, patch]` records.
   They carry no templates and insert no application markup.
-- Exactly one markerless `[2, sequence, 4, 0, {}]` terminal follows the final
+- Exactly one markerless `[3, sequence, 4, 0, {}]` terminal follows the final
   tail bytes. A boundary-free streaming render emits the terminal from
   `start`.
 - Each record script is followed by one generated `<webui-hydrate>` sentinel.
@@ -3624,6 +3668,15 @@ the selected fragment path and uses `FragmentList::contains_boundary` to avoid
 probing boundary-free subgraphs. Capture buffers are swapped and recycled rather
 than rebuilt for nested spans.
 
+Range records keep one bounded prior-projection descriptor. Under an unchanged
+state revision, an equal projection emits only `stateRef`; a proven superset
+emits `stateRef` plus its top-level `stateDelta`. The descriptor stores compact
+interned key IDs rather than projected values, so eliminating repeated JSON does
+not clone the state tree. The synchronous helper borrows one state and retains
+one render context for the complete response. Async owned sessions can move
+fresh state through `start_owned` and `resume_owned`, or use `resume_current`
+when the retained snapshot is already authoritative.
+
 The browser performs no `MutationObserver`, polling, or document-wide query on
 a valid path. It resolves root-local markers, walks each committed range once,
 and retains root references only for updatable occurrences and pending
@@ -3683,6 +3736,11 @@ page.update(search.instance_id, &search_patch)?;
 ```
 
 The patch is projected through the update plan captured by that checkpoint.
+When no state changed, `resume_current` avoids an overlay while retaining the
+same checkpoint-only return. An owned `StreamingSession` additionally accepts
+`start_owned(Value)` and `resume_owned(..., Value, ...)`, allowing a host to
+transfer freshly loaded state into the continuation before returning its worker
+to the pool and awaiting the next operation.
 
 ### Host-owned streaming sessions
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2846,7 +2846,7 @@ into `<f-repeat>` markup.
 
 ## Progressive Streaming Hydration
 
-Progressive streaming is one version-3 contract shared by the compiler, Rust
+Progressive streaming is one unversioned contract shared by the compiler, Rust
 handler, host bindings, CLI proxy, and browser coordinator. It discovers
 boundaries by executing the compiled fragment graph and hydrates complete
 regions while the document is still loading.
@@ -2931,7 +2931,7 @@ regions while the document is still loading.
     prior projection is a proven subset under the same server state revision.
     Global metadata merges additively. Boundary state remains ephemeral and is
     not published to `window.__webui.state`.
-11. **Fail closed.** Version, tuple arity, record sequence, occurrence sequence,
+11. **Fail closed.** Tuple arity, record sequence, occurrence sequence,
     target kind, marker closure, span ancestry, and all configured work and
     retention limits are mandatory. Malformed, truncated, stale, duplicate, or
     overflowing input halts the coordinator, suppresses successful completion,
@@ -2942,12 +2942,11 @@ regions while the document is still loading.
     partial navigation, and component-template operations do not emit streaming
     markers or browser records.
 
-### Stream contract (version 3, normative)
+### Stream contract (normative)
 
-Version 3 adds ordered range-state references and deltas. Version 2 made
-`componentStyles` mandatory on every checkpoint. Version 1 and version 2 peers
-are rejected at the envelope gate rather than interpreting an incompatible
-record.
+The four-field envelope below is the only supported streaming wire contract.
+There is no runtime compatibility branch; legacy versioned envelopes are
+rejected by the tuple-shape gate.
 
 These invariants are binding. Every one is enforced somewhere — by the
 compiler, by the coordinator, or by a test — and none may be relaxed without a
@@ -2960,11 +2959,11 @@ contract rather than introduce a parallel one.
    terminal record carries one response-local record sequence starting at `0`
    and increasing by exactly one. Any other value is rejected and halts the
    stream. There is no reordering buffer and no out-of-order tolerance.
-2. **Typed records and exactly one empty terminal.** The five-element envelope
-   is `[version, record_sequence, kind, target, payload]`. `kind` is `0` for a
+2. **Typed records and exactly one empty terminal.** The four-element envelope
+   is `[record_sequence, kind, target, payload]`. `kind` is `0` for a
    final boundary checkpoint, `1` for an updatable boundary checkpoint, `2`
    for a state update, and `4` for the terminal. Every response ends with
-   exactly one markerless `[3, sequence, 4, 0, {}]` after all scriptless tail
+   exactly one markerless `[sequence, 4, 0, {}]` after all scriptless tail
    bytes. A record arriving after it is corruption: it is rejected, its
    scaffolding released, and the stream is halted without disturbing the
    successful completion the terminal record already drove. The empty terminal
@@ -3122,27 +3121,25 @@ contract rather than introduce a parallel one.
     checkpoint, update, and terminal write flushes through the same transport,
     preserving its backpressure and disconnect errors.
 
-**Compatibility**
+**Wire shape**
 
-20. **The reader validates transport and version, not its own serializer.**
+20. **The reader validates transport shape, not its own serializer.**
     A record is written by this repository's handler and read back by this
     repository's coordinator, so the coordinator re-derives nothing the
-    serializer already guaranteed. Exactly three conditions are checked before
+    serializer already guaranteed. Exactly two conditions are checked before
     the tuple is trusted: `JSON.parse` success, which is a *complete*
     truncation detector because every proper prefix of a JSON array is invalid
-    JSON (rule 3 seen from the transport side); a five-element array, so
-    destructuring is total; and `version`. Everything past those is document
+    JSON (rule 3 seen from the transport side); and a four-element array, so
+    destructuring is total. Everything past those is document
     state rather than record shape, and is enforced where it is actually
     known — the coordinator halts the stream on a sequence or target mismatch,
     and commits inside an error boundary so any payload defect fails closed
     instead of hydrating partially.
-21. **`version` is the only compatibility mechanism.** Because rule 20 removes
-    per-field checks, a stale cached client reads an unrecognized `kind` as a
-    final checkpoint. Any new record kind, tuple shape, or incompatible payload
-    meaning must therefore bump `version`, which is gated before any element is
-    read. Purely additive payload fields do not bump it and are ignored by
-    older readers, which is what makes tolerating an unexpected terminal
-    payload (rule 2) safe rather than lax.
+21. **There is one clean-break contract.** The handler and coordinator change
+    together. A versioned or otherwise obsolete tuple is rejected by rule 20;
+    no compatibility parser or alternate serializer is retained. Any
+    incompatible change updates this contract, both endpoints, and their tests
+    in one release.
 
 ### Directive spelling and the structural signal namespace
 
@@ -3276,18 +3273,18 @@ produce:
 <search-box data-ws data-ws-enclosing="0">...</search-box>
 <!--/wb:0-->
 <script type="application/json" data-webui-boundary>
-  [3,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0,"state":{"todos":[]},"templates":{}}]
+  [0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0,"state":{"todos":[]},"templates":{}}]
 </script>
 <webui-hydrate></webui-hydrate>
 ...ntp-page tail...
 </ntp-page>
 <!--/ws:0-->
 <script type="application/json" data-webui-boundary>
-  [3,1,3,0,{"stateRef":0,"stateDelta":{"toolbar":{}},"templates":{}}]
+  [1,3,0,{"stateRef":0,"stateDelta":{"toolbar":{}},"templates":{}}]
 </script>
 <webui-hydrate></webui-hydrate>
 <script type="application/json" data-webui-boundary>
-  [3,2,4,0,{}]
+  [2,4,0,{}]
 </script>
 <webui-hydrate></webui-hydrate>
 ```
@@ -3296,7 +3293,7 @@ produce:
   existing `<!--wr-->` / `<!--wc-->` family documented under "Plugin data and
   SSR hydration markers" above — same removal-after-hydration contract.
 - The stream envelope is the script-safe tuple
-  `[version, record_sequence, kind, target, payload]`. A boundary checkpoint
+  `[record_sequence, kind, target, payload]`. A boundary checkpoint
   uses kind `0` (final) or `1` (updatable), its compiler-assigned boundary ID as
   `target`, and a bootstrap object as `payload`. The first reusable projection
   carries `state`; a later proven superset under the same revision may instead
@@ -3332,16 +3329,16 @@ produce:
   definitions are loaded (see races below).
 - The handler emits one marker pair, one payload, and one sentinel per boundary,
   then calls `flush()` (see "Flush contract"). State updates are markerless
-  `[3, record_sequence, 2, boundary_id, projected_state]` records followed by
+  `[record_sequence, 2, boundary_id, projected_state]` records followed by
   the same sentinel and flush; they resolve only through roots captured by the
   updatable checkpoint. The coordinator removes every payload and sentinel
   after processing and removes checkpoint markers after hydration commits.
 - At `body_end`, the handler writes any host-provided body injection and then
-  emits one empty markerless `[3,next_sequence,4,0,{}]` terminal record. The
+  emits one empty markerless `[next_sequence,4,0,{}]` terminal record. The
   terminal flush also commits preceding native/scriptless tail bytes, but those
   bytes never manufacture another state or template projection. A static
   streaming document with no boundaries therefore emits exactly
-  `[3,0,4,0,{}]`. Streaming mode does **not** also emit a page-wide
+  `[0,4,0,{}]`. Streaming mode does **not** also emit a page-wide
   `#webui-data` block. Boundary checkpoints share the existing `WebUiBootstrap`
   and `write_selected_state` paths, so there is no second state-selection
   implementation. A request-local key scratch vector is cleared and reused
@@ -3358,8 +3355,8 @@ produce:
   rendering ignores namespaced raw structural signals; ordinary element and
   fragment rendering is identical in both modes. Boundary emission is gated on
   session mode and reuses the existing per-signal dedup pattern.
-- Every browser record is the five-element tuple
-  `[3, sequence, kind, target, payload]`.
+- Every browser record is the four-element tuple
+  `[sequence, kind, target, payload]`.
 - Kinds are `0` final checkpoint, `1` updatable checkpoint, `2` state update,
   `3` generated span completion, and `4` terminal.
 - A checkpoint target is `BoundaryInstanceId`; a span-completion target is
@@ -3374,9 +3371,9 @@ produce:
   `enclosingSpanInstanceId`, projected `state`, and additive template,
   inventory, route, nonce, CSS, and style deltas as needed. Span completion
   payloads use the same bootstrap fields except declaration identity.
-- State updates are markerless `[3, sequence, 2, instanceId, patch]` records.
+- State updates are markerless `[sequence, 2, instanceId, patch]` records.
   They carry no templates and insert no application markup.
-- Exactly one markerless `[3, sequence, 4, 0, {}]` terminal follows the final
+- Exactly one markerless `[sequence, 4, 0, {}]` terminal follows the final
   tail bytes. A boundary-free streaming render emits the terminal from
   `start`.
 - Each record script is followed by one generated `<webui-hydrate>` sentinel.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1123,18 +1123,14 @@ pub struct StreamStep {
 }
 
 impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
-    pub fn start(&mut self, state: &Value) -> Result<StreamStatus>;
-    pub fn start_owned(&mut self, state: Value) -> Result<StreamStatus>;
-    pub fn resume(
+    pub fn start<'state>(
         &mut self,
-        instance_id: BoundaryInstanceId,
-        state: &Value,
-        mode: BoundaryMode,
+        state: impl Into<StreamingState<'state>>,
     ) -> Result<StreamStatus>;
-    pub fn resume_owned(
+    pub fn resume<'state>(
         &mut self,
         instance_id: BoundaryInstanceId,
-        state: Value,
+        state: impl Into<StreamingState<'state>>,
         mode: BoundaryMode,
     ) -> Result<StreamStatus>;
     pub fn resume_current(
@@ -1152,18 +1148,14 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
 }
 
 impl StreamingSession {
-    pub fn start(&mut self, state: &Value) -> Result<StreamStep>;
-    pub fn start_owned(&mut self, state: Value) -> Result<StreamStep>;
-    pub fn resume(
+    pub fn start<'state>(
         &mut self,
-        instance_id: BoundaryInstanceId,
-        state: &Value,
-        mode: BoundaryMode,
+        state: impl Into<StreamingState<'state>>,
     ) -> Result<StreamStep>;
-    pub fn resume_owned(
+    pub fn resume<'state>(
         &mut self,
         instance_id: BoundaryInstanceId,
-        state: Value,
+        state: impl Into<StreamingState<'state>>,
         mode: BoundaryMode,
     ) -> Result<StreamStep>;
     pub fn resume_current(
@@ -1220,12 +1212,13 @@ byte.
 
 `resume_current` preserves the checkpoint-only return and the pause before
 `advance`, but commits against the retained snapshot without comparing another
-state tree. Owned hosts that just decoded or loaded a `Value` use `start_owned`
-and `resume_owned` to move selected top-level values into the session rather
-than cloning them. `WebUIHandler::render_streaming` drives the whole response in
-one prepared render context while borrowing its one state value; it preserves
-the same flush positions without cloning the state or rebuilding that context
-between records.
+state tree. `start` and `resume` accept either owned or borrowed state through
+`StreamingState`: owned values move changed top-level values into the session,
+while borrowed values let shared-state callers retain ownership. Equal values
+preserve the prior state-reference base.
+`WebUIHandler::render_streaming` drives the whole response in one prepared
+render context while borrowing its one state value; it preserves the same flush
+positions without cloning the state or rebuilding that context between records.
 
 ### Per-Render HTML Injection
 
@@ -3670,9 +3663,9 @@ state revision, an equal projection emits only `stateRef`; a proven superset
 emits `stateRef` plus its top-level `stateDelta`. The descriptor stores compact
 interned key IDs rather than projected values, so eliminating repeated JSON does
 not clone the state tree. The synchronous helper borrows one state and retains
-one render context for the complete response. Async owned sessions can move
-fresh state through `start_owned` and `resume_owned`, or use `resume_current`
-when the retained snapshot is already authoritative.
+one render context for the complete response. Async owned sessions pass `Value` to `start` and `resume` to move fresh state,
+pass `&Value` when retaining caller ownership, or use `resume_current` when the
+retained snapshot is already authoritative.
 
 The browser performs no `MutationObserver`, polling, or document-wide query on
 a valid path. It resolves root-local markers, walks each committed range once,
@@ -3734,10 +3727,10 @@ page.update(search.instance_id, &search_patch)?;
 
 The patch is projected through the update plan captured by that checkpoint.
 When no state changed, `resume_current` avoids an overlay while retaining the
-same checkpoint-only return. An owned `StreamingSession` additionally accepts
-`start_owned(Value)` and `resume_owned(..., Value, ...)`, allowing a host to
-transfer freshly loaded state into the continuation before returning its worker
-to the pool and awaiting the next operation.
+same checkpoint-only return. `StreamingSession::start` and `resume` accept owned
+`Value`s, allowing a host to transfer freshly loaded state into the continuation
+before returning its worker to the pool and awaiting the next operation. They
+also accept borrowed values for shared-state callers.
 
 ### Host-owned streaming sessions
 

--- a/crates/webui-cli/src/commands/serve/streaming_api.rs
+++ b/crates/webui-cli/src/commands/serve/streaming_api.rs
@@ -1239,8 +1239,8 @@ mod tests {
             .iter()
             .position(|segment| {
                 segment
-                    .windows(b"[2,1,2,0,".len())
-                    .any(|window| window == b"[2,1,2,0,")
+                    .windows(b"[3,1,2,0,".len())
+                    .any(|window| window == b"[3,1,2,0,")
             })
             .unwrap_or_else(|| panic!("update segment is missing"));
         let tail = segments
@@ -1255,8 +1255,8 @@ mod tests {
             .iter()
             .position(|segment| {
                 segment
-                    .windows(b"[2,3,4,0,{}]".len())
-                    .any(|window| window == b"[2,3,4,0,{}]")
+                    .windows(b"[3,3,4,0,{}]".len())
+                    .any(|window| window == b"[3,3,4,0,{}]")
             })
             .unwrap_or_else(|| panic!("terminal segment is missing"));
         assert!(content < update);
@@ -1270,7 +1270,7 @@ mod tests {
             .unwrap_or_else(|error| panic!("renderer produced invalid UTF-8: {error}"));
         assert!(html.contains("data-boundary=\"content\""));
         assert!(html.contains("data-boundary=\"tail\""));
-        assert!(html.contains("[2,3,4,0,{}]"));
+        assert!(html.contains("[3,3,4,0,{}]"));
     }
 
     #[test]
@@ -1311,8 +1311,8 @@ mod tests {
             .windows(b"<footer data-page-tail>".len())
             .any(|window| window == b"<footer data-page-tail>"));
         assert!(!segments[checkpoint]
-            .windows(b"[2,1,4,0,{}]".len())
-            .any(|window| window == b"[2,1,4,0,{}]"));
+            .windows(b"[3,1,4,0,{}]".len())
+            .any(|window| window == b"[3,1,4,0,{}]"));
         assert!(segments[checkpoint].ends_with(b"<webui-hydrate></webui-hydrate>"));
         assert!(segments[tail].starts_with(b"<footer data-page-tail>"));
     }
@@ -1384,7 +1384,7 @@ mod tests {
         let (result, segments) = run_commands(valid_streaming_config(Vec::new(), &[]), commands);
         result.unwrap_or_else(|error| panic!("boundary-free render failed: {error}"));
         let html = join_segments(&segments);
-        assert!(String::from_utf8_lossy(&html).contains("[2,0,4,0,{}]"));
+        assert!(String::from_utf8_lossy(&html).contains("[3,0,4,0,{}]"));
     }
 
     #[test]

--- a/crates/webui-cli/src/commands/serve/streaming_api.rs
+++ b/crates/webui-cli/src/commands/serve/streaming_api.rs
@@ -1239,8 +1239,8 @@ mod tests {
             .iter()
             .position(|segment| {
                 segment
-                    .windows(b"[3,1,2,0,".len())
-                    .any(|window| window == b"[3,1,2,0,")
+                    .windows(b"[1,2,0,".len())
+                    .any(|window| window == b"[1,2,0,")
             })
             .unwrap_or_else(|| panic!("update segment is missing"));
         let tail = segments
@@ -1255,8 +1255,8 @@ mod tests {
             .iter()
             .position(|segment| {
                 segment
-                    .windows(b"[3,3,4,0,{}]".len())
-                    .any(|window| window == b"[3,3,4,0,{}]")
+                    .windows(b"[3,4,0,{}]".len())
+                    .any(|window| window == b"[3,4,0,{}]")
             })
             .unwrap_or_else(|| panic!("terminal segment is missing"));
         assert!(content < update);
@@ -1270,7 +1270,7 @@ mod tests {
             .unwrap_or_else(|error| panic!("renderer produced invalid UTF-8: {error}"));
         assert!(html.contains("data-boundary=\"content\""));
         assert!(html.contains("data-boundary=\"tail\""));
-        assert!(html.contains("[3,3,4,0,{}]"));
+        assert!(html.contains("[3,4,0,{}]"));
     }
 
     #[test]
@@ -1311,8 +1311,8 @@ mod tests {
             .windows(b"<footer data-page-tail>".len())
             .any(|window| window == b"<footer data-page-tail>"));
         assert!(!segments[checkpoint]
-            .windows(b"[3,1,4,0,{}]".len())
-            .any(|window| window == b"[3,1,4,0,{}]"));
+            .windows(b"[1,4,0,{}]".len())
+            .any(|window| window == b"[1,4,0,{}]"));
         assert!(segments[checkpoint].ends_with(b"<webui-hydrate></webui-hydrate>"));
         assert!(segments[tail].starts_with(b"<footer data-page-tail>"));
     }
@@ -1384,7 +1384,7 @@ mod tests {
         let (result, segments) = run_commands(valid_streaming_config(Vec::new(), &[]), commands);
         result.unwrap_or_else(|error| panic!("boundary-free render failed: {error}"));
         let html = join_segments(&segments);
-        assert!(String::from_utf8_lossy(&html).contains("[3,0,4,0,{}]"));
+        assert!(String::from_utf8_lossy(&html).contains("[0,4,0,{}]"));
     }
 
     #[test]

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -808,7 +808,7 @@ pub unsafe extern "C" fn webui_streaming_session_start(
         let Some(state) = (unsafe { streaming_json_arg(state_json, "state_json") }) else {
             return std::ptr::null_mut();
         };
-        match context.session.start(&state) {
+        match context.session.start_owned(state) {
             Ok(step) => owned_streaming_step(step),
             Err(error) => {
                 set_last_error(error.to_string());
@@ -860,7 +860,7 @@ pub unsafe extern "C" fn webui_streaming_session_resume(
         };
         match context
             .session
-            .resume(BoundaryInstanceId::from_raw(instance_id), &state, mode)
+            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
         {
             Ok(step) => owned_streaming_step(step),
             Err(error) => {

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -808,7 +808,7 @@ pub unsafe extern "C" fn webui_streaming_session_start(
         let Some(state) = (unsafe { streaming_json_arg(state_json, "state_json") }) else {
             return std::ptr::null_mut();
         };
-        match context.session.start_owned(state) {
+        match context.session.start(state) {
             Ok(step) => owned_streaming_step(step),
             Err(error) => {
                 set_last_error(error.to_string());
@@ -860,7 +860,7 @@ pub unsafe extern "C" fn webui_streaming_session_resume(
         };
         match context
             .session
-            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
+            .resume(BoundaryInstanceId::from_raw(instance_id), state, mode)
         {
             Ok(step) => owned_streaming_step(step),
             Err(error) => {

--- a/crates/webui-handler/README.md
+++ b/crates/webui-handler/README.md
@@ -32,14 +32,14 @@ Available via all bindings: Rust (`Protocol::render_component_templates`), Node/
 
 ```rust
 let mut session = StreamingSession::new(handler, protocol, options)?;
-let mut step = session.start_owned(initial_state)?;
+let mut step = session.start(initial_state)?;
 
 while !step.done {
     step = match step.boundary.as_ref() {
         Some(boundary) => {
             let state = load_state(&boundary.owner, &boundary.name, boundary.key.as_ref())?;
             // Writes only this occurrence, through its checkpoint.
-            session.resume_owned(boundary.instance_id, state, BoundaryMode::Final)?
+            session.resume(boundary.instance_id, state, BoundaryMode::Final)?
         }
         // Writes the shell bytes up to the next occurrence or the terminal.
         None => session.advance()?,
@@ -62,10 +62,11 @@ follow through the next occurrence or terminal. This makes an early
 component-local child independently flushable without an authored sibling
 boundary.
 
-Use `start_owned` and `resume_owned` when state was freshly loaded or decoded;
-the session moves selected top-level values instead of cloning or deeply
-comparing them. Use `resume_current` when the retained snapshot is already
-authoritative. All three resume forms stop after the checkpoint flush, so an
+`start` and `resume` accept either owned or borrowed state. Pass a freshly loaded
+or decoded `Value` to move changed top-level values without cloning, or `&Value`
+when retaining caller ownership. Equal values preserve the prior reference base.
+Use `resume_current` when the retained snapshot is already authoritative and no
+comparison is needed. Both resume forms stop after the checkpoint flush, so an
 async host can release its worker before calling `advance`.
 
 Commit an occurrence as `BoundaryMode::Updatable` to call

--- a/crates/webui-handler/README.md
+++ b/crates/webui-handler/README.md
@@ -32,14 +32,14 @@ Available via all bindings: Rust (`Protocol::render_component_templates`), Node/
 
 ```rust
 let mut session = StreamingSession::new(handler, protocol, options)?;
-let mut step = session.start(&initial_state)?;
+let mut step = session.start_owned(initial_state)?;
 
 while !step.done {
     step = match step.boundary.as_ref() {
         Some(boundary) => {
             let state = load_state(&boundary.owner, &boundary.name, boundary.key.as_ref())?;
             // Writes only this occurrence, through its checkpoint.
-            session.resume(boundary.instance_id, &state, BoundaryMode::Final)?
+            session.resume_owned(boundary.instance_id, state, BoundaryMode::Final)?
         }
         // Writes the shell bytes up to the next occurrence or the terminal.
         None => session.advance()?,
@@ -61,6 +61,12 @@ and sentinel, then returns. `advance` writes the parent or shell bytes that
 follow through the next occurrence or terminal. This makes an early
 component-local child independently flushable without an authored sibling
 boundary.
+
+Use `start_owned` and `resume_owned` when state was freshly loaded or decoded;
+the session moves selected top-level values instead of cloning or deeply
+comparing them. Use `resume_current` when the retained snapshot is already
+authoritative. All three resume forms stop after the checkpoint flush, so an
+async host can release its worker before calling `advance`.
 
 Commit an occurrence as `BoundaryMode::Updatable` to call
 `update(instance_id, patch)` later, including between its `resume` and the

--- a/crates/webui-handler/benches/streaming_hydration_bench.rs
+++ b/crates/webui-handler/benches/streaming_hydration_bench.rs
@@ -389,7 +389,7 @@ fn verify_streaming_case(boundaries: usize) -> StreamingCase {
         assert!(
             streaming
                 .output
-                .contains(&format!("[3,{sequence},0,{sequence},")),
+                .contains(&format!("[{sequence},0,{sequence},")),
             "streaming output is missing boundary {sequence} envelope"
         );
     }
@@ -397,18 +397,18 @@ fn verify_streaming_case(boundaries: usize) -> StreamingCase {
     assert!(
         streaming
             .output
-            .contains(&format!("[3,{boundaries},4,0,{{}}]")),
+            .contains(&format!("[{boundaries},4,0,{{}}]")),
         "streaming output is missing the terminal envelope"
     ); // The empty terminal record is always the last envelope and never carries a
        // bootstrap, regardless of native or scriptless tail bytes.
        // Every envelope (each boundary commit plus the terminal) opens with the
        // boundary sentinel prefix, so the prefix count equals boundaries + 1.
     assert_eq!(
-        occurrences(&streaming.output, "data-webui-boundary>[3,"),
+        occurrences(&streaming.output, "data-webui-boundary>["),
         boundaries + 1,
         "each envelope opens with the boundary sentinel prefix"
     );
-    if let Some(terminal) = streaming.output.find(&format!("[3,{boundaries},4,0,{{}}]")) {
+    if let Some(terminal) = streaming.output.find(&format!("[{boundaries},4,0,{{}}]")) {
         if boundaries > 0 {
             match streaming
                 .output

--- a/crates/webui-handler/benches/streaming_hydration_bench.rs
+++ b/crates/webui-handler/benches/streaming_hydration_bench.rs
@@ -15,12 +15,14 @@
 //! harness in `examples/integration/streaming-browser-bench` owns browser-side
 //! validation.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use serde_json::{json, Value};
 use std::hint::black_box;
+use std::sync::Arc;
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
 use webui_handler::{
-    BoundaryMode, FlushWriter, Protocol, RenderOptions, ResponseWriter, WebUIHandler,
+    BoundaryMode, FlushWriter, Protocol, RenderOptions, ResponseWriter, SessionOptions,
+    StreamingSession, WebUIHandler,
 };
 use webui_parser::plugin::webui::WebUIParserPlugin;
 use webui_parser::{ComponentRegistration, CssStrategy, HtmlParser};
@@ -194,6 +196,100 @@ fn render_streaming(
     }
 }
 
+fn render_split(
+    handler: &WebUIHandler,
+    protocol: &Protocol,
+    state: &Value,
+    writer: &mut BenchWriter,
+) {
+    let options = RenderOptions::new(ENTRY_ID, REQUEST_PATH);
+    let mut response = match handler.stream_response(protocol, &options, writer) {
+        Ok(response) => response,
+        Err(error) => panic!("starting split streaming response failed: {error}"),
+    };
+    let mut status = match response.start(state) {
+        Ok(status) => status,
+        Err(error) => panic!("starting split streaming traversal failed: {error}"),
+    };
+    while !status.done {
+        status = match status.boundary.as_ref() {
+            Some(boundary) => {
+                match response.resume_current(boundary.instance_id, BoundaryMode::Final) {
+                    Ok(status) => status,
+                    Err(error) => panic!("resuming split streaming traversal failed: {error}"),
+                }
+            }
+            None => match response.advance() {
+                Ok(status) => status,
+                Err(error) => panic!("advancing split streaming traversal failed: {error}"),
+            },
+        };
+    }
+}
+
+fn render_split_owned_state(
+    handler: &WebUIHandler,
+    protocol: &Protocol,
+    state: Value,
+    writer: &mut BenchWriter,
+) {
+    let options = RenderOptions::new(ENTRY_ID, REQUEST_PATH);
+    let mut response = match handler.stream_response(protocol, &options, writer) {
+        Ok(response) => response,
+        Err(error) => panic!("starting split streaming response failed: {error}"),
+    };
+    let mut status = match response.start_owned(state) {
+        Ok(status) => status,
+        Err(error) => panic!("starting owned-state streaming traversal failed: {error}"),
+    };
+    while !status.done {
+        status = match status.boundary.as_ref() {
+            Some(boundary) => {
+                match response.resume_current(boundary.instance_id, BoundaryMode::Final) {
+                    Ok(status) => status,
+                    Err(error) => panic!("resuming split streaming traversal failed: {error}"),
+                }
+            }
+            None => match response.advance() {
+                Ok(status) => status,
+                Err(error) => panic!("advancing split streaming traversal failed: {error}"),
+            },
+        };
+    }
+}
+
+fn render_owned_split(handler: Arc<WebUIHandler>, protocol: Arc<Protocol>, state: Value) -> usize {
+    let mut session = match StreamingSession::new(
+        handler,
+        protocol,
+        SessionOptions::new(ENTRY_ID, REQUEST_PATH),
+    ) {
+        Ok(session) => session,
+        Err(error) => panic!("creating owned streaming session failed: {error}"),
+    };
+    let mut step = match session.start_owned(state) {
+        Ok(step) => step,
+        Err(error) => panic!("starting owned streaming traversal failed: {error}"),
+    };
+    let mut bytes = step.bytes.len();
+    while !step.done {
+        step = match step.boundary.as_ref() {
+            Some(boundary) => {
+                match session.resume_current(boundary.instance_id, BoundaryMode::Final) {
+                    Ok(step) => step,
+                    Err(error) => panic!("resuming owned streaming traversal failed: {error}"),
+                }
+            }
+            None => match session.advance() {
+                Ok(step) => step,
+                Err(error) => panic!("advancing owned streaming traversal failed: {error}"),
+            },
+        };
+        bytes += step.bytes.len();
+    }
+    bytes
+}
+
 fn verify_streaming_case(boundaries: usize) -> StreamingCase {
     let protocol = parser_protocol(boundaries);
     let handler = hydration_handler();
@@ -293,7 +389,7 @@ fn verify_streaming_case(boundaries: usize) -> StreamingCase {
         assert!(
             streaming
                 .output
-                .contains(&format!("[2,{sequence},0,{sequence},")),
+                .contains(&format!("[3,{sequence},0,{sequence},")),
             "streaming output is missing boundary {sequence} envelope"
         );
     }
@@ -301,18 +397,18 @@ fn verify_streaming_case(boundaries: usize) -> StreamingCase {
     assert!(
         streaming
             .output
-            .contains(&format!("[2,{boundaries},4,0,{{}}]")),
+            .contains(&format!("[3,{boundaries},4,0,{{}}]")),
         "streaming output is missing the terminal envelope"
     ); // The empty terminal record is always the last envelope and never carries a
        // bootstrap, regardless of native or scriptless tail bytes.
        // Every envelope (each boundary commit plus the terminal) opens with the
        // boundary sentinel prefix, so the prefix count equals boundaries + 1.
     assert_eq!(
-        occurrences(&streaming.output, "data-webui-boundary>[2,"),
+        occurrences(&streaming.output, "data-webui-boundary>[3,"),
         boundaries + 1,
         "each envelope opens with the boundary sentinel prefix"
     );
-    if let Some(terminal) = streaming.output.find(&format!("[2,{boundaries},4,0,{{}}]")) {
+    if let Some(terminal) = streaming.output.find(&format!("[3,{boundaries},4,0,{{}}]")) {
         if boundaries > 0 {
             match streaming
                 .output
@@ -585,6 +681,8 @@ fn bench_large_state_boundaries(c: &mut Criterion) {
     for boundaries in LARGE_STATE_BOUNDARIES.iter().copied() {
         let protocol = full_state_protocol(boundaries);
         let handler = hydration_handler();
+        let mut legacy = BenchWriter::new(0);
+        render_legacy(&handler, &protocol, &state, &mut legacy);
         let mut writer = BenchWriter::new(boundaries + 2);
         render_streaming(&handler, &protocol, &state, &mut writer);
         let bytes = writer.output.len();
@@ -593,8 +691,14 @@ fn bench_large_state_boundaries(c: &mut Criterion) {
             boundaries + 1,
             "each boundary plus the terminal needs one envelope"
         );
+        assert_eq!(
+            occurrences(&writer.output, "\"rows\":["),
+            1,
+            "unchanged full state must be serialized once per response"
+        );
         println!(
-            "streaming_large_state boundaries={boundaries}: rows={LARGE_STATE_ROWS}, output_bytes={bytes}"
+            "streaming_large_state boundaries={boundaries}: rows={LARGE_STATE_ROWS}, buffered_bytes={}, streaming_bytes={bytes}",
+            legacy.output.len(),
         );
 
         group.throughput(Throughput::Bytes(bytes as u64));
@@ -618,6 +722,89 @@ fn bench_large_state_boundaries(c: &mut Criterion) {
         );
     }
     group.finish();
+
+    let boundaries = 8;
+    let protocol = full_state_protocol(boundaries);
+    let handler = hydration_handler();
+    let mut legacy = BenchWriter::new(0);
+    render_legacy(&handler, &protocol, &state, &mut legacy);
+    let mut streaming = BenchWriter::new(boundaries + 2);
+    render_streaming(&handler, &protocol, &state, &mut streaming);
+    let expected_streaming_bytes = streaming.output.len();
+    let mut compare = c.benchmark_group("streaming_large_state_compare");
+    compare.throughput(Throughput::Bytes(legacy.output.len() as u64));
+    compare.bench_function("buffered", |b| {
+        let handler = hydration_handler();
+        let mut writer = BenchWriter::new(0);
+        b.iter(|| {
+            writer.reset();
+            render_legacy(
+                &handler,
+                black_box(&protocol),
+                black_box(&state),
+                &mut writer,
+            );
+            black_box(writer.output.len());
+        });
+    });
+    compare.throughput(Throughput::Bytes(expected_streaming_bytes as u64));
+    compare.bench_function("streaming_fused", |b| {
+        let handler = hydration_handler();
+        let mut writer = BenchWriter::new(boundaries + 2);
+        b.iter(|| {
+            writer.reset();
+            render_streaming(
+                &handler,
+                black_box(&protocol),
+                black_box(&state),
+                &mut writer,
+            );
+            black_box(writer.output.len());
+        });
+    });
+    compare.bench_function("streaming_split", |b| {
+        let handler = hydration_handler();
+        let mut writer = BenchWriter::new(boundaries + 2);
+        b.iter(|| {
+            writer.reset();
+            render_split(
+                &handler,
+                black_box(&protocol),
+                black_box(&state),
+                &mut writer,
+            );
+            black_box(writer.output.len());
+        });
+    });
+    compare.bench_function("streaming_split_owned_state", |b| {
+        let handler = hydration_handler();
+        let mut writer = BenchWriter::new(boundaries + 2);
+        b.iter_batched(
+            || state.clone(),
+            |owned_state| {
+                writer.reset();
+                render_split_owned_state(&handler, black_box(&protocol), owned_state, &mut writer);
+                black_box(writer.output.len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    let owned_handler = Arc::new(hydration_handler());
+    let owned_protocol = Arc::new(full_state_protocol(boundaries));
+    compare.bench_function("streaming_owned_split", |b| {
+        b.iter_batched(
+            || state.clone(),
+            |owned_state| {
+                black_box(render_owned_split(
+                    Arc::clone(&owned_handler),
+                    Arc::clone(&owned_protocol),
+                    owned_state,
+                ));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    compare.finish();
 }
 
 /// Build the same authored page as [`parser_protocol`] with an island whose

--- a/crates/webui-handler/benches/streaming_hydration_bench.rs
+++ b/crates/webui-handler/benches/streaming_hydration_bench.rs
@@ -227,38 +227,11 @@ fn render_split(
     }
 }
 
-fn render_split_owned_state(
-    handler: &WebUIHandler,
-    protocol: &Protocol,
-    state: Value,
-    writer: &mut BenchWriter,
-) {
-    let options = RenderOptions::new(ENTRY_ID, REQUEST_PATH);
-    let mut response = match handler.stream_response(protocol, &options, writer) {
-        Ok(response) => response,
-        Err(error) => panic!("starting split streaming response failed: {error}"),
-    };
-    let mut status = match response.start_owned(state) {
-        Ok(status) => status,
-        Err(error) => panic!("starting owned-state streaming traversal failed: {error}"),
-    };
-    while !status.done {
-        status = match status.boundary.as_ref() {
-            Some(boundary) => {
-                match response.resume_current(boundary.instance_id, BoundaryMode::Final) {
-                    Ok(status) => status,
-                    Err(error) => panic!("resuming split streaming traversal failed: {error}"),
-                }
-            }
-            None => match response.advance() {
-                Ok(status) => status,
-                Err(error) => panic!("advancing split streaming traversal failed: {error}"),
-            },
-        };
-    }
-}
-
-fn render_owned_split(handler: Arc<WebUIHandler>, protocol: Arc<Protocol>, state: Value) -> usize {
+fn render_owned_split(
+    handler: Arc<WebUIHandler>,
+    protocol: Arc<Protocol>,
+    states: Vec<Value>,
+) -> usize {
     let mut session = match StreamingSession::new(
         handler,
         protocol,
@@ -267,19 +240,31 @@ fn render_owned_split(handler: Arc<WebUIHandler>, protocol: Arc<Protocol>, state
         Ok(session) => session,
         Err(error) => panic!("creating owned streaming session failed: {error}"),
     };
-    let mut step = match session.start_owned(state) {
+    let mut states = states.into_iter();
+    let initial_state = match states.next() {
+        Some(state) => state,
+        None => panic!("owned streaming benchmark requires initial state"),
+    };
+    let mut step = match session.start(initial_state) {
         Ok(step) => step,
         Err(error) => panic!("starting owned streaming traversal failed: {error}"),
     };
     let mut bytes = step.bytes.len();
     while !step.done {
         step = match step.boundary.as_ref() {
-            Some(boundary) => {
-                match session.resume_current(boundary.instance_id, BoundaryMode::Final) {
-                    Ok(step) => step,
-                    Err(error) => panic!("resuming owned streaming traversal failed: {error}"),
+            Some(boundary) => match states.next() {
+                Some(state) => {
+                    match session.resume(boundary.instance_id, state, BoundaryMode::Final) {
+                        Ok(step) => step,
+                        Err(error) => {
+                            panic!("resuming owned streaming traversal failed: {error}")
+                        }
+                    }
                 }
-            }
+                None => {
+                    panic!("owned streaming benchmark requires state for every boundary")
+                }
+            },
             None => match session.advance() {
                 Ok(step) => step,
                 Err(error) => panic!("advancing owned streaming traversal failed: {error}"),
@@ -776,29 +761,21 @@ fn bench_large_state_boundaries(c: &mut Criterion) {
             black_box(writer.output.len());
         });
     });
-    compare.bench_function("streaming_split_owned_state", |b| {
-        let handler = hydration_handler();
-        let mut writer = BenchWriter::new(boundaries + 2);
-        b.iter_batched(
-            || state.clone(),
-            |owned_state| {
-                writer.reset();
-                render_split_owned_state(&handler, black_box(&protocol), owned_state, &mut writer);
-                black_box(writer.output.len());
-            },
-            BatchSize::SmallInput,
-        );
-    });
     let owned_handler = Arc::new(hydration_handler());
     let owned_protocol = Arc::new(full_state_protocol(boundaries));
     compare.bench_function("streaming_owned_split", |b| {
         b.iter_batched(
-            || state.clone(),
-            |owned_state| {
+            || {
+                let mut states = Vec::with_capacity(boundaries + 1);
+                states.push(state.clone());
+                states.resize_with(boundaries + 1, || Value::Object(serde_json::Map::new()));
+                states
+            },
+            |owned_states| {
                 black_box(render_owned_split(
                     Arc::clone(&owned_handler),
                     Arc::clone(&owned_protocol),
-                    owned_state,
+                    black_box(owned_states),
                 ));
             },
             BatchSize::SmallInput,

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -13646,7 +13646,7 @@ mod tests {
         assert!(boundary_flush.contains("<!--wb:0-->"));
         assert!(boundary_flush.contains("<!--/wb:0-->"));
         assert!(
-            boundary_flush.contains(r#"[3,0,0,0,{"declarationId":0,"componentStyles":"#),
+            boundary_flush.contains(r#"[0,0,0,{"declarationId":0,"componentStyles":"#),
             "boundary flush: {boundary_flush}"
         );
         assert!(boundary_flush.contains(r#""inventory":"01","state":{"count":1}"#));
@@ -13657,9 +13657,9 @@ mod tests {
         // another state/template projection.
         let terminal_flush = &writer.output[writer.flushes[1]..writer.flushes[2]];
         assert!(terminal_flush.contains("slow tail"));
-        assert!(writer.output.contains("[3,1,4,0,{}]"));
-        assert!(!writer.output.contains("[3,1,0,1,"));
-        assert!(!writer.output.contains("[3,2,4,0,{}]"));
+        assert!(writer.output.contains("[1,4,0,{}]"));
+        assert!(!writer.output.contains("[1,0,1,"));
+        assert!(!writer.output.contains("[2,4,0,{}]"));
 
         let marker = writer
             .output
@@ -13698,7 +13698,7 @@ mod tests {
             1,
             "full state belongs only to the interactive boundary"
         );
-        assert!(writer.output.contains("[3,1,4,0,{}]"));
+        assert!(writer.output.contains("[1,4,0,{}]"));
     }
 
     /// Streaming must place the reserved-state injects exactly where the
@@ -13834,7 +13834,7 @@ mod tests {
 
         assert_eq!(writer.flushes.len(), 1);
         assert!(writer.output.contains(STREAMING_MARKER));
-        assert!(writer.output.contains("[3,0,4,0,{}]"));
+        assert!(writer.output.contains("[0,4,0,{}]"));
         assert!(!writer.output.contains("serverOnly"));
         assert!(!writer.output.contains("id=\"webui-data\""));
         assert!(!writer.output.contains("<!--wb:"));
@@ -15033,7 +15033,7 @@ mod tests {
         assert!(b0.contains(r#""templates":{"comp-a":"#), "b0: {b0}");
         assert!(b0.contains(r#""a_count":1"#), "b0: {b0}");
         assert!(
-            b0.contains(r#"[3,0,0,0,{"declarationId":0,"componentStyles":"#),
+            b0.contains(r#"[0,0,0,{"declarationId":0,"componentStyles":"#),
             "b0: {b0}"
         );
         assert!(b0.contains(r#""inventory":"01""#), "b0: {b0}");
@@ -15044,7 +15044,7 @@ mod tests {
         assert!(b1.contains(r#""templates":{"comp-b":"#), "b1: {b1}");
         assert!(b1.contains(r#""b_count":2"#), "b1: {b1}");
         assert!(
-            b1.contains(r#"[3,1,0,1,{"declarationId":1,"componentStyles":"#),
+            b1.contains(r#"[1,0,1,{"declarationId":1,"componentStyles":"#),
             "b1: {b1}"
         );
         assert!(b1.contains(r#""inventory":"02""#), "b1: {b1}");
@@ -15057,7 +15057,7 @@ mod tests {
         // Boundary 2: comp-a reused — state present, template absent (empty delta).
         assert!(b2.contains(r#""a_count":1"#), "b2: {b2}");
         assert!(
-            b2.contains(r#"[3,2,0,2,{"declarationId":2,"componentStyles":"#),
+            b2.contains(r#"[2,0,2,{"declarationId":2,"componentStyles":"#),
             "b2: {b2}"
         );
         assert!(b2.contains(r#""inventory":"""#), "b2: {b2}");
@@ -15098,7 +15098,7 @@ mod tests {
                 payload_start + checkpoint[payload_start..].find("</script>").unwrap();
             let record: Value =
                 serde_json::from_str(&checkpoint[payload_start..payload_end]).unwrap();
-            record[4]["componentStyles"].clone()
+            record[3]["componentStyles"].clone()
         };
 
         let first = checkpoint_styles(segment(0));

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -260,6 +260,34 @@ pub trait ResponseWriter {
     }
 }
 
+/// Serialize every application state key except a sorted base projection.
+///
+/// Streaming uses this only when a prior keyed projection is a proven subset
+/// of the current full-state projection. The browser merges the emitted delta
+/// over that exact prior range state.
+struct StateWithoutSelectedKeys<'a> {
+    value: &'a Value,
+    keys: KeyView<'a>,
+}
+
+impl Serialize for StateWithoutSelectedKeys<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Value::Object(map) = self.value else {
+            return serializer.serialize_map(Some(0))?.end();
+        };
+        let mut out = serializer.serialize_map(None)?;
+        for (key, value) in map {
+            if key != STATE_INJECT_KEY && !self.keys.contains(key) {
+                out.serialize_entry(key, value)?;
+            }
+        }
+        out.end()
+    }
+}
+
 /// A response writer that can hand buffered bytes to its transport immediately.
 ///
 /// Progressive hydration requires this semantic flush at every committed
@@ -547,6 +575,7 @@ pub(crate) struct RenderFragmentList<'protocol> {
     fragments: &'protocol [WebUIFragment],
     metadata: &'protocol [RenderFragmentMetadata],
     attr_names: &'protocol str,
+    contains_boundary: bool,
     /// True when this list contains at least one `<webui-route>` fragment.
     /// Renders skip the sibling route pre-scan entirely when it is false.
     has_routes: bool,
@@ -765,6 +794,7 @@ impl<'protocol> ResolvedRenderFragmentIndex<'protocol> {
             fragments: &fragment_list.fragments,
             metadata,
             attr_names: &self.index.attr_names,
+            contains_boundary: fragment_list.contains_boundary,
             has_routes,
         })
     }
@@ -1143,11 +1173,22 @@ fn recycle_borrowed_scope<'protocol, 'state>(
     }
 }
 
+pub(crate) enum WebUiBootstrapState<'a> {
+    Complete {
+        value: &'a Value,
+        selection: StateSelection<'a>,
+    },
+    Reference {
+        record_sequence: usize,
+        value: &'a Value,
+        delta: Option<StateSelection<'a>>,
+    },
+}
+
 pub(crate) struct WebUiBootstrap<'a> {
     pub(crate) declaration_id: Option<u32>,
     pub(crate) enclosing_span_instance_id: Option<u32>,
-    pub(crate) state: &'a Value,
-    pub(crate) state_selection: StateSelection<'a>,
+    pub(crate) state: WebUiBootstrapState<'a>,
     pub(crate) chain: &'a [Value],
     pub(crate) inventory: &'a str,
     pub(crate) nonce: Option<&'a str>,
@@ -1431,6 +1472,16 @@ pub(crate) fn write_selected_state(
         StateSelection::Full => return write_full_state(writer, scratch, state),
         StateSelection::Keys(keys) => KeyView::Borrowed(keys.as_slice()),
         StateSelection::KeyIds(selection) => KeyView::Ids(*selection),
+        StateSelection::FullExceptKeyIds(selection) => {
+            return write_script_safe_json(
+                writer,
+                scratch,
+                &StateWithoutSelectedKeys {
+                    value: state,
+                    keys: KeyView::Ids(*selection),
+                },
+            );
+        }
     };
     if keys.is_empty() {
         return writer.write("{}");
@@ -1473,6 +1524,8 @@ pub(crate) enum StateSelection<'a> {
     /// all — the streaming record keeps its scratch as plain integers that
     /// survive every semantic step.
     KeyIds(HydrationKeySelection<'a>),
+    /// Preserve full state except keys inherited from a referenced range state.
+    FullExceptKeyIds(HydrationKeySelection<'a>),
 }
 
 /// A projection expressed as interned hydration key IDs.
@@ -1712,8 +1765,29 @@ pub(crate) fn write_webui_bootstrap(
     if let Some(nonce) = bootstrap.nonce {
         write_json_field(writer, scratch, &mut wrote_field, "nonce", nonce)?;
     }
-    write_json_field_name(writer, &mut wrote_field, "state")?;
-    write_selected_state(writer, scratch, bootstrap.state, &bootstrap.state_selection)?;
+    match bootstrap.state {
+        WebUiBootstrapState::Complete { value, selection } => {
+            write_json_field_name(writer, &mut wrote_field, "state")?;
+            write_selected_state(writer, scratch, value, &selection)?;
+        }
+        WebUiBootstrapState::Reference {
+            record_sequence,
+            value,
+            delta,
+        } => {
+            write_json_field(
+                writer,
+                scratch,
+                &mut wrote_field,
+                "stateRef",
+                &record_sequence,
+            )?;
+            if let Some(delta) = delta {
+                write_json_field_name(writer, &mut wrote_field, "stateDelta")?;
+                write_selected_state(writer, scratch, value, &delta)?;
+            }
+        }
+    }
     if !bootstrap.style_specs.is_empty() {
         write_json_field(
             writer,
@@ -3392,8 +3466,10 @@ impl WebUIHandler {
                     WebUiBootstrap {
                         declaration_id: None,
                         enclosing_span_instance_id: None,
-                        state: context.state,
-                        state_selection,
+                        state: WebUiBootstrapState::Complete {
+                            value: context.state,
+                            selection: state_selection,
+                        },
                         chain: &chain_json,
                         inventory: &inventory_hex,
                         nonce: context.nonce,
@@ -3621,20 +3697,20 @@ impl WebUIHandler {
             } else if attr.complex {
                 // Complex attribute — resolve value, don't render to HTML, store as state
                 if context.collecting_component_attrs && !attr.attr_skip {
-                    let state_backed_value = if context.streaming.is_none() {
-                        resolve_state_backed_value(
-                            &attr.value,
-                            &context.loop_vars,
-                            context.visible_loop_scope,
-                            LocalValueSources {
-                                owned: &context.local_vars,
-                                borrowed: &context.local_borrowed_vars,
-                            },
-                            context.state,
-                        )
-                    } else {
-                        None
-                    };
+                    // Streaming starts borrowed too. The continuation VM
+                    // materializes these values only when the target component
+                    // can actually suspend; boundary-free components finish in
+                    // this call and retain the ordinary zero-copy path.
+                    let state_backed_value = resolve_state_backed_value(
+                        &attr.value,
+                        &context.loop_vars,
+                        context.visible_loop_scope,
+                        LocalValueSources {
+                            owned: &context.local_vars,
+                            borrowed: &context.local_borrowed_vars,
+                        },
+                        context.state,
+                    );
                     if let Some(value) = state_backed_value {
                         let name = component_name.ok_or_else(missing_component_attr_name_error)?;
                         context.component_attrs.remove(name);
@@ -3647,13 +3723,9 @@ impl WebUIHandler {
                 }
             } else {
                 // Dynamic attribute — resolve and render
-                // Streaming continuations must own component locals across host
-                // calls, so borrowing there would add a second lookup before the
-                // VM materializes the same value.
-                let state_backed_value = if context.collecting_component_attrs
-                    && !attr.attr_skip
-                    && context.streaming.is_none()
-                {
+                // As above, a boundary-bearing continuation materializes a
+                // borrowed component scope before it can escape this call.
+                let state_backed_value = if context.collecting_component_attrs && !attr.attr_skip {
                     resolve_state_backed_value(
                         &attr.value,
                         &context.loop_vars,
@@ -12063,7 +12135,9 @@ mod tests {
 
         match collect_navigation_state(&protocol, ["app-shell"]) {
             StateSelection::Keys(keys) => assert_eq!(keys, vec!["selected"]),
-            StateSelection::Full | StateSelection::KeyIds(_) => {
+            StateSelection::Full
+            | StateSelection::KeyIds(_)
+            | StateSelection::FullExceptKeyIds(_) => {
                 panic!("legacy navigation keys should remain owned and projected")
             }
         }
@@ -13572,7 +13646,7 @@ mod tests {
         assert!(boundary_flush.contains("<!--wb:0-->"));
         assert!(boundary_flush.contains("<!--/wb:0-->"));
         assert!(
-            boundary_flush.contains(r#"[2,0,0,0,{"declarationId":0,"componentStyles":"#),
+            boundary_flush.contains(r#"[3,0,0,0,{"declarationId":0,"componentStyles":"#),
             "boundary flush: {boundary_flush}"
         );
         assert!(boundary_flush.contains(r#""inventory":"01","state":{"count":1}"#));
@@ -13583,9 +13657,9 @@ mod tests {
         // another state/template projection.
         let terminal_flush = &writer.output[writer.flushes[1]..writer.flushes[2]];
         assert!(terminal_flush.contains("slow tail"));
-        assert!(writer.output.contains("[2,1,4,0,{}]"));
-        assert!(!writer.output.contains("[2,1,0,1,"));
-        assert!(!writer.output.contains("[2,2,4,0,{}]"));
+        assert!(writer.output.contains("[3,1,4,0,{}]"));
+        assert!(!writer.output.contains("[3,1,0,1,"));
+        assert!(!writer.output.contains("[3,2,4,0,{}]"));
 
         let marker = writer
             .output
@@ -13624,7 +13698,7 @@ mod tests {
             1,
             "full state belongs only to the interactive boundary"
         );
-        assert!(writer.output.contains("[2,1,4,0,{}]"));
+        assert!(writer.output.contains("[3,1,4,0,{}]"));
     }
 
     /// Streaming must place the reserved-state injects exactly where the
@@ -13760,7 +13834,7 @@ mod tests {
 
         assert_eq!(writer.flushes.len(), 1);
         assert!(writer.output.contains(STREAMING_MARKER));
-        assert!(writer.output.contains("[2,0,4,0,{}]"));
+        assert!(writer.output.contains("[3,0,4,0,{}]"));
         assert!(!writer.output.contains("serverOnly"));
         assert!(!writer.output.contains("id=\"webui-data\""));
         assert!(!writer.output.contains("<!--wb:"));
@@ -14959,7 +15033,7 @@ mod tests {
         assert!(b0.contains(r#""templates":{"comp-a":"#), "b0: {b0}");
         assert!(b0.contains(r#""a_count":1"#), "b0: {b0}");
         assert!(
-            b0.contains(r#"[2,0,0,0,{"declarationId":0,"componentStyles":"#),
+            b0.contains(r#"[3,0,0,0,{"declarationId":0,"componentStyles":"#),
             "b0: {b0}"
         );
         assert!(b0.contains(r#""inventory":"01""#), "b0: {b0}");
@@ -14970,7 +15044,7 @@ mod tests {
         assert!(b1.contains(r#""templates":{"comp-b":"#), "b1: {b1}");
         assert!(b1.contains(r#""b_count":2"#), "b1: {b1}");
         assert!(
-            b1.contains(r#"[2,1,0,1,{"declarationId":1,"componentStyles":"#),
+            b1.contains(r#"[3,1,0,1,{"declarationId":1,"componentStyles":"#),
             "b1: {b1}"
         );
         assert!(b1.contains(r#""inventory":"02""#), "b1: {b1}");
@@ -14983,7 +15057,7 @@ mod tests {
         // Boundary 2: comp-a reused — state present, template absent (empty delta).
         assert!(b2.contains(r#""a_count":1"#), "b2: {b2}");
         assert!(
-            b2.contains(r#"[2,2,0,2,{"declarationId":2,"componentStyles":"#),
+            b2.contains(r#"[3,2,0,2,{"declarationId":2,"componentStyles":"#),
             "b2: {b2}"
         );
         assert!(b2.contains(r#""inventory":"""#), "b2: {b2}");

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -1185,7 +1185,7 @@ pub(crate) enum WebUiBootstrapState<'a> {
     },
 }
 
-pub(crate) struct WebUiBootstrap<'a> {
+pub(crate) struct WebUiBootstrap<'a, ComponentStyles: Serialize + ?Sized = Value> {
     pub(crate) declaration_id: Option<u32>,
     pub(crate) enclosing_span_instance_id: Option<u32>,
     pub(crate) state: WebUiBootstrapState<'a>,
@@ -1194,7 +1194,7 @@ pub(crate) struct WebUiBootstrap<'a> {
     pub(crate) nonce: Option<&'a str>,
     pub(crate) css_hrefs: &'a [&'a str],
     pub(crate) style_specs: &'a [&'a str],
-    pub(crate) component_styles: &'a Value,
+    pub(crate) component_styles: &'a ComponentStyles,
     pub(crate) templates: &'a [WebUiTemplatePayload<'a>],
 }
 
@@ -1708,10 +1708,10 @@ fn collect_component_state_into<'a, 'b>(
     false
 }
 
-pub(crate) fn write_webui_bootstrap(
+pub(crate) fn write_webui_bootstrap<ComponentStyles: Serialize + ?Sized>(
     writer: &mut dyn ResponseWriter,
     scratch: &mut Vec<u8>,
-    bootstrap: WebUiBootstrap<'_>,
+    bootstrap: WebUiBootstrap<'_, ComponentStyles>,
 ) -> Result<()> {
     let mut wrote_field = false;
 

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -53,7 +53,7 @@ use streaming::{
 };
 pub use streaming::{
     BoundaryDescriptor, BoundaryInstanceId, BoundaryKey, BoundaryMode, BufferSink, SessionOptions,
-    SpanInstanceId, StreamStatus, StreamStep, StreamingResponse, StreamingSession,
+    SpanInstanceId, StreamStatus, StreamStep, StreamingResponse, StreamingSession, StreamingState,
     MAX_BOUNDARY_OCCURRENCES, MAX_CONTINUATION_DEPTH, MAX_KEYED_INSTANCES, MAX_SPAN_NESTING,
 };
 use thiserror::Error;

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1419,7 +1419,9 @@ fn select_raw_state<'de>(
         // Key-ID projections are produced only by the streaming continuation,
         // which serializes through `write_selected_state` and never reaches
         // partial navigation's raw-JSON projection.
-        StateSelection::KeyIds(_) => return Err(unexpected_key_id_selection()),
+        StateSelection::KeyIds(_) | StateSelection::FullExceptKeyIds(_) => {
+            return Err(unexpected_key_id_selection());
+        }
     };
     project_raw_state(state_json, state_keys).map(SelectedRawState::Keys)
 }
@@ -2627,7 +2629,9 @@ fn select_owned_state(state: Value, selection: &StateSelection<'_>) -> Value {
         StateSelection::Full => return state,
         StateSelection::Keys(keys) => keys.as_slice(),
         // Streaming's key-ID projection never reaches partial navigation.
-        StateSelection::KeyIds(_) => return Value::Object(Map::new()),
+        StateSelection::KeyIds(_) | StateSelection::FullExceptKeyIds(_) => {
+            return Value::Object(Map::new());
+        }
     };
     let Value::Object(mut source) = state else {
         return Value::Object(Map::new());

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -494,6 +494,7 @@ impl StyleInventoryView<'_> {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn collect_component_style_delta<'a>(
     protocol: &WebUIProtocol,
     roots: impl IntoIterator<Item = &'a str>,
@@ -509,6 +510,262 @@ pub(crate) fn collect_component_style_delta<'a>(
             chunks_are_indexed: true,
         }),
     )
+}
+
+pub(crate) struct BorrowedComponentStyleDelta<'a> {
+    strategy: webui_protocol::CssStrategy,
+    resources: Vec<BorrowedStyleResource<'a>>,
+    closures: Vec<BorrowedStyleClosure<'a>>,
+    ordered: Vec<&'a str>,
+}
+
+struct BorrowedStyleResource<'a> {
+    name: &'a str,
+    resource: &'a str,
+    members: Option<&'a [String]>,
+}
+
+struct BorrowedStyleClosure<'a> {
+    root: &'a str,
+    start: usize,
+    end: usize,
+}
+
+impl BorrowedComponentStyleDelta<'_> {
+    pub(crate) fn resource_names(&self) -> impl Iterator<Item = &str> {
+        self.resources.iter().map(|resource| resource.name)
+    }
+}
+
+impl Serialize for BorrowedComponentStyleDelta<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut payload = serializer.serialize_map(Some(4))?;
+        payload.serialize_entry(
+            "closures",
+            &BorrowedStyleClosures {
+                closures: &self.closures,
+                ordered: &self.ordered,
+            },
+        )?;
+        payload.serialize_entry(
+            "resources",
+            &BorrowedStyleResources {
+                strategy: self.strategy,
+                resources: &self.resources,
+            },
+        )?;
+        payload.serialize_entry("strategy", self.strategy.wire_name())?;
+        payload.serialize_entry("version", &1)?;
+        payload.end()
+    }
+}
+
+struct BorrowedStyleResources<'a> {
+    strategy: webui_protocol::CssStrategy,
+    resources: &'a [BorrowedStyleResource<'a>],
+}
+
+impl Serialize for BorrowedStyleResources<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut resources = serializer.serialize_map(Some(self.resources.len()))?;
+        for resource in self.resources {
+            resources.serialize_entry(
+                resource.name,
+                &BorrowedStyleResourceValue {
+                    strategy: self.strategy,
+                    resource,
+                },
+            )?;
+        }
+        resources.end()
+    }
+}
+
+struct BorrowedStyleResourceValue<'a> {
+    strategy: webui_protocol::CssStrategy,
+    resource: &'a BorrowedStyleResource<'a>,
+}
+
+impl Serialize for BorrowedStyleResourceValue<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let field_count = match (self.strategy, self.resource.members.is_some()) {
+            (webui_protocol::CssStrategy::Module, true) => 4,
+            (webui_protocol::CssStrategy::Module, false) | (_, true) => 3,
+            (_, false) => 2,
+        };
+        let mut resource = serializer.serialize_map(Some(field_count))?;
+        match self.strategy {
+            webui_protocol::CssStrategy::Link => {
+                resource.serialize_entry("href", self.resource.resource)?;
+                resource.serialize_entry("kind", "link")?;
+                if let Some(members) = self.resource.members {
+                    resource.serialize_entry("members", members)?;
+                }
+            }
+            webui_protocol::CssStrategy::Style => {
+                resource.serialize_entry("css", self.resource.resource)?;
+                resource.serialize_entry("kind", "style")?;
+                if let Some(members) = self.resource.members {
+                    resource.serialize_entry("members", members)?;
+                }
+            }
+            webui_protocol::CssStrategy::Module => {
+                resource.serialize_entry("css", self.resource.resource)?;
+                resource.serialize_entry("kind", "module")?;
+                if let Some(members) = self.resource.members {
+                    resource.serialize_entry("members", members)?;
+                }
+                resource.serialize_entry("specifier", self.resource.name)?;
+            }
+        }
+        resource.end()
+    }
+}
+
+struct BorrowedStyleClosures<'a> {
+    closures: &'a [BorrowedStyleClosure<'a>],
+    ordered: &'a [&'a str],
+}
+
+impl Serialize for BorrowedStyleClosures<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut closures = serializer.serialize_map(Some(self.closures.len()))?;
+        for closure in self.closures {
+            closures.serialize_entry(closure.root, &self.ordered[closure.start..closure.end])?;
+        }
+        closures.end()
+    }
+}
+
+pub(crate) fn collect_borrowed_component_style_delta<'a>(
+    protocol: &'a WebUIProtocol,
+    roots: impl IntoIterator<Item = &'a str>,
+    style_inventory: &[u8],
+    style_resource_index: &HashMap<String, u32>,
+    chunk_index: &HashMap<&str, u32>,
+) -> Result<BorrowedComponentStyleDelta<'a>, HandlerError> {
+    if protocol.style_closures.is_empty() {
+        if protocol
+            .components
+            .keys()
+            .any(|tag| protocol.component_style_resource(tag).is_some())
+        {
+            return Err(HandlerError::Invariant(
+                "component style closure metadata is required by this protocol".to_string(),
+            ));
+        }
+        return Ok(BorrowedComponentStyleDelta {
+            strategy: protocol.css_strategy(),
+            resources: Vec::new(),
+            closures: Vec::new(),
+            ordered: Vec::new(),
+        });
+    }
+
+    let mut seen_roots = HashSet::new();
+    let roots: Vec<&str> = roots
+        .into_iter()
+        .filter(|root| seen_roots.insert(*root))
+        .collect();
+    let client_inventory = StyleInventoryView {
+        bits: style_inventory,
+        index: style_resource_index,
+        chunks_are_indexed: true,
+    };
+    let covered_components = covered_components(protocol, &roots, Some(client_inventory));
+    let unit_capacity = roots
+        .iter()
+        .filter_map(|root| protocol.style_closures.get(*root))
+        .map(WebUIProtocol::style_closure_unit_count)
+        .sum();
+    let mut resources = Vec::with_capacity(unit_capacity);
+    let mut closures = Vec::with_capacity(roots.len());
+    let mut ordered = Vec::with_capacity(unit_capacity);
+    let mut emitted = HashSet::with_capacity(unit_capacity);
+    let mut serialized_resources = HashSet::with_capacity(unit_capacity);
+
+    for root in roots {
+        let Some(closure) = protocol.style_closures.get(root) else {
+            if !protocol.fragments.contains_key(root) && !protocol.components.contains_key(root) {
+                continue;
+            }
+            return Err(HandlerError::Invariant(format!(
+                "component style closure metadata is missing root `{root}`"
+            )));
+        };
+        if closure.style_chunks.is_empty()
+            && !closure.component_tags.is_empty()
+            && closure
+                .component_tags
+                .iter()
+                .all(|tag| covered_components.contains(tag.as_str()))
+        {
+            continue;
+        }
+
+        let start = ordered.len();
+        emitted.clear();
+        let unit_count = WebUIProtocol::style_closure_unit_count(closure);
+        for position in 0..unit_count {
+            let Some(unit) = protocol.style_closure_unit(closure, chunk_index, position) else {
+                continue;
+            };
+            let name = unit.name;
+            let resource = unit.resource.ok_or_else(|| match unit.chunk {
+                Some(index) => HandlerError::Invariant(format!(
+                    "component style closure `{root}` references missing style chunk {index}"
+                )),
+                None => HandlerError::Invariant(format!(
+                    "component style closure `{root}` references missing resource `{name}`"
+                )),
+            })?;
+            if !emitted.insert(name) {
+                continue;
+            }
+
+            let (client_has_it, members) = match unit.chunk {
+                Some(index) => (
+                    client_inventory.contains_chunk(name),
+                    protocol.style_chunk_members(index),
+                ),
+                None => (client_inventory.contains_component(name), None),
+            };
+            if !client_has_it && serialized_resources.insert(name) {
+                resources.push(BorrowedStyleResource {
+                    name,
+                    resource,
+                    members: members.filter(|members| members.len() > 1),
+                });
+            }
+            ordered.push(name);
+        }
+        closures.push(BorrowedStyleClosure {
+            root,
+            start,
+            end: ordered.len(),
+        });
+    }
+
+    resources.sort_unstable_by_key(|resource| resource.name);
+    closures.sort_unstable_by_key(|closure| closure.root);
+    Ok(BorrowedComponentStyleDelta {
+        strategy: protocol.css_strategy(),
+        resources,
+        closures,
+        ordered,
+    })
 }
 
 fn collect_component_styles_for_inventory<'a>(
@@ -4909,6 +5166,75 @@ mod tests {
             serde_json::json!({}),
             "the exact style-resource inventory should suppress a registered chunk"
         );
+        let chunk_index = protocol.style_chunk_index();
+        let borrowed = collect_borrowed_component_style_delta(
+            &protocol,
+            ["index.html"],
+            &style_inventory,
+            &style_index,
+            &chunk_index,
+        )
+        .unwrap();
+        assert_eq!(
+            serde_json::to_string(&borrowed).unwrap(),
+            serde_json::to_string(&from_style_inventory).unwrap(),
+            "the borrowed streaming serializer must preserve the canonical style payload bytes"
+        );
+    }
+
+    #[test]
+    fn borrowed_streaming_style_payload_matches_owned_for_every_strategy() {
+        for strategy in [
+            webui_protocol::CssStrategy::Link,
+            webui_protocol::CssStrategy::Style,
+            webui_protocol::CssStrategy::Module,
+        ] {
+            let mut protocol = WebUIProtocol::default();
+            protocol.set_css_strategy(strategy);
+            protocol
+                .fragments
+                .insert("index.html".to_string(), FragmentList::default());
+            protocol.components.insert(
+                "a-card".to_string(),
+                webui_protocol::ComponentData {
+                    css: ".a-card{display:block}".to_string(),
+                    css_href: "/a-card.css".to_string(),
+                    ..Default::default()
+                },
+            );
+            protocol.style_closures.insert(
+                "index.html".to_string(),
+                webui_protocol::ComponentStyleClosure {
+                    component_tags: vec!["a-card".to_string()],
+                    style_chunks: Vec::new(),
+                },
+            );
+
+            let style_index = build_component_index(&protocol);
+            let style_inventory = vec![0u8; style_index.len().div_ceil(8)];
+            let owned = collect_component_style_delta(
+                &protocol,
+                ["index.html"],
+                &style_inventory,
+                &style_index,
+            )
+            .unwrap();
+            let chunk_index = protocol.style_chunk_index();
+            let borrowed = collect_borrowed_component_style_delta(
+                &protocol,
+                ["index.html"],
+                &style_inventory,
+                &style_index,
+                &chunk_index,
+            )
+            .unwrap();
+
+            assert_eq!(
+                serde_json::to_string(&borrowed).unwrap(),
+                serde_json::to_string(&owned).unwrap(),
+                "borrowed payload differs for {strategy:?}"
+            );
+        }
     }
 
     /// A closure that lists members must still deliver the chunk that ships

--- a/crates/webui-handler/src/streaming/checkpoint.rs
+++ b/crates/webui-handler/src/streaming/checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Version-3 checkpoint, update, span-completion, and terminal serialization.
+//! Checkpoint, update, span-completion, and terminal serialization.
 
 use super::error::component_style_payload_resources_missing_error;
 use super::inventory::{
@@ -23,7 +23,6 @@ pub(super) const RECORD_KIND_UPDATABLE_CHECKPOINT: usize = 1;
 pub(super) const RECORD_KIND_STATE_UPDATE: usize = 2;
 pub(super) const RECORD_KIND_SPAN_COMPLETION: usize = 3;
 pub(super) const RECORD_KIND_TERMINAL: usize = 4;
-const STREAMING_PROTOCOL_VERSION: usize = 3;
 
 /// The range-bearing record currently being committed.
 pub(super) enum RangeRecord {
@@ -558,7 +557,7 @@ fn write_record_open(
     write_record_header(context.writer, record_sequence, kind, target)
 }
 
-/// Emit `>[<version>,<sequence>,<kind>,<target>,` in one writer call.
+/// Emit `>[<sequence>,<kind>,<target>,` in one writer call.
 fn write_record_header(
     writer: &mut dyn crate::ResponseWriter,
     record_sequence: usize,
@@ -567,8 +566,6 @@ fn write_record_header(
 ) -> Result<()> {
     let mut buffer = MarkerBuffer::new();
     buffer.push_str(">[")?;
-    buffer.push_usize(STREAMING_PROTOCOL_VERSION)?;
-    buffer.push_str(",")?;
     buffer.push_usize(record_sequence)?;
     buffer.push_str(",")?;
     buffer.push_usize(kind)?;

--- a/crates/webui-handler/src/streaming/checkpoint.rs
+++ b/crates/webui-handler/src/streaming/checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//! Version-2 checkpoint, update, span-completion, and terminal serialization.
+//! Version-3 checkpoint, update, span-completion, and terminal serialization.
 
 use super::error::component_style_payload_resources_missing_error;
 use super::inventory::{
@@ -15,7 +15,7 @@ use crate::plugin::WebUiTemplatePayload;
 use crate::{
     collect_hydration_key_ids_into, write_selected_state, write_webui_bootstrap, HandlerError,
     HydrationKeySelection, Result, StateSelection, WebUIHandler, WebUIProcessContext,
-    WebUiBootstrap,
+    WebUiBootstrap, WebUiBootstrapState,
 };
 
 pub(super) const RECORD_KIND_FINAL_CHECKPOINT: usize = 0;
@@ -23,7 +23,7 @@ pub(super) const RECORD_KIND_UPDATABLE_CHECKPOINT: usize = 1;
 pub(super) const RECORD_KIND_STATE_UPDATE: usize = 2;
 pub(super) const RECORD_KIND_SPAN_COMPLETION: usize = 3;
 pub(super) const RECORD_KIND_TERMINAL: usize = 4;
-const STREAMING_PROTOCOL_VERSION: usize = 2;
+const STREAMING_PROTOCOL_VERSION: usize = 3;
 
 /// The range-bearing record currently being committed.
 pub(super) enum RangeRecord {
@@ -55,6 +55,45 @@ impl RangeRecord {
             } => RECORD_KIND_FINAL_CHECKPOINT,
             Self::Span { .. } => RECORD_KIND_SPAN_COMPLETION,
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StateDelta {
+    Empty,
+    Keys,
+    FullExceptLast,
+}
+
+/// Build `current - base` while proving that the sorted base is a subset.
+fn collect_state_key_delta(base: &[u32], current: &[u32], delta: &mut Vec<u32>) -> bool {
+    let mut base_index = 0usize;
+    let mut current_index = 0usize;
+    while current_index < current.len() {
+        if base_index == base.len() {
+            delta.extend_from_slice(&current[current_index..]);
+            return true;
+        }
+        match current[current_index].cmp(&base[base_index]) {
+            std::cmp::Ordering::Less => {
+                delta.push(current[current_index]);
+                current_index += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                current_index += 1;
+                base_index += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                delta.clear();
+                return false;
+            }
+        }
+    }
+    if base_index == base.len() {
+        true
+    } else {
+        delta.clear();
+        false
     }
 }
 
@@ -156,6 +195,66 @@ impl WebUIHandler {
             checkpoint_tags.iter().copied(),
             &mut state_key_ids,
         );
+        let (
+            record_sequence,
+            state_revision,
+            last_state_record_sequence,
+            last_state_revision,
+            last_state_full,
+            mut last_state_key_ids,
+            mut state_delta_key_ids,
+        ) = {
+            let streaming = streaming_state(context)?;
+            (
+                streaming.next_record_sequence,
+                streaming.state_revision,
+                streaming.last_state_record_sequence,
+                streaming.last_state_revision,
+                streaming.last_state_full,
+                std::mem::take(&mut streaming.last_state_key_ids),
+                std::mem::take(&mut streaming.state_delta_key_ids),
+            )
+        };
+        state_delta_key_ids.clear();
+        let can_reference = context
+            .state
+            .as_object()
+            .is_some_and(|state| !state.is_empty())
+            && last_state_record_sequence.is_some()
+            && last_state_revision == state_revision;
+        let can_reference = can_reference && (last_state_full || !last_state_key_ids.is_empty());
+        let state_ref = last_state_record_sequence.and_then(|sequence| {
+            if !can_reference {
+                return None;
+            }
+            if requires_full_state {
+                return Some((
+                    sequence,
+                    if last_state_full {
+                        StateDelta::Empty
+                    } else {
+                        StateDelta::FullExceptLast
+                    },
+                ));
+            }
+            if last_state_full
+                || !collect_state_key_delta(
+                    &last_state_key_ids,
+                    &state_key_ids,
+                    &mut state_delta_key_ids,
+                )
+            {
+                return None;
+            }
+            Some((
+                sequence,
+                if state_delta_key_ids.is_empty() {
+                    StateDelta::Empty
+                } else {
+                    StateDelta::Keys
+                },
+            ))
+        });
         let chain = if first_checkpoint {
             crate::WebUIHandler::ensure_request_route_chain(context);
             match context.route_chain.as_deref() {
@@ -242,26 +341,50 @@ impl WebUIHandler {
             } => (Some(declaration_id), enclosing_span_instance_id),
             RangeRecord::Span { .. } => (None, None),
         };
-        let state_selection = if requires_full_state {
-            StateSelection::Full
-        } else {
-            StateSelection::KeyIds(HydrationKeySelection {
-                ids: &state_key_ids,
-                index: checkpoint_reachability,
-            })
-        };
         let inventory = context
             .streaming
             .as_ref()
             .map_or("", |streaming| streaming.inventory_hex.as_str());
+        let bootstrap_state = match state_ref {
+            Some((record_sequence, delta)) => {
+                let delta = match delta {
+                    StateDelta::Empty => None,
+                    StateDelta::Keys => Some(StateSelection::KeyIds(HydrationKeySelection {
+                        ids: &state_delta_key_ids,
+                        index: checkpoint_reachability,
+                    })),
+                    StateDelta::FullExceptLast => {
+                        Some(StateSelection::FullExceptKeyIds(HydrationKeySelection {
+                            ids: &last_state_key_ids,
+                            index: checkpoint_reachability,
+                        }))
+                    }
+                };
+                WebUiBootstrapState::Reference {
+                    record_sequence,
+                    value: context.state,
+                    delta,
+                }
+            }
+            _ => WebUiBootstrapState::Complete {
+                value: context.state,
+                selection: if requires_full_state {
+                    StateSelection::Full
+                } else {
+                    StateSelection::KeyIds(HydrationKeySelection {
+                        ids: &state_key_ids,
+                        index: checkpoint_reachability,
+                    })
+                },
+            },
+        };
         write_webui_bootstrap(
             context.writer,
             &mut context.json_scratch,
             WebUiBootstrap {
                 declaration_id,
                 enclosing_span_instance_id,
-                state: context.state,
-                state_selection,
+                state: bootstrap_state,
                 chain: &chain,
                 inventory,
                 nonce: context.nonce,
@@ -304,6 +427,7 @@ impl WebUIHandler {
             if streaming.update_plans.len() <= target {
                 streaming.update_plans.resize_with(target + 1, || None);
             }
+
             // Reuse the slot's existing key buffer so a boundary that commits
             // updatable more than once in a response does not re-allocate.
             let mut plan = streaming.update_plans[target]
@@ -318,6 +442,21 @@ impl WebUIHandler {
                 plan.key_ids.extend_from_slice(&state_key_ids);
             }
             streaming.update_plans[target] = Some(plan);
+        }
+        if requires_full_state {
+            last_state_key_ids.clear();
+        } else {
+            last_state_key_ids.clear();
+            last_state_key_ids.extend_from_slice(&state_key_ids);
+        }
+        state_delta_key_ids.clear();
+        {
+            let streaming = streaming_state(context)?;
+            streaming.last_state_record_sequence = Some(record_sequence);
+            streaming.last_state_revision = state_revision;
+            streaming.last_state_full = requires_full_state;
+            streaming.last_state_key_ids = last_state_key_ids;
+            streaming.state_delta_key_ids = state_delta_key_ids;
         }
         finish_capture(
             context,

--- a/crates/webui-handler/src/streaming/checkpoint.rs
+++ b/crates/webui-handler/src/streaming/checkpoint.rs
@@ -3,7 +3,6 @@
 
 //! Checkpoint, update, span-completion, and terminal serialization.
 
-use super::error::component_style_payload_resources_missing_error;
 use super::inventory::{
     commit_checkpoint_inventory, expand_static_checkpoint_reachability,
     mark_streaming_style_resource_sent, mark_streaming_template_sent,
@@ -177,7 +176,6 @@ impl WebUIHandler {
                 }
             }
         }
-
         let template_payloads = context.plugin.as_ref().and_then(|plugin| {
             plugin.collect_template_payloads_slice(context.protocol, &new_template_tags)
         });
@@ -314,18 +312,15 @@ impl WebUIHandler {
             let style_inventory = context.streaming.as_ref().map_or(&[][..], |streaming| {
                 streaming.style_resource_inventory.as_slice()
             });
-            crate::route_handler::collect_component_style_delta(
+            crate::route_handler::collect_borrowed_component_style_delta(
                 context.protocol,
                 style_roots,
                 style_inventory,
                 context.style_resource_index,
+                &context.style_chunk_index,
             )?
         };
-        let resources = component_styles
-            .get("resources")
-            .and_then(serde_json::Value::as_object)
-            .ok_or_else(component_style_payload_resources_missing_error)?;
-        for resource in resources.keys() {
+        for resource in component_styles.resource_names() {
             let Some(&index) = context.style_resource_index.get(resource) else {
                 continue;
             };
@@ -415,7 +410,6 @@ impl WebUIHandler {
         }
         context.writer.write("<webui-hydrate></webui-hydrate>")?;
         flush_streaming_transport(context)?;
-
         let target = usize::try_from(record.target())
             .map_err(|_| invalid_record_target_error(record.target()))?;
         if let RangeRecord::Boundary {

--- a/crates/webui-handler/src/streaming/error.rs
+++ b/crates/webui-handler/src/streaming/error.rs
@@ -16,12 +16,6 @@ pub(crate) fn streaming_boundary_error(signal: &str, reason: &str) -> HandlerErr
 
 #[cold]
 #[inline(never)]
-pub(super) fn component_style_payload_resources_missing_error() -> HandlerError {
-    HandlerError::Invariant("component style payload resources are missing".to_string())
-}
-
-#[cold]
-#[inline(never)]
 pub(super) fn component_style_inventory_error(reason: &'static str) -> HandlerError {
     HandlerError::Invariant(reason.to_string())
 }

--- a/crates/webui-handler/src/streaming/mod.rs
+++ b/crates/webui-handler/src/streaming/mod.rs
@@ -355,16 +355,12 @@ impl WebUIHandler {
 
     /// Render every runtime boundary in document order as final.
     ///
-    /// Drives the same `start → resume → advance → …` cycle the public step
-    /// machine exposes, against one frozen snapshot: the value is snapshotted
-    /// when the response starts and every occurrence commits against that
-    /// snapshot, so a large state is projected once per response rather than
-    /// re-merged once per boundary. Having no host to hand bytes to between a
-    /// commit and the parent bytes that follow it, the helper fuses those two
-    /// goals into one continuation setup per boundary; the emitted bytes and
-    /// flush positions are identical to driving the steps separately. Hosts
-    /// that need asynchronous work — or genuinely new state — between
-    /// occurrences should use [`Self::stream_response`] or [`StreamingSession`].
+    /// Uses one prepared render context and borrows the caller's state for the
+    /// complete traversal. Every compiler-selected flush still reaches the
+    /// transport, but the synchronous convenience path does not clone the state
+    /// or rebuild the continuation context at each boundary. Hosts that need
+    /// asynchronous work between occurrences should use
+    /// [`Self::stream_response`] or [`StreamingSession`].
     pub fn render_streaming<'a, W: FlushWriter + ?Sized>(
         &self,
         protocol: &'a Protocol,
@@ -372,17 +368,7 @@ impl WebUIHandler {
         options: &RenderOptions<'a>,
         writer: &'a mut W,
     ) -> Result<()> {
-        let mut response = self.stream_response(protocol, options, writer)?;
-        let mut status = response.start(state)?;
-        while !status.done {
-            let Some(boundary) = status.boundary.as_ref() else {
-                return Err(HandlerError::Invariant(
-                    "unfinished streaming step has no pending boundary".to_string(),
-                ));
-            };
-            status =
-                response.resume_current_and_advance(boundary.instance_id, BoundaryMode::Final)?;
-        }
-        Ok(())
+        self.stream_response(protocol, options, writer)?
+            .render_all(state)
     }
 }

--- a/crates/webui-handler/src/streaming/mod.rs
+++ b/crates/webui-handler/src/streaming/mod.rs
@@ -30,8 +30,8 @@ pub(crate) use root::{
 };
 pub use session::{
     BoundaryDescriptor, BoundaryInstanceId, BoundaryKey, BoundaryMode, SpanInstanceId,
-    StreamStatus, StreamingResponse, MAX_BOUNDARY_OCCURRENCES, MAX_CONTINUATION_DEPTH,
-    MAX_KEYED_INSTANCES, MAX_SPAN_NESTING,
+    StreamStatus, StreamingResponse, StreamingState, MAX_BOUNDARY_OCCURRENCES,
+    MAX_CONTINUATION_DEPTH, MAX_KEYED_INSTANCES, MAX_SPAN_NESTING,
 };
 pub(crate) use state::StreamingRenderState;
 pub(crate) use vm::PreparedContinuationStatePlan;

--- a/crates/webui-handler/src/streaming/owned.rs
+++ b/crates/webui-handler/src/streaming/owned.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 
 use super::session::{
     BoundaryDescriptor, BoundaryInstanceId, BoundaryMode, SessionCall, SessionCore, StreamStatus,
+    StreamingState,
 };
 use super::StreamingSink;
 use crate::route_handler::Protocol;
@@ -137,18 +138,19 @@ impl StreamingSession {
     }
 
     /// Render until the first runtime boundary occurrence or terminal.
-    pub fn start(&mut self, state: &Value) -> Result<StreamStep> {
-        self.step(|core, call| core.start(call, state))
-    }
-
-    /// Render to the first occurrence by moving caller-owned state into the
-    /// continuation snapshot.
     ///
-    /// Async hosts that freshly decode or load state should prefer this method:
-    /// a full-state continuation takes ownership of the value without cloning
-    /// it, while a keyed continuation moves only its selected top-level values.
-    pub fn start_owned(&mut self, state: Value) -> Result<StreamStep> {
-        self.step(move |core, call| core.start_owned(call, state))
+    /// Pass an owned [`Value`] to move it into the continuation, or a reference
+    /// to retain caller ownership and clone only the required projection.
+    pub fn start<'state>(
+        &mut self,
+        state: impl Into<StreamingState<'state>>,
+    ) -> Result<StreamStep> {
+        match state.into() {
+            StreamingState::Borrowed(state) => self.step(|core, call| core.start(call, state)),
+            StreamingState::Owned(state) => {
+                self.step(move |core, call| core.start_owned(call, state))
+            }
+        }
     }
 
     /// Commit the pending occurrence through its checkpoint, then stop.
@@ -160,29 +162,23 @@ impl StreamingSession {
     /// as many updatable occurrences as the browser retains. The refusal
     /// produces no bytes and leaves the occurrence pending, so it can be
     /// committed with [`BoundaryMode::Final`] instead.
-    pub fn resume(
+    /// Pass an owned [`Value`] to move changed subtrees, or a reference to retain
+    /// caller ownership. Equal values preserve the prior state-reference base.
+    /// Use [`Self::resume_current`] when no state changed.
+    pub fn resume<'state>(
         &mut self,
         instance_id: BoundaryInstanceId,
-        state: &Value,
+        state: impl Into<StreamingState<'state>>,
         mode: BoundaryMode,
     ) -> Result<StreamStep> {
-        self.step(|core, call| core.resume(call, instance_id, state, mode))
-    }
-
-    /// Commit the pending occurrence by moving caller-owned state into the
-    /// retained continuation snapshot, then stop at its checkpoint flush.
-    ///
-    /// This is the preferred async-host path when the state was freshly decoded
-    /// or loaded for this occurrence. Moving changed top-level values avoids
-    /// cloning or deeply comparing their subtrees while preserving the same
-    /// patch semantics as [`Self::resume`].
-    pub fn resume_owned(
-        &mut self,
-        instance_id: BoundaryInstanceId,
-        state: Value,
-        mode: BoundaryMode,
-    ) -> Result<StreamStep> {
-        self.step(move |core, call| core.resume_owned(call, instance_id, state, mode))
+        match state.into() {
+            StreamingState::Borrowed(state) => {
+                self.step(|core, call| core.resume(call, instance_id, state, mode))
+            }
+            StreamingState::Owned(state) => {
+                self.step(move |core, call| core.resume_owned(call, instance_id, state, mode))
+            }
+        }
     }
 
     /// Commit the pending occurrence against the session's retained state.
@@ -375,7 +371,7 @@ mod tests {
         )
         .expect("session");
 
-        let state = Value::Object(serde_json::Map::new());
+        let state = Arc::new(Value::Object(serde_json::Map::new()));
         let mut step = session.start(&state).expect("start");
         let mut steps = 1usize;
         while !step.done {

--- a/crates/webui-handler/src/streaming/owned.rs
+++ b/crates/webui-handler/src/streaming/owned.rs
@@ -141,6 +141,16 @@ impl StreamingSession {
         self.step(|core, call| core.start(call, state))
     }
 
+    /// Render to the first occurrence by moving caller-owned state into the
+    /// continuation snapshot.
+    ///
+    /// Async hosts that freshly decode or load state should prefer this method:
+    /// a full-state continuation takes ownership of the value without cloning
+    /// it, while a keyed continuation moves only its selected top-level values.
+    pub fn start_owned(&mut self, state: Value) -> Result<StreamStep> {
+        self.step(move |core, call| core.start_owned(call, state))
+    }
+
     /// Commit the pending occurrence through its checkpoint, then stop.
     ///
     /// The returned bytes hold that occurrence's record and nothing that
@@ -157,6 +167,35 @@ impl StreamingSession {
         mode: BoundaryMode,
     ) -> Result<StreamStep> {
         self.step(|core, call| core.resume(call, instance_id, state, mode))
+    }
+
+    /// Commit the pending occurrence by moving caller-owned state into the
+    /// retained continuation snapshot, then stop at its checkpoint flush.
+    ///
+    /// This is the preferred async-host path when the state was freshly decoded
+    /// or loaded for this occurrence. Moving changed top-level values avoids
+    /// cloning or deeply comparing their subtrees while preserving the same
+    /// patch semantics as [`Self::resume`].
+    pub fn resume_owned(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        state: Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStep> {
+        self.step(move |core, call| core.resume_owned(call, instance_id, state, mode))
+    }
+
+    /// Commit the pending occurrence against the session's retained state.
+    ///
+    /// The call still returns immediately after the checkpoint flush, preserving
+    /// the host's async pause point before [`Self::advance`], but avoids a state
+    /// overlay when no data changed since the preceding step.
+    pub fn resume_current(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        mode: BoundaryMode,
+    ) -> Result<StreamStep> {
+        self.step(|core, call| core.resume_current(call, instance_id, mode))
     }
 
     /// Write the ordinary parent bytes that follow a committed occurrence.

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -113,6 +113,42 @@ impl BoundaryKey {
     }
 }
 
+/// Borrowed or owned JSON state supplied to a streaming step.
+///
+/// `Value`, `&Value`, and references to smart pointers such as `&Arc<Value>`
+/// convert implicitly, so callers use one method name without losing ownership
+/// control.
+pub enum StreamingState<'a> {
+    /// State retained by the caller; the session clones only its projection.
+    Borrowed(&'a Value),
+    /// State transferred to the session so changed subtrees can move.
+    Owned(Value),
+}
+
+impl<'a, T> From<&'a T> for StreamingState<'a>
+where
+    T: std::borrow::Borrow<Value> + ?Sized,
+{
+    fn from(state: &'a T) -> Self {
+        Self::Borrowed(std::borrow::Borrow::borrow(state))
+    }
+}
+
+impl<'a, T> From<&'a mut T> for StreamingState<'a>
+where
+    T: std::borrow::Borrow<Value> + ?Sized,
+{
+    fn from(state: &'a mut T) -> Self {
+        Self::Borrowed(std::borrow::Borrow::borrow(&*state))
+    }
+}
+
+impl From<Value> for StreamingState<'_> {
+    fn from(state: Value) -> Self {
+        Self::Owned(state)
+    }
+}
+
 /// Runtime occurrence returned when traversal suspends.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BoundaryDescriptor {
@@ -207,19 +243,18 @@ impl WebUIHandler {
 
 impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
     /// Render until the first runtime boundary occurrence or terminal.
-    pub fn start(&mut self, state: &Value) -> Result<StreamStatus> {
-        let (core, call) = self.parts();
-        core.start(call, state)
-    }
-
-    /// Render to the first occurrence by moving caller-owned state into the
-    /// continuation snapshot.
     ///
-    /// This retains the writer-backed transport path while avoiding a full-state
-    /// clone when an async host already owns freshly decoded state.
-    pub fn start_owned(&mut self, state: Value) -> Result<StreamStatus> {
+    /// Pass an owned [`Value`] to move it into the continuation, or a reference
+    /// to retain caller ownership and clone only the required projection.
+    pub fn start<'state>(
+        &mut self,
+        state: impl Into<StreamingState<'state>>,
+    ) -> Result<StreamStatus> {
         let (core, call) = self.parts();
-        core.start_owned(call, state)
+        match state.into() {
+            StreamingState::Borrowed(state) => core.start(call, state),
+            StreamingState::Owned(state) => core.start_owned(call, state),
+        }
     }
 
     /// Commit the pending occurrence through its checkpoint, then stop.
@@ -232,26 +267,19 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
     /// as many updatable occurrences as the browser retains. The refusal is
     /// raised before any byte or state moves, so the same occurrence stays
     /// pending and can be committed with [`BoundaryMode::Final`] instead.
-    pub fn resume(
+    /// Pass an owned [`Value`] to move changed subtrees, or a reference to retain
+    /// caller ownership. Use [`Self::resume_current`] when no state changed.
+    pub fn resume<'state>(
         &mut self,
         instance_id: BoundaryInstanceId,
-        state: &Value,
+        state: impl Into<StreamingState<'state>>,
         mode: BoundaryMode,
     ) -> Result<StreamStatus> {
         let (core, call) = self.parts();
-        core.resume(call, instance_id, state, mode)
-    }
-
-    /// Commit the pending occurrence by moving caller-owned state into the
-    /// retained continuation snapshot, then stop after its checkpoint flush.
-    pub fn resume_owned(
-        &mut self,
-        instance_id: BoundaryInstanceId,
-        state: Value,
-        mode: BoundaryMode,
-    ) -> Result<StreamStatus> {
-        let (core, call) = self.parts();
-        core.resume_owned(call, instance_id, state, mode)
+        match state.into() {
+            StreamingState::Borrowed(state) => core.resume(call, instance_id, state, mode),
+            StreamingState::Owned(state) => core.resume_owned(call, instance_id, state, mode),
+        }
     }
 
     /// Commit the pending occurrence against the retained state snapshot.

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -11,8 +11,10 @@ use serde_json::{Number, Value};
 
 use super::error::{boundary_order_error, state_update_type_error};
 use super::state::{
-    increment_streaming_record_sequence, overlay_full_state, overlay_selected_state,
-    selected_state_snapshot, StreamingProgress, StreamingRenderState,
+    increment_state_revision, increment_streaming_record_sequence, overlay_full_state,
+    overlay_full_state_owned, overlay_selected_state, overlay_selected_state_owned,
+    selected_state_snapshot, selected_state_snapshot_owned, StreamingProgress,
+    StreamingRenderState,
 };
 use super::vm::{ContinuationVm, StepGoal};
 use super::StreamingSink;
@@ -210,6 +212,16 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
         core.start(call, state)
     }
 
+    /// Render to the first occurrence by moving caller-owned state into the
+    /// continuation snapshot.
+    ///
+    /// This retains the writer-backed transport path while avoiding a full-state
+    /// clone when an async host already owns freshly decoded state.
+    pub fn start_owned(&mut self, state: Value) -> Result<StreamStatus> {
+        let (core, call) = self.parts();
+        core.start_owned(call, state)
+    }
+
     /// Commit the pending occurrence through its checkpoint, then stop.
     ///
     /// The bytes written by this call are exactly the occurrence's own record —
@@ -228,6 +240,31 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
     ) -> Result<StreamStatus> {
         let (core, call) = self.parts();
         core.resume(call, instance_id, state, mode)
+    }
+
+    /// Commit the pending occurrence by moving caller-owned state into the
+    /// retained continuation snapshot, then stop after its checkpoint flush.
+    pub fn resume_owned(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        state: Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStatus> {
+        let (core, call) = self.parts();
+        core.resume_owned(call, instance_id, state, mode)
+    }
+
+    /// Commit the pending occurrence against the retained state snapshot.
+    ///
+    /// This preserves the checkpoint flush and async pause point while avoiding
+    /// an overlay when no top-level state changed since the preceding step.
+    pub fn resume_current(
+        &mut self,
+        instance_id: BoundaryInstanceId,
+        mode: BoundaryMode,
+    ) -> Result<StreamStatus> {
+        let (core, call) = self.parts();
+        core.resume_current(call, instance_id, mode)
     }
 
     /// Write the ordinary parent bytes that follow a committed occurrence.
@@ -249,18 +286,9 @@ impl<W: FlushWriter + ?Sized> StreamingResponse<'_, W> {
         core.update(call, instance_id, patch)
     }
 
-    /// Commit the pending occurrence and continue to the next one.
-    ///
-    /// Used by [`WebUIHandler::render_streaming`], which has no host to hand
-    /// the checkpoint bytes to between the two steps and drives every
-    /// occurrence from the single value it already snapshotted at start.
-    pub(crate) fn resume_current_and_advance(
-        &mut self,
-        instance_id: BoundaryInstanceId,
-        mode: BoundaryMode,
-    ) -> Result<StreamStatus> {
+    pub(crate) fn render_all(&mut self, state: &Value) -> Result<()> {
         let (core, call) = self.parts();
-        core.resume_current_and_advance(call, instance_id, mode)
+        core.render_all(call, state)
     }
 
     /// Whether the response has emitted its terminal and ended its writer.
@@ -393,6 +421,27 @@ impl SessionCore {
         self.run_step(call, StepGoal::NextBoundary, None)
     }
 
+    pub(crate) fn start_owned(
+        &mut self,
+        call: SessionCall<'_, '_>,
+        state: Value,
+    ) -> Result<StreamStatus> {
+        self.require_usable("start")?;
+        if self.started {
+            return Err(boundary_order_error(
+                "start",
+                "the streaming response has already started",
+            ));
+        }
+        self.frozen_state = if self.requires_full_state {
+            state
+        } else {
+            selected_state_snapshot_owned(state, &self.frozen_keys)
+        };
+        self.started = true;
+        self.run_step(call, StepGoal::NextBoundary, None)
+    }
+
     pub(crate) fn resume(
         &mut self,
         call: SessionCall<'_, '_>,
@@ -403,32 +452,35 @@ impl SessionCore {
         self.require_resumable()?;
         self.vm.validate_resume(instance_id)?;
         self.vm.validate_resume_mode(mode)?;
-        if self.requires_full_state {
-            overlay_full_state(&mut self.frozen_state, state);
+        let changed = if self.requires_full_state {
+            overlay_full_state(&mut self.frozen_state, state)
         } else {
-            overlay_selected_state(&mut self.frozen_state, state, &self.frozen_keys);
-        }
+            overlay_selected_state(&mut self.frozen_state, state, &self.frozen_keys)
+        };
+        self.record_state_change(changed)?;
         self.run_step(call, StepGoal::CommitBoundary, Some((instance_id, mode)))
     }
 
-    pub(crate) fn advance(&mut self, call: SessionCall<'_, '_>) -> Result<StreamStatus> {
-        self.require_advanceable()?;
-        self.run_step(call, StepGoal::NextBoundary, None)
+    pub(crate) fn resume_owned(
+        &mut self,
+        call: SessionCall<'_, '_>,
+        instance_id: BoundaryInstanceId,
+        state: Value,
+        mode: BoundaryMode,
+    ) -> Result<StreamStatus> {
+        self.require_resumable()?;
+        self.vm.validate_resume(instance_id)?;
+        self.vm.validate_resume_mode(mode)?;
+        let changed = if self.requires_full_state {
+            overlay_full_state_owned(&mut self.frozen_state, state)
+        } else {
+            overlay_selected_state_owned(&mut self.frozen_state, state, &self.frozen_keys)
+        };
+        self.record_state_change(changed)?;
+        self.run_step(call, StepGoal::CommitBoundary, Some((instance_id, mode)))
     }
 
-    /// Commit the pending occurrence and continue to the next one in a single
-    /// continuation setup.
-    ///
-    /// The public step machine deliberately returns at the checkpoint so a host
-    /// can write and release that occurrence on its own. The one-shot
-    /// [`WebUIHandler::render_streaming`] helper has no host in between, and
-    /// splitting the work would cost a second continuation hand-off — every
-    /// retained scope map, inventory buffer, and scratch vector moving in and
-    /// back out — plus a re-resolution of the parked record the step-local
-    /// cache already holds. [`StepGoal::NextBoundary`] commits the active
-    /// occurrence and keeps walking, so the fused call emits exactly the bytes
-    /// and flushes the split steps would.
-    pub(crate) fn resume_current_and_advance(
+    pub(crate) fn resume_current(
         &mut self,
         call: SessionCall<'_, '_>,
         instance_id: BoundaryInstanceId,
@@ -437,7 +489,62 @@ impl SessionCore {
         self.require_resumable()?;
         self.vm.validate_resume(instance_id)?;
         self.vm.validate_resume_mode(mode)?;
-        self.run_step(call, StepGoal::NextBoundary, Some((instance_id, mode)))
+        self.run_step(call, StepGoal::CommitBoundary, Some((instance_id, mode)))
+    }
+
+    pub(crate) fn advance(&mut self, call: SessionCall<'_, '_>) -> Result<StreamStatus> {
+        self.require_advanceable()?;
+        self.run_step(call, StepGoal::NextBoundary, None)
+    }
+
+    /// Render a one-shot streaming response in one prepared process context.
+    ///
+    /// The synchronous helper has no async host handoff, so retaining the
+    /// caller's state borrow for the complete traversal avoids both a state clone
+    /// and per-boundary context teardown while preserving every transport flush.
+    pub(crate) fn render_all(&mut self, call: SessionCall<'_, '_>, state: &Value) -> Result<()> {
+        self.require_usable("render_streaming")?;
+        if self.started {
+            return Err(boundary_order_error(
+                "render_streaming",
+                "the streaming response has already started",
+            ));
+        }
+        self.started = true;
+        let handler = call.handler;
+        let protocol = call.protocol;
+        let result = self.with_context(call, state, |vm, context| {
+            let mut status = vm.advance(StepGoal::NextBoundary, handler, protocol, context)?;
+            while !status.done {
+                context.writer.stream_flush()?;
+                let Some(boundary) = status.boundary.as_ref() else {
+                    return Err(HandlerError::Invariant(
+                        "unfinished streaming step has no pending boundary".to_string(),
+                    ));
+                };
+                vm.validate_resume(boundary.instance_id)?;
+                vm.validate_resume_mode(BoundaryMode::Final)?;
+                vm.begin_resume(boundary.instance_id, BoundaryMode::Final, context)?;
+                status = vm.advance(StepGoal::NextBoundary, handler, protocol, context)?;
+            }
+            Ok(())
+        });
+        match result {
+            Ok(()) if !self.shadow_style_roots.is_empty() => {
+                self.failed = true;
+                Err(HandlerError::Invariant(
+                    "a Shadow CSS tree escaped its component instance".to_string(),
+                ))
+            }
+            Ok(()) => {
+                self.done = true;
+                Ok(())
+            }
+            Err(error) => {
+                self.failed = true;
+                Err(error)
+            }
+        }
     }
 
     pub(crate) fn update(
@@ -510,6 +617,13 @@ impl SessionCore {
                 Err(error)
             }
         }
+    }
+
+    fn record_state_change(&mut self, changed: bool) -> Result<()> {
+        if changed {
+            increment_state_revision(self.streaming.as_mut().ok_or_else(missing_progress_error)?)?;
+        }
+        Ok(())
     }
 
     fn with_context<'data, 'state, T>(

--- a/crates/webui-handler/src/streaming/state.rs
+++ b/crates/webui-handler/src/streaming/state.rs
@@ -49,6 +49,15 @@ pub(crate) struct StreamingRenderState<'data> {
     pub(super) pending_root: Option<PendingStreamingRoot<'data>>,
     pub(super) generated_root_ready: bool,
     pub(super) next_record_sequence: usize,
+    /// Changes only when a host overlay changes the retained render snapshot.
+    pub(super) state_revision: usize,
+    /// Exact prior range record eligible as a browser state base.
+    pub(super) last_state_record_sequence: Option<usize>,
+    pub(super) last_state_revision: usize,
+    pub(super) last_state_full: bool,
+    pub(super) last_state_key_ids: Vec<u32>,
+    /// Reusable `current - prior` projection scratch.
+    pub(super) state_delta_key_ids: Vec<u32>,
     pub(super) bootstrap_sent: bool,
     pub(super) body_ended: bool,
     pub(super) inventory: Vec<u8>,
@@ -99,6 +108,12 @@ pub(crate) struct StreamingProgress {
     pub(super) pending_span_host: Option<u32>,
     pub(super) generated_root_ready: bool,
     pub(super) next_record_sequence: usize,
+    pub(super) state_revision: usize,
+    pub(super) last_state_record_sequence: Option<usize>,
+    pub(super) last_state_revision: usize,
+    pub(super) last_state_full: bool,
+    pub(super) last_state_key_ids: Vec<u32>,
+    pub(super) state_delta_key_ids: Vec<u32>,
     pub(super) bootstrap_sent: bool,
     pub(super) body_ended: bool,
     pub(super) inventory: Vec<u8>,
@@ -127,6 +142,12 @@ impl StreamingProgress {
             pending_span_host: None,
             generated_root_ready: false,
             next_record_sequence: 0,
+            state_revision: 0,
+            last_state_record_sequence: None,
+            last_state_revision: 0,
+            last_state_full: false,
+            last_state_key_ids: Vec::new(),
+            state_delta_key_ids: Vec::new(),
             bootstrap_sent: false,
             body_ended: false,
             inventory: vec![0; inventory_bytes],
@@ -165,6 +186,12 @@ impl<'data> StreamingRenderState<'data> {
             pending_span_host: progress.pending_span_host,
             generated_root_ready: progress.generated_root_ready,
             next_record_sequence: progress.next_record_sequence,
+            state_revision: progress.state_revision,
+            last_state_record_sequence: progress.last_state_record_sequence,
+            last_state_revision: progress.last_state_revision,
+            last_state_full: progress.last_state_full,
+            last_state_key_ids: progress.last_state_key_ids,
+            state_delta_key_ids: progress.state_delta_key_ids,
             bootstrap_sent: progress.bootstrap_sent,
             body_ended: progress.body_ended,
             inventory: progress.inventory,
@@ -190,6 +217,12 @@ impl<'data> StreamingRenderState<'data> {
             pending_span_host: self.pending_span_host,
             generated_root_ready: self.generated_root_ready,
             next_record_sequence: self.next_record_sequence,
+            state_revision: self.state_revision,
+            last_state_record_sequence: self.last_state_record_sequence,
+            last_state_revision: self.last_state_revision,
+            last_state_full: self.last_state_full,
+            last_state_key_ids: self.last_state_key_ids,
+            state_delta_key_ids: self.state_delta_key_ids,
             bootstrap_sent: self.bootstrap_sent,
             body_ended: self.body_ended,
             inventory: self.inventory,
@@ -263,6 +296,22 @@ pub(crate) fn selected_state_snapshot(
     serde_json::Value::Object(selected)
 }
 
+pub(crate) fn selected_state_snapshot_owned(
+    state: serde_json::Value,
+    keys: &[Box<str>],
+) -> serde_json::Value {
+    let serde_json::Value::Object(mut source) = state else {
+        return serde_json::Value::Object(serde_json::Map::new());
+    };
+    let mut selected = serde_json::Map::with_capacity(keys.len());
+    for key in keys {
+        if let Some(value) = source.remove(key.as_ref()) {
+            selected.insert(key.to_string(), value);
+        }
+    }
+    serde_json::Value::Object(selected)
+}
+
 /// Merge the caller's state for this step into the retained continuation
 /// snapshot.
 ///
@@ -280,15 +329,17 @@ pub(crate) fn overlay_selected_state(
     frozen: &mut serde_json::Value,
     state: &serde_json::Value,
     keys: &[Box<str>],
-) {
+) -> bool {
+    let mut changed = false;
     if !frozen.is_object() {
         *frozen = serde_json::Value::Object(serde_json::Map::new());
+        changed = true;
     }
     let serde_json::Value::Object(source) = state else {
-        return;
+        return changed;
     };
     let serde_json::Value::Object(target) = frozen else {
-        return;
+        return changed;
     };
     for key in keys {
         let Some(value) = source.get(key.as_ref()) else {
@@ -298,13 +349,16 @@ pub(crate) fn overlay_selected_state(
             Some(slot) => {
                 if slot != value {
                     slot.clone_from(value);
+                    changed = true;
                 }
             }
             None => {
                 target.insert(key.to_string(), value.clone());
+                changed = true;
             }
         }
     }
+    changed
 }
 
 /// Merge every top-level key of the caller's state into the retained snapshot.
@@ -312,28 +366,100 @@ pub(crate) fn overlay_selected_state(
 /// Same patch semantics as [`overlay_selected_state`]: omitted keys keep their
 /// snapshot value, nothing is removed, and an unchanged subtree is neither
 /// copied nor reallocated.
-pub(crate) fn overlay_full_state(frozen: &mut serde_json::Value, state: &serde_json::Value) {
+pub(crate) fn overlay_full_state(
+    frozen: &mut serde_json::Value,
+    state: &serde_json::Value,
+) -> bool {
     let serde_json::Value::Object(source) = state else {
-        return;
+        return false;
     };
+    let mut changed = false;
     if !frozen.is_object() {
         *frozen = serde_json::Value::Object(serde_json::Map::new());
+        changed = true;
     }
     let serde_json::Value::Object(target) = frozen else {
-        return;
+        return changed;
     };
     for (key, value) in source {
         match target.get_mut(key) {
             Some(slot) => {
                 if slot != value {
                     slot.clone_from(value);
+                    changed = true;
                 }
             }
             None => {
                 target.insert(key.clone(), value.clone());
+                changed = true;
             }
         }
     }
+    changed
+}
+
+/// Move selected caller-owned values into the continuation snapshot.
+///
+/// The owned path deliberately avoids deep equality checks. Supplying a key is
+/// treated as a new revision even when its value is equal, trading a cheap
+/// revision increment for avoiding an O(value size) comparison before moving
+/// the already-owned subtree.
+pub(crate) fn overlay_selected_state_owned(
+    frozen: &mut serde_json::Value,
+    state: serde_json::Value,
+    keys: &[Box<str>],
+) -> bool {
+    let serde_json::Value::Object(mut source) = state else {
+        return false;
+    };
+    if !frozen.is_object() {
+        *frozen = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let serde_json::Value::Object(target) = frozen else {
+        return false;
+    };
+    let mut changed = false;
+    for key in keys {
+        let Some(value) = source.remove(key.as_ref()) else {
+            continue;
+        };
+        target.insert(key.to_string(), value);
+        changed = true;
+    }
+    changed
+}
+
+/// Move every top-level caller-owned value into the continuation snapshot.
+pub(crate) fn overlay_full_state_owned(
+    frozen: &mut serde_json::Value,
+    state: serde_json::Value,
+) -> bool {
+    let serde_json::Value::Object(source) = state else {
+        return false;
+    };
+    if !frozen.is_object() {
+        *frozen = serde_json::Value::Object(serde_json::Map::new());
+    }
+    let serde_json::Value::Object(target) = frozen else {
+        return false;
+    };
+    let changed = !source.is_empty();
+    target.extend(source);
+    changed
+}
+
+pub(crate) fn increment_state_revision(progress: &mut StreamingProgress) -> Result<()> {
+    progress.state_revision = progress
+        .state_revision
+        .checked_add(1)
+        .ok_or_else(state_revision_overflow_error)?;
+    Ok(())
+}
+
+#[cold]
+#[inline(never)]
+fn state_revision_overflow_error() -> HandlerError {
+    HandlerError::Invariant("streaming state revision overflowed the platform limit".to_string())
 }
 
 pub(crate) fn protocol_fragment<'a>(

--- a/crates/webui-handler/src/streaming/state.rs
+++ b/crates/webui-handler/src/streaming/state.rs
@@ -400,10 +400,9 @@ pub(crate) fn overlay_full_state(
 
 /// Move selected caller-owned values into the continuation snapshot.
 ///
-/// The owned path deliberately avoids deep equality checks. Supplying a key is
-/// treated as a new revision even when its value is equal, trading a cheap
-/// revision increment for avoiding an O(value size) comparison before moving
-/// the already-owned subtree.
+/// Exact equality checks keep the state revision stable when a binding supplies
+/// the same complete state on every resume. Changed subtrees are moved rather
+/// than cloned.
 pub(crate) fn overlay_selected_state_owned(
     frozen: &mut serde_json::Value,
     state: serde_json::Value,
@@ -423,8 +422,18 @@ pub(crate) fn overlay_selected_state_owned(
         let Some(value) = source.remove(key.as_ref()) else {
             continue;
         };
-        target.insert(key.to_string(), value);
-        changed = true;
+        match target.get_mut(key.as_ref()) {
+            Some(slot) => {
+                if slot != &value {
+                    *slot = value;
+                    changed = true;
+                }
+            }
+            None => {
+                target.insert(key.to_string(), value);
+                changed = true;
+            }
+        }
     }
     changed
 }
@@ -443,8 +452,21 @@ pub(crate) fn overlay_full_state_owned(
     let serde_json::Value::Object(target) = frozen else {
         return false;
     };
-    let changed = !source.is_empty();
-    target.extend(source);
+    let mut changed = false;
+    for (key, value) in source {
+        match target.get_mut(&key) {
+            Some(slot) => {
+                if slot != &value {
+                    *slot = value;
+                    changed = true;
+                }
+            }
+            None => {
+                target.insert(key, value);
+                changed = true;
+            }
+        }
+    }
     changed
 }
 

--- a/crates/webui-handler/src/streaming/vm.rs
+++ b/crates/webui-handler/src/streaming/vm.rs
@@ -584,6 +584,24 @@ impl ContinuationVm {
                     }));
                 }
                 Some(Fragment::Component(component)) => {
+                    let target = context
+                        .render_fragments
+                        .list(frame.render_slot)
+                        .and_then(|prepared| prepared.target(index));
+                    if target
+                        .and_then(|target| context.render_fragments.list(target))
+                        .is_some_and(|list| !list.contains_boundary)
+                    {
+                        self.render_boundary_free(context, |context| {
+                            handler.process_component(
+                                component,
+                                target,
+                                ComponentHostOrigin::ParserProduced,
+                                context,
+                            )
+                        })?;
+                        continue;
+                    }
                     self.push(Frame::Fragment(frame))?;
                     self.begin_component(
                         component,
@@ -594,11 +612,37 @@ impl ContinuationVm {
                     return Ok(None);
                 }
                 Some(Fragment::IfCond(if_cond)) => {
+                    let target = context
+                        .render_fragments
+                        .list(frame.render_slot)
+                        .and_then(|prepared| prepared.target(index));
+                    if target
+                        .and_then(|target| context.render_fragments.list(target))
+                        .is_some_and(|list| !list.contains_boundary)
+                    {
+                        self.render_boundary_free(context, |context| {
+                            handler.process_if(if_cond, target, context)
+                        })?;
+                        continue;
+                    }
                     self.push(Frame::Fragment(frame))?;
                     self.begin_if(if_cond, handler, protocol, context)?;
                     return Ok(None);
                 }
                 Some(Fragment::ForLoop(for_loop)) => {
+                    let target = context
+                        .render_fragments
+                        .list(frame.render_slot)
+                        .and_then(|prepared| prepared.target(index));
+                    if target
+                        .and_then(|target| context.render_fragments.list(target))
+                        .is_some_and(|list| !list.contains_boundary)
+                    {
+                        self.render_boundary_free(context, |context| {
+                            handler.process_for_loop(for_loop, target, context)
+                        })?;
+                        continue;
+                    }
                     self.push(Frame::Fragment(frame))?;
                     self.begin_repeat(for_loop, handler, protocol, context)?;
                     return Ok(None);
@@ -620,6 +664,39 @@ impl ContinuationVm {
                 }
                 None => {}
             }
+        }
+    }
+
+    /// Run a proven boundary-free subgraph through the normal borrowed renderer.
+    ///
+    /// Outside an active authored boundary, rendered components belong to the
+    /// innermost generated span. Swap that span's capture into the context for
+    /// the duration of the atomic walk so its inventory and projection remain
+    /// local to the span completion record.
+    fn render_boundary_free<'data, 'state, 'output, T>(
+        &mut self,
+        context: &mut WebUIProcessContext<'data, 'state, 'output>,
+        operation: impl FnOnce(&mut WebUIProcessContext<'data, 'state, 'output>) -> Result<T>,
+    ) -> Result<T> {
+        let captures_span = context
+            .streaming
+            .as_ref()
+            .is_some_and(|streaming| streaming.active_boundary.is_none())
+            && !self.open_spans.is_empty();
+        if !captures_span {
+            return operation(context);
+        }
+        let Some(span) = self.open_spans.last_mut() else {
+            return operation(context);
+        };
+        streaming_state(context)?.swap_capture(&mut span.capture);
+        let result = operation(context);
+        let restored = streaming_state(context).map(|streaming| {
+            streaming.swap_capture(&mut span.capture);
+        });
+        match (result, restored) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) | (Ok(_), Err(error)) => Err(error),
         }
     }
 

--- a/crates/webui-handler/tests/streaming.rs
+++ b/crates/webui-handler/tests/streaming.rs
@@ -123,7 +123,7 @@ fn span_completion_reuses_the_exact_prior_full_state() {
         "nested": { "count": 42 }
     });
 
-    let start = session.start_owned(state).unwrap();
+    let start = session.start(state).unwrap();
     let boundary = start.boundary.unwrap();
     let committed = session
         .resume_current(boundary.instance_id, BoundaryMode::Updatable)
@@ -187,14 +187,14 @@ fn span_completion_reuses_a_subset_and_serializes_only_its_delta() {
     );
     let mut session = new_session(Arc::new(Protocol::new(protocol)), "/");
     let start = session
-        .start_owned(test_json!({
+        .start(test_json!({
             "todos": "large-shared-state",
             "toolbar": "ready"
         }))
         .unwrap();
     let boundary = start.boundary.unwrap();
     let committed = session
-        .resume_owned(
+        .resume(
             boundary.instance_id,
             test_json!({ "todos": "large-shared-state" }),
             BoundaryMode::Final,
@@ -233,7 +233,7 @@ fn changed_resume_state_starts_a_new_reference_base() {
     );
     let mut session = new_session(Arc::new(Protocol::new(protocol)), "/");
     let first = session
-        .start_owned(test_json!({ "todos": "first" }))
+        .start(test_json!({ "todos": "first" }))
         .unwrap()
         .boundary
         .unwrap();
@@ -242,7 +242,7 @@ fn changed_resume_state_starts_a_new_reference_base() {
         .unwrap();
     let second = session.advance().unwrap().boundary.unwrap();
     let committed = session
-        .resume_owned(
+        .resume(
             second.instance_id,
             test_json!({ "todos": "second" }),
             BoundaryMode::Final,
@@ -255,6 +255,51 @@ fn changed_resume_state_starts_a_new_reference_base() {
         !html.contains("stateRef"),
         "a state revision must not reference an older projection"
     );
+}
+
+#[test]
+fn unchanged_owned_resume_preserves_the_reference_base() {
+    for strategy in [InitialStateStrategy::Full, InitialStateStrategy::Components] {
+        let mut protocol = parsed_protocol_data(
+            &document(concat!(
+                r#"<boundary name="first"><child-box></child-box></boundary>"#,
+                r#"<boundary name="second"><child-box></child-box></boundary>"#,
+            )),
+            &[("child-box", "<span>{{todos}}</span>")],
+        );
+        protocol.initial_state_strategy = strategy as i32;
+        protocol.components.insert(
+            "child-box".to_string(),
+            ComponentData {
+                hydration_mode: StateProjectionMode::Keys as i32,
+                hydration_keys: vec!["todos".to_string()],
+                uses_shadow_dom: true,
+                ..Default::default()
+            },
+        );
+        let state = test_json!({ "todos": "large-shared-state" });
+        let mut session = new_session(Arc::new(Protocol::new(protocol)), "/");
+        let first = session.start(state.clone()).unwrap().boundary.unwrap();
+        let first_commit = session
+            .resume(first.instance_id, state.clone(), BoundaryMode::Final)
+            .unwrap();
+        let second = session.advance().unwrap().boundary.unwrap();
+        let second_commit = session
+            .resume(second.instance_id, state, BoundaryMode::Final)
+            .unwrap();
+        let html = String::from_utf8([first_commit.bytes, second_commit.bytes].concat()).unwrap();
+
+        assert_eq!(
+            html.matches(r#""state":{"todos":"large-shared-state"}"#)
+                .count(),
+            1,
+            "unchanged projected state must be serialized once"
+        );
+        assert!(
+            html.contains(r#""stateRef":"#),
+            "the unchanged second resume must reference the first projection: {html}"
+        );
+    }
 }
 
 #[test]
@@ -1161,12 +1206,12 @@ fn borrowed_api_moves_owned_state_without_losing_the_async_pause() {
         .unwrap();
 
     let first = response
-        .start_owned(test_json!({ "value": "initial" }))
+        .start(test_json!({ "value": "initial" }))
         .unwrap()
         .boundary
         .unwrap();
     let committed = response
-        .resume_owned(
+        .resume(
             first.instance_id,
             test_json!({ "value": "resolved" }),
             BoundaryMode::Final,

--- a/crates/webui-handler/tests/streaming.rs
+++ b/crates/webui-handler/tests/streaming.rs
@@ -56,7 +56,7 @@ fn document(body: &str) -> String {
 }
 
 #[test]
-fn component_local_boundary_suspends_and_emits_v3_span_contract() {
+fn component_local_boundary_suspends_and_emits_span_contract() {
     let protocol = parsed_protocol(
         &document(r#"<shell-card title="frozen"></shell-card>"#),
         &[
@@ -87,7 +87,7 @@ fn component_local_boundary_suspends_and_emits_v3_span_contract() {
     assert!(!committed.done && committed.boundary.is_none());
     let html = String::from_utf8(committed.bytes).unwrap();
     assert!(html.contains(r#"<!--wb:0--><child-box label="frozen" data-ws data-ws-enclosing="0">"#));
-    assert!(html.contains(r#"<!--/wb:0--><script type="application/json" data-webui-boundary>[3,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0"#));
+    assert!(html.contains(r#"<!--/wb:0--><script type="application/json" data-webui-boundary>[0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0"#));
     // The committed step stops at its checkpoint: the component tail and the
     // span completion that follow belong to the next step.
     assert!(!html.contains("<footer>tail</footer>"));
@@ -98,9 +98,9 @@ fn component_local_boundary_suspends_and_emits_v3_span_contract() {
     let tail = String::from_utf8(end.bytes).unwrap();
     assert!(tail.contains("<footer>tail</footer>"));
     assert!(tail.contains(
-        r#"</shell-card><!--/ws:0--><script type="application/json" data-webui-boundary>[3,1,3,0,"#
+        r#"</shell-card><!--/ws:0--><script type="application/json" data-webui-boundary>[1,3,0,"#
     ));
-    assert!(tail.contains("[3,2,4,0,{}]"));
+    assert!(tail.contains("[2,4,0,{}]"));
     assert!(tail.contains("</script><webui-hydrate></webui-hydrate>"));
 }
 
@@ -145,7 +145,7 @@ fn span_completion_reuses_the_exact_prior_full_state() {
         "the span must reference rather than reserialize its parent's full state"
     );
     assert!(
-        html.contains(r#"[3,2,3,0,{"componentStyles":"#) && html.contains(r#""stateRef":0"#),
+        html.contains(r#"[2,3,0,{"componentStyles":"#) && html.contains(r#""stateRef":0"#),
         "the span completion must carry a backward reference: {html}"
     );
     assert!(
@@ -316,13 +316,13 @@ fn resume_writes_only_the_committed_boundary_and_advance_writes_the_tail() {
     assert!(bytes.starts_with("<!--wb:0--><p>results</p><!--/wb:0--><script"));
     assert!(bytes.ends_with("<webui-hydrate></webui-hydrate>"));
     assert!(!bytes.contains("<footer>tail</footer>"));
-    assert!(!bytes.contains("[3,1,4,0,{}]"));
+    assert!(!bytes.contains("[1,4,0,{}]"));
 
     let tail = session.advance().unwrap();
     assert!(tail.done);
     let tail = String::from_utf8(tail.bytes).unwrap();
     assert!(tail.starts_with("<footer>tail</footer>"));
-    assert!(tail.contains("[3,1,4,0,{}]"));
+    assert!(tail.contains("[1,4,0,{}]"));
     assert!(!tail.contains("<!--wb:0-->"));
 }
 
@@ -605,7 +605,7 @@ fn false_if_discovers_no_occurrence_and_boundary_free_start_completes() {
     let html = String::from_utf8(step.bytes).unwrap();
     assert!(!html.contains("<!--wb:"));
     assert!(html.contains("<p>done</p>"));
-    assert!(html.contains("[3,0,4,0,{}]"));
+    assert!(html.contains("[0,4,0,{}]"));
 }
 
 #[test]
@@ -625,9 +625,9 @@ fn component_false_if_emits_generated_span_without_occurrence() {
     assert!(hidden_html.contains("<!--ws:0--><conditional-card"));
     assert!(hidden_html.contains(r#"data-ws data-ws-span="0">"#));
     assert!(hidden_html.contains(
-        r#"</conditional-card><!--/ws:0--><script type="application/json" data-webui-boundary>[3,0,3,0,"#
+        r#"</conditional-card><!--/ws:0--><script type="application/json" data-webui-boundary>[0,3,0,"#
     ));
-    assert!(hidden_html.contains("[3,1,4,0,{}]"));
+    assert!(hidden_html.contains("[1,4,0,{}]"));
 
     let mut shown = new_session(protocol, "/");
     let shown = shown.start(&test_json!({ "show": true })).unwrap();
@@ -824,8 +824,8 @@ fn generated_route_false_if_emits_span_without_boundary_occurrence() {
     assert!(!html.contains("<!--wb:"));
     assert!(html.contains(r#"<!--ws:0--><route-page data-ws data-ws-span="0">"#));
     assert!(html.contains("</route-page><!--/ws:0-->"));
-    assert!(html.contains(r#"<script type="application/json" data-webui-boundary>[3,0,3,0,"#));
-    assert!(html.contains("[3,1,4,0,{}]"));
+    assert!(html.contains(r#"<script type="application/json" data-webui-boundary>[0,3,0,"#));
+    assert!(html.contains("[1,4,0,{}]"));
 }
 
 #[test]
@@ -876,8 +876,8 @@ fn nested_component_spans_are_outer_first_and_complete_inner_first() {
     let inner_end = html.find("<!--/ws:1-->").unwrap();
     let outer_end = html.find("<!--/ws:0-->").unwrap();
     assert!(inner_end < outer_end);
-    assert!(html[inner_end..].contains("[3,1,3,1,"));
-    assert!(html[outer_end..].contains("[3,2,3,0,"));
+    assert!(html[inner_end..].contains("[1,3,1,"));
+    assert!(html[outer_end..].contains("[2,3,0,"));
 }
 
 #[test]
@@ -908,7 +908,7 @@ fn update_targets_one_runtime_instance() {
             .unwrap(),
     )
     .unwrap();
-    assert!(update.contains("[3,1,2,0,{\"count\":2}]"));
+    assert!(update.contains("[1,2,0,{\"count\":2}]"));
 
     assert!(session.advance().unwrap().done);
     assert!(session
@@ -949,7 +949,7 @@ fn update_before_terminal_targets_the_runtime_occurrence() {
             .unwrap(),
     )
     .unwrap();
-    assert!(update.contains("[3,1,2,0,{\"count\":2}]"));
+    assert!(update.contains("[1,2,0,{\"count\":2}]"));
     assert!(session
         .resume(second.instance_id, &test_json!({}), BoundaryMode::Final)
         .unwrap()

--- a/crates/webui-handler/tests/streaming_v3.rs
+++ b/crates/webui-handler/tests/streaming_v3.rs
@@ -3,6 +3,8 @@
 
 #![allow(clippy::disallowed_methods)]
 
+//! Progressive streaming protocol integration coverage.
+
 use std::sync::Arc;
 
 use webui_handler::{
@@ -54,7 +56,7 @@ fn document(body: &str) -> String {
 }
 
 #[test]
-fn component_local_boundary_suspends_and_emits_v2_span_contract() {
+fn component_local_boundary_suspends_and_emits_v3_span_contract() {
     let protocol = parsed_protocol(
         &document(r#"<shell-card title="frozen"></shell-card>"#),
         &[
@@ -85,7 +87,7 @@ fn component_local_boundary_suspends_and_emits_v2_span_contract() {
     assert!(!committed.done && committed.boundary.is_none());
     let html = String::from_utf8(committed.bytes).unwrap();
     assert!(html.contains(r#"<!--wb:0--><child-box label="frozen" data-ws data-ws-enclosing="0">"#));
-    assert!(html.contains(r#"<!--/wb:0--><script type="application/json" data-webui-boundary>[2,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0"#));
+    assert!(html.contains(r#"<!--/wb:0--><script type="application/json" data-webui-boundary>[3,0,0,0,{"declarationId":0,"enclosingSpanInstanceId":0"#));
     // The committed step stops at its checkpoint: the component tail and the
     // span completion that follow belong to the next step.
     assert!(!html.contains("<footer>tail</footer>"));
@@ -96,10 +98,163 @@ fn component_local_boundary_suspends_and_emits_v2_span_contract() {
     let tail = String::from_utf8(end.bytes).unwrap();
     assert!(tail.contains("<footer>tail</footer>"));
     assert!(tail.contains(
-        r#"</shell-card><!--/ws:0--><script type="application/json" data-webui-boundary>[2,1,3,0,"#
+        r#"</shell-card><!--/ws:0--><script type="application/json" data-webui-boundary>[3,1,3,0,"#
     ));
-    assert!(tail.contains("[2,2,4,0,{}]"));
+    assert!(tail.contains("[3,2,4,0,{}]"));
     assert!(tail.contains("</script><webui-hydrate></webui-hydrate>"));
+}
+
+#[test]
+fn span_completion_reuses_the_exact_prior_full_state() {
+    let protocol = parsed_protocol(
+        &document("<shell-card></shell-card>"),
+        &[
+            (
+                "shell-card",
+                r#"<boundary name="inside"><child-box></child-box></boundary><tail-box></tail-box>"#,
+            ),
+            ("child-box", "<span>child</span>"),
+            ("tail-box", "<footer>tail</footer>"),
+        ],
+    );
+    let mut session = new_session(protocol, "/");
+    let state = test_json!({
+        "large": "the-state-value-must-appear-only-once",
+        "nested": { "count": 42 }
+    });
+
+    let start = session.start_owned(state).unwrap();
+    let boundary = start.boundary.unwrap();
+    let committed = session
+        .resume_current(boundary.instance_id, BoundaryMode::Updatable)
+        .unwrap();
+    let update = session
+        .update(
+            boundary.instance_id,
+            &test_json!({ "nested": { "count": 43 } }),
+        )
+        .unwrap();
+    let completed = session.advance().unwrap();
+    assert!(completed.done);
+
+    let html = String::from_utf8([committed.bytes, update, completed.bytes].concat()).unwrap();
+    assert_eq!(
+        html.matches("the-state-value-must-appear-only-once")
+            .count(),
+        1,
+        "the span must reference rather than reserialize its parent's full state"
+    );
+    assert!(
+        html.contains(r#"[3,2,3,0,{"componentStyles":"#) && html.contains(r#""stateRef":0"#),
+        "the span completion must carry a backward reference: {html}"
+    );
+    assert!(
+        html.contains(r#""inventory":"06","stateRef":0"#),
+        "boundary-free descendants after the checkpoint must stay in the span capture: {html}"
+    );
+}
+
+#[test]
+fn span_completion_reuses_a_subset_and_serializes_only_its_delta() {
+    let mut protocol = parsed_protocol_data(
+        &document("<shell-card></shell-card>"),
+        &[
+            (
+                "shell-card",
+                r#"<boundary name="inside"><child-box></child-box></boundary><footer>tail</footer>"#,
+            ),
+            ("child-box", "<span>child</span>"),
+        ],
+    );
+    protocol.initial_state_strategy = InitialStateStrategy::Components as i32;
+    protocol.components.insert(
+        "shell-card".to_string(),
+        ComponentData {
+            hydration_mode: StateProjectionMode::Keys as i32,
+            hydration_keys: vec!["todos".to_string(), "toolbar".to_string()],
+            uses_shadow_dom: true,
+            ..Default::default()
+        },
+    );
+    protocol.components.insert(
+        "child-box".to_string(),
+        ComponentData {
+            hydration_mode: StateProjectionMode::Keys as i32,
+            hydration_keys: vec!["todos".to_string()],
+            uses_shadow_dom: true,
+            ..Default::default()
+        },
+    );
+    let mut session = new_session(Arc::new(Protocol::new(protocol)), "/");
+    let start = session
+        .start_owned(test_json!({
+            "todos": "large-shared-state",
+            "toolbar": "ready"
+        }))
+        .unwrap();
+    let boundary = start.boundary.unwrap();
+    let committed = session
+        .resume_owned(
+            boundary.instance_id,
+            test_json!({ "todos": "large-shared-state" }),
+            BoundaryMode::Final,
+        )
+        .unwrap();
+    let completed = session.advance().unwrap();
+
+    let html = String::from_utf8([committed.bytes, completed.bytes].concat()).unwrap();
+    assert_eq!(
+        html.matches("large-shared-state").count(),
+        1,
+        "the shared projection must be serialized only once"
+    );
+    assert!(html.contains(r#""state":{"todos":"large-shared-state"}"#));
+    assert!(html.contains(r#""stateRef":0,"stateDelta":{"toolbar":"ready"}"#));
+}
+
+#[test]
+fn changed_resume_state_starts_a_new_reference_base() {
+    let mut protocol = parsed_protocol_data(
+        &document(concat!(
+            r#"<boundary name="first"><child-box></child-box></boundary>"#,
+            r#"<boundary name="second"><child-box></child-box></boundary>"#,
+        )),
+        &[("child-box", "<span>child</span>")],
+    );
+    protocol.initial_state_strategy = InitialStateStrategy::Components as i32;
+    protocol.components.insert(
+        "child-box".to_string(),
+        ComponentData {
+            hydration_mode: StateProjectionMode::Keys as i32,
+            hydration_keys: vec!["todos".to_string()],
+            uses_shadow_dom: true,
+            ..Default::default()
+        },
+    );
+    let mut session = new_session(Arc::new(Protocol::new(protocol)), "/");
+    let first = session
+        .start_owned(test_json!({ "todos": "first" }))
+        .unwrap()
+        .boundary
+        .unwrap();
+    session
+        .resume_current(first.instance_id, BoundaryMode::Final)
+        .unwrap();
+    let second = session.advance().unwrap().boundary.unwrap();
+    let committed = session
+        .resume_owned(
+            second.instance_id,
+            test_json!({ "todos": "second" }),
+            BoundaryMode::Final,
+        )
+        .unwrap();
+    let html = String::from_utf8(committed.bytes).unwrap();
+
+    assert!(html.contains(r#""state":{"todos":"second"}"#));
+    assert!(
+        !html.contains("stateRef"),
+        "a state revision must not reference an older projection"
+    );
 }
 
 #[test]
@@ -161,13 +316,13 @@ fn resume_writes_only_the_committed_boundary_and_advance_writes_the_tail() {
     assert!(bytes.starts_with("<!--wb:0--><p>results</p><!--/wb:0--><script"));
     assert!(bytes.ends_with("<webui-hydrate></webui-hydrate>"));
     assert!(!bytes.contains("<footer>tail</footer>"));
-    assert!(!bytes.contains("[2,1,4,0,{}]"));
+    assert!(!bytes.contains("[3,1,4,0,{}]"));
 
     let tail = session.advance().unwrap();
     assert!(tail.done);
     let tail = String::from_utf8(tail.bytes).unwrap();
     assert!(tail.starts_with("<footer>tail</footer>"));
-    assert!(tail.contains("[2,1,4,0,{}]"));
+    assert!(tail.contains("[3,1,4,0,{}]"));
     assert!(!tail.contains("<!--wb:0-->"));
 }
 
@@ -450,7 +605,7 @@ fn false_if_discovers_no_occurrence_and_boundary_free_start_completes() {
     let html = String::from_utf8(step.bytes).unwrap();
     assert!(!html.contains("<!--wb:"));
     assert!(html.contains("<p>done</p>"));
-    assert!(html.contains("[2,0,4,0,{}]"));
+    assert!(html.contains("[3,0,4,0,{}]"));
 }
 
 #[test]
@@ -470,9 +625,9 @@ fn component_false_if_emits_generated_span_without_occurrence() {
     assert!(hidden_html.contains("<!--ws:0--><conditional-card"));
     assert!(hidden_html.contains(r#"data-ws data-ws-span="0">"#));
     assert!(hidden_html.contains(
-        r#"</conditional-card><!--/ws:0--><script type="application/json" data-webui-boundary>[2,0,3,0,"#
+        r#"</conditional-card><!--/ws:0--><script type="application/json" data-webui-boundary>[3,0,3,0,"#
     ));
-    assert!(hidden_html.contains("[2,1,4,0,{}]"));
+    assert!(hidden_html.contains("[3,1,4,0,{}]"));
 
     let mut shown = new_session(protocol, "/");
     let shown = shown.start(&test_json!({ "show": true })).unwrap();
@@ -669,8 +824,8 @@ fn generated_route_false_if_emits_span_without_boundary_occurrence() {
     assert!(!html.contains("<!--wb:"));
     assert!(html.contains(r#"<!--ws:0--><route-page data-ws data-ws-span="0">"#));
     assert!(html.contains("</route-page><!--/ws:0-->"));
-    assert!(html.contains(r#"<script type="application/json" data-webui-boundary>[2,0,3,0,"#));
-    assert!(html.contains("[2,1,4,0,{}]"));
+    assert!(html.contains(r#"<script type="application/json" data-webui-boundary>[3,0,3,0,"#));
+    assert!(html.contains("[3,1,4,0,{}]"));
 }
 
 #[test]
@@ -721,8 +876,8 @@ fn nested_component_spans_are_outer_first_and_complete_inner_first() {
     let inner_end = html.find("<!--/ws:1-->").unwrap();
     let outer_end = html.find("<!--/ws:0-->").unwrap();
     assert!(inner_end < outer_end);
-    assert!(html[inner_end..].contains("[2,1,3,1,"));
-    assert!(html[outer_end..].contains("[2,2,3,0,"));
+    assert!(html[inner_end..].contains("[3,1,3,1,"));
+    assert!(html[outer_end..].contains("[3,2,3,0,"));
 }
 
 #[test]
@@ -753,7 +908,7 @@ fn update_targets_one_runtime_instance() {
             .unwrap(),
     )
     .unwrap();
-    assert!(update.contains("[2,1,2,0,{\"count\":2}]"));
+    assert!(update.contains("[3,1,2,0,{\"count\":2}]"));
 
     assert!(session.advance().unwrap().done);
     assert!(session
@@ -794,7 +949,7 @@ fn update_before_terminal_targets_the_runtime_occurrence() {
             .unwrap(),
     )
     .unwrap();
-    assert!(update.contains("[2,1,2,0,{\"count\":2}]"));
+    assert!(update.contains("[3,1,2,0,{\"count\":2}]"));
     assert!(session
         .resume(second.instance_id, &test_json!({}), BoundaryMode::Final)
         .unwrap()
@@ -967,7 +1122,7 @@ fn borrowed_api_flushes_each_returned_semantic_step() {
     let first = response.start(&test_json!({})).unwrap();
     let boundary = first.boundary.unwrap();
     assert!(response
-        .resume(boundary.instance_id, &test_json!({}), BoundaryMode::Final)
+        .resume_current(boundary.instance_id, BoundaryMode::Final)
         .unwrap()
         .boundary
         .is_none());
@@ -984,6 +1139,51 @@ fn borrowed_api_flushes_each_returned_semantic_step() {
     assert!(!writer.output[..checkpoint].contains("<footer>tail</footer>"));
     assert!(writer.output[checkpoint..].starts_with("<footer>tail</footer>"));
     assert!(writer.ended);
+}
+
+#[test]
+fn borrowed_api_moves_owned_state_without_losing_the_async_pause() {
+    let protocol = parsed_protocol(
+        &document(concat!(
+            r#"<boundary name="first"><p>{{value}}</p></boundary>"#,
+            r#"<boundary name="second"><p>{{value}}</p></boundary>"#,
+        )),
+        &[],
+    );
+    let handler = WebUIHandler::new();
+    let mut writer = FlushStringWriter::default();
+    let mut response = handler
+        .stream_response(
+            &protocol,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+
+    let first = response
+        .start_owned(test_json!({ "value": "initial" }))
+        .unwrap()
+        .boundary
+        .unwrap();
+    let committed = response
+        .resume_owned(
+            first.instance_id,
+            test_json!({ "value": "resolved" }),
+            BoundaryMode::Final,
+        )
+        .unwrap();
+    assert!(committed.boundary.is_none() && !committed.done);
+
+    let second = response.advance().unwrap().boundary.unwrap();
+    let committed = response
+        .resume_current(second.instance_id, BoundaryMode::Final)
+        .unwrap();
+    assert!(committed.boundary.is_none() && !committed.done);
+    assert!(response.advance().unwrap().done);
+    drop(response);
+
+    assert!(writer.output.contains("<p>resolved</p>"));
+    assert_eq!(writer.flushes, 4);
 }
 
 #[test]

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -551,7 +551,7 @@ impl StreamingSession {
     pub fn start(&mut self, state_json: String) -> napi::Result<JsStreamStep> {
         let state = parse_state_json(&state_json)?;
         self.inner
-            .start_owned(state)
+            .start(state)
             .and_then(stream_step)
             .map_err(streaming_error)
     }
@@ -570,7 +570,7 @@ impl StreamingSession {
         let state = parse_state_json(&state_json)?;
         let mode = parse_boundary_mode(mode.as_deref())?;
         self.inner
-            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
+            .resume(BoundaryInstanceId::from_raw(instance_id), state, mode)
             .and_then(stream_step)
             .map_err(streaming_error)
     }

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -551,7 +551,7 @@ impl StreamingSession {
     pub fn start(&mut self, state_json: String) -> napi::Result<JsStreamStep> {
         let state = parse_state_json(&state_json)?;
         self.inner
-            .start(&state)
+            .start_owned(state)
             .and_then(stream_step)
             .map_err(streaming_error)
     }
@@ -570,7 +570,7 @@ impl StreamingSession {
         let state = parse_state_json(&state_json)?;
         let mode = parse_boundary_mode(mode.as_deref())?;
         self.inner
-            .resume(BoundaryInstanceId::from_raw(instance_id), &state, mode)
+            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
             .and_then(stream_step)
             .map_err(streaming_error)
     }

--- a/crates/webui-python/src/lib.rs
+++ b/crates/webui-python/src/lib.rs
@@ -342,7 +342,7 @@ impl NativeStreamingSession {
             .detach(|| {
                 let state = parse_state(&input)?;
                 self.session_binding()?
-                    .start_owned(state)
+                    .start(state)
                     .map_err(streaming_binding_error)
             })
             .map_err(BindingError::into_py_error)?;
@@ -366,7 +366,7 @@ impl NativeStreamingSession {
                     BoundaryMode::Final
                 };
                 self.session_binding()?
-                    .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
+                    .resume(BoundaryInstanceId::from_raw(instance_id), state, mode)
                     .map_err(streaming_binding_error)
             })
             .map_err(BindingError::into_py_error)?;

--- a/crates/webui-python/src/lib.rs
+++ b/crates/webui-python/src/lib.rs
@@ -342,7 +342,7 @@ impl NativeStreamingSession {
             .detach(|| {
                 let state = parse_state(&input)?;
                 self.session_binding()?
-                    .start(&state)
+                    .start_owned(state)
                     .map_err(streaming_binding_error)
             })
             .map_err(BindingError::into_py_error)?;
@@ -366,7 +366,7 @@ impl NativeStreamingSession {
                     BoundaryMode::Final
                 };
                 self.session_binding()?
-                    .resume(BoundaryInstanceId::from_raw(instance_id), &state, mode)
+                    .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
                     .map_err(streaming_binding_error)
             })
             .map_err(BindingError::into_py_error)?;

--- a/crates/webui-wasm/src/handler.rs
+++ b/crates/webui-wasm/src/handler.rs
@@ -263,7 +263,7 @@ impl StreamingSession {
     #[wasm_bindgen(js_name = start)]
     pub fn start(&mut self, state_json: &str) -> Result<Object, JsValue> {
         let state = session_state(state_json)?;
-        let step = self.inner.start(&state).map_err(streaming_error)?;
+        let step = self.inner.start_owned(state).map_err(streaming_error)?;
         stream_step_object(step)
     }
 
@@ -282,7 +282,7 @@ impl StreamingSession {
         let mode = parse_boundary_mode(mode.as_deref())?;
         let step = self
             .inner
-            .resume(BoundaryInstanceId::from_raw(instance_id), &state, mode)
+            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
             .map_err(streaming_error)?;
         stream_step_object(step)
     }

--- a/crates/webui-wasm/src/handler.rs
+++ b/crates/webui-wasm/src/handler.rs
@@ -263,7 +263,7 @@ impl StreamingSession {
     #[wasm_bindgen(js_name = start)]
     pub fn start(&mut self, state_json: &str) -> Result<Object, JsValue> {
         let state = session_state(state_json)?;
-        let step = self.inner.start_owned(state).map_err(streaming_error)?;
+        let step = self.inner.start(state).map_err(streaming_error)?;
         stream_step_object(step)
     }
 
@@ -282,7 +282,7 @@ impl StreamingSession {
         let mode = parse_boundary_mode(mode.as_deref())?;
         let step = self
             .inner
-            .resume_owned(BoundaryInstanceId::from_raw(instance_id), state, mode)
+            .resume(BoundaryInstanceId::from_raw(instance_id), state, mode)
             .map_err(streaming_error)?;
         stream_step_object(step)
     }

--- a/crates/webui/src/lib.rs
+++ b/crates/webui/src/lib.rs
@@ -38,7 +38,8 @@ pub use webui_handler::Result as HandlerResult;
 pub use webui_handler::{
     plugin::HandlerPlugin, BoundaryDescriptor, BoundaryInstanceId, BoundaryKey, BoundaryMode,
     FlushWriter, HandlerError, Protocol, RenderOptions, ResponseWriter, SessionOptions,
-    SpanInstanceId, StreamStatus, StreamStep, StreamingResponse, StreamingSession, WebUIHandler,
+    SpanInstanceId, StreamStatus, StreamStep, StreamingResponse, StreamingSession, StreamingState,
+    WebUIHandler,
 };
 pub use webui_parser::plugin::{ComponentTemplateArtifact, StateSurface};
 pub use webui_parser::CssStrategy;

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -872,8 +872,8 @@ outlets, and selected route content.
   context for the complete response. Host-driven `stream_response` sessions use
   each `resume` state as an overlay for newly resolved occurrence data.
   `resume_current` skips the overlay when retained state is authoritative.
-  Owned sessions can move freshly decoded values through `start_owned` and
-  `resume_owned`.
+  `start` and `resume` move freshly decoded owned `Value`s or borrow shared
+  values through the same method names.
 - Range records may reference the exact prior range state by sequence
   and carry only a top-level delta. Missing, stale, forward, mismatched, or
   malformed references fail closed.

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -874,7 +874,7 @@ outlets, and selected route content.
   `resume_current` skips the overlay when retained state is authoritative.
   Owned sessions can move freshly decoded values through `start_owned` and
   `resume_owned`.
-- Version-3 range records may reference the exact prior range state by sequence
+- Range records may reference the exact prior range state by sequence
   and carry only a top-level delta. Missing, stale, forward, mismatched, or
   malformed references fail closed.
 - A component-local boundary uses generated parent spans. Its early marked child

--- a/docs/ai/SKILL.md
+++ b/docs/ai/SKILL.md
@@ -868,9 +868,15 @@ outlets, and selected route content.
   `hydratedCallback()`.
 - State resolution across a suspension is lexical locals, resume state, then
   the frozen projected parent state.
-- `render_streaming` projects its one state value once for the complete
-  response. Host-driven `stream_response` sessions use each `resume` state as
-  an overlay for newly resolved occurrence data.
+- `render_streaming` borrows one state value and keeps one prepared render
+  context for the complete response. Host-driven `stream_response` sessions use
+  each `resume` state as an overlay for newly resolved occurrence data.
+  `resume_current` skips the overlay when retained state is authoritative.
+  Owned sessions can move freshly decoded values through `start_owned` and
+  `resume_owned`.
+- Version-3 range records may reference the exact prior range state by sequence
+  and carry only a top-level delta. Missing, stale, forward, mismatched, or
+  malformed references fail closed.
 - A component-local boundary uses generated parent spans. Its early marked child
   may hydrate before the opaque parent tail in light or shadow DOM.
 - `webui:boundary-hydrated` is emitted only when

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -393,14 +393,22 @@ markers, and temporary attributes. Final occurrences release roots immediately.
 Updatable occurrences retain only live roots and a pending shallow patch until
 terminal.
 
-The browser protocol is `[2, sequence, kind, target, payload]`. Kinds are final
+The browser protocol is `[3, sequence, kind, target, payload]`. Kinds are final
 checkpoint, updatable checkpoint, update, generated span completion, and
 terminal. A malformed, truncated, out-of-order, or over-limit stream fails
 closed, suppresses successful completion, and releases discoverable deferred
 state within fixed bounds.
 
+Range records normally carry their projected `state`. When the exact preceding
+range projection is a proven subset under the same server state revision, a
+record instead carries `stateRef` plus only its top-level `stateDelta`. The
+coordinator resolves the state before activation and keeps prior state immutable
+for delayed roots. Missing, stale, forward, mismatched, or malformed references
+fail closed. State-update records remain independent patches and never alter
+the range-state reference base.
+
 At `body_end`, the handler emits one markerless empty terminal envelope:
-`[2,nextSequence,4,0,{}]`. Its flush also commits any preceding native or static
+`[3,nextSequence,4,0,{}]`. Its flush also commits any preceding native or static
 tail HTML, but terminal records never repeat template metadata or state. A
 truncated or malformed stream, or one exceeding a client work bound such as the
 queued-boundary or marker-scan limit, logs an error, suppresses

--- a/docs/guide/concepts/hydration.md
+++ b/docs/guide/concepts/hydration.md
@@ -393,7 +393,8 @@ markers, and temporary attributes. Final occurrences release roots immediately.
 Updatable occurrences retain only live roots and a pending shallow patch until
 terminal.
 
-The browser protocol is `[3, sequence, kind, target, payload]`. Kinds are final
+The browser protocol is the single unversioned
+`[sequence, kind, target, payload]` contract. Kinds are final
 checkpoint, updatable checkpoint, update, generated span completion, and
 terminal. A malformed, truncated, out-of-order, or over-limit stream fails
 closed, suppresses successful completion, and releases discoverable deferred
@@ -408,7 +409,7 @@ fail closed. State-update records remain independent patches and never alter
 the range-state reference base.
 
 At `body_end`, the handler emits one markerless empty terminal envelope:
-`[3,nextSequence,4,0,{}]`. Its flush also commits any preceding native or static
+`[nextSequence,4,0,{}]`. Its flush also commits any preceding native or static
 tail HTML, but terminal records never repeat template metadata or state. A
 truncated or malformed stream, or one exceeding a client work bound such as the
 queued-boundary or marker-scan limit, logs an error, suppresses
@@ -416,14 +417,12 @@ queued-boundary or marker-scan limit, logs an error, suppresses
 fixed bounds. Valid commits perform no document-wide scan; a bounded sweep is a
 fatal-cleanup fallback only.
 
-The client trusts records past three checks, because the same WebUI version
-wrote them: `JSON.parse` (which alone detects any truncation, since a cut-off
-record is never valid JSON), a five-element array, and the envelope `version`.
-Everything else is enforced where it is actually knowable — a sequence or
-boundary-target mismatch halts the stream, and a defective payload fails the
-commit closed. Unrecognized *additive* payload fields are ignored rather than
-fatal, so a cached older bundle keeps working against a newer server; anything
-incompatible bumps `version` instead.
+The client trusts records past two checks, because the same WebUI release wrote
+them: `JSON.parse` (which alone detects any truncation, since a cut-off record
+is never valid JSON) and the four-element tuple shape. Everything else is
+enforced where it is actually knowable - a sequence or boundary-target mismatch
+halts the stream, and a defective payload fails the commit closed. There is no
+compatibility parser; obsolete tuple shapes are rejected.
 
 ### CSP and delivery
 

--- a/docs/guide/concepts/performance.md
+++ b/docs/guide/concepts/performance.md
@@ -219,8 +219,8 @@ Each layer of the architecture contributes to the overall performance profile:
   `advance`, or `update`, so Node, WASM, Python, C, and .NET hosts write through
   their native backpressure APIs. A boundary-only `resume` can flush immediately;
   `advance` carries the following parent and tail bytes. Rust hosts can transfer
-  freshly loaded values through `start_owned` and `resume_owned`, or call
-  `resume_current` when the retained snapshot is unchanged. `webui serve
+  freshly loaded values by passing owned `Value`s to `start` and `resume`, or
+  call `resume_current` when the retained snapshot is unchanged. `webui serve
   --api-port` uses a capacity-one version-2 control channel over the same
   session.
   Hosts must also bound concurrent blocking renders before calling

--- a/docs/guide/concepts/performance.md
+++ b/docs/guide/concepts/performance.md
@@ -200,8 +200,11 @@ Each layer of the architecture contributes to the overall performance profile:
   generated component spans instead of cloning full state for every boundary or
   prebuilding a request plan. A repeat body cannot reach a boundary, so each
   `<for>` finishes inside its current step and no repeat iterator survives a
-  host call. Full-state fallback snapshots once per response;
-  `render_streaming` reuses that snapshot for every occurrence. Boundary-free
+  host call. The synchronous `render_streaming` path borrows one state and uses
+  one prepared render context for the complete response. Ordered range records
+  reuse the exact prior projection by sequence and serialize only top-level
+  additions or replacements when the current projection is a proven superset
+  under the same state revision. Boundary-free
   fragment records are skipped through a build-time `contains_boundary` bit.
   Capture and projection scratch buffers retain capacity across checkpoints.
 - **Bounded browser activation.** Each checkpoint or generated span completion
@@ -215,7 +218,9 @@ Each layer of the architecture contributes to the overall performance profile:
   `StreamingSession` calls return one byte chunk for `start`, `resume`,
   `advance`, or `update`, so Node, WASM, Python, C, and .NET hosts write through
   their native backpressure APIs. A boundary-only `resume` can flush immediately;
-  `advance` carries the following parent and tail bytes. `webui serve
+  `advance` carries the following parent and tail bytes. Rust hosts can transfer
+  freshly loaded values through `start_owned` and `resume_owned`, or call
+  `resume_current` when the retained snapshot is unchanged. `webui serve
   --api-port` uses a capacity-one version-2 control channel over the same
   session.
   Hosts must also bound concurrent blocking renders before calling

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -355,7 +355,7 @@ initially false conditions or empty repeats. Unrelated later boundaries remain
 excluded. Template metadata is sent only when first reachable, inventory still
 tracks only rendered SSR roots, and repeated instances receive checkpoint-local
 state without duplicate metadata. The final terminal envelope is always
-`[3,nextSequence,4,0,{}]`; its flush also commits preceding static tail bytes.
+`[nextSequence,4,0,{}]`; its flush also commits preceding static tail bytes.
 
 At `start`, WebUI freezes only projected top-level keys required to continue,
 plus lexical locals and route/component scope. Resume state overlays that frozen
@@ -366,7 +366,7 @@ When a boundary occurs inside a reusable component, WebUI emits a generated
 span for the unfinished parent. The early child checkpoint can hydrate across
 light or open shadow DOM before the parent tail. A later span-completion record
 activates the parent exactly once. The terminal envelope is
-`[3,nextSequence,4,0,{}]`.
+`[nextSequence,4,0,{}]`.
 
 The bounded channel limits bytes retained by a running render, but it does not
 bound how many requests can queue in Tokio's blocking pool. Acquire a

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -294,11 +294,13 @@ The status states are exact: a descriptor requires `resume`; no descriptor with
 completed status has no descriptor, and the writer already contains the tail
 and terminal.
 
-`WebUIHandler::render_streaming` uses one state value for the complete response:
-it projects and freezes that value once, then resumes each occurrence directly
-against the same snapshot. The lower-level `stream_response` API keeps the
-public `resume` overlay because hosts may supply newly resolved state for each
-occurrence.
+`WebUIHandler::render_streaming` uses one prepared render context and borrows
+one state value for the complete response. It preserves every checkpoint flush
+without cloning the state or rebuilding the context between boundaries. The
+lower-level `stream_response` API keeps the public `resume` overlay because
+hosts may supply newly resolved state for each occurrence. When no state
+changed, `resume_current` skips that overlay while retaining the checkpoint
+pause before `advance`.
 
 Every descriptor contains `instance_id`, `declaration_id`, `owner`, `name`, and
 an optional string or numeric `key`. A component-owned declaration reached from
@@ -353,7 +355,7 @@ initially false conditions or empty repeats. Unrelated later boundaries remain
 excluded. Template metadata is sent only when first reachable, inventory still
 tracks only rendered SSR roots, and repeated instances receive checkpoint-local
 state without duplicate metadata. The final terminal envelope is always
-`[2,nextSequence,4,0,{}]`; its flush also commits preceding static tail bytes.
+`[3,nextSequence,4,0,{}]`; its flush also commits preceding static tail bytes.
 
 At `start`, WebUI freezes only projected top-level keys required to continue,
 plus lexical locals and route/component scope. Resume state overlays that frozen
@@ -364,7 +366,7 @@ When a boundary occurs inside a reusable component, WebUI emits a generated
 span for the unfinished parent. The early child checkpoint can hydrate across
 light or open shadow DOM before the parent tail. A later span-completion record
 activates the parent exactly once. The terminal envelope is
-`[2,nextSequence,4,0,{}]`.
+`[3,nextSequence,4,0,{}]`.
 
 The bounded channel limits bytes retained by a running render, but it does not
 bound how many requests can queue in Tokio's blocking pool. Acquire a
@@ -530,7 +532,10 @@ component.
 |---|---|
 | `WebUIHandler::stream_response(protocol, options, writer)` | Create one progressive response session |
 | `StreamingResponse::start(state)` | Render and flush through the first runtime occurrence or terminal |
+| `StreamingResponse::start_owned(state)` | Move freshly loaded state into the continuation, then render through the first occurrence or terminal |
 | `StreamingResponse::resume(instance_id, state, mode)` | Render and flush only the pending occurrence through its checkpoint |
+| `StreamingResponse::resume_owned(instance_id, state, mode)` | Move a newly loaded state overlay, then flush only the pending occurrence |
+| `StreamingResponse::resume_current(instance_id, mode)` | Commit with retained state and preserve the checkpoint pause |
 | `StreamingResponse::advance()` | Render following parent bytes through the next occurrence or terminal |
 | `StreamingResponse::update(instance_id, patch)` | Send projected object state to a committed updatable occurrence |
 | `StreamingResponse::is_done()` | Report whether terminal and writer end completed |
@@ -541,8 +546,8 @@ same language.
 
 When you would rather own the bytes - for example to feed a channel, a test
 harness, or a transport whose writer cannot be borrowed for that long —
-`StreamingSession` offers the same four operations and returns a `Vec<u8>` per
-call instead:
+`StreamingSession` offers the same step machine and returns a `Vec<u8>` per
+call instead. Its owned-state variants avoid copying freshly loaded values:
 
 ```rust
 let mut session = StreamingSession::new(
@@ -550,7 +555,7 @@ let mut session = StreamingSession::new(
     Arc::clone(&protocol),
     SessionOptions::new("index.html", "/"),
 )?;
-let mut step = session.start(&initial_state)?;
+let mut step = session.start_owned(initial_state)?;
 loop {
     sink.send(std::mem::take(&mut step.bytes))?;
     if step.done {
@@ -560,7 +565,7 @@ loop {
         Some(boundary) => {
             let state =
                 load_state(&boundary.owner, &boundary.name, boundary.key.as_ref())?;
-            session.resume(boundary.instance_id, &state, BoundaryMode::Final)?
+            session.resume_owned(boundary.instance_id, state, BoundaryMode::Final)?
         }
         None => session.advance()?,
     };
@@ -568,7 +573,11 @@ loop {
 ```
 
 The session holds its own `Arc` clones, so it may outlive the bindings you
-created it from.
+created it from. `start_owned` and `resume_owned` move freshly decoded or loaded
+state into the continuation without cloning large subtrees. If no state changed,
+`resume_current` avoids both a clone and a deep equality walk. Every resume form
+still returns immediately after the checkpoint flush; `advance` remains a
+separate call after any async wait.
 
 This is the same type Node, WASM, C, and C# drive, so behaviour is identical
 across hosts. Prefer `stream_response` in Rust servers: it writes straight into

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -531,10 +531,8 @@ component.
 | API | Description |
 |---|---|
 | `WebUIHandler::stream_response(protocol, options, writer)` | Create one progressive response session |
-| `StreamingResponse::start(state)` | Render and flush through the first runtime occurrence or terminal |
-| `StreamingResponse::start_owned(state)` | Move freshly loaded state into the continuation, then render through the first occurrence or terminal |
-| `StreamingResponse::resume(instance_id, state, mode)` | Render and flush only the pending occurrence through its checkpoint |
-| `StreamingResponse::resume_owned(instance_id, state, mode)` | Move a newly loaded state overlay, then flush only the pending occurrence |
+| `StreamingResponse::start(state)` | Borrow or move state, then render and flush through the first runtime occurrence or terminal |
+| `StreamingResponse::resume(instance_id, state, mode)` | Borrow or move a state overlay, then flush only the pending occurrence |
 | `StreamingResponse::resume_current(instance_id, mode)` | Commit with retained state and preserve the checkpoint pause |
 | `StreamingResponse::advance()` | Render following parent bytes through the next occurrence or terminal |
 | `StreamingResponse::update(instance_id, patch)` | Send projected object state to a committed updatable occurrence |
@@ -555,7 +553,7 @@ let mut session = StreamingSession::new(
     Arc::clone(&protocol),
     SessionOptions::new("index.html", "/"),
 )?;
-let mut step = session.start_owned(initial_state)?;
+let mut step = session.start(initial_state)?;
 loop {
     sink.send(std::mem::take(&mut step.bytes))?;
     if step.done {
@@ -565,7 +563,7 @@ loop {
         Some(boundary) => {
             let state =
                 load_state(&boundary.owner, &boundary.name, boundary.key.as_ref())?;
-            session.resume_owned(boundary.instance_id, state, BoundaryMode::Final)?
+            session.resume(boundary.instance_id, state, BoundaryMode::Final)?
         }
         None => session.advance()?,
     };
@@ -573,11 +571,13 @@ loop {
 ```
 
 The session holds its own `Arc` clones, so it may outlive the bindings you
-created it from. `start_owned` and `resume_owned` move freshly decoded or loaded
-state into the continuation without cloning large subtrees. If no state changed,
-`resume_current` avoids both a clone and a deep equality walk. Every resume form
-still returns immediately after the checkpoint flush; `advance` remains a
-separate call after any async wait.
+created it from. `start` and `resume` accept either owned `Value`s or borrowed
+state: moving freshly decoded or loaded values avoids clones of changed
+subtrees, while borrowing lets shared-state callers retain ownership. Equal
+values keep the prior state-reference base. If the host already knows no state
+changed, `resume_current` also avoids the equality walk. Every resume form still
+returns immediately after the checkpoint flush; `advance` remains a separate
+call after any async wait.
 
 This is the same type Node, WASM, C, and C# drive, so behaviour is identical
 across hosts. Prefer `stream_response` in Rust servers: it writes straight into

--- a/examples/integration/streaming-browser-bench/README.md
+++ b/examples/integration/streaming-browser-bench/README.md
@@ -72,12 +72,12 @@ roots (1500) and the **same** total projected state value bytes (24 KiB of
 `label` values); only the boundary count (and marker layout) changes. "Projected
 state value bytes" counts the streamed `label` values a real app would ship, and
 deliberately excludes unavoidable per-boundary protocol/property overhead (the
-v2 `[2,recordSequence,kind,target,{...}]` envelope framing, required
+v3 `[3,recordSequence,kind,target,{...}]` envelope framing, required
 `declarationId`, the first-boundary `templates` block, and the tiny fixed `note`
 property) - that overhead is inherent to having more boundaries, not equal work
 to hold constant. It is projected-state value bytes, not total wire bytes.
 
-Each streamed boundary uses the v2 browser contract - `<!--wb:N-->` markers + SSR
+Each streamed boundary uses the v3 browser contract - `<!--wb:N-->` markers + SSR
 roots carrying `data-ws` + an inert `[data-webui-boundary]` JSON script + a
 `<webui-hydrate>` sentinel - appended one at a time, with the driver spinning the
 coordinator's microtask pump until that boundary's scaffolding is removed (a

--- a/examples/integration/streaming-browser-bench/README.md
+++ b/examples/integration/streaming-browser-bench/README.md
@@ -72,12 +72,12 @@ roots (1500) and the **same** total projected state value bytes (24 KiB of
 `label` values); only the boundary count (and marker layout) changes. "Projected
 state value bytes" counts the streamed `label` values a real app would ship, and
 deliberately excludes unavoidable per-boundary protocol/property overhead (the
-v3 `[3,recordSequence,kind,target,{...}]` envelope framing, required
+`[recordSequence,kind,target,{...}]` envelope framing, required
 `declarationId`, the first-boundary `templates` block, and the tiny fixed `note`
 property) - that overhead is inherent to having more boundaries, not equal work
 to hold constant. It is projected-state value bytes, not total wire bytes.
 
-Each streamed boundary uses the v3 browser contract - `<!--wb:N-->` markers + SSR
+Each streamed boundary uses the browser contract - `<!--wb:N-->` markers + SSR
 roots carrying `data-ws` + an inert `[data-webui-boundary]` JSON script + a
 `<webui-hydrate>` sentinel - appended one at a time, with the driver spinning the
 coordinator's microtask pump until that boundary's scaffolding is removed (a

--- a/examples/integration/streaming-browser-bench/tests/hydration_matrix.spec.ts
+++ b/examples/integration/streaming-browser-bench/tests/hydration_matrix.spec.ts
@@ -296,7 +296,7 @@ function parseBoundaryRecord(fragment: string): unknown[] {
 }
 
 test.describe('progressive streaming hydration matrix', () => {
-  test('generates gapless v2 checkpoint, update, and terminal records', () => {
+  test('generates gapless v3 checkpoint, update, and terminal records', () => {
     const checkpointScenario = buildStreamingScenario(3, 'flat', 'eager', true);
     const checkpointRecords = [
       ...checkpointScenario.boundaries,
@@ -304,7 +304,7 @@ test.describe('progressive streaming hydration matrix', () => {
     ].map(parseBoundaryRecord);
 
     expect(checkpointRecords.map((record) => record.length)).toEqual([5, 5, 5, 5, 5]);
-    expect(checkpointRecords.map((record) => record[0])).toEqual([2, 2, 2, 2, 2]);
+    expect(checkpointRecords.map((record) => record[0])).toEqual([3, 3, 3, 3, 3]);
     expect(checkpointRecords.map((record) => record[1])).toEqual([0, 1, 2, 3, 4]);
     expect(checkpointRecords.map((record) => record[2])).toEqual([0, 0, 0, 0, 4]);
     expect(checkpointRecords.map((record) => record[3])).toEqual([0, 1, 2, 3, 0]);
@@ -316,19 +316,19 @@ test.describe('progressive streaming hydration matrix', () => {
         'flat entry checkpoints omit enclosingSpanInstanceId',
       ).toBe(false);
     }
-    expect(checkpointRecords[4]).toEqual([2, 4, 4, 0, {}]);
+    expect(checkpointRecords[4]).toEqual([3, 4, 4, 0, {}]);
 
     const updateScenario = buildStateUpdateScenario(3, 100);
     const updateRecords = [
       ...updateScenario.boundaries,
       updateScenario.terminal,
     ].map(parseBoundaryRecord);
-    expect(updateRecords.map((record) => record[0])).toEqual([2, 2, 2, 2, 2]);
+    expect(updateRecords.map((record) => record[0])).toEqual([3, 3, 3, 3, 3]);
     expect(updateRecords.map((record) => record[1])).toEqual([0, 1, 2, 3, 4]);
     expect(updateRecords.map((record) => record[2])).toEqual([1, 2, 2, 2, 4]);
     expect(updateRecords.map((record) => record[3])).toEqual([0, 0, 0, 0, 0]);
     expect((updateRecords[0][4] as Record<string, unknown>).declarationId).toBe(0);
-    expect(updateRecords[4]).toEqual([2, 4, 4, 0, {}]);
+    expect(updateRecords[4]).toEqual([3, 4, 4, 0, {}]);
   });
 
   test('measures real coordinator + WebUIElement hydration across boundary counts', async ({ browser }) => {

--- a/examples/integration/streaming-browser-bench/tests/hydration_matrix.spec.ts
+++ b/examples/integration/streaming-browser-bench/tests/hydration_matrix.spec.ts
@@ -296,39 +296,37 @@ function parseBoundaryRecord(fragment: string): unknown[] {
 }
 
 test.describe('progressive streaming hydration matrix', () => {
-  test('generates gapless v3 checkpoint, update, and terminal records', () => {
+  test('generates gapless checkpoint, update, and terminal records', () => {
     const checkpointScenario = buildStreamingScenario(3, 'flat', 'eager', true);
     const checkpointRecords = [
       ...checkpointScenario.boundaries,
       checkpointScenario.terminal,
     ].map(parseBoundaryRecord);
 
-    expect(checkpointRecords.map((record) => record.length)).toEqual([5, 5, 5, 5, 5]);
-    expect(checkpointRecords.map((record) => record[0])).toEqual([3, 3, 3, 3, 3]);
-    expect(checkpointRecords.map((record) => record[1])).toEqual([0, 1, 2, 3, 4]);
-    expect(checkpointRecords.map((record) => record[2])).toEqual([0, 0, 0, 0, 4]);
-    expect(checkpointRecords.map((record) => record[3])).toEqual([0, 1, 2, 3, 0]);
+    expect(checkpointRecords.map((record) => record.length)).toEqual([4, 4, 4, 4, 4]);
+    expect(checkpointRecords.map((record) => record[0])).toEqual([0, 1, 2, 3, 4]);
+    expect(checkpointRecords.map((record) => record[1])).toEqual([0, 0, 0, 0, 4]);
+    expect(checkpointRecords.map((record) => record[2])).toEqual([0, 1, 2, 3, 0]);
     for (const record of checkpointRecords.slice(0, -1)) {
-      const bootstrap = record[4] as Record<string, unknown>;
+      const bootstrap = record[3] as Record<string, unknown>;
       expect(bootstrap.declarationId).toBe(0);
       expect(
         Object.prototype.hasOwnProperty.call(bootstrap, 'enclosingSpanInstanceId'),
         'flat entry checkpoints omit enclosingSpanInstanceId',
       ).toBe(false);
     }
-    expect(checkpointRecords[4]).toEqual([3, 4, 4, 0, {}]);
+    expect(checkpointRecords[4]).toEqual([4, 4, 0, {}]);
 
     const updateScenario = buildStateUpdateScenario(3, 100);
     const updateRecords = [
       ...updateScenario.boundaries,
       updateScenario.terminal,
     ].map(parseBoundaryRecord);
-    expect(updateRecords.map((record) => record[0])).toEqual([3, 3, 3, 3, 3]);
-    expect(updateRecords.map((record) => record[1])).toEqual([0, 1, 2, 3, 4]);
-    expect(updateRecords.map((record) => record[2])).toEqual([1, 2, 2, 2, 4]);
-    expect(updateRecords.map((record) => record[3])).toEqual([0, 0, 0, 0, 0]);
-    expect((updateRecords[0][4] as Record<string, unknown>).declarationId).toBe(0);
-    expect(updateRecords[4]).toEqual([3, 4, 4, 0, {}]);
+    expect(updateRecords.map((record) => record[0])).toEqual([0, 1, 2, 3, 4]);
+    expect(updateRecords.map((record) => record[1])).toEqual([1, 2, 2, 2, 4]);
+    expect(updateRecords.map((record) => record[2])).toEqual([0, 0, 0, 0, 0]);
+    expect((updateRecords[0][3] as Record<string, unknown>).declarationId).toBe(0);
+    expect(updateRecords[4]).toEqual([4, 4, 0, {}]);
   });
 
   test('measures real coordinator + WebUIElement hydration across boundary counts', async ({ browser }) => {

--- a/examples/integration/streaming-browser-bench/tests/lib/scenarios.ts
+++ b/examples/integration/streaming-browser-bench/tests/lib/scenarios.ts
@@ -15,7 +15,7 @@
  * coordinator (`packages/webui-framework/src/streaming.ts`) parses:
  *
  *   <!--wb:N--> <bench-island data-ws>...</bench-island> <!--/wb:N-->
- *   <script type="application/json" data-webui-boundary>[3,recordSequence,kind,target,payload]</script>
+ *   <script type="application/json" data-webui-boundary>[recordSequence,kind,target,payload]</script>
  *   <webui-hydrate></webui-hydrate>
  *
  * No whitespace is emitted between the `<!--/wb:N-->` end marker and the
@@ -37,7 +37,7 @@ export const TOTAL_ROOTS = 1500;
  * This counts only the bytes of the streamed `label` values (the dominant
  * projected state a real app would ship), summed across all boundaries. It
  * deliberately excludes the unavoidable per-boundary protocol/property overhead
- * — the v3 `[3,recordSequence,kind,target,{...}]` envelope framing, required
+ * — the `[recordSequence,kind,target,{...}]` envelope framing, required
  * `declarationId`, the `templates` block (first boundary only), and the tiny fixed
  * `note` property — because that overhead is inherent to having more boundaries
  * and is not "equal work" to hold constant. It is therefore projected-state
@@ -176,7 +176,6 @@ function boundaryFragment(
   };
   if (withTemplates) bootstrap.templates = { [ISLAND_TAG]: ISLAND_TEMPLATE };
   const envelope = JSON.stringify([
-    3,
     recordSequence,
     kind,
     boundaryInstanceId,
@@ -196,7 +195,6 @@ function stateUpdateFragment(
   label: string,
 ): string {
   const envelope = JSON.stringify([
-    3,
     recordSequence,
     2,
     boundaryId,
@@ -206,9 +204,9 @@ function stateUpdateFragment(
     + `<${'webui-hydrate'}></${'webui-hydrate'}>`;
 }
 
-/** The v3 terminal envelope: no markers, terminal kind 4, empty payload. */
+/** The terminal envelope: no markers, terminal kind 4, empty payload. */
 function terminalFragment(recordSequence: number): string {
-  const envelope = JSON.stringify([3, recordSequence, 4, 0, {}]);
+  const envelope = JSON.stringify([recordSequence, 4, 0, {}]);
   return `<script type="application/json" data-webui-boundary>${envelope}</script>`
     + `<${'webui-hydrate'}></${'webui-hydrate'}>`;
 }
@@ -217,7 +215,6 @@ function terminalFragment(recordSequence: number): string {
  * content boundary parses roots after the class has the same template metadata. */
 function templateSetupFragment(): string {
   const envelope = JSON.stringify([
-    3,
     0,
     0,
     0,

--- a/examples/integration/streaming-browser-bench/tests/lib/scenarios.ts
+++ b/examples/integration/streaming-browser-bench/tests/lib/scenarios.ts
@@ -15,7 +15,7 @@
  * coordinator (`packages/webui-framework/src/streaming.ts`) parses:
  *
  *   <!--wb:N--> <bench-island data-ws>...</bench-island> <!--/wb:N-->
- *   <script type="application/json" data-webui-boundary>[2,recordSequence,kind,target,payload]</script>
+ *   <script type="application/json" data-webui-boundary>[3,recordSequence,kind,target,payload]</script>
  *   <webui-hydrate></webui-hydrate>
  *
  * No whitespace is emitted between the `<!--/wb:N-->` end marker and the
@@ -37,7 +37,7 @@ export const TOTAL_ROOTS = 1500;
  * This counts only the bytes of the streamed `label` values (the dominant
  * projected state a real app would ship), summed across all boundaries. It
  * deliberately excludes the unavoidable per-boundary protocol/property overhead
- * — the v2 `[2,recordSequence,kind,target,{...}]` envelope framing, required
+ * — the v3 `[3,recordSequence,kind,target,{...}]` envelope framing, required
  * `declarationId`, the `templates` block (first boundary only), and the tiny fixed
  * `note` property — because that overhead is inherent to having more boundaries
  * and is not "equal work" to hold constant. It is therefore projected-state
@@ -176,7 +176,7 @@ function boundaryFragment(
   };
   if (withTemplates) bootstrap.templates = { [ISLAND_TAG]: ISLAND_TEMPLATE };
   const envelope = JSON.stringify([
-    2,
+    3,
     recordSequence,
     kind,
     boundaryInstanceId,
@@ -196,7 +196,7 @@ function stateUpdateFragment(
   label: string,
 ): string {
   const envelope = JSON.stringify([
-    2,
+    3,
     recordSequence,
     2,
     boundaryId,
@@ -206,9 +206,9 @@ function stateUpdateFragment(
     + `<${'webui-hydrate'}></${'webui-hydrate'}>`;
 }
 
-/** The v2 terminal envelope: no markers, terminal kind 4, empty payload. */
+/** The v3 terminal envelope: no markers, terminal kind 4, empty payload. */
 function terminalFragment(recordSequence: number): string {
-  const envelope = JSON.stringify([2, recordSequence, 4, 0, {}]);
+  const envelope = JSON.stringify([3, recordSequence, 4, 0, {}]);
   return `<script type="application/json" data-webui-boundary>${envelope}</script>`
     + `<${'webui-hydrate'}></${'webui-hydrate'}>`;
 }
@@ -217,7 +217,7 @@ function terminalFragment(recordSequence: number): string {
  * content boundary parses roots after the class has the same template metadata. */
 function templateSetupFragment(): string {
   const envelope = JSON.stringify([
-    2,
+    3,
     0,
     0,
     0,

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -269,8 +269,8 @@ activation. The coordinator does not publish that state to
 scaffolding after commit. Updates apply state to retained roots and never insert
 markup or rerun hydration.
 
-The browser reads version-3
-`[3, sequence, kind, target, payload]` records for final checkpoints,
+The browser reads the single unversioned
+`[sequence, kind, target, payload]` contract for final checkpoints,
 updatable checkpoints, updates, span completions, and terminal. Every commit
 also emits a `performance.mark()` - `webui:boundary:<id>`,
 `webui:boundary:<id>:update`, `webui:span:<id>`, or

--- a/packages/webui-framework/README.md
+++ b/packages/webui-framework/README.md
@@ -269,14 +269,20 @@ activation. The coordinator does not publish that state to
 scaffolding after commit. Updates apply state to retained roots and never insert
 markup or rerun hydration.
 
-The browser reads version-2
-`[2, sequence, kind, target, payload]` records for final checkpoints,
+The browser reads version-3
+`[3, sequence, kind, target, payload]` records for final checkpoints,
 updatable checkpoints, updates, span completions, and terminal. Every commit
 also emits a `performance.mark()` - `webui:boundary:<id>`,
 `webui:boundary:<id>:update`, `webui:span:<id>`, or
 `webui:streaming:terminal` - which needs no flag or listener.
 Set `window.__WEBUI_STREAMING_DEBUG__ = true` only when tooling needs the live
 `webui:boundary-hydrated` event as well.
+
+A range record can reuse the exact preceding range state with `stateRef` and
+carry only a top-level `stateDelta`. References are backward-only and resolved
+before activation; missing, stale, forward, or malformed references halt and
+clean up the stream. The reference base is released on terminal, cancellation,
+failure, or coordinator reset.
 
 Set `window.__WEBUI_STREAMING_SLICE_MS__` to a positive millisecond budget to
 make the coordinator yield between boundaries instead of draining its queue in

--- a/packages/webui-framework/src/streaming-bootstrap.ts
+++ b/packages/webui-framework/src/streaming-bootstrap.ts
@@ -25,6 +25,8 @@ export function applyBoundaryBootstrap(
     if (
       key === 'templates' ||
       key === 'state' ||
+      key === 'stateRef' ||
+      key === 'stateDelta' ||
       key === 'componentStyles' ||
       key === 'declarationId' ||
       key === 'enclosingSpanInstanceId'

--- a/packages/webui-framework/src/streaming-coordinator.ts
+++ b/packages/webui-framework/src/streaming-coordinator.ts
@@ -57,6 +57,10 @@ import type {
 } from './streaming-protocol.js';
 import { applyStateUpdate } from './streaming-state.js';
 import {
+  clearRangeState,
+  resolveRangeState,
+} from './streaming-record-state.js';
+import {
   abandonOpenSpans,
   completeSpan,
   hasOpenSpans,
@@ -218,6 +222,7 @@ function fail(reason: string): void {
   abandonPendingWaiters();
   abandonOpenSpans();
   clearUpdatableBoundaries();
+  clearRangeState();
   settlePendingTerminal(false);
   for (let i = queueHead; i < queue.length; i++) {
     discardRejectedBoundary(queue[i]);
@@ -404,11 +409,13 @@ function commitRecord(
   markBoundaryPending();
   let committed = false;
   try {
+    const state = resolveRangeState(payload, sequence);
     if (span) {
-      hydrateSpanCompletion(payload as SpanCompletionPayload, range, target);
+      hydrateSpanCompletion(payload as SpanCompletionPayload, state, range, target);
     } else {
       hydrateCheckpoint(
         payload as BoundaryBootstrap,
+        state,
         range,
         target,
         updatable,
@@ -442,6 +449,7 @@ function commitRecord(
 
 function hydrateCheckpoint(
   bootstrap: BoundaryBootstrap,
+  state: Record<string, unknown> | undefined,
   range: HydrationRange,
   target: number,
   updatable: boolean,
@@ -465,7 +473,7 @@ function hydrateCheckpoint(
     activateRootsBetween(
       range.start,
       range.end,
-      bootstrap.state,
+      state,
       boundary,
       bypass,
     );
@@ -481,6 +489,7 @@ function newUpdatableBoundary(): UpdatableBoundary {
 
 function hydrateSpanCompletion(
   payload: SpanCompletionPayload,
+  state: Record<string, unknown> | undefined,
   range: HydrationRange,
   target: number,
 ): void {
@@ -488,7 +497,7 @@ function hydrateSpanCompletion(
   if (invalid) throw new Error(invalid);
   applyBoundaryBootstrap(payload);
   // `prepareSpanCompletion` already rejected a markerless range.
-  activateRootsBetween(range.start!, range.end!, payload.state);
+  activateRootsBetween(range.start!, range.end!, state);
   completeSpan(target);
 }
 
@@ -589,6 +598,7 @@ function commitTerminal(
   removeBoundaryScaffolding(sentinel, scriptEl, null, null);
   terminalCommitted = true;
   pendingTerminalSequence = sequence;
+  clearRangeState();
   clearUpdatableBoundaries(true);
   scheduleTerminalValidation();
 }
@@ -703,6 +713,7 @@ export function resetStreamingCoordinatorStateForTests(): void {
   abandonOpenSpans();
   settlePendingTerminal(false);
   clearUpdatableBoundaries();
+  clearRangeState();
   coordinatorGeneration++;
   queue.length = 0;
   queueHead = 0;

--- a/packages/webui-framework/src/streaming-coordinator.ts
+++ b/packages/webui-framework/src/streaming-coordinator.ts
@@ -280,7 +280,7 @@ function processSentinel(sentinel: Element): void {
     return;
   }
 
-  const [, sequence, kind, target, payload] = parsed.envelope;
+  const [sequence, kind, target, payload] = parsed.envelope;
   if (sequence !== nextExpectedRecordSequence) {
     failBoundary(
       sentinel,

--- a/packages/webui-framework/src/streaming-pipeline.test.ts
+++ b/packages/webui-framework/src/streaming-pipeline.test.ts
@@ -530,7 +530,6 @@ function buildBoundary(sequence: number, terminal: number, roots: FakeElement[],
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       sequence,
       terminal === 1 ? 4 : 0,
       terminal === 1 ? 0 : sequence,
@@ -550,7 +549,6 @@ function buildMarkerless(sequence: number, terminal: number, bootstrap: object):
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       sequence,
       terminal === 1 ? 4 : 0,
       0,
@@ -577,7 +575,6 @@ function buildUpdatableBoundary(
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       recordSequence,
       1,
       boundaryId,
@@ -597,7 +594,7 @@ function buildStateUpdate(
 ): BuiltBoundary {
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
-    text: JSON.stringify([3, recordSequence, 2, boundaryId, patch]),
+    text: JSON.stringify([recordSequence, 2, boundaryId, patch]),
   });
   const sentinel = element('webui-hydrate');
   const root = body();
@@ -619,7 +616,6 @@ function buildSpanCompletion(
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       recordSequence,
       3,
       spanId,
@@ -697,7 +693,6 @@ function buildSpanScenario(
   const boundaryScript = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       boundarySequence,
       options.updatable ? 1 : 0,
       0,
@@ -732,7 +727,6 @@ function buildSpanScenario(
   const spanScript = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      3,
       spanSequence,
       3,
       spanId,
@@ -1487,7 +1481,7 @@ describe('streaming coordinator pipeline', () => {
     const previousError = console.error;
     console.error = () => {};
     try {
-      const boundary = buildRawBoundary(0, '[3,0,0,0,{"state":{}}]', []);
+      const boundary = buildRawBoundary(0, '[0,0,0,{"state":{}}]', []);
       enqueue(boundary.sentinel);
       await flush();
 
@@ -1507,7 +1501,7 @@ describe('streaming coordinator pipeline', () => {
     try {
       const boundary = buildRawBoundary(
         0,
-        JSON.stringify([3, 0, 0, 0, null]),
+        JSON.stringify([0, 0, 0, null]),
         [],
       );
       enqueue(boundary.sentinel);
@@ -1686,7 +1680,7 @@ describe('streaming coordinator pipeline', () => {
       hook() {},
       abandon() { abandoned++; },
     });
-    const b = buildRawBoundary(0, '[3,0,0,{', [root0]);
+    const b = buildRawBoundary(0, '[0,0,{', [root0]);
 
     enqueue(b.sentinel);
     await flush();
@@ -1718,7 +1712,7 @@ describe('streaming coordinator pipeline', () => {
     const end = comment('/wb:0');
     const scriptEl = element('script', {
       attrs: { 'data-webui-boundary': '' },
-      text: JSON.stringify([3, 0, 0, 0, { declarationId: 0 }]),
+      text: JSON.stringify([0, 0, 0, { declarationId: 0 }]),
     });
     const sentinel = element('webui-hydrate');
     const root = body();
@@ -1836,7 +1830,6 @@ describe('streaming coordinator pipeline', () => {
     const innerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        3,
         0,
         3,
         1,
@@ -1857,7 +1850,6 @@ describe('streaming coordinator pipeline', () => {
     const outerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        3,
         1,
         3,
         0,
@@ -2330,7 +2322,6 @@ describe('streaming coordinator pipeline', () => {
     const boundaryScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        3,
         0,
         0,
         0,
@@ -2355,7 +2346,6 @@ describe('streaming coordinator pipeline', () => {
     const innerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        3,
         1,
         3,
         1,
@@ -2376,7 +2366,6 @@ describe('streaming coordinator pipeline', () => {
     const outerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        3,
         2,
         3,
         0,
@@ -2819,7 +2808,7 @@ describe('streaming coordinator pipeline', () => {
     assert.equal(__getLifecycleStateForTests().pendingLateActivations, 1);
 
     // Halt via a malformed boundary at the next sequence.
-    const bad = buildRawBoundary(1, '[3,1,0,{', []);
+    const bad = buildRawBoundary(1, '[1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
     assert.equal(__isHaltedForTests(), true);
@@ -2856,7 +2845,7 @@ describe('streaming coordinator pipeline', () => {
     await flush();
     detach(outer);
 
-    const bad = buildRawBoundary(1, '[3,1,0,{', []);
+    const bad = buildRawBoundary(1, '[1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
 
@@ -3008,7 +2997,7 @@ describe('streaming coordinator pipeline', () => {
 
   test('an illegal record queued behind terminal aborts before hydration-complete', async () => {
     const terminal = buildMarkerless(0, 1, {});
-    const post = buildRawBoundary(1, '[3,1,0,{}]', []);
+    const post = buildRawBoundary(1, '[1,0,{}]', []);
 
     // Both records are present before the single pump runs. The terminal must
     // remain tentative until the queue validates the record behind it.
@@ -3332,7 +3321,7 @@ describe('streaming coordinator pipeline', () => {
   test('a rejected (malformed) boundary strips data-ws from its roots, keeping them', async () => {
     const root0 = element('my-ws', { attrs: { 'data-ws': '' }, hook() {} });
     assert.equal(hasWs(root0), true, 'root starts marked as a streamed host');
-    const b = buildRawBoundary(0, '[3,0,0,{', [root0]);
+    const b = buildRawBoundary(0, '[0,0,{', [root0]);
 
     enqueue(b.sentinel);
     await flush();
@@ -3363,7 +3352,7 @@ describe('streaming coordinator pipeline', () => {
     assert.equal(hasWs(late), true, 'a deferred undefined-tag root keeps data-ws until activation');
 
     // Halt via a malformed follow-up boundary.
-    const bad = buildRawBoundary(1, '[3,1,0,{', []);
+    const bad = buildRawBoundary(1, '[1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
 

--- a/packages/webui-framework/src/streaming-pipeline.test.ts
+++ b/packages/webui-framework/src/streaming-pipeline.test.ts
@@ -530,7 +530,7 @@ function buildBoundary(sequence: number, terminal: number, roots: FakeElement[],
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       sequence,
       terminal === 1 ? 4 : 0,
       terminal === 1 ? 0 : sequence,
@@ -550,7 +550,7 @@ function buildMarkerless(sequence: number, terminal: number, bootstrap: object):
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       sequence,
       terminal === 1 ? 4 : 0,
       0,
@@ -577,7 +577,7 @@ function buildUpdatableBoundary(
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       recordSequence,
       1,
       boundaryId,
@@ -597,7 +597,7 @@ function buildStateUpdate(
 ): BuiltBoundary {
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
-    text: JSON.stringify([2, recordSequence, 2, boundaryId, patch]),
+    text: JSON.stringify([3, recordSequence, 2, boundaryId, patch]),
   });
   const sentinel = element('webui-hydrate');
   const root = body();
@@ -619,7 +619,7 @@ function buildSpanCompletion(
   const scriptEl = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       recordSequence,
       3,
       spanId,
@@ -697,7 +697,7 @@ function buildSpanScenario(
   const boundaryScript = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       boundarySequence,
       options.updatable ? 1 : 0,
       0,
@@ -732,7 +732,7 @@ function buildSpanScenario(
   const spanScript = element('script', {
     attrs: { 'data-webui-boundary': '' },
     text: JSON.stringify([
-      2,
+      3,
       spanSequence,
       3,
       spanId,
@@ -1487,7 +1487,7 @@ describe('streaming coordinator pipeline', () => {
     const previousError = console.error;
     console.error = () => {};
     try {
-      const boundary = buildRawBoundary(0, '[2,0,0,0,{"state":{}}]', []);
+      const boundary = buildRawBoundary(0, '[3,0,0,0,{"state":{}}]', []);
       enqueue(boundary.sentinel);
       await flush();
 
@@ -1507,7 +1507,7 @@ describe('streaming coordinator pipeline', () => {
     try {
       const boundary = buildRawBoundary(
         0,
-        JSON.stringify([2, 0, 0, 0, null]),
+        JSON.stringify([3, 0, 0, 0, null]),
         [],
       );
       enqueue(boundary.sentinel);
@@ -1515,6 +1515,31 @@ describe('streaming coordinator pipeline', () => {
 
       assert.equal(__isHaltedForTests(), true);
       assert.equal(__getLifecycleStateForTests().completed, false);
+    } finally {
+      console.error = previousError;
+    }
+  });
+
+  test('halts and cleans the range when a state reference has no prior range', async () => {
+    const previousError = console.error;
+    console.error = () => {};
+    try {
+      let activations = 0;
+      const root = element('missing-state-ref', {
+        hook() {
+          activations++;
+        },
+      });
+      predefine('missing-state-ref');
+      const boundary = buildBoundary(0, 0, [root], { stateRef: 9 });
+
+      enqueue(boundary.sentinel);
+      await flush();
+
+      assert.equal(activations, 0);
+      assert.equal(__isHaltedForTests(), true);
+      assertScaffoldCleaned(boundary);
+      assert.equal(hasStreamingAttrs(root), false);
     } finally {
       console.error = previousError;
     }
@@ -1661,7 +1686,7 @@ describe('streaming coordinator pipeline', () => {
       hook() {},
       abandon() { abandoned++; },
     });
-    const b = buildRawBoundary(0, '[2,0,0,{', [root0]);
+    const b = buildRawBoundary(0, '[3,0,0,{', [root0]);
 
     enqueue(b.sentinel);
     await flush();
@@ -1693,7 +1718,7 @@ describe('streaming coordinator pipeline', () => {
     const end = comment('/wb:0');
     const scriptEl = element('script', {
       attrs: { 'data-webui-boundary': '' },
-      text: JSON.stringify([2, 0, 0, 0, { declarationId: 0 }]),
+      text: JSON.stringify([3, 0, 0, 0, { declarationId: 0 }]),
     });
     const sentinel = element('webui-hydrate');
     const root = body();
@@ -1811,7 +1836,7 @@ describe('streaming coordinator pipeline', () => {
     const innerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        2,
+        3,
         0,
         3,
         1,
@@ -1832,7 +1857,7 @@ describe('streaming coordinator pipeline', () => {
     const outerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        2,
+        3,
         1,
         3,
         0,
@@ -2305,7 +2330,7 @@ describe('streaming coordinator pipeline', () => {
     const boundaryScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        2,
+        3,
         0,
         0,
         0,
@@ -2330,7 +2355,7 @@ describe('streaming coordinator pipeline', () => {
     const innerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        2,
+        3,
         1,
         3,
         1,
@@ -2351,7 +2376,7 @@ describe('streaming coordinator pipeline', () => {
     const outerScript = element('script', {
       attrs: { 'data-webui-boundary': '' },
       text: JSON.stringify([
-        2,
+        3,
         2,
         3,
         0,
@@ -2794,7 +2819,7 @@ describe('streaming coordinator pipeline', () => {
     assert.equal(__getLifecycleStateForTests().pendingLateActivations, 1);
 
     // Halt via a malformed boundary at the next sequence.
-    const bad = buildRawBoundary(1, '[2,1,0,{', []);
+    const bad = buildRawBoundary(1, '[3,1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
     assert.equal(__isHaltedForTests(), true);
@@ -2831,7 +2856,7 @@ describe('streaming coordinator pipeline', () => {
     await flush();
     detach(outer);
 
-    const bad = buildRawBoundary(1, '[2,1,0,{', []);
+    const bad = buildRawBoundary(1, '[3,1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
 
@@ -2983,7 +3008,7 @@ describe('streaming coordinator pipeline', () => {
 
   test('an illegal record queued behind terminal aborts before hydration-complete', async () => {
     const terminal = buildMarkerless(0, 1, {});
-    const post = buildRawBoundary(1, '[2,1,0,{}]', []);
+    const post = buildRawBoundary(1, '[3,1,0,{}]', []);
 
     // Both records are present before the single pump runs. The terminal must
     // remain tentative until the queue validates the record behind it.
@@ -3203,6 +3228,88 @@ describe('streaming coordinator pipeline', () => {
     assert.deepEqual(received, { seq: 0 }, 'the delayed root activates with the state its own boundary carried');
   });
 
+  test('reconstructs independently arriving state deltas without mutating an earlier delayed root', async () => {
+    let delayedState: Record<string, unknown> | undefined;
+    let currentState: Record<string, unknown> | undefined;
+    const delayed = element('state-ref-delayed', {
+      hook(state) {
+        delayedState = state;
+      },
+    });
+    const first = buildBoundary(0, 0, [delayed], {
+      state: { todos: [{ id: 1 }] },
+    });
+    enqueue(first.sentinel);
+    await flush();
+
+    const current = element('state-ref-current', {
+      hook(state) {
+        currentState = state;
+      },
+    });
+    predefine('state-ref-current');
+    const second = buildUpdatableBoundary(1, 1, [current], {
+      stateRef: 0,
+      stateDelta: { toolbar: { active: true } },
+    });
+    enqueue(second.sentinel);
+    await flush();
+
+    assert.deepEqual(currentState, {
+      todos: [{ id: 1 }],
+      toolbar: { active: true },
+    });
+    defineTag('state-ref-delayed');
+    await flush();
+    assert.deepEqual(
+      delayedState,
+      { todos: [{ id: 1 }] },
+      'a later delta must not mutate the referenced boundary state',
+    );
+  });
+
+  test('keeps range-state references independent from updatable boundary patches', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const firstRoot = element('state-ref-updatable', {
+      hook() {},
+      setState(state) {
+        updates.push(state);
+      },
+    });
+    predefine('state-ref-updatable');
+    enqueue(buildUpdatableBoundary(
+      0,
+      0,
+      [firstRoot],
+      { state: { shared: 'base' } },
+    ).sentinel);
+    await flush();
+
+    enqueue(buildStateUpdate(1, 0, { shared: 'updated' }).sentinel);
+    await flush();
+
+    let secondState: Record<string, unknown> | undefined;
+    const secondRoot = element('state-ref-second', {
+      hook(state) {
+        secondState = state;
+      },
+    });
+    predefine('state-ref-second');
+    enqueue(buildUpdatableBoundary(
+      2,
+      1,
+      [secondRoot],
+      { stateRef: 0, stateDelta: { local: true } },
+    ).sentinel);
+    await flush();
+
+    assert.deepEqual(updates, [{ shared: 'updated' }]);
+    assert.deepEqual(secondState, { shared: 'base', local: true });
+    enqueue(buildMarkerless(3, 1, {}).sentinel);
+    await flush();
+    assert.equal(__isHaltedForTests(), false);
+  });
+
   test('a boundary carrying no state stashes presence and activates with undefined', async () => {
     let received: Record<string, unknown> | undefined | 'unset' = 'unset';
     const late = element('my-nostate', { hook(state) { received = state; } });
@@ -3225,7 +3332,7 @@ describe('streaming coordinator pipeline', () => {
   test('a rejected (malformed) boundary strips data-ws from its roots, keeping them', async () => {
     const root0 = element('my-ws', { attrs: { 'data-ws': '' }, hook() {} });
     assert.equal(hasWs(root0), true, 'root starts marked as a streamed host');
-    const b = buildRawBoundary(0, '[2,0,0,{', [root0]);
+    const b = buildRawBoundary(0, '[3,0,0,{', [root0]);
 
     enqueue(b.sentinel);
     await flush();
@@ -3256,7 +3363,7 @@ describe('streaming coordinator pipeline', () => {
     assert.equal(hasWs(late), true, 'a deferred undefined-tag root keeps data-ws until activation');
 
     // Halt via a malformed follow-up boundary.
-    const bad = buildRawBoundary(1, '[2,1,0,{', []);
+    const bad = buildRawBoundary(1, '[3,1,0,{', []);
     enqueue(bad.sentinel);
     await flush();
 

--- a/packages/webui-framework/src/streaming-protocol.ts
+++ b/packages/webui-framework/src/streaming-protocol.ts
@@ -5,7 +5,7 @@ import type { TemplateMeta } from './template.js';
 import type { ComponentStyles } from './element/styles.js';
 
 /** Clean-break component-local streaming protocol version. */
-export const STREAMING_PROTOCOL_VERSION = 2;
+export const STREAMING_PROTOCOL_VERSION = 3;
 
 /** Boundary-local data carried by one streamed hydration checkpoint. */
 export interface BoundaryBootstrap {
@@ -19,6 +19,10 @@ export interface BoundaryBootstrap {
    */
   enclosingSpanInstanceId?: number;
   state?: Record<string, unknown>;
+  /** Exact prior range-record sequence whose resolved state is the delta base. */
+  stateRef?: number;
+  /** Top-level additions or replacements over `stateRef`. */
+  stateDelta?: Record<string, unknown>;
   templates?: Record<string, TemplateMeta>;
   inventory?: string;
   nonce?: string;
@@ -56,6 +60,10 @@ export type BoundaryRecordKind =
  */
 export interface SpanCompletionPayload {
   state?: Record<string, unknown>;
+  /** Exact prior range-record sequence whose resolved state is the delta base. */
+  stateRef?: number;
+  /** Top-level additions or replacements over `stateRef`. */
+  stateDelta?: Record<string, unknown>;
   templates?: Record<string, TemplateMeta>;
   inventory?: string;
   nonce?: string;

--- a/packages/webui-framework/src/streaming-protocol.ts
+++ b/packages/webui-framework/src/streaming-protocol.ts
@@ -4,9 +4,6 @@
 import type { TemplateMeta } from './template.js';
 import type { ComponentStyles } from './element/styles.js';
 
-/** Clean-break component-local streaming protocol version. */
-export const STREAMING_PROTOCOL_VERSION = 3;
-
 /** Boundary-local data carried by one streamed hydration checkpoint. */
 export interface BoundaryBootstrap {
   /** Compiler declaration that produced this runtime boundary occurrence. */
@@ -78,9 +75,8 @@ export type BoundaryRecordPayload =
   | SpanCompletionPayload
   | Record<string, unknown>;
 
-/** Compact versioned wire record for one streamed response operation. */
+/** Compact wire record for one streamed response operation. */
 export type BoundaryEnvelope = readonly [
-  version: number,
   recordSequence: number,
   kind: BoundaryRecordKind,
   target: number,
@@ -101,15 +97,11 @@ function invalid(reason: string): ParseBoundaryEnvelopeResult {
  * Only two failure modes are real, so only two are checked. A response cut off
  * mid-record leaves a proper prefix of a JSON array, and every proper prefix of
  * a JSON array is invalid JSON, which makes `JSON.parse` a complete truncation
- * detector. Separately, the client bundle is HTTP-cached and can therefore be
- * older than the server that produced the response, so the version is gated
- * before any element of the tuple is trusted.
+ * detector. A complete record must then have the one supported tuple shape.
  *
  * Past those checks the tuple was written by our own serializer and is not
- * re-validated. That makes `version` load-bearing: any new record kind or tuple
- * shape must bump it. Sequence, kind, and target ordering are document state
- * and are checked by the coordinator, which fails the stream closed on a
- * mismatch.
+ * re-validated. Sequence, kind, and target ordering are document state and are
+ * checked by the coordinator, which fails the stream closed on a mismatch.
  */
 export function parseBoundaryEnvelope(text: string): ParseBoundaryEnvelopeResult {
   let parsed: unknown;
@@ -119,14 +111,9 @@ export function parseBoundaryEnvelope(text: string): ParseBoundaryEnvelopeResult
     return invalid('boundary payload is not valid JSON');
   }
 
-  if (!Array.isArray(parsed) || parsed.length !== 5) {
+  if (!Array.isArray(parsed) || parsed.length !== 4) {
     return invalid(
-      'boundary envelope must be a 5-element [version, recordSequence, kind, target, payload] array',
-    );
-  }
-  if (parsed[0] !== STREAMING_PROTOCOL_VERSION) {
-    return invalid(
-      `unsupported boundary envelope version ${JSON.stringify(parsed[0])}`,
+      'boundary envelope must be a 4-element [recordSequence, kind, target, payload] array',
     );
   }
 

--- a/packages/webui-framework/src/streaming-record-state.test.ts
+++ b/packages/webui-framework/src/streaming-record-state.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { strict as assert } from 'node:assert';
+import { beforeEach, describe, test } from 'node:test';
+
+import type { BoundaryBootstrap } from './streaming-protocol.js';
+import {
+  clearRangeState,
+  resolveRangeState,
+} from './streaming-record-state.js';
+
+function payload(
+  value: Omit<BoundaryBootstrap, 'componentStyles' | 'declarationId'>,
+): BoundaryBootstrap {
+  return {
+    declarationId: 0,
+    componentStyles: {} as BoundaryBootstrap['componentStyles'],
+    ...value,
+  };
+}
+
+describe('streaming range state references', () => {
+  beforeEach(clearRangeState);
+
+  test('reuses an exact prior projection without aliasing component state', () => {
+    const first = resolveRangeState(
+      payload({ state: { todos: [{ id: 1 }] } }),
+      0,
+    );
+    const second = resolveRangeState(payload({ stateRef: 0 }), 1);
+
+    assert.deepEqual(second, first);
+    assert.notStrictEqual(second, first);
+    assert.notStrictEqual(second?.todos, first?.todos);
+    const firstTodos = first?.todos as Array<{ id: number }>;
+    firstTodos[0].id = 9;
+    assert.deepEqual(second, { todos: [{ id: 1 }] });
+  });
+
+  test('applies a top-level delta without mutating the referenced state', () => {
+    const first = resolveRangeState(
+      payload({ state: { todos: [{ id: 1 }] } }),
+      0,
+    );
+    const second = resolveRangeState(
+      payload({ stateRef: 0, stateDelta: { toolbar: { active: true } } }),
+      2,
+    );
+
+    assert.deepEqual(first, { todos: [{ id: 1 }] });
+    assert.deepEqual(second, {
+      todos: [{ id: 1 }],
+      toolbar: { active: true },
+    });
+  });
+
+  test('rejects missing, stale, forward, and malformed references', () => {
+    assert.throws(
+      () => resolveRangeState(payload({ stateRef: 0 }), 1),
+      /prior range record none/,
+    );
+
+    clearRangeState();
+    resolveRangeState(payload({ state: { a: 1 } }), 0);
+    assert.throws(
+      () => resolveRangeState(payload({ stateRef: 2 }), 1),
+      /invalid streaming state reference/,
+    );
+    assert.throws(
+      () => resolveRangeState(payload({ stateRef: 0, state: { a: 1 } }), 1),
+      /must not include complete state/,
+    );
+    assert.throws(
+      () =>
+        resolveRangeState(
+          payload({
+            stateRef: 0,
+            stateDelta: [] as unknown as Record<string, unknown>,
+          }),
+          1,
+        ),
+      /state delta must be an object/,
+    );
+
+    clearRangeState();
+    resolveRangeState(payload({ state: { a: 1 } }), 0);
+    resolveRangeState(payload({ stateRef: 0 }), 1);
+    assert.throws(
+      () => resolveRangeState(payload({ stateRef: 0 }), 2),
+      /does not match prior range record 1/,
+    );
+  });
+
+  test('releases the reference base on cancellation or reset', () => {
+    resolveRangeState(payload({ state: { retained: true } }), 0);
+    clearRangeState();
+
+    assert.throws(
+      () => resolveRangeState(payload({ stateRef: 0 }), 1),
+      /prior range record none/,
+    );
+  });
+});

--- a/packages/webui-framework/src/streaming-record-state.ts
+++ b/packages/webui-framework/src/streaming-record-state.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import type {
+  BoundaryBootstrap,
+  SpanCompletionPayload,
+} from './streaming-protocol.js';
+
+type RangePayload = BoundaryBootstrap | SpanCompletionPayload;
+type StreamedState = Record<string, unknown> | undefined;
+
+let lastRangeSequence: number | undefined;
+let lastRangeState: StreamedState;
+
+/**
+ * Resolve one range record's exact state from its complete projection or an
+ * ordered reference to the immediately preceding range record.
+ */
+export function resolveRangeState(
+  payload: RangePayload,
+  sequence: number,
+): StreamedState {
+  const reference = payload.stateRef;
+  if (reference === undefined) {
+    if (payload.stateDelta !== undefined) {
+      throw new Error('streaming state delta is missing its stateRef');
+    }
+    const state = payload.state;
+    if (state !== undefined && !isStateObject(state)) {
+      throw new Error('streaming range state must be an object');
+    }
+    lastRangeSequence = sequence;
+    lastRangeState = cloneState(state);
+    return state;
+  }
+
+  if (
+    !Number.isSafeInteger(reference) ||
+    reference < 0 ||
+    reference >= sequence
+  ) {
+    throw new Error(`invalid streaming state reference ${String(reference)}`);
+  }
+  if (payload.state !== undefined) {
+    throw new Error('referenced streaming state must not include complete state');
+  }
+  if (lastRangeSequence === undefined || reference !== lastRangeSequence) {
+    throw new Error(
+      `streaming state reference ${reference} does not match prior range record ${
+        lastRangeSequence === undefined ? 'none' : lastRangeSequence
+      }`,
+    );
+  }
+
+  const delta = payload.stateDelta;
+  if (delta !== undefined && !isStateObject(delta)) {
+    throw new Error('streaming state delta must be an object');
+  }
+  const state = mergeStateDelta(lastRangeState, delta);
+  lastRangeSequence = sequence;
+  lastRangeState = state;
+  return cloneState(state);
+}
+
+export function clearRangeState(): void {
+  lastRangeSequence = undefined;
+  lastRangeState = undefined;
+}
+
+function isStateObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeStateDelta(
+  base: StreamedState,
+  delta: Record<string, unknown> | undefined,
+): StreamedState {
+  if (delta === undefined || Object.keys(delta).length === 0) return base;
+  if (base === undefined) {
+    throw new Error('streaming state delta references missing base state');
+  }
+  return { ...base, ...delta };
+}
+
+function cloneState(state: StreamedState): StreamedState {
+  return state === undefined ? undefined : structuredClone(state);
+}

--- a/packages/webui-framework/src/streaming.test.ts
+++ b/packages/webui-framework/src/streaming.test.ts
@@ -20,13 +20,13 @@ const { parseBoundaryEnvelope } = await import('./streaming.js');
 describe('parseBoundaryEnvelope', () => {
   test('accepts a well-formed non-terminal boundary envelope', () => {
     const result = parseBoundaryEnvelope(
-      '[2,0,0,0,{"declarationId":7,"inventory":"01","state":{"count":1},"templates":{"my-counter":{"h":"<button></button>"}}}]',
+      '[3,0,0,0,{"declarationId":7,"inventory":"01","state":{"count":1},"templates":{"my-counter":{"h":"<button></button>"}}}]',
     );
     assert.equal(result.ok, true);
     if (!result.ok) return;
     const [version, sequence, kind, target, payload] = result.envelope;
     const bootstrap = payload as BoundaryBootstrap;
-    assert.equal(version, 2);
+    assert.equal(version, 3);
     assert.equal(sequence, 0);
     assert.equal(kind, 0);
     assert.equal(target, 0);
@@ -37,7 +37,7 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('accepts the empty terminal boundary envelope', () => {
-    const result = parseBoundaryEnvelope('[2,2,4,0,{}]');
+    const result = parseBoundaryEnvelope('[3,2,4,0,{}]');
     assert.equal(result.ok, true);
     if (!result.ok) return;
     const [, sequence, kind, target, bootstrap] = result.envelope;
@@ -48,7 +48,7 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('accepts a projected state update record', () => {
-    const result = parseBoundaryEnvelope('[2,2,2,0,{"forecast":"Sunny"}]');
+    const result = parseBoundaryEnvelope('[3,2,2,0,{"forecast":"Sunny"}]');
     assert.equal(result.ok, true);
     if (!result.ok) return;
     const [, sequence, kind, target, patch] = result.envelope;
@@ -60,7 +60,7 @@ describe('parseBoundaryEnvelope', () => {
 
   test('accepts a component span completion in its separate target namespace', () => {
     const result = parseBoundaryEnvelope(
-      '[2,3,3,0,{"state":{"parent":"complete"},"inventory":"03"}]',
+      '[3,3,3,0,{"state":{"parent":"complete"},"inventory":"03"}]',
     );
     assert.equal(result.ok, true);
     if (!result.ok) return;
@@ -75,28 +75,28 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('rejects invalid JSON', () => {
-    const result = parseBoundaryEnvelope('[2,0,0,0,{');
+    const result = parseBoundaryEnvelope('[3,0,0,0,{');
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.reason, /not valid JSON/);
   });
 
   test('rejects a non-array envelope', () => {
-    const result = parseBoundaryEnvelope('{"version":2}');
+    const result = parseBoundaryEnvelope('{"version":3}');
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.reason, /5-element/);
   });
 
   test('rejects an envelope with the wrong element count', () => {
-    const result = parseBoundaryEnvelope('[2,0,0,0]');
+    const result = parseBoundaryEnvelope('[3,0,0,0]');
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.reason, /5-element/);
   });
 
   test('rejects an unsupported version', () => {
-    const result = parseBoundaryEnvelope('[1,0,0,0,{}]');
+    const result = parseBoundaryEnvelope('[2,0,0,0,{}]');
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.reason, /unsupported boundary envelope version/);
@@ -108,11 +108,11 @@ describe('parseBoundaryEnvelope', () => {
   // coordinator instead, which is covered in streaming-pipeline.test.ts.
   test('passes malformed trailing fields through to the coordinator', () => {
     for (const record of [
-      '[2,-1,0,0,{}]',
-      '[2,0,9,0,{}]',
-      '[2,0,0,-1,{}]',
-      '[2,0,0,0,null]',
-      '[2,2,4,0,{"state":{"count":1}}]',
+      '[3,-1,0,0,{}]',
+      '[3,0,9,0,{}]',
+      '[3,0,0,-1,{}]',
+      '[3,0,0,0,null]',
+      '[3,2,4,0,{"state":{"count":1}}]',
     ]) {
       const result = parseBoundaryEnvelope(record);
       assert.equal(result.ok, true, `expected ${record} to parse`);

--- a/packages/webui-framework/src/streaming.test.ts
+++ b/packages/webui-framework/src/streaming.test.ts
@@ -20,13 +20,12 @@ const { parseBoundaryEnvelope } = await import('./streaming.js');
 describe('parseBoundaryEnvelope', () => {
   test('accepts a well-formed non-terminal boundary envelope', () => {
     const result = parseBoundaryEnvelope(
-      '[3,0,0,0,{"declarationId":7,"inventory":"01","state":{"count":1},"templates":{"my-counter":{"h":"<button></button>"}}}]',
+      '[0,0,0,{"declarationId":7,"inventory":"01","state":{"count":1},"templates":{"my-counter":{"h":"<button></button>"}}}]',
     );
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    const [version, sequence, kind, target, payload] = result.envelope;
+    const [sequence, kind, target, payload] = result.envelope;
     const bootstrap = payload as BoundaryBootstrap;
-    assert.equal(version, 3);
     assert.equal(sequence, 0);
     assert.equal(kind, 0);
     assert.equal(target, 0);
@@ -37,10 +36,10 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('accepts the empty terminal boundary envelope', () => {
-    const result = parseBoundaryEnvelope('[3,2,4,0,{}]');
+    const result = parseBoundaryEnvelope('[2,4,0,{}]');
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    const [, sequence, kind, target, bootstrap] = result.envelope;
+    const [sequence, kind, target, bootstrap] = result.envelope;
     assert.equal(sequence, 2);
     assert.equal(kind, 4);
     assert.equal(target, 0);
@@ -48,10 +47,10 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('accepts a projected state update record', () => {
-    const result = parseBoundaryEnvelope('[3,2,2,0,{"forecast":"Sunny"}]');
+    const result = parseBoundaryEnvelope('[2,2,0,{"forecast":"Sunny"}]');
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    const [, sequence, kind, target, patch] = result.envelope;
+    const [sequence, kind, target, patch] = result.envelope;
     assert.equal(sequence, 2);
     assert.equal(kind, 2);
     assert.equal(target, 0);
@@ -60,11 +59,11 @@ describe('parseBoundaryEnvelope', () => {
 
   test('accepts a component span completion in its separate target namespace', () => {
     const result = parseBoundaryEnvelope(
-      '[3,3,3,0,{"state":{"parent":"complete"},"inventory":"03"}]',
+      '[3,3,0,{"state":{"parent":"complete"},"inventory":"03"}]',
     );
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    const [, sequence, kind, target, payload] = result.envelope;
+    const [sequence, kind, target, payload] = result.envelope;
     assert.equal(sequence, 3);
     assert.equal(kind, 3);
     assert.equal(target, 0);
@@ -75,44 +74,44 @@ describe('parseBoundaryEnvelope', () => {
   });
 
   test('rejects invalid JSON', () => {
-    const result = parseBoundaryEnvelope('[3,0,0,0,{');
+    const result = parseBoundaryEnvelope('[0,0,0,{');
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.reason, /not valid JSON/);
   });
 
   test('rejects a non-array envelope', () => {
-    const result = parseBoundaryEnvelope('{"version":3}');
+    const result = parseBoundaryEnvelope('{"sequence":0}');
     assert.equal(result.ok, false);
     if (result.ok) return;
-    assert.match(result.reason, /5-element/);
+    assert.match(result.reason, /4-element/);
   });
 
   test('rejects an envelope with the wrong element count', () => {
-    const result = parseBoundaryEnvelope('[3,0,0,0]');
+    const result = parseBoundaryEnvelope('[0,0,0]');
     assert.equal(result.ok, false);
     if (result.ok) return;
-    assert.match(result.reason, /5-element/);
+    assert.match(result.reason, /4-element/);
   });
 
-  test('rejects an unsupported version', () => {
-    const result = parseBoundaryEnvelope('[2,0,0,0,{}]');
+  test('rejects a legacy versioned envelope', () => {
+    const result = parseBoundaryEnvelope('[3,0,0,0,{}]');
     assert.equal(result.ok, false);
     if (result.ok) return;
-    assert.match(result.reason, /unsupported boundary envelope version/);
+    assert.match(result.reason, /4-element/);
   });
 
-  // Fields past the version gate are written by the Rust checkpoint serializer
+  // Fields past the tuple-shape gate are written by the Rust checkpoint serializer
   // and are deliberately not re-validated here. A record that reaches this
   // parser intact but is inconsistent with document state is rejected by the
   // coordinator instead, which is covered in streaming-pipeline.test.ts.
   test('passes malformed trailing fields through to the coordinator', () => {
     for (const record of [
-      '[3,-1,0,0,{}]',
-      '[3,0,9,0,{}]',
-      '[3,0,0,-1,{}]',
-      '[3,0,0,0,null]',
-      '[3,2,4,0,{"state":{"count":1}}]',
+      '[-1,0,0,{}]',
+      '[0,9,0,{}]',
+      '[0,0,-1,{}]',
+      '[0,0,0,null]',
+      '[2,4,0,{"state":{"count":1}}]',
     ]) {
       const result = parseBoundaryEnvelope(record);
       assert.equal(result.ok, true, `expected ${record} to parse`);


### PR DESCRIPTION
## Why

Progressive streaming was doing substantially more work than buffered rendering before any network cost: 2.216 ms versus 0.493 ms in the Light DOM todo benchmark. Two records also serialized nearly identical projected state, adding about 87 KB per response. The host additionally needs to pause after a committed boundary flush, await data without holding a worker thread, then resume the same response efficiently.

## What changed

- Reuse prior projected state through strict backward-only `stateRef` and `stateDelta` records instead of serializing the same JSON again.
- Validate missing, stale, forward, and projection-mismatched references in the browser coordinator.
- Retain continuation state across `start`, boundary-only `resume`, and parent/tail `advance` steps so the checkpoint remains a real async pause point.
- Use one public `start` and `resume` API for owned or borrowed state, with `resume_current` as the no-overlay fast path.
- Stream component-style metadata from borrowed protocol data instead of materializing temporary JSON maps, sets, vectors, and cloned strings.
- Keep a single unversioned four-field streaming record envelope with no compatibility branch.
- Update Rust, Node, WASM, Python, C/C#, CLI proxy, browser, specification, and integration documentation together.

## Performance

### Light DOM todo core profile

These are in-process render measurements taken before Actix or network work. The optimized profile used the same Light DOM todo workload after the core state-reuse and continuation changes.

| Metric | WebUI 0.0.27 baseline | Optimized core | Change |
|---|---:|---:|---:|
| Buffered render CPU | 0.493 ms | 0.469 ms | -4.9% |
| Streaming render CPU | 2.216 ms | 0.538 ms | -75.7% |
| Streaming / buffered CPU ratio | 4.49x | 1.15x | 74.4% less relative overhead |
| Streaming response bytes | 425,517 B | 338,019 B | -87,498 B (-20.6%) |

The byte reduction is the removed duplicate projection: the original final checkpoint carried about 87,174 bytes of state and the following span record carried about 88,109 bytes of nearly identical state. The optimized stream emits a strict backward reference plus only the required delta.

### Allocation attribution

This is an apples-to-apples counting-allocator comparison on the same final fixture before and after borrowed `componentStyles` serialization. Counts are exact per render.

| Render path | Before borrowed styles | Final | Change | Relative to final buffered |
|---|---:|---:|---:|---:|
| Buffered | 998 | 998 | 0 | baseline |
| Fused streaming | 1,050 | 981 | -69 (-6.6%) | 17 fewer |
| Async-resumable split streaming | 1,063 | 994 | -69 (-6.5%) | 4 fewer |

### One-worker completed-response throughput

| Metric | Before: WebUI 0.0.27 | After: optimized core | Observed change |
|---|---:|---:|---:|
| Completed streaming RPS | 220-260 | 1,426.90-1,470.80 | 5.49x-6.69x (+448.8% to +568.5%) |

The change range compares the lowest after result with the highest before result at its conservative end, and the highest after result with the lowest before result at its upper end. These are actual completed-response measurements from separate benchmark campaigns, not one alternating A/B run, so the range is descriptive rather than a claim that every point is attributable solely to this Rust change. The optimized live runs averaged 338,288.9 response bytes.

All optimized live runs retained seven semantic transport chunks and a single Actix render worker. No flush coalescing, extra render workers, buffered fallback, affinity change, or benchmark-only shortcut was used.

## Correctness

Coverage includes independently processed records, malformed and missing references, exact projection identity, unchanged and changed owned resumes, updatable-boundary patches, cancellation, ordering, checkpoint isolation, span completion, and browser hydration behavior.

## Review notes

This intentionally replaces the versioned streaming envelope rather than carrying a runtime compatibility branch. The next WebUI release should be 0.0.28 so `microsoft/webui-benchmarks` can consume the optimized core.