### PR TITLE
fix: correct FAST 2 child hydration offset regression

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -333,9 +333,10 @@ pub struct WebUIFragmentPlugin {
 ```
 
 FAST 3 element metadata is a four-byte little-endian binding count. FAST 2
-ordinary element metadata uses the same four-byte form; a root template with
-host bindings appends one lifecycle byte. Bit 0 tells the FAST 2 handler to
-restart child marker indexes after emitting the root host-binding marker.
+element metadata is always five bytes: the same count followed by lifecycle
+flags. Bit 0 tells the FAST 2 handler to restart child marker indexes after
+emitting the root host-binding marker. Four-byte FAST 2 payloads are rejected;
+there is no compatibility branch for the prior intermediate format.
 
 #### Route Fragment
 Route fragments define declarative URL-based routes linking path templates to fragment bodies.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -332,6 +332,11 @@ pub struct WebUIFragmentPlugin {
 }
 ```
 
+FAST 3 element metadata is a four-byte little-endian binding count. FAST 2
+ordinary element metadata uses the same four-byte form; a root template with
+host bindings appends one lifecycle byte. Bit 0 tells the FAST 2 handler to
+restart child marker indexes after emitting the root host-binding marker.
+
 #### Route Fragment
 Route fragments define declarative URL-based routes linking path templates to fragment bodies.
 The parser emits these from `<route>` elements; the handler uses them for server-side route matching.
@@ -2139,8 +2144,10 @@ parser view returned as `TransformedComponentSource::parser_content`:
   `<template @click="{…}">`); because their `ComponentProcessing` enables root
   attribute processing, those bindings flow through the same
   `process_attribute`/`finish_opening_tag` count as any other element. The
-  server emits a `FastElementData` binding count for the root that keeps the
-  client hydration markers aligned with the client template's binding order.
+  server emits a FAST binding count for the root that keeps the client hydration
+  markers aligned with the client template's binding order. FAST 2 marks that
+  root metadata as the end of the separately consumed host-binding range, so
+  child marker indexes restart at zero instead of applying the host offset twice.
 
 The transform separately returns the authored inner `<template>` (with its
 client-only bindings) as `TransformedComponentSource::artifact_content`, rather

--- a/crates/webui-handler/src/plugin/fast_v2.rs
+++ b/crates/webui-handler/src/plugin/fast_v2.rs
@@ -185,7 +185,7 @@ impl HandlerPlugin for FastV2HydrationPlugin {
         if !self.is_active() {
             return Ok(());
         }
-        let (decoded, reset_child_scope) = FastElementData::decode_v2(data).map_err(|error| {
+        let (decoded, reset_child_index) = FastElementData::decode_v2(data).map_err(|error| {
             HandlerError::PluginData(format!(
                 "FAST v2 hydration plugin received invalid element data: {error}"
             ))
@@ -195,7 +195,7 @@ impl HandlerPlugin for FastV2HydrationPlugin {
             self.build_attribute_marker(binding_index, decoded.binding_count);
             writer.write(&self.buffer)?;
         }
-        if reset_child_scope {
+        if reset_child_index {
             if let Some(counter) = self.scopes.last_mut() {
                 *counter = 0;
             }

--- a/crates/webui-handler/src/plugin/fast_v2.rs
+++ b/crates/webui-handler/src/plugin/fast_v2.rs
@@ -185,15 +185,20 @@ impl HandlerPlugin for FastV2HydrationPlugin {
         if !self.is_active() {
             return Ok(());
         }
-        let decoded = FastElementData::decode(data).map_err(|error| {
+        let (decoded, reset_child_scope) = FastElementData::decode_v2(data).map_err(|error| {
             HandlerError::PluginData(format!(
-                "FAST v2 hydration plugin expected 4 bytes of element data: {error}"
+                "FAST v2 hydration plugin received invalid element data: {error}"
             ))
         })?;
         if decoded.binding_count > 0 {
             let binding_index = self.next_index_n(decoded.binding_count);
             self.build_attribute_marker(binding_index, decoded.binding_count);
             writer.write(&self.buffer)?;
+        }
+        if reset_child_scope {
+            if let Some(counter) = self.scopes.last_mut() {
+                *counter = 0;
+            }
         }
         Ok(())
     }
@@ -307,6 +312,68 @@ mod tests {
         writer.output.clear();
         plugin.on_binding_start("next", false, &mut writer).unwrap();
         assert_eq!(writer.output, "<!--fe-b$$start$$3$$next$$fe-b-->");
+    }
+
+    #[test]
+    fn test_fast_v2_root_host_bindings_reset_child_index() {
+        let mut plugin = FastV2HydrationPlugin::new();
+        plugin.push_scope();
+        let mut writer = TestWriter::new();
+        let root = FastElementData { binding_count: 2 }.encode_v2(true);
+        plugin.on_element_data(&root, &mut writer).unwrap();
+        plugin
+            .on_element_data(&1u32.to_le_bytes(), &mut writer)
+            .unwrap();
+        assert_eq!(writer.output, " data-fe-c-0-2 data-fe-b-0");
+    }
+
+    #[test]
+    fn test_fast_v2_parser_and_handler_keep_child_index_local() {
+        use crate::{RenderOptions, WebUIHandler};
+        use webui_parser::{
+            plugin::fast_v2::FastV2ParserPlugin, ComponentRegistration, HtmlParser,
+        };
+        use webui_protocol::WebUIProtocol;
+
+        let mut parser = HtmlParser::with_plugin(Box::new(FastV2ParserPlugin::new()));
+        parser
+            .component_registry_mut()
+            .register_component(ComponentRegistration::new(
+                "binding-card",
+                r#"<f-template name="binding-card" shadowrootmode="open"><template @click="{click($e)}" @keydown="{keydown($e)}"><slot f-ref="{slot}"></slot></template></f-template>"#,
+                None,
+                true,
+            ))
+            .unwrap();
+        parser
+            .parse("index.html", "<binding-card></binding-card>")
+            .unwrap();
+        let mut protocol = WebUIProtocol::new(parser.into_fragment_records());
+        protocol
+            .components
+            .entry("binding-card".to_string())
+            .or_default()
+            .uses_shadow_dom = true;
+        protocol.populate_style_closures(&["index.html"]);
+        let handler = WebUIHandler::with_plugin(|| Box::new(FastV2HydrationPlugin::new()));
+        let mut writer = TestWriter::new();
+        handler
+            .handle(
+                &protocol,
+                &serde_json::json!({}),
+                &RenderOptions::new("index.html", "/"),
+                &mut writer,
+            )
+            .unwrap();
+
+        assert!(
+            writer.output.contains(concat!(
+                r#"<template shadowrootmode="open" data-fe-c-0-2>"#,
+                r#"<slot data-fe-b-0></slot></template>"#
+            )),
+            "FAST 2 child markers should exclude consumed host bindings: {}",
+            writer.output
+        );
     }
 
     #[test]

--- a/crates/webui-handler/src/plugin/fast_v2.rs
+++ b/crates/webui-handler/src/plugin/fast_v2.rs
@@ -289,14 +289,14 @@ mod tests {
         let mut single = FastV2HydrationPlugin::new();
         single.push_scope();
         let mut writer = TestWriter::new();
-        let one = 1u32.to_le_bytes();
+        let one = FastElementData { binding_count: 1 }.encode_v2(false);
         single.on_element_data(&one, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-b-0");
 
         let mut multi = FastV2HydrationPlugin::new();
         multi.push_scope();
         writer.output.clear();
-        let three = 3u32.to_le_bytes();
+        let three = FastElementData { binding_count: 3 }.encode_v2(false);
         multi.on_element_data(&three, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-c-0-3");
     }
@@ -306,7 +306,7 @@ mod tests {
         let mut plugin = FastV2HydrationPlugin::new();
         plugin.push_scope();
         let mut writer = TestWriter::new();
-        let three = 3u32.to_le_bytes();
+        let three = FastElementData { binding_count: 3 }.encode_v2(false);
         plugin.on_element_data(&three, &mut writer).unwrap();
 
         writer.output.clear();
@@ -321,10 +321,22 @@ mod tests {
         let mut writer = TestWriter::new();
         let root = FastElementData { binding_count: 2 }.encode_v2(true);
         plugin.on_element_data(&root, &mut writer).unwrap();
-        plugin
-            .on_element_data(&1u32.to_le_bytes(), &mut writer)
-            .unwrap();
+        let child = FastElementData { binding_count: 1 }.encode_v2(false);
+        plugin.on_element_data(&child, &mut writer).unwrap();
         assert_eq!(writer.output, " data-fe-c-0-2 data-fe-b-0");
+    }
+
+    #[test]
+    fn test_fast_v2_rejects_four_byte_element_data() {
+        let mut plugin = FastV2HydrationPlugin::new();
+        plugin.push_scope();
+        let mut writer = TestWriter::new();
+        let result = plugin.on_element_data(&1u32.to_le_bytes(), &mut writer);
+        assert!(
+            matches!(result, Err(crate::HandlerError::PluginData(ref msg)) if msg.contains("5 bytes")),
+            "four-byte FAST 2 data should be rejected: {result:?}"
+        );
+        assert_eq!(writer.output, "");
     }
 
     #[test]
@@ -384,7 +396,7 @@ mod tests {
         plugin.on_binding_end("x", false, &mut writer).unwrap();
         plugin.on_repeat_item_start(0, &mut writer).unwrap();
         plugin.on_repeat_item_end(0, &mut writer).unwrap();
-        let data = 3u32.to_le_bytes();
+        let data = FastElementData { binding_count: 3 }.encode_v2(false);
         plugin.on_element_data(&data, &mut writer).unwrap();
         assert_eq!(writer.output, "");
     }

--- a/crates/webui-handler/src/plugin/fast_v3.rs
+++ b/crates/webui-handler/src/plugin/fast_v3.rs
@@ -154,9 +154,9 @@ impl HandlerPlugin for FastV3HydrationPlugin {
         if !self.is_active() {
             return Ok(());
         }
-        let decoded = FastElementData::decode(data).map_err(|error| {
+        let decoded = FastElementData::decode_v3(data).map_err(|error| {
             HandlerError::PluginData(format!(
-                "FAST hydration plugin expected 4 bytes of element data: {error}"
+                "FAST 3 hydration plugin expected 4 bytes of element data: {error}"
             ))
         })?;
         if decoded.binding_count > 0 {

--- a/crates/webui-parser/src/plugin/fast/shared.rs
+++ b/crates/webui-parser/src/plugin/fast/shared.rs
@@ -41,7 +41,7 @@ pub(crate) fn finish_element(binding_attribute_count: u32) -> Option<Vec<u8>> {
     }
 }
 
-// Encode the FAST 2 root lifecycle only when host bindings need a marker.
+// Encode FAST 2 binding metadata and its root lifecycle flag.
 #[inline]
 pub(crate) fn finish_v2_element(
     binding_attribute_count: u32,
@@ -49,7 +49,7 @@ pub(crate) fn finish_v2_element(
 ) -> Option<Vec<u8>> {
     if binding_attribute_count == 0 {
         None
-    } else if reset_child_scope {
+    } else {
         Some(
             FastElementData {
                 binding_count: binding_attribute_count,
@@ -57,8 +57,6 @@ pub(crate) fn finish_v2_element(
             .encode_v2(reset_child_scope)
             .to_vec(),
         )
-    } else {
-        finish_element(binding_attribute_count)
     }
 }
 

--- a/crates/webui-parser/src/plugin/fast/shared.rs
+++ b/crates/webui-parser/src/plugin/fast/shared.rs
@@ -41,6 +41,27 @@ pub(crate) fn finish_element(binding_attribute_count: u32) -> Option<Vec<u8>> {
     }
 }
 
+// Encode the FAST 2 root lifecycle only when host bindings need a marker.
+#[inline]
+pub(crate) fn finish_v2_element(
+    binding_attribute_count: u32,
+    reset_child_scope: bool,
+) -> Option<Vec<u8>> {
+    if binding_attribute_count == 0 {
+        None
+    } else if reset_child_scope {
+        Some(
+            FastElementData {
+                binding_count: binding_attribute_count,
+            }
+            .encode_v2(reset_child_scope)
+            .to_vec(),
+        )
+    } else {
+        finish_element(binding_attribute_count)
+    }
+}
+
 // FAST reads these options from `<f-template>`; adopted styles remain inner.
 #[inline]
 pub(crate) fn is_hoisted_shadow_attr(name: &str) -> bool {

--- a/crates/webui-parser/src/plugin/fast/shared.rs
+++ b/crates/webui-parser/src/plugin/fast/shared.rs
@@ -8,7 +8,6 @@ use super::convert::{convert_template, F_TEMPLATE_NAME};
 use super::diagnostic::converter_error;
 use crate::html_parser::{leading_content, parse_tag};
 use crate::Result;
-use webui_protocol::FastElementData;
 
 // Classify client-only FAST attributes that SSR skips but hydration counts.
 #[inline]
@@ -22,41 +21,6 @@ pub(crate) fn classify_attribute(attr_name: &str) -> AttributeAction {
         AttributeAction::SkipAndCountBinding
     } else {
         AttributeAction::Keep
-    }
-}
-
-// Encode binding metadata for dynamic attributes.
-#[inline]
-pub(crate) fn finish_element(binding_attribute_count: u32) -> Option<Vec<u8>> {
-    if binding_attribute_count > 0 {
-        Some(
-            FastElementData {
-                binding_count: binding_attribute_count,
-            }
-            .encode()
-            .to_vec(),
-        )
-    } else {
-        None
-    }
-}
-
-// Encode FAST 2 binding metadata and its root lifecycle flag.
-#[inline]
-pub(crate) fn finish_v2_element(
-    binding_attribute_count: u32,
-    reset_child_scope: bool,
-) -> Option<Vec<u8>> {
-    if binding_attribute_count == 0 {
-        None
-    } else {
-        Some(
-            FastElementData {
-                binding_count: binding_attribute_count,
-            }
-            .encode_v2(reset_child_scope)
-            .to_vec(),
-        )
     }
 }
 

--- a/crates/webui-parser/src/plugin/fast/v2.rs
+++ b/crates/webui-parser/src/plugin/fast/v2.rs
@@ -554,6 +554,8 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use super::*;
+    use webui_protocol::FastElementData;
+
     fn make_component(tag: &str, html: &str, css: Option<&str>) -> Component {
         Component {
             tag_name: tag.to_string(),
@@ -650,7 +652,10 @@ mod tests {
         let data = plugin.finish_element(3);
         assert!(data.is_some());
         let bytes = data.as_deref().unwrap_or_default();
-        assert_eq!(bytes, &3u32.to_le_bytes());
+        assert_eq!(
+            bytes,
+            &FastElementData { binding_count: 3 }.encode_v2(false)
+        );
     }
 
     #[test]
@@ -659,7 +664,10 @@ mod tests {
         let data = plugin.finish_element(256);
         assert!(data.is_some());
         let bytes = data.as_deref().unwrap_or_default();
-        assert_eq!(bytes, &256u32.to_le_bytes());
+        assert_eq!(
+            bytes,
+            &FastElementData { binding_count: 256 }.encode_v2(false)
+        );
     }
 
     #[test]

--- a/crates/webui-parser/src/plugin/fast/v2.rs
+++ b/crates/webui-parser/src/plugin/fast/v2.rs
@@ -45,6 +45,8 @@ struct TrackedComponent {
 pub struct FastV2ParserPlugin {
     /// Components tracked during parsing, in discovery order.
     components: Vec<TrackedComponent>,
+    /// Whether the next root template carries the FAST 2 host-binding boundary.
+    reset_child_scope_after_root: bool,
 }
 
 impl FastV2ParserPlugin {
@@ -53,6 +55,7 @@ impl FastV2ParserPlugin {
     pub fn new() -> Self {
         Self {
             components: Vec::new(),
+            reset_child_scope_after_root: false,
         }
     }
 
@@ -151,6 +154,7 @@ impl ParserPlugin for FastV2ParserPlugin {
 
     fn component_built(&mut self, context: ComponentBuildContext<'_>) -> Result<()> {
         require_fast_shadow_dom(context.component.tag_name.as_str(), context.uses_shadow_dom)?;
+        self.reset_child_scope_after_root = true;
         self.track_component(context);
         Ok(())
     }
@@ -160,7 +164,12 @@ impl ParserPlugin for FastV2ParserPlugin {
     }
 
     fn finish_opening_tag(&mut self, context: ElementStartContext<'_>) -> Option<Vec<u8>> {
-        super::shared::finish_element(context.binding_count)
+        let reset_child_scope =
+            self.reset_child_scope_after_root && context.tag_name.eq_ignore_ascii_case("template");
+        if reset_child_scope {
+            self.reset_child_scope_after_root = false;
+        }
+        super::shared::finish_v2_element(context.binding_count, reset_child_scope)
     }
 
     fn finish(self: Box<Self>) -> Result<ParserPluginArtifacts> {

--- a/crates/webui-parser/src/plugin/fast/v2.rs
+++ b/crates/webui-parser/src/plugin/fast/v2.rs
@@ -20,6 +20,16 @@ use super::v3::{
 use crate::component_registry::Component;
 use crate::html_parser::{find_element_end, find_tag_close, opening_tag_name};
 use crate::{CssLinkOptions, CssStrategy, Result};
+use webui_protocol::FastElementData;
+
+#[inline]
+fn finish_element(binding_count: u32, reset_child_index: bool) -> Option<Vec<u8>> {
+    (binding_count > 0).then(|| {
+        FastElementData { binding_count }
+            .encode_v2(reset_child_index)
+            .to_vec()
+    })
+}
 
 /// Information about a tracked component for `<f-template>` generation.
 struct TrackedComponent {
@@ -46,7 +56,7 @@ pub struct FastV2ParserPlugin {
     /// Components tracked during parsing, in discovery order.
     components: Vec<TrackedComponent>,
     /// Whether the next root template carries the FAST 2 host-binding boundary.
-    reset_child_scope_after_root: bool,
+    reset_child_index_after_root: bool,
 }
 
 impl FastV2ParserPlugin {
@@ -55,7 +65,7 @@ impl FastV2ParserPlugin {
     pub fn new() -> Self {
         Self {
             components: Vec::new(),
-            reset_child_scope_after_root: false,
+            reset_child_index_after_root: false,
         }
     }
 
@@ -154,7 +164,7 @@ impl ParserPlugin for FastV2ParserPlugin {
 
     fn component_built(&mut self, context: ComponentBuildContext<'_>) -> Result<()> {
         require_fast_shadow_dom(context.component.tag_name.as_str(), context.uses_shadow_dom)?;
-        self.reset_child_scope_after_root = true;
+        self.reset_child_index_after_root = true;
         self.track_component(context);
         Ok(())
     }
@@ -164,12 +174,12 @@ impl ParserPlugin for FastV2ParserPlugin {
     }
 
     fn finish_opening_tag(&mut self, context: ElementStartContext<'_>) -> Option<Vec<u8>> {
-        let reset_child_scope =
-            self.reset_child_scope_after_root && context.tag_name.eq_ignore_ascii_case("template");
-        if reset_child_scope {
-            self.reset_child_scope_after_root = false;
+        let reset_child_index =
+            self.reset_child_index_after_root && context.tag_name.eq_ignore_ascii_case("template");
+        if reset_child_index {
+            self.reset_child_index_after_root = false;
         }
-        super::shared::finish_v2_element(context.binding_count, reset_child_scope)
+        finish_element(context.binding_count, reset_child_index)
     }
 
     fn finish(self: Box<Self>) -> Result<ParserPluginArtifacts> {
@@ -554,7 +564,6 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use super::*;
-    use webui_protocol::FastElementData;
 
     fn make_component(tag: &str, html: &str, css: Option<&str>) -> Component {
         Component {

--- a/crates/webui-parser/src/plugin/fast/v3.rs
+++ b/crates/webui-parser/src/plugin/fast/v3.rs
@@ -18,6 +18,12 @@ use crate::html_parser::{
     find_element_end, find_tag_close, leading_content, opening_tag_name, starts_with_html_tag_name,
 };
 use crate::{CssLinkOptions, CssStrategy, Result};
+use webui_protocol::FastElementData;
+
+#[inline]
+fn finish_element(binding_count: u32) -> Option<Vec<u8>> {
+    (binding_count > 0).then(|| FastElementData { binding_count }.encode_v3().to_vec())
+}
 
 /// Information about a tracked component for `<f-template>` generation.
 struct TrackedComponent {
@@ -158,7 +164,7 @@ impl ParserPlugin for FastV3ParserPlugin {
     }
 
     fn finish_opening_tag(&mut self, context: ElementStartContext<'_>) -> Option<Vec<u8>> {
-        super::shared::finish_element(context.binding_count)
+        finish_element(context.binding_count)
     }
 
     fn finish(self: Box<Self>) -> Result<ParserPluginArtifacts> {

--- a/crates/webui-parser/src/tests/fast_parser.rs
+++ b/crates/webui-parser/src/tests/fast_parser.rs
@@ -309,7 +309,7 @@ fn plugin_build_leaves_ssr_output_style_free() {
     assert!(!ssr.contains("<style>"));
 }
 
-fn assert_component_source(plugin: Box<dyn ParserPlugin>) {
+fn assert_component_source(plugin: Box<dyn ParserPlugin>, fast_v2: bool) {
     let mut parser =
         HtmlParser::with_plugin_options(plugin, (CssStrategy::Style, DomStrategy::Shadow));
     parser
@@ -338,10 +338,17 @@ fn assert_component_source(plugin: Box<dyn ParserPlugin>) {
     );
     assert_stream!(records, "if-1", [for_loop("item", "items", "for-1"),]);
     let for_fragments = &records["for-1"].fragments;
+    let expected_element_data = if fast_v2 {
+        webui_protocol::FastElementData { binding_count: 5 }
+            .encode_v2(false)
+            .to_vec()
+    } else {
+        5u32.to_le_bytes().to_vec()
+    };
     assert!(for_fragments.iter().any(|fragment| {
         matches!(
             fragment.fragment.as_ref(),
-            Some(Fragment::Plugin(data)) if data.data == 5u32.to_le_bytes()
+            Some(Fragment::Plugin(data)) if data.data == expected_element_data
         )
     }));
     assert!(!for_fragments.iter().any(|fragment| {
@@ -375,18 +382,18 @@ fn assert_component_source(plugin: Box<dyn ParserPlugin>) {
 
 #[test]
 fn v2_uses_authored_component_source() {
-    assert_component_source(Box::new(plugin::fast_v2::FastV2ParserPlugin::new()));
+    assert_component_source(Box::new(plugin::fast_v2::FastV2ParserPlugin::new()), true);
 }
 
 #[test]
 #[allow(deprecated)]
 fn compatibility_plugin_uses_authored_component_source() {
-    assert_component_source(Box::new(plugin::fast::FastParserPlugin::new()));
+    assert_component_source(Box::new(plugin::fast::FastParserPlugin::new()), true);
 }
 
 #[test]
 fn v3_uses_authored_component_source() {
-    assert_component_source(Box::new(plugin::fast_v3::FastV3ParserPlugin::new()));
+    assert_component_source(Box::new(plugin::fast_v3::FastV3ParserPlugin::new()), false);
 }
 
 #[test]

--- a/crates/webui-parser/src/tests/fast_parser.rs
+++ b/crates/webui-parser/src/tests/fast_parser.rs
@@ -540,7 +540,7 @@ fn client_attributes_are_counted_in_source_order_without_markers() {
     assert!(!templates[0].template.contains("data-webui-internal-"));
 }
 
-fn assert_root_template_bindings_counted(plugin: Box<dyn ParserPlugin>) {
+fn root_template_binding_data(plugin: Box<dyn ParserPlugin>) -> Vec<Vec<u8>> {
     let mut parser = HtmlParser::with_plugin(plugin);
     parser
         .component_registry
@@ -555,17 +555,15 @@ fn assert_root_template_bindings_counted(plugin: Box<dyn ParserPlugin>) {
         .parse("index.html", "<root-binding-card></root-binding-card>")
         .expect("parse entry");
     let fragments = &parser.fragment_records["root-binding-card"].fragments;
-    let counts: Vec<u32> = fragments
+    let data: Vec<Vec<u8>> = fragments
         .iter()
         .filter_map(|fragment| {
             let Some(Fragment::Plugin(data)) = fragment.fragment.as_ref() else {
                 return None;
             };
-            (data.data.len() == 4)
-                .then(|| u32::from_le_bytes(data.data[..4].try_into().expect("four-byte count")))
+            Some(data.data.clone())
         })
         .collect();
-    assert_eq!(counts, vec![3, 1]);
 
     let raw: String = fragments
         .iter()
@@ -578,16 +576,40 @@ fn assert_root_template_bindings_counted(plugin: Box<dyn ParserPlugin>) {
         assert!(!raw.contains(client_attr));
     }
     assert!(raw.contains(r#"shadowrootmode="open""#));
+    data
 }
 
 #[test]
 fn v2_counts_root_template_bindings() {
-    assert_root_template_bindings_counted(Box::new(plugin::fast_v2::FastV2ParserPlugin::new()));
+    let data = root_template_binding_data(Box::new(plugin::fast_v2::FastV2ParserPlugin::new()));
+    let decoded: Vec<_> = data
+        .iter()
+        .map(|bytes| {
+            webui_protocol::FastElementData::decode_v2(bytes)
+                .expect("FAST 2 element data should decode")
+        })
+        .collect();
+    assert_eq!(
+        decoded,
+        vec![
+            (webui_protocol::FastElementData { binding_count: 3 }, true),
+            (webui_protocol::FastElementData { binding_count: 1 }, false),
+        ]
+    );
 }
 
 #[test]
 fn v3_counts_root_template_bindings() {
-    assert_root_template_bindings_counted(Box::new(plugin::fast_v3::FastV3ParserPlugin::new()));
+    let data = root_template_binding_data(Box::new(plugin::fast_v3::FastV3ParserPlugin::new()));
+    let counts: Vec<_> = data
+        .iter()
+        .map(|bytes| {
+            webui_protocol::FastElementData::decode(bytes)
+                .expect("FAST 3 element data should decode")
+                .binding_count
+        })
+        .collect();
+    assert_eq!(counts, vec![3, 1]);
 }
 
 #[test]

--- a/crates/webui-parser/src/tests/fast_parser.rs
+++ b/crates/webui-parser/src/tests/fast_parser.rs
@@ -611,7 +611,7 @@ fn v3_counts_root_template_bindings() {
     let counts: Vec<_> = data
         .iter()
         .map(|bytes| {
-            webui_protocol::FastElementData::decode(bytes)
+            webui_protocol::FastElementData::decode_v3(bytes)
                 .expect("FAST 3 element data should decode")
                 .binding_count
         })

--- a/crates/webui-protocol/src/plugin/fast.rs
+++ b/crates/webui-protocol/src/plugin/fast.rs
@@ -3,9 +3,10 @@
 
 use crate::{ProtocolError, Result};
 
-const FAST_ELEMENT_DATA_LEN: usize = 4;
-const FAST_V2_ELEMENT_DATA_LEN: usize = 5;
-const FAST_V2_RESET_CHILD_SCOPE: u8 = 1;
+const FAST_BINDING_COUNT_LEN: usize = 4;
+const FAST_V2_ELEMENT_DATA_LEN: usize = FAST_BINDING_COUNT_LEN + 1;
+const FAST_V3_ELEMENT_DATA_LEN: usize = FAST_BINDING_COUNT_LEN;
+const FAST_V2_RESET_CHILD_INDEX: u8 = 1;
 
 /// FAST hydration element metadata encoded in plugin fragments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,32 +16,32 @@ pub struct FastElementData {
 }
 
 impl FastElementData {
-    /// Encode this metadata using the FAST 4-byte little-endian wire format.
+    /// Encode this metadata using the FAST 3 four-byte little-endian wire format.
     #[must_use]
-    pub fn encode(self) -> [u8; FAST_ELEMENT_DATA_LEN] {
+    pub fn encode_v3(self) -> [u8; FAST_V3_ELEMENT_DATA_LEN] {
         self.binding_count.to_le_bytes()
     }
 
-    /// Encode FAST 2 metadata with an optional child-scope lifecycle flag.
+    /// Encode FAST 2 metadata with its child-index lifecycle flag.
     #[must_use]
-    pub fn encode_v2(self, reset_child_scope: bool) -> [u8; FAST_V2_ELEMENT_DATA_LEN] {
+    pub fn encode_v2(self, reset_child_index: bool) -> [u8; FAST_V2_ELEMENT_DATA_LEN] {
         let mut data = [0; FAST_V2_ELEMENT_DATA_LEN];
-        data[..FAST_ELEMENT_DATA_LEN].copy_from_slice(&self.binding_count.to_le_bytes());
-        if reset_child_scope {
-            data[FAST_ELEMENT_DATA_LEN] = FAST_V2_RESET_CHILD_SCOPE;
+        data[..FAST_BINDING_COUNT_LEN].copy_from_slice(&self.binding_count.to_le_bytes());
+        if reset_child_index {
+            data[FAST_BINDING_COUNT_LEN] = FAST_V2_RESET_CHILD_INDEX;
         }
         data
     }
 
-    /// Decode FAST hydration metadata from protocol bytes.
+    /// Decode FAST 3 hydration metadata from protocol bytes.
     ///
     /// # Errors
     ///
     /// Returns [`ProtocolError::Validation`] when the payload length is not 4 bytes.
-    pub fn decode(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() != FAST_ELEMENT_DATA_LEN {
+    pub fn decode_v3(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != FAST_V3_ELEMENT_DATA_LEN {
             return Err(ProtocolError::Validation(format!(
-                "FAST element data must be {FAST_ELEMENT_DATA_LEN} bytes, received {}",
+                "FAST 3 element data must be {FAST_V3_ELEMENT_DATA_LEN} bytes, received {}",
                 bytes.len()
             )));
         }
@@ -63,14 +64,14 @@ impl FastElementData {
             )));
         };
         let binding_count = u32::from_le_bytes([*a, *b, *c, *d]);
-        if *flags & !FAST_V2_RESET_CHILD_SCOPE != 0 {
+        if *flags & !FAST_V2_RESET_CHILD_INDEX != 0 {
             return Err(ProtocolError::Validation(format!(
                 "FAST 2 element data contains unsupported flags: 0x{flags:02x}"
             )));
         }
         Ok((
             Self { binding_count },
-            *flags & FAST_V2_RESET_CHILD_SCOPE != 0,
+            *flags & FAST_V2_RESET_CHILD_INDEX != 0,
         ))
     }
 }
@@ -81,15 +82,15 @@ mod tests {
     use crate::ProtocolError;
 
     #[test]
-    fn test_fast_element_data_roundtrip() {
-        let encoded = FastElementData { binding_count: 3 }.encode();
-        let decoded = FastElementData::decode(&encoded).expect("decode should succeed");
+    fn test_fast_v3_element_data_roundtrip() {
+        let encoded = FastElementData { binding_count: 3 }.encode_v3();
+        let decoded = FastElementData::decode_v3(&encoded).expect("decode should succeed");
         assert_eq!(decoded.binding_count, 3);
     }
 
     #[test]
-    fn test_fast_element_data_rejects_invalid_length() {
-        let result = FastElementData::decode(&[1, 2]);
+    fn test_fast_v3_element_data_rejects_invalid_length() {
+        let result = FastElementData::decode_v3(&[1, 2]);
         assert!(
             matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("4 bytes")),
             "invalid payload length should be rejected: {result:?}"

--- a/crates/webui-protocol/src/plugin/fast.rs
+++ b/crates/webui-protocol/src/plugin/fast.rs
@@ -50,31 +50,27 @@ impl FastElementData {
         })
     }
 
-    /// Decode current or legacy FAST 2 element metadata.
+    /// Decode FAST 2 element metadata.
     ///
     /// # Errors
     ///
     /// Returns [`ProtocolError::Validation`] for unsupported payload lengths or flags.
     pub fn decode_v2(bytes: &[u8]) -> Result<(Self, bool)> {
-        let binding_count = match bytes {
-            [a, b, c, d] | [a, b, c, d, _] => u32::from_le_bytes([*a, *b, *c, *d]),
-            _ => {
-                return Err(ProtocolError::Validation(format!(
-                    "FAST 2 element data must be {FAST_ELEMENT_DATA_LEN} legacy bytes or \
-                     {FAST_V2_ELEMENT_DATA_LEN} bytes, received {}",
-                    bytes.len()
-                )));
-            }
+        let [a, b, c, d, flags] = bytes else {
+            return Err(ProtocolError::Validation(format!(
+                "FAST 2 element data must be {FAST_V2_ELEMENT_DATA_LEN} bytes, received {}",
+                bytes.len()
+            )));
         };
-        let flags = bytes.get(FAST_ELEMENT_DATA_LEN).copied().unwrap_or(0);
-        if flags & !FAST_V2_RESET_CHILD_SCOPE != 0 {
+        let binding_count = u32::from_le_bytes([*a, *b, *c, *d]);
+        if *flags & !FAST_V2_RESET_CHILD_SCOPE != 0 {
             return Err(ProtocolError::Validation(format!(
                 "FAST 2 element data contains unsupported flags: 0x{flags:02x}"
             )));
         }
         Ok((
             Self { binding_count },
-            flags & FAST_V2_RESET_CHILD_SCOPE != 0,
+            *flags & FAST_V2_RESET_CHILD_SCOPE != 0,
         ))
     }
 }
@@ -108,10 +104,12 @@ mod tests {
     }
 
     #[test]
-    fn test_fast_v2_element_data_accepts_legacy_count() {
-        let decoded =
-            FastElementData::decode_v2(&3u32.to_le_bytes()).expect("legacy data should decode");
-        assert_eq!(decoded, (FastElementData { binding_count: 3 }, false));
+    fn test_fast_v2_element_data_rejects_four_byte_count() {
+        let result = FastElementData::decode_v2(&3u32.to_le_bytes());
+        assert!(
+            matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("5 bytes")),
+            "four-byte FAST 2 data should be rejected: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/webui-protocol/src/plugin/fast.rs
+++ b/crates/webui-protocol/src/plugin/fast.rs
@@ -4,6 +4,8 @@
 use crate::{ProtocolError, Result};
 
 const FAST_ELEMENT_DATA_LEN: usize = 4;
+const FAST_V2_ELEMENT_DATA_LEN: usize = 5;
+const FAST_V2_RESET_CHILD_SCOPE: u8 = 1;
 
 /// FAST hydration element metadata encoded in plugin fragments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +19,17 @@ impl FastElementData {
     #[must_use]
     pub fn encode(self) -> [u8; FAST_ELEMENT_DATA_LEN] {
         self.binding_count.to_le_bytes()
+    }
+
+    /// Encode FAST 2 metadata with an optional child-scope lifecycle flag.
+    #[must_use]
+    pub fn encode_v2(self, reset_child_scope: bool) -> [u8; FAST_V2_ELEMENT_DATA_LEN] {
+        let mut data = [0; FAST_V2_ELEMENT_DATA_LEN];
+        data[..FAST_ELEMENT_DATA_LEN].copy_from_slice(&self.binding_count.to_le_bytes());
+        if reset_child_scope {
+            data[FAST_ELEMENT_DATA_LEN] = FAST_V2_RESET_CHILD_SCOPE;
+        }
+        data
     }
 
     /// Decode FAST hydration metadata from protocol bytes.
@@ -35,6 +48,34 @@ impl FastElementData {
         Ok(Self {
             binding_count: u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
         })
+    }
+
+    /// Decode current or legacy FAST 2 element metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::Validation`] for unsupported payload lengths or flags.
+    pub fn decode_v2(bytes: &[u8]) -> Result<(Self, bool)> {
+        let binding_count = match bytes {
+            [a, b, c, d] | [a, b, c, d, _] => u32::from_le_bytes([*a, *b, *c, *d]),
+            _ => {
+                return Err(ProtocolError::Validation(format!(
+                    "FAST 2 element data must be {FAST_ELEMENT_DATA_LEN} legacy bytes or \
+                     {FAST_V2_ELEMENT_DATA_LEN} bytes, received {}",
+                    bytes.len()
+                )));
+            }
+        };
+        let flags = bytes.get(FAST_ELEMENT_DATA_LEN).copied().unwrap_or(0);
+        if flags & !FAST_V2_RESET_CHILD_SCOPE != 0 {
+            return Err(ProtocolError::Validation(format!(
+                "FAST 2 element data contains unsupported flags: 0x{flags:02x}"
+            )));
+        }
+        Ok((
+            Self { binding_count },
+            flags & FAST_V2_RESET_CHILD_SCOPE != 0,
+        ))
     }
 }
 
@@ -56,6 +97,29 @@ mod tests {
         assert!(
             matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("4 bytes")),
             "invalid payload length should be rejected: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_fast_v2_element_data_roundtrip() {
+        let encoded = FastElementData { binding_count: 3 }.encode_v2(true);
+        let decoded = FastElementData::decode_v2(&encoded).expect("decode should succeed");
+        assert_eq!(decoded, (FastElementData { binding_count: 3 }, true));
+    }
+
+    #[test]
+    fn test_fast_v2_element_data_accepts_legacy_count() {
+        let decoded =
+            FastElementData::decode_v2(&3u32.to_le_bytes()).expect("legacy data should decode");
+        assert_eq!(decoded, (FastElementData { binding_count: 3 }, false));
+    }
+
+    #[test]
+    fn test_fast_v2_element_data_rejects_unknown_flags() {
+        let result = FastElementData::decode_v2(&[3, 0, 0, 0, 2]);
+        assert!(
+            matches!(result, Err(ProtocolError::Validation(ref msg)) if msg.contains("unsupported flags")),
+            "unknown flags should be rejected: {result:?}"
         );
     }
 }


### PR DESCRIPTION
## Regression

Commit `eb41c6ccd` (`feat: add plugin-owned FAST component discovery`, #378) enabled `process_root_template_attributes` for FAST parser plugins so bindings authored on a component's root `<template>` participate in SSR hydration metadata.

That behavior exposed a FAST 2 indexing mismatch. FAST 2 consumes declarative-template host bindings separately and applies their factory count as the child hydration offset. The server also carried that count into child marker IDs, so a root marker such as `data-fe-c-0-2` was followed by `data-fe-b-2` instead of `data-fe-b-0`. FAST then applied the host offset a second time, causing child bindings to resolve against the wrong factories and surfacing as FAST 2 component hydration failures.

## Fix

- Define one strict five-byte FAST 2 element metadata format: a four-byte binding count followed by lifecycle flags.
- Mark root-template host metadata so the FAST 2 handler resets the child marker index after emitting the host marker.
- Reject four-byte FAST 2 payloads rather than retaining a compatibility branch.
- Keep FAST 3 on its separate four-byte format with explicitly versioned `encode_v3` and `decode_v3` methods.
- Keep version-specific metadata emission in `fast/v2.rs` and `fast/v3.rs`; shared FAST code contains only behavior used by both versions.
- Leave the generic `HandlerPlugin` contract unchanged, avoiding a FAST-specific lifecycle hook in handler core.

The corrected output is `data-fe-c-0-2` for the root host bindings followed by `data-fe-b-0` for the first child binding.

## Coverage

- Protocol tests cover strict FAST 2 and FAST 3 encoding, decoding, invalid lengths, and unsupported flags.
- Parser tests verify FAST 2 root lifecycle metadata without changing FAST 3 metadata.
- Handler tests verify child-index reset behavior and rejection of the obsolete four-byte FAST 2 shape.
- An end-to-end parser-to-handler regression test locks in the exact root and first-child markers.
- `cargo xtask check` passes all lint, audit, test, native/WASM/example build, benchmark validation, and docs phases.

This is fixed upstream in WebUI; no Chromium source patch or generic plugin module is required.