### PR TITLE
perf: reduce partial response allocations

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -127,7 +127,8 @@ Standard criterion harnesses. Each crate has its own `benches/` dir:
 * `crates/webui/benches/contact_book_bench.rs`: end-to-end render
 * `crates/webui/benches/streaming_bench.rs`: writer-path wall-clock + TTFB
 * `crates/webui/benches/component_assets_bench.rs`: static asset graph rendering
-* `crates/webui/benches/server_request_bench.rs`: router-aware full HTML and JSON requests
+* `crates/webui/benches/server_request_bench.rs`: router-aware full HTML and
+  JSON requests, including sparse projection from a large parsed state tree
 
 These integrate with criterion's HTML reports
 (`target/criterion/report/index.html`) and native baseline support

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -993,6 +993,13 @@ impl Protocol {
     pub fn tokens(&self) -> &[String];
     pub fn render_partial(
         &self,
+        state: Value,
+        entry_id: &str,
+        request_path: &str,
+        inventory_hex: &str,
+    ) -> Result<String, HandlerError>;
+    pub fn render_partial_json(
+        &self,
         state_json: &str,
         entry_id: &str,
         request_path: &str,
@@ -2692,14 +2699,18 @@ not a secrecy boundary. Any state selected by exact metadata or preserved by a
 full fallback is client-facing. Hosts must not place secrets in browser render
 state.
 
-**Partial state.** `Protocol::render_partial()` accepts raw JSON and applies the
-active route's navigation surfaces with the same `None` / `Keys` / `All`
-rules. On `Keys`, a streaming JSON visitor validates the complete object,
-skips unselected values without materializing them, and borrows selected raw
-values into the response. On `All`, raw APIs validate and preserve the borrowed
-JSON object without materializing it. Scriptless routes therefore receive only
-template roots needed for the destination; uncertain routes receive complete
-state.
+**Partial state.** `Protocol::render_partial()` accepts an owned parsed
+`serde_json::Value` and applies the active route's navigation surfaces with the
+same `None` / `Keys` / `All` rules. Selected values move into the response, so
+Rust servers do not serialize and reparse the complete state tree. The
+high-level `serve_request()` helper uses this path.
+`Protocol::render_partial_json()` is the serialized-input boundary used by
+Node, FFI, WASM, and Python hosts. On `Keys`, a streaming JSON visitor validates
+the complete object, skips unselected values without materializing them, and
+borrows selected raw values into the response. On `All`, it validates and
+preserves the borrowed JSON object without materializing it. Scriptless routes
+therefore receive only template roots needed for the destination; uncertain
+routes receive complete state.
 
 `a[]` uses compact tuple forms to avoid runtime parsing:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -516,11 +516,13 @@ emit WebUI `templates` or `templateFns`.
 8. Mounts components at changed levels, creates `<webui-route>` stubs at outlet positions.
 9. Parent components and their state are preserved.
 
-**Partial response:** `Protocol::render_partial()` returns the complete response
-with projected top-level `state`. Raw-state input is validated
-with a streaming serde visitor that enforces `serde_json::Value` numeric limits,
-skips unselected values without materializing them, and borrows selected raw
-values into the response. FFI, Node, WASM, and .NET expose only the complete
+**Partial response:** `Protocol::render_partial()` accepts owned
+`serde_json::Value` state and returns the complete response with projected
+top-level `state`, moving selected values without a serialize/reparse cycle.
+`Protocol::render_partial_json()` accepts raw state and validates it with a
+streaming serde visitor that enforces `serde_json::Value` numeric limits, skips
+unselected values without materializing them, and borrows selected raw values
+into the response. FFI, Node, WASM, and .NET expose only the complete
 `renderPartial` contract.
 
 - `state`: route-scoped navigation data projected with each reachable component's `navigation_keys`; included by complete-response host APIs or supplied as NDJSON Chunk 2 by a streaming host. The router applies it to components via `setState()`

--- a/crates/webui-cli/src/commands/serve.rs
+++ b/crates/webui-cli/src/commands/serve.rs
@@ -1234,8 +1234,8 @@ async fn handle_json_partial(
                 &entry,
                 &paths.route_path,
             );
-            for (k, v) in &nested_params {
-                map.insert(k.clone(), Value::String(v.clone()));
+            for (key, value) in nested_params {
+                map.insert(key, Value::String(value));
             }
         }
     }
@@ -1250,17 +1250,7 @@ async fn handle_json_partial(
 
     // Build the complete partial response (componentStyles, templates, inventory, path, chain)
     let partial = if let Some(proto) = &protocol {
-        let state_json = match serde_json::to_string(&state_data) {
-            Ok(value) => value,
-            Err(error) => {
-                return HttpResponse::InternalServerError()
-                    .content_type("application/json")
-                    .body(format!(
-                        r#"{{"error":"state serialization failed: {error}"}}"#
-                    ));
-            }
-        };
-        match proto.render_partial(&state_json, &entry, &paths.route_path, &client_inv_hex) {
+        match proto.render_partial(state_data, &entry, &paths.route_path, &client_inv_hex) {
             Ok(value) => value,
             Err(e) => {
                 return HttpResponse::InternalServerError()
@@ -1286,7 +1276,12 @@ fn collect_needed_template_names(
 ) -> (Vec<String>, String) {
     let protocol = Protocol::new(protocol.clone());
     let json = protocol
-        .render_partial("{}", entry_fragment_id, request_path, inventory_hex)
+        .render_partial(
+            Value::Object(serde_json::Map::new()),
+            entry_fragment_id,
+            request_path,
+            inventory_hex,
+        )
         .unwrap();
     let response: Value = serde_json::from_str(&json).unwrap();
     let names = response["templates"]

--- a/crates/webui-ffi/src/lib.rs
+++ b/crates/webui-ffi/src/lib.rs
@@ -473,7 +473,7 @@ pub unsafe extern "C" fn webui_protocol_render_partial(
             }
         };
 
-        let output = match protocol_context.protocol.render_partial(
+        let output = match protocol_context.protocol.render_partial_json(
             state_str,
             entry_str,
             request_path_str,

--- a/crates/webui-handler/benches/bootstrap_state_bench.rs
+++ b/crates/webui-handler/benches/bootstrap_state_bench.rs
@@ -742,7 +742,7 @@ fn partial_state_serialization_bench(c: &mut Criterion) {
             |b, input| {
                 b.iter(|| {
                     let output = full_protocol
-                        .render_partial(black_box(input), "index.html", "/", "")
+                        .render_partial_json(black_box(input), "index.html", "/", "")
                         .unwrap_or_else(|error| {
                             panic!("full partial response serialization failed: {error}")
                         });
@@ -757,7 +757,7 @@ fn partial_state_serialization_bench(c: &mut Criterion) {
             |b, input| {
                 b.iter(|| {
                     let output = projected_protocol
-                        .render_partial(black_box(input), "index.html", "/", "")
+                        .render_partial_json(black_box(input), "index.html", "/", "")
                         .unwrap_or_else(|error| {
                             panic!("projected partial response serialization failed: {error}")
                         });
@@ -772,7 +772,7 @@ fn partial_state_serialization_bench(c: &mut Criterion) {
             |b, input| {
                 b.iter(|| {
                     let output = scriptless_protocol
-                        .render_partial(black_box(input), "index.html", "/", "")
+                        .render_partial_json(black_box(input), "index.html", "/", "")
                         .unwrap_or_else(|error| {
                             panic!("scriptless partial response serialization failed: {error}")
                         });
@@ -787,7 +787,7 @@ fn partial_state_serialization_bench(c: &mut Criterion) {
             |b, input| {
                 b.iter(|| {
                     let output = static_protocol
-                        .render_partial(black_box(input), "index.html", "/", "")
+                        .render_partial_json(black_box(input), "index.html", "/", "")
                         .unwrap_or_else(|error| {
                             panic!("static partial response serialization failed: {error}")
                         });

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -100,7 +100,7 @@ fn build_mixed_protocol() -> Protocol {
                 WebUIFragment::raw("</ul>"),
                 WebUIFragment::if_cond(ConditionExpr::identifier("show_footer"), "footer-frag"),
                 // Simulate parser-plugin payload consumed by FastV2HydrationPlugin.
-                WebUIFragment::plugin((3u32).to_le_bytes().to_vec()),
+                WebUIFragment::plugin(vec![3, 0, 0, 0, 0]),
                 WebUIFragment::raw("</x-card>"),
             ],
             contains_boundary: false,

--- a/crates/webui-handler/benches/handler_bench.rs
+++ b/crates/webui-handler/benches/handler_bench.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::hint::black_box;
 use webui_handler::plugin::fast_v2::FastV2HydrationPlugin;
 use webui_handler::{Protocol, RenderOptions, ResponseWriter, WebUIHandler};
+use webui_protocol::plugin::FastElementData;
 use webui_protocol::{
     ComparisonOperator, ConditionExpr, FragmentList, LogicalOperator, WebUIFragment, WebUIProtocol,
 };
@@ -99,8 +100,11 @@ fn build_mixed_protocol() -> Protocol {
                 WebUIFragment::for_loop("item", "items", "item-frag"),
                 WebUIFragment::raw("</ul>"),
                 WebUIFragment::if_cond(ConditionExpr::identifier("show_footer"), "footer-frag"),
-                // Simulate parser-plugin payload consumed by FastV2HydrationPlugin.
-                WebUIFragment::plugin(vec![3, 0, 0, 0, 0]),
+                WebUIFragment::plugin(
+                    FastElementData { binding_count: 3 }
+                        .encode_v2(false)
+                        .to_vec(),
+                ),
                 WebUIFragment::raw("</x-card>"),
             ],
             contains_boundary: false,

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -292,8 +292,12 @@ impl Protocol {
         &self.protocol.tokens
     }
 
-    /// Produce a complete partial-navigation response.
-    pub fn render_partial(
+    /// Produce a complete partial-navigation response from serialized state.
+    ///
+    /// This variant validates serialized host input while borrowing selected raw
+    /// values into the response. Rust callers that already own parsed state
+    /// should use [`Self::render_partial`] instead.
+    pub fn render_partial_json(
         &self,
         state_json: &str,
         entry_id: &str,
@@ -310,6 +314,30 @@ impl Protocol {
             &mut index,
         )?;
         serialize_partial_response(&response, state_json, &state_selection)
+    }
+
+    /// Produce a complete partial-navigation response from parsed state.
+    ///
+    /// This ownership-taking variant moves selected values into the response
+    /// instead of serializing and reparsing the complete state tree. Use it when
+    /// the caller already owns a [`serde_json::Value`] for the request.
+    pub fn render_partial(
+        &self,
+        state: Value,
+        entry_id: &str,
+        request_path: &str,
+        inventory_hex: &str,
+    ) -> Result<String, HandlerError> {
+        self.ensure_style_metadata()?;
+        let mut index = self.request_index();
+        let (response, state_selection) = render_partial_indexed_with_state(
+            self.protocol(),
+            entry_id,
+            request_path,
+            inventory_hex,
+            &mut index,
+        )?;
+        serialize_partial_value_response(&response, state, &state_selection)
     }
 
     /// Render component template payloads for requested component tags.
@@ -1471,6 +1499,19 @@ fn serialize_partial_response(
         .map_err(|error| partial_serialize_error(&error.to_string()))
 }
 
+fn serialize_partial_value_response(
+    response: &Value,
+    state: Value,
+    state_selection: &StateSelection<'_>,
+) -> Result<String, HandlerError> {
+    let response = response
+        .as_object()
+        .ok_or_else(partial_response_not_object)?;
+    let state = select_owned_state(state, state_selection);
+    serde_json::to_string(&PartialResponseWithState { response, state })
+        .map_err(|error| partial_serialize_error(&error.to_string()))
+}
+
 fn validate_json(json: &str) -> Result<(), HandlerError> {
     validate_json_inner(json).map_err(|error| invalid_state_json(&error.to_string()))
 }
@@ -1573,12 +1614,12 @@ impl<'de> Visitor<'de> for ValidJsonVisitor {
     }
 }
 
-struct PartialResponseWithState<'a, 'state> {
+struct PartialResponseWithState<'a, State> {
     response: &'a Map<String, Value>,
-    state: SelectedRawState<'state>,
+    state: State,
 }
 
-impl Serialize for PartialResponseWithState<'_, '_> {
+impl<State: Serialize> Serialize for PartialResponseWithState<'_, State> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -2880,10 +2921,15 @@ fn render_partial_indexed_with_state<'a>(
     Ok((Value::Object(result), state_selection))
 }
 
-#[cfg(test)]
 fn select_owned_state(state: Value, selection: &StateSelection<'_>) -> Value {
     let state_keys = match selection {
-        StateSelection::Full => return state,
+        StateSelection::Full => {
+            let mut state = state;
+            if let Value::Object(state) = &mut state {
+                state.remove(crate::STATE_INJECT_KEY);
+            }
+            return state;
+        }
         StateSelection::Keys(keys) => keys.as_slice(),
         // Streaming's key-ID projection never reaches partial navigation.
         StateSelection::KeyIds(_) | StateSelection::FullExceptKeyIds(_) => {
@@ -2895,6 +2941,9 @@ fn select_owned_state(state: Value, selection: &StateSelection<'_>) -> Value {
     };
     let mut projected = Map::with_capacity(state_keys.len().min(source.len()));
     for &key in state_keys {
+        if key == crate::STATE_INJECT_KEY {
+            continue;
+        }
         if let Some(value) = source.remove(key) {
             projected.insert(key.to_owned(), value);
         }
@@ -3792,7 +3841,7 @@ mod tests {
     fn partial_state_serialization_preserves_validated_raw_json() {
         let prepared = prepared_partial_protocol(&["value"]);
         let output = prepared
-            .render_partial(
+            .render_partial_json(
                 r#"{"serverOnly":"drop","value":1e2}"#,
                 "index.html",
                 "/",
@@ -3810,7 +3859,7 @@ mod tests {
     fn partial_state_projection_strips_reserved_inject_key() {
         let prepared = prepared_partial_protocol(&[crate::STATE_INJECT_KEY, "value"]);
         let output = prepared
-            .render_partial(
+            .render_partial_json(
                 r#"{"$webui":{"bodyEnd":"<script>secret</script>"},"serverOnly":"drop","value":1}"#,
                 "index.html",
                 "/",
@@ -3824,10 +3873,35 @@ mod tests {
     }
 
     #[test]
+    fn parsed_partial_state_moves_selected_values_into_response() {
+        let prepared = prepared_partial_protocol(&[crate::STATE_INJECT_KEY, "value"]);
+        let output = prepared
+            .render_partial(
+                serde_json::json!({
+                    "$webui": {"bodyEnd": "<script>secret</script>"},
+                    "serverOnly": ["large", "discarded", "value"],
+                    "value": {"nested": "kept"}
+                }),
+                "index.html",
+                "/",
+                "",
+            )
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(
+            parsed["state"],
+            serde_json::json!({"value": {"nested": "kept"}})
+        );
+        assert!(!output.contains("serverOnly"));
+        assert!(!output.contains("<script>secret</script>"), "{output}");
+    }
+
+    #[test]
     fn uncertain_partial_surface_preserves_complete_raw_state() {
         let prepared = prepared_full_state_partial_protocol();
         let output = prepared
-            .render_partial(
+            .render_partial_json(
                 r#"{"serverOnly":"keep","value":1e2}"#,
                 "index.html",
                 "/",
@@ -3845,7 +3919,7 @@ mod tests {
             r#"{"$\u0077\u0065\u0062\u0075\u0069":{"bodyEnd":"<script>secret</script>"},"serverOnly":"keep","value":1}"#,
         ] {
             let output = prepared
-                .render_partial(state, "index.html", "/", "")
+                .render_partial_json(state, "index.html", "/", "")
                 .unwrap();
             let parsed: Value = serde_json::from_str(&output).unwrap();
 
@@ -3858,10 +3932,34 @@ mod tests {
     }
 
     #[test]
-    fn uncertain_partial_surface_preserves_nested_reserved_key_bytes() {
+    fn parsed_full_partial_state_strips_reserved_inject_key() {
         let prepared = prepared_full_state_partial_protocol();
         let output = prepared
             .render_partial(
+                serde_json::json!({
+                    "$webui": {"bodyEnd": "<script>secret</script>"},
+                    "serverOnly": "keep",
+                    "value": 1
+                }),
+                "index.html",
+                "/",
+                "",
+            )
+            .unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(
+            parsed["state"],
+            serde_json::json!({"serverOnly": "keep", "value": 1})
+        );
+        assert!(!output.contains("<script>secret</script>"), "{output}");
+    }
+
+    #[test]
+    fn uncertain_partial_surface_preserves_nested_reserved_key_bytes() {
+        let prepared = prepared_full_state_partial_protocol();
+        let output = prepared
+            .render_partial_json(
                 r#"{"outer": { "$webui": {"bodyEnd": "application data"} }, "value": 1e2}"#,
                 "index.html",
                 "/",
@@ -3881,7 +3979,7 @@ mod tests {
     fn partial_state_serialization_rejects_invalid_json() {
         let prepared = prepared_partial_protocol(&[]);
         let error = prepared
-            .render_partial(r#"{"broken":"#, "index.html", "/", "")
+            .render_partial_json(r#"{"broken":"#, "index.html", "/", "")
             .expect_err("invalid state JSON must fail");
         assert!(
             matches!(error, HandlerError::InvalidState(_)),
@@ -3894,7 +3992,7 @@ mod tests {
     fn partial_state_serialization_emits_empty_state_without_client_components() {
         let prepared = Protocol::new(WebUIProtocol::default());
         let output = prepared
-            .render_partial(r#"{"serverOnly":"drop"}"#, "index.html", "/", "")
+            .render_partial_json(r#"{"serverOnly":"drop"}"#, "index.html", "/", "")
             .unwrap();
         let parsed: Value = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed["state"], serde_json::json!({}));
@@ -3905,7 +4003,7 @@ mod tests {
         let prepared = prepared_partial_protocol(&["value"]);
         for state in [r#"{"value":1e9999}"#, r#"{"serverOnly":1e9999,"value":1}"#] {
             let error = prepared
-                .render_partial(state, "index.html", "/", "")
+                .render_partial_json(state, "index.html", "/", "")
                 .expect_err("out-of-range state numbers must fail");
             assert!(
                 matches!(error, HandlerError::InvalidState(_)),
@@ -3919,7 +4017,7 @@ mod tests {
     fn partial_state_serialization_uses_last_duplicate_and_decodes_keys() {
         let prepared = prepared_partial_protocol(&["value"]);
         let output = prepared
-            .render_partial(r#"{"value":1,"va\u006cue":2}"#, "index.html", "/", "")
+            .render_partial_json(r#"{"value":1,"va\u006cue":2}"#, "index.html", "/", "")
             .unwrap();
         let parsed: Value = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed["state"], serde_json::json!({"value": 2}));

--- a/crates/webui-node/src/lib.rs
+++ b/crates/webui-node/src/lib.rs
@@ -409,7 +409,7 @@ impl Protocol {
         inventory_hex: String,
     ) -> napi::Result<String> {
         self.inner
-            .render_partial(&state_json, &entry_id, &request_path, &inventory_hex)
+            .render_partial_json(&state_json, &entry_id, &request_path, &inventory_hex)
             .map_err(|e| NapiError::from_reason(format!("render_partial failed: {e}")))
     }
 

--- a/crates/webui-python/src/lib.rs
+++ b/crates/webui-python/src/lib.rs
@@ -240,7 +240,7 @@ impl NativeRenderer {
             .detach(|| {
                 let state_json = input.as_str()?;
                 self.protocol
-                    .render_partial(state_json, &options.0, &options.1, &options.2)
+                    .render_partial_json(state_json, &options.0, &options.1, &options.2)
                     .map(String::into_bytes)
                     .map_err(partial_binding_error)
             })

--- a/crates/webui-wasm/src/handler.rs
+++ b/crates/webui-wasm/src/handler.rs
@@ -171,7 +171,7 @@ impl Protocol {
         inventory_hex: &str,
     ) -> Result<String, JsValue> {
         self.inner
-            .render_partial(state_json, entry_id, request_path, inventory_hex)
+            .render_partial_json(state_json, entry_id, request_path, inventory_hex)
             .map_err(|error| JsValue::from_str(&format!("render_partial failed: {error}")))
     }
 

--- a/crates/webui/README.md
+++ b/crates/webui/README.md
@@ -175,9 +175,18 @@ For servers handling client-side navigation, produce a complete JSON partial:
 
 ```rust
 let partial = protocol.render_partial(
-    state_json, "index.html", "/users/42", inventory_hex,
+    state, "index.html", "/users/42", inventory_hex,
 )?;
 // Returns: { state, templates, inventory, path, chain }
+```
+
+Serialized host boundaries can call `render_partial_json()` to validate and
+project raw JSON without materializing a duplicate state tree:
+
+```rust
+let partial = protocol.render_partial_json(
+    state_json, "index.html", "/users/42", inventory_hex,
+)?;
 ```
 
 ## Types

--- a/crates/webui/benches/README.md
+++ b/crates/webui/benches/README.md
@@ -16,7 +16,8 @@ Four criterion benches in this directory:
   generation and chunk rendering.
 * **`server_request_bench.rs`** — high-level router-aware request
   handling for full documents with and without a CSP nonce, plus JSON
-  partial responses.
+  partial responses including a large state with sparse navigation
+  projection.
 
 Two **examples** (in `crates/webui/examples/`) round out the suite:
 

--- a/crates/webui/benches/server_request_bench.rs
+++ b/crates/webui/benches/server_request_bench.rs
@@ -137,7 +137,7 @@ fn server_request_bench(c: &mut Criterion) {
                     ServeResponse::Html(_) => panic!("partial request returned HTML"),
                 }
             },
-            BatchSize::SmallInput,
+            BatchSize::LargeInput,
         );
     });
 }

--- a/crates/webui/benches/server_request_bench.rs
+++ b/crates/webui/benches/server_request_bench.rs
@@ -6,10 +6,11 @@
 use std::collections::HashMap;
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use webui::server::{serve_request, ServeRequest, ServeResponse};
 use webui::{Protocol, RenderOptions, WebUIHandler};
 use webui_handler::plugin::webui::WebUIHydrationPlugin;
+use webui_protocol::StateProjectionMode;
 use webui_protocol::{ComponentData, FragmentList, WebUIFragment, WebUIProtocol};
 
 const ENTRY_ID: &str = "index.html";
@@ -52,6 +53,8 @@ fn benchmark_protocol() -> Protocol {
         ComponentData {
             template_json: r#"{"h":"<main>ready</main>","th":1}"#.to_string(),
             template_functions: "[function(){return true}]".to_string(),
+            navigation_keys: vec!["selected".to_string()],
+            navigation_mode: Some(StateProjectionMode::Keys as i32),
             ..Default::default()
         },
     );
@@ -68,6 +71,7 @@ fn server_request_bench(c: &mut Criterion) {
         "",
     );
     let partial_request = ServeRequest::new(RenderOptions::new(ENTRY_ID, REQUEST_PATH), true, "");
+    let large_state = large_projected_state();
 
     c.bench_function("server_request/full_html_without_nonce", |b| {
         b.iter(|| {
@@ -116,6 +120,40 @@ fn server_request_bench(c: &mut Criterion) {
             }
         });
     });
+
+    c.bench_function("server_request/json_partial_large_projected_state", |b| {
+        b.iter_batched(
+            || large_state.clone(),
+            |state| {
+                let response = serve_request(
+                    black_box(&protocol),
+                    black_box(&handler),
+                    state,
+                    black_box(&partial_request),
+                )
+                .unwrap_or_else(|error| panic!("server request render failed: {error}"));
+                match response {
+                    ServeResponse::Json(json) => black_box(json.len()),
+                    ServeResponse::Html(_) => panic!("partial request returned HTML"),
+                }
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn large_projected_state() -> serde_json::Value {
+    let mut unused = Vec::with_capacity(1_000);
+    for index in 0..1_000 {
+        unused.push(serde_json::json!({
+            "id": index,
+            "payload": "x".repeat(128),
+        }));
+    }
+    serde_json::json!({
+        "selected": "kept",
+        "unused": unused,
+    })
 }
 
 criterion_group!(benches, server_request_bench);

--- a/crates/webui/src/server.rs
+++ b/crates/webui/src/server.rs
@@ -111,18 +111,16 @@ pub fn serve_request(
     );
     let mut data = state;
     if let Some(map) = data.as_object_mut() {
-        for (k, v) in &params {
-            map.insert(k.clone(), serde_json::Value::String(v.clone()));
+        for (key, value) in params {
+            map.insert(key, serde_json::Value::String(value));
         }
     }
 
     if request.accept_json {
         // JSON partial response for client-side navigation.
-        let state_json =
-            serde_json::to_string(&data).map_err(|e| format!("state serialization failed: {e}"))?;
         let partial = protocol
             .render_partial(
-                &state_json,
+                data,
                 options.entry_id,
                 options.request_path,
                 request.inventory_hex,

--- a/crates/webui/tests/example_apps_hydration.rs
+++ b/crates/webui/tests/example_apps_hydration.rs
@@ -179,12 +179,7 @@ fn routes_example_without_manifest_preserves_full_state() {
 
     let runtime_protocol = Protocol::new(protocol);
     let partial_json = runtime_protocol
-        .render_partial(
-            &serde_json::to_string(&state).expect("state should serialize"),
-            "index.html",
-            "/",
-            "",
-        )
+        .render_partial(state, "index.html", "/", "")
         .unwrap_or_else(|error| panic!("routes partial should render: {error}"));
     let partial: Value =
         serde_json::from_str(&partial_json).expect("partial response should be valid JSON");

--- a/docs/guide/concepts/routing.md
+++ b/docs/guide/concepts/routing.md
@@ -776,9 +776,11 @@ bootstrap. The CSS list contains the matched route chain, not inactive siblings.
 ### Partial Navigation
 
 Rust `Protocol::render_partial()` and every host binding return the complete
-response, including the state needed by active-route components. Raw state
-input is validated in full while unneeded values are skipped without
-constructing a duplicate JSON tree.
+response, including the state needed by active-route components. The Rust API
+consumes a `serde_json::Value` and moves selected values into the response
+without serializing and reparsing the complete tree. Serialized host boundaries
+use `Protocol::render_partial_json()`; raw input is validated in full while
+unneeded values are skipped without constructing a duplicate JSON tree.
 
 After storing new template metadata, the router dispatches
 `webui:templates-registered`. Optional runtimes may synchronously add resource
@@ -796,7 +798,7 @@ For repeated Rust requests, load one `Protocol`:
 ```rust
 let protocol = Protocol::from_protobuf(&protocol_bytes)?;
 let json = protocol.render_partial(
-    state_json,
+    state,
     "index.html",
     request_path,
     inventory_hex,

--- a/docs/guide/integrations/rust.md
+++ b/docs/guide/integrations/rust.md
@@ -186,6 +186,9 @@ For a full document, the helper passes the complete options directly to
 Use a fresh nonce for each document response and send the same value in the
 Content Security Policy header. JSON partial responses use the options' entry
 and request path plus the client inventory; they do not emit document scripts.
+The helper transfers its owned `serde_json::Value` to
+`Protocol::render_partial()`, so projection drops unselected values without
+first serializing the complete request state.
 
 ## Streaming SSR
 
@@ -525,6 +528,8 @@ component.
 |---|---|
 | `ServeRequest::new(render_options, accept_json, inventory_hex)` | Store the complete borrowed render configuration and the client's partial-navigation metadata without a heap allocation |
 | `serve_request(protocol, handler, state, request)` | Inject route parameters, then return either a full `ServeResponse::Html` document rendered with the supplied options or a `ServeResponse::Json` partial |
+| `Protocol::render_partial(state, entry_id, request_path, inventory_hex)` | Consume parsed Rust state and move its selected values into a complete JSON partial without a serialize/reparse cycle |
+| `Protocol::render_partial_json(state_json, entry_id, request_path, inventory_hex)` | Validate and project serialized state without materializing a duplicate state tree |
 
 ### Host-driven streaming
 

--- a/examples/app/commerce/server/src/frontend.rs
+++ b/examples/app/commerce/server/src/frontend.rs
@@ -116,17 +116,9 @@ impl FrontendRuntime {
         inventory_hex: &str,
         state: Value,
     ) -> Value {
-        let state_json = match serde_json::to_string(&state) {
-            Ok(value) => value,
-            Err(error) => {
-                return serde_json::json!({
-                    "error": format!("state serialization failed: {error}")
-                });
-            }
-        };
         match self
             .protocol
-            .render_partial(&state_json, &self.entry, route_path, inventory_hex)
+            .render_partial(state, &self.entry, route_path, inventory_hex)
         {
             Ok(json) => serde_json::from_str(&json).unwrap_or_else(|error| {
                 serde_json::json!({

--- a/examples/app/commerce/server/src/server.rs
+++ b/examples/app/commerce/server/src/server.rs
@@ -86,7 +86,7 @@ async fn handle_frontend_request(
     }
 
     if context.wants_json() {
-        return Ok(partial_response(&context, data.get_ref(), &page_state));
+        return Ok(partial_response(&context, data.get_ref(), page_state));
     }
 
     let nonce = security::generate_nonce();
@@ -189,16 +189,12 @@ fn cart_mutation_input(payload: CartMutationPayload) -> CartMutationInput {
     }
 }
 
-fn partial_response(
-    context: &RequestContext,
-    state: &AppState,
-    page_state: &Value,
-) -> HttpResponse {
+fn partial_response(context: &RequestContext, state: &AppState, page_state: Value) -> HttpResponse {
     let payload = state.frontend().render_partial(
         context.route_path(),
         context.request_path(),
         context.inventory_hex(),
-        page_state.clone(),
+        page_state,
     );
 
     let mut builder = HttpResponse::Ok();


### PR DESCRIPTION
## Why

Rust partial-navigation requests already own a parsed `serde_json::Value`, but the server path serialized the complete state tree before the handler parsed it again and discarded unselected keys. Large sparsely projected states therefore paid substantial temporary memory and CPU costs per request.

## What changed

- Make `Protocol::render_partial(Value, ...)` the ownership-taking Rust path so selected values move directly into the response.
- Keep `Protocol::render_partial_json(&str, ...)` for Node, FFI, WASM, and Python boundaries, where the streaming JSON visitor avoids materializing a full duplicate state tree.
- Update Rust server, CLI, integration, and commerce call sites to use the owned path and move route parameters without cloning.
- Preserve `$webui` exclusion for both full and keyed owned-state projection.
- Add a large sparse-projection benchmark and repair the stale FAST v2 benchmark payload.
- Synchronize the specification and Rust integration documentation.

## Performance

| Metric | Before | After | Change |
|---|---:|---:|---:|
| P50 latency | 157.8 us | 66.1 us | -58.1% |
| Allocated bytes/request | 266,283 B | 4,739 B | -98.2% |
| Allocations/request | 66 | 55 | -16.7% |
| Output size | 231 B | 231 B | unchanged |

The complete 12-target Rust benchmark suite completed successfully.

## Validation

- `cargo xtask check`
- `cargo xtask bench all`