### PR TITLE
perf: cut per-render handler allocations

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -44,6 +44,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::cell::{Cell, OnceCell};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{self, Write as _};
 use std::sync::Arc;
 use streaming::{
     consume_streaming_component_root, ensure_no_pending_streaming_root,
@@ -1252,6 +1253,83 @@ fn missing_component_attr_name_error() -> HandlerError {
     HandlerError::Invariant("prepared component attribute name is missing".to_string())
 }
 
+/// Fixed-capacity [`fmt::Write`] sink used to render JSON scalars on the stack.
+///
+/// `serde_json::Number` is backed by `i64`, `u64`, or `f64` (the crate is built
+/// without `arbitrary_precision`), so its longest rendering is the 24-byte
+/// `ryu` form of an extreme `f64`. The buffer is oversized well past that, and
+/// an overflow is reported rather than truncated so callers fall back to the
+/// allocating path instead of emitting a malformed value.
+struct ScalarBuffer {
+    buf: [u8; 48],
+    len: usize,
+}
+
+impl ScalarBuffer {
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            buf: [0; 48],
+            len: 0,
+        }
+    }
+
+    #[inline]
+    fn as_str(&self) -> Option<&str> {
+        std::str::from_utf8(&self.buf[..self.len]).ok()
+    }
+}
+
+impl fmt::Write for ScalarBuffer {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+        let end = self.len.checked_add(bytes.len()).ok_or(fmt::Error)?;
+        let slot = self.buf.get_mut(self.len..end).ok_or(fmt::Error)?;
+        slot.copy_from_slice(bytes);
+        self.len = end;
+        Ok(())
+    }
+}
+
+/// Render a JSON scalar that can never contain HTML-significant bytes.
+///
+/// Numbers, booleans, and `null` render identically escaped and unescaped, so
+/// this bypasses both the `Value::to_string` allocation and the `encode_safe`
+/// scan that the generic display path performs. Returns `None` when `value` is
+/// a string, array, or object, leaving those to the caller's fallback.
+fn format_plain_json_scalar<'buf>(
+    buffer: &'buf mut ScalarBuffer,
+    value: &Value,
+) -> Option<&'buf str> {
+    match value {
+        Value::Bool(true) => Some("true"),
+        Value::Bool(false) => Some("false"),
+        Value::Null => Some("null"),
+        Value::Number(number) => {
+            // `Display for Number` is the same serializer `Value::to_string`
+            // drives, so the bytes are identical to the allocating path.
+            write!(buffer, "{number}").ok()?;
+            buffer.as_str()
+        }
+        _ => None,
+    }
+}
+
+/// Write a JSON scalar straight to the sink, skipping escaping and allocation.
+///
+/// Returns `false` when `value` needs the caller's allocating fallback.
+fn write_plain_json_scalar(writer: &mut dyn ResponseWriter, value: &Value) -> Result<bool> {
+    let mut buffer = ScalarBuffer::new();
+    match format_plain_json_scalar(&mut buffer, value) {
+        Some(rendered) => {
+            writer.write(rendered)?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
 /// Write a usize as decimal digits directly to the writer, avoiding `format!` allocation.
 pub(crate) fn write_usize(writer: &mut dyn ResponseWriter, mut n: usize) -> Result<()> {
     if n == 0 {
@@ -2214,7 +2292,7 @@ impl WebUIHandler {
                 }
                 Some(Fragment::Component(component)) => {
                     self.process_component(
-                        component,
+                        &component.fragment_id,
                         fragment_list.target(index),
                         ComponentHostOrigin::ParserProduced,
                         context,
@@ -2300,15 +2378,14 @@ impl WebUIHandler {
             let comp = &matched_child.fragment_id;
 
             if !comp.is_empty() {
-                let saved_route_base = context.route_base.clone();
-                let saved_route_children = std::mem::take(&mut context.route_children);
-
-                if rm.consumed_segments > 0 {
-                    context.route_base = Cow::Owned(route_matcher::compute_route_base(
+                let saved_route_base = (rm.consumed_segments > 0).then(|| {
+                    let base = route_matcher::compute_route_base(
                         context.request_path,
                         rm.consumed_segments,
-                    ));
-                }
+                    );
+                    std::mem::replace(&mut context.route_base, Cow::Owned(base))
+                });
+                let saved_route_children = std::mem::take(&mut context.route_children);
 
                 context.route_children = grandchildren;
 
@@ -2351,21 +2428,16 @@ impl WebUIHandler {
                 prepare_generated_streaming_root(comp, context)?;
                 context.writer.write(">")?;
 
-                self.process_component(
-                    &webui_protocol::WebUIFragmentComponent {
-                        fragment_id: comp.clone(),
-                    },
-                    None,
-                    ComponentHostOrigin::HandlerGenerated,
-                    context,
-                )?;
+                self.process_component(comp, None, ComponentHostOrigin::HandlerGenerated, context)?;
 
                 context.writer.write("</")?;
                 context.writer.write(comp)?;
                 context.writer.write(">")?;
                 context.writer.write("</webui-route>")?;
 
-                context.route_base = saved_route_base;
+                if let Some(saved) = saved_route_base {
+                    context.route_base = saved;
+                }
                 context.route_children = saved_route_children;
             }
         }
@@ -2742,32 +2814,22 @@ impl WebUIHandler {
     ///
     /// Only components rendered on the current route get inline definitions;
     /// navigation responses carry later definitions in `componentStyles`.
-    fn emit_css_module(
-        &self,
-        component: &webui_protocol::WebUIFragmentComponent,
-        context: &mut WebUIProcessContext,
-    ) -> Result<()> {
+    fn emit_css_module(&self, fragment_id: &str, context: &mut WebUIProcessContext) -> Result<()> {
         if context.css_strategy != webui_protocol::CssStrategy::Module {
             return Ok(());
         }
         let metadata_already_streamed = context.streaming.as_ref().is_some_and(|streaming| {
-            streaming_template_already_sent(
-                streaming,
-                context.component_index,
-                &component.fragment_id,
-            )
+            streaming_template_already_sent(streaming, context.component_index, fragment_id)
         });
-        if !metadata_already_streamed
-            && !context.rendered_components.contains(&component.fragment_id)
-        {
+        if !metadata_already_streamed && !context.rendered_components.contains(fragment_id) {
             if let Some(css) = context
                 .protocol
                 .components
-                .get(&component.fragment_id)
+                .get(fragment_id)
                 .map(|c| c.css.as_str())
                 .filter(|s| !s.is_empty())
             {
-                self.emit_css_module_importmap(&component.fragment_id, css, context)?;
+                self.emit_css_module_importmap(fragment_id, css, context)?;
             }
         }
         Ok(())
@@ -2806,14 +2868,12 @@ impl WebUIHandler {
             write_usize(context.writer, ri)?;
             context.writer.write("\" active>")?;
 
-            let saved_route_base = context.route_base.clone();
+            let saved_route_base = best_route.as_ref().map(|(_, rm)| {
+                let base =
+                    route_matcher::compute_route_base(context.request_path, rm.consumed_segments);
+                std::mem::replace(&mut context.route_base, Cow::Owned(base))
+            });
             let saved_route_children = std::mem::take(&mut context.route_children);
-            if let Some((_, ref rm)) = best_route {
-                context.route_base = Cow::Owned(route_matcher::compute_route_base(
-                    context.request_path,
-                    rm.consumed_segments,
-                ));
-            }
             context.route_children = route_frag.children.clone();
 
             if !route_frag.content_fragment_id.is_empty() {
@@ -2828,10 +2888,6 @@ impl WebUIHandler {
                         context,
                     )?;
                 }
-                let comp = webui_protocol::WebUIFragmentComponent {
-                    fragment_id: route_frag.fragment_id.clone(),
-                };
-
                 context.writer.write("<")?;
                 context.writer.write(&route_frag.fragment_id)?;
                 if let Some(p) = &context.plugin {
@@ -2842,7 +2898,7 @@ impl WebUIHandler {
                 context.writer.write(">")?;
 
                 self.process_component(
-                    &comp,
+                    &route_frag.fragment_id,
                     None,
                     ComponentHostOrigin::HandlerGenerated,
                     context,
@@ -2852,7 +2908,9 @@ impl WebUIHandler {
                 context.writer.write(&route_frag.fragment_id)?;
                 context.writer.write(">")?;
             }
-            context.route_base = saved_route_base;
+            if let Some(saved) = saved_route_base {
+                context.route_base = saved;
+            }
             context.route_children = saved_route_children;
         } else {
             context.writer.write(" style=\"display:none\">")?;
@@ -2865,16 +2923,16 @@ impl WebUIHandler {
     /// Process a component fragment.
     fn process_component(
         &self,
-        component: &webui_protocol::WebUIFragmentComponent,
+        fragment_id: &str,
         target: Option<usize>,
         origin: ComponentHostOrigin,
         context: &mut WebUIProcessContext,
     ) -> Result<()> {
         if context.streaming.is_some() {
-            consume_streaming_component_root(&component.fragment_id, origin, context)?;
+            consume_streaming_component_root(fragment_id, origin, context)?;
             // Capture only after root parity succeeds, so malformed protocols
             // cannot contribute unmarked hosts to a checkpoint.
-            record_checkpoint_tag(context, &component.fragment_id);
+            record_checkpoint_tag(context, fragment_id);
         }
 
         // Emit the component's CSS module importmap into its light DOM and track
@@ -2882,16 +2940,14 @@ impl WebUIHandler {
         // is a set, so gating the `insert` (and its `String` clone) behind the
         // first-encounter check avoids allocating a throwaway `String` for every
         // duplicate instance while keeping the set contents identical.
-        if !context.rendered_components.contains(&component.fragment_id) {
-            self.emit_css_module(component, context)?;
-            context
-                .rendered_components
-                .insert(component.fragment_id.clone());
+        if !context.rendered_components.contains(fragment_id) {
+            self.emit_css_module(fragment_id, context)?;
+            context.rendered_components.insert(fragment_id.to_string());
         }
 
-        let owns_css_tree = Self::component_owns_css_tree(&component.fragment_id, context.protocol);
+        let owns_css_tree = Self::component_owns_css_tree(fragment_id, context.protocol);
         if owns_css_tree {
-            Self::push_shadow_style_root(&component.fragment_id, context)?;
+            Self::push_shadow_style_root(fragment_id, context)?;
         }
 
         // Save parent scope. `mem::take` leaves an alloc-free empty map behind.
@@ -2921,11 +2977,11 @@ impl WebUIHandler {
             p.push_scope();
         }
 
-        let render_result = self.process_fragment_target(target, &component.fragment_id, context);
+        let render_result = self.process_fragment_target(target, fragment_id, context);
         context.visible_loop_scope = saved_loop_scope;
 
         if owns_css_tree {
-            Self::pop_shadow_style_root(&component.fragment_id, context)?;
+            Self::pop_shadow_style_root(fragment_id, context)?;
         }
         render_result?;
 
@@ -3574,6 +3630,11 @@ impl WebUIHandler {
         raw: bool,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
+        // Numbers, booleans, and null render the same escaped or not, and never
+        // need a heap buffer to reach the writer.
+        if write_plain_json_scalar(writer, value)? {
+            return Ok(());
+        }
         if raw {
             match value {
                 Value::String(s) => writer.write(s),
@@ -3768,12 +3829,20 @@ impl WebUIHandler {
                         write_attr(context.writer, &attr.name, "")?;
                     }
                     Some(other) => {
-                        let s = other.to_string();
-                        write_attr(
-                            context.writer,
-                            &attr.name,
-                            &crate::html_encode::encode_safe(&s),
-                        )?;
+                        let mut scalar = ScalarBuffer::new();
+                        match format_plain_json_scalar(&mut scalar, other) {
+                            Some(rendered) => {
+                                write_attr(context.writer, &attr.name, rendered)?;
+                            }
+                            None => {
+                                let s = other.to_string();
+                                write_attr(
+                                    context.writer,
+                                    &attr.name,
+                                    &crate::html_encode::encode_safe(&s),
+                                )?;
+                            }
+                        }
                     }
                 }
 
@@ -3830,7 +3899,13 @@ impl WebUIHandler {
                     ) {
                         match value.as_ref() {
                             Value::String(s) => raw_value.push_str(s),
-                            _ => raw_value.push_str(&value.to_string()),
+                            other => {
+                                let mut scalar = ScalarBuffer::new();
+                                match format_plain_json_scalar(&mut scalar, other) {
+                                    Some(rendered) => raw_value.push_str(rendered),
+                                    None => raw_value.push_str(&other.to_string()),
+                                }
+                            }
                         }
                     }
                 }
@@ -3989,6 +4064,68 @@ fn handle(
 ) -> Result<()> {
     let handler = WebUIHandler::new();
     handler.handle(protocol, state, options, writer)
+}
+
+#[cfg(test)]
+mod scalar_buffer_tests {
+    use super::*;
+
+    /// Every scalar the stack formatter claims must serialize byte-identically
+    /// to the `Value::to_string` path it replaced.
+    #[test]
+    fn plain_scalars_match_value_to_string() {
+        let cases = [
+            Value::Null,
+            Value::Bool(true),
+            Value::Bool(false),
+            serde_json::json!(0),
+            serde_json::json!(-1),
+            serde_json::json!(42),
+            serde_json::json!(i64::MIN),
+            serde_json::json!(i64::MAX),
+            serde_json::json!(u64::MAX),
+            serde_json::json!(0.5),
+            serde_json::json!(-0.0_f64),
+            serde_json::json!(1.7976931348623157e308_f64),
+            serde_json::json!(-1.7976931348623157e308_f64),
+            serde_json::json!(f64::MIN_POSITIVE),
+        ];
+        for value in cases {
+            let mut buffer = ScalarBuffer::new();
+            let rendered = format_plain_json_scalar(&mut buffer, &value);
+            assert_eq!(
+                rendered,
+                Some(value.to_string().as_str()),
+                "scalar rendering diverged for {value:?}"
+            );
+        }
+    }
+
+    /// Strings, arrays, and objects must fall through to the caller's escaping
+    /// fallback rather than being emitted unescaped.
+    #[test]
+    fn non_plain_values_are_declined() {
+        let cases = [
+            serde_json::json!("<script>"),
+            serde_json::json!([1, 2]),
+            serde_json::json!({ "a": 1 }),
+        ];
+        for value in cases {
+            let mut buffer = ScalarBuffer::new();
+            assert_eq!(
+                format_plain_json_scalar(&mut buffer, &value),
+                None,
+                "expected fallback for {value:?}"
+            );
+        }
+    }
+
+    /// Overflow must be reported, never silently truncated into bad output.
+    #[test]
+    fn overflow_is_reported_instead_of_truncating() {
+        let mut buffer = ScalarBuffer::new();
+        assert!(write!(&mut buffer, "{}", "x".repeat(49)).is_err());
+    }
 }
 
 #[cfg(test)]

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -2070,25 +2070,75 @@ fn has_template_payload(component: &webui_protocol::ComponentData) -> bool {
 }
 
 #[derive(Debug)]
-struct QueuedFragment {
-    id: String,
-    inventoryable: bool,
-    /// Base path for resolving relative route paths at this level.
-    route_base: String,
+/// Interning arena for the route-base paths produced during a graph walk.
+///
+/// A walk queues one entry per graph edge but descends through only a handful
+/// of nested route levels, so every queued fragment used to carry its own
+/// `String` copy of a path shared by many siblings. Storing each distinct base
+/// once and referencing it by index makes [`QueuedFragment`] `Copy` and removes
+/// a heap allocation per queued edge.
+struct RouteBaseArena {
+    bases: Vec<String>,
 }
 
+impl RouteBaseArena {
+    /// Index of the implicit `/` root base, present in every arena.
+    const ROOT: u32 = 0;
+
+    fn new() -> Self {
+        Self {
+            bases: vec!["/".to_string()],
+        }
+    }
+
+    /// Intern `base`, reusing an existing slot when the path is already known.
+    ///
+    /// The linear scan is deliberate: route nesting is shallow (a handful of
+    /// levels), so scanning beats hashing and keeps the arena allocation-free
+    /// after the first sighting of each level.
+    fn intern(&mut self, base: &str) -> u32 {
+        if let Some(position) = self.bases.iter().position(|known| known == base) {
+            // Arena length is bounded by route nesting depth.
+            #[allow(clippy::cast_possible_truncation)]
+            return position as u32;
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let id = self.bases.len() as u32;
+        self.bases.push(base.to_string());
+        id
+    }
+
+    fn get(&self, id: u32) -> &str {
+        self.bases.get(id as usize).map_or("/", String::as_str)
+    }
+}
+
+/// One pending node in a fragment-graph walk.
+///
+/// `id` borrows the protocol's fragment name and `route_base` indexes a
+/// [`RouteBaseArena`], so queueing an edge copies 16 bytes instead of
+/// allocating two `String`s.
+#[derive(Clone, Copy)]
+struct QueuedFragment<'protocol> {
+    id: &'protocol str,
+    inventoryable: bool,
+    /// Base path for resolving relative route paths at this level.
+    route_base: u32,
+}
+
+/// Key identifying an already-walked fragment.
+///
+/// Route-insensitive walks collapse every base into `None` so a fragment is
+/// visited once regardless of the path that reached it.
+type VisitedKey<'protocol> = (&'protocol str, Option<u32>);
+
 #[inline]
-fn mark_fragment_visited(
-    visited: &mut HashSet<(String, String)>,
-    queued: &QueuedFragment,
+fn mark_fragment_visited<'protocol>(
+    visited: &mut HashSet<VisitedKey<'protocol>>,
+    queued: &QueuedFragment<'protocol>,
     route_sensitive: bool,
 ) -> bool {
-    let route_base = if route_sensitive {
-        queued.route_base.clone()
-    } else {
-        String::new()
-    };
-    visited.insert((queued.id.clone(), route_base))
+    visited.insert((queued.id, route_sensitive.then_some(queued.route_base)))
 }
 
 /// Shared context for route child walkers, bundling common parameters
@@ -2109,19 +2159,26 @@ struct ChildWalkCtx<'a> {
 /// Components are marked `inventoryable` when they have a corresponding entry
 /// in `protocol.components` with a non-empty template payload — these are the
 /// components whose client metadata the browser may need during navigation.
-fn collect_inventoryable_components(
-    protocol: &WebUIProtocol,
-    entry_id: &str,
+fn collect_inventoryable_components<'protocol>(
+    protocol: &'protocol WebUIProtocol,
+    entry_id: &'protocol str,
     request_path: Option<&str>,
     root_inventoryable: bool,
     route_index: &CompiledRouteIndex,
 ) -> Vec<String> {
+    let mut arena = RouteBaseArena::new();
     let stack = vec![QueuedFragment {
-        id: entry_id.to_string(),
+        id: entry_id,
         inventoryable: root_inventoryable,
-        route_base: "/".to_string(),
+        route_base: RouteBaseArena::ROOT,
     }];
-    collect_inventoryable_components_from_stack(protocol, request_path, route_index, stack)
+    collect_inventoryable_components_from_stack(
+        protocol,
+        request_path,
+        route_index,
+        stack,
+        &mut arena,
+    )
 }
 
 /// Collect the transitive client component surface rooted in this checkpoint's
@@ -2131,32 +2188,44 @@ fn collect_inventoryable_components(
 /// Roots arrive as startup-built component indexes so the caller's capture stays
 /// free of any protocol borrow; names are resolved here, on the uncommon
 /// request-aware path that already converts every root to an owned string.
-pub(crate) fn collect_reachable_components_from_roots(
-    protocol: &WebUIProtocol,
+pub(crate) fn collect_reachable_components_from_roots<'protocol>(
+    protocol: &'protocol WebUIProtocol,
     roots: &[(u32, Option<Box<str>>)],
-    reachability: &ComponentReachabilityIndex,
+    reachability: &'protocol ComponentReachabilityIndex,
     request_path: &str,
     route_index: &CompiledRouteIndex,
 ) -> Vec<String> {
+    let mut arena = RouteBaseArena::new();
     let mut stack = Vec::with_capacity(roots.len());
     for (root, route_base) in roots.iter().rev() {
         let Some(name) = reachability.name(*root) else {
             continue;
         };
+        let route_base = match route_base.as_deref() {
+            Some(base) => arena.intern(base),
+            None => RouteBaseArena::ROOT,
+        };
         stack.push(QueuedFragment {
-            id: name.to_string(),
+            id: name,
             inventoryable: true,
-            route_base: route_base.as_deref().unwrap_or("/").to_string(),
+            route_base,
         });
     }
-    collect_inventoryable_components_from_stack(protocol, Some(request_path), route_index, stack)
+    collect_inventoryable_components_from_stack(
+        protocol,
+        Some(request_path),
+        route_index,
+        stack,
+        &mut arena,
+    )
 }
 
-fn collect_inventoryable_components_from_stack(
-    protocol: &WebUIProtocol,
+fn collect_inventoryable_components_from_stack<'protocol>(
+    protocol: &'protocol WebUIProtocol,
     request_path: Option<&str>,
     route_index: &CompiledRouteIndex,
-    mut stack: Vec<QueuedFragment>,
+    mut stack: Vec<QueuedFragment<'protocol>>,
+    arena: &mut RouteBaseArena,
 ) -> Vec<String> {
     let mut visited_fragments = HashSet::new();
     let route_sensitive = request_path.is_some();
@@ -2171,15 +2240,15 @@ fn collect_inventoryable_components_from_stack(
             continue;
         }
 
-        if queued.inventoryable && seen_components.insert(queued.id.clone()) {
-            component_ids.push(queued.id.clone());
+        if queued.inventoryable && seen_components.insert(queued.id) {
+            component_ids.push(queued.id.to_string());
         }
 
         if !mark_fragment_visited(&mut visited_fragments, &queued, route_sensitive) {
             continue;
         }
 
-        let Some(frag_list) = protocol.fragments.get(&queued.id) else {
+        let Some(frag_list) = protocol.fragments.get(queued.id) else {
             continue;
         };
 
@@ -2187,7 +2256,7 @@ fn collect_inventoryable_components_from_stack(
             route_renderer::find_best_route_match(
                 &frag_list.fragments,
                 path,
-                &queued.route_base,
+                arena.get(queued.route_base),
                 route_index,
             )
         });
@@ -2198,31 +2267,31 @@ fn collect_inventoryable_components_from_stack(
             match frag.fragment.as_ref() {
                 Some(Fragment::Component(component)) => {
                     stack.push(QueuedFragment {
-                        id: component.fragment_id.clone(),
+                        id: &component.fragment_id,
                         inventoryable: true,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::ForLoop(for_loop)) => {
                     stack.push(QueuedFragment {
-                        id: for_loop.fragment_id.clone(),
+                        id: &for_loop.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::IfCond(if_cond)) => {
                     stack.push(QueuedFragment {
-                        id: if_cond.fragment_id.clone(),
+                        id: &if_cond.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
 
                 Some(Fragment::Attribute(attr)) if !attr.template.is_empty() => {
                     stack.push(QueuedFragment {
-                        id: attr.template.clone(),
+                        id: &attr.template,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::Route(route_frag)) => {
@@ -2231,30 +2300,27 @@ fn collect_inventoryable_components_from_stack(
                         .is_some_and(|(best_key, _)| best_key == route_frag.fragment_id.as_str());
                     if is_selected && !route_frag.content_fragment_id.is_empty() {
                         stack.push(QueuedFragment {
-                            id: route_frag.content_fragment_id.clone(),
+                            id: &route_frag.content_fragment_id,
                             inventoryable: false,
-                            route_base: queued.route_base.clone(),
+                            route_base: queued.route_base,
                         });
                     }
                     if is_selected && !route_frag.fragment_id.is_empty() {
                         // Compute new route base from consumed segments
-                        let child_route_base = if let Some((_, ref rm)) = matched_route {
-                            if let Some(path) = request_path {
-                                route_matcher::compute_route_base(path, rm.consumed_segments)
-                            } else {
-                                queued.route_base.clone()
-                            }
-                        } else {
-                            queued.route_base.clone()
+                        let child_route_base = match (&matched_route, request_path) {
+                            (Some((_, rm)), Some(path)) => arena.intern(
+                                &route_matcher::compute_route_base(path, rm.consumed_segments),
+                            ),
+                            _ => queued.route_base,
                         };
 
                         stack.push(QueuedFragment {
-                            id: route_frag.fragment_id.clone(),
+                            id: &route_frag.fragment_id,
                             inventoryable: protocol
                                 .components
                                 .get(&route_frag.fragment_id)
                                 .is_some_and(has_template_payload),
-                            route_base: child_route_base.clone(),
+                            route_base: child_route_base,
                         });
 
                         // Inventory pending/error components for the entire
@@ -2266,7 +2332,7 @@ fn collect_inventoryable_components_from_stack(
                         // the target route.
                         collect_route_boundary_components(
                             std::slice::from_ref(route_frag),
-                            &child_route_base,
+                            child_route_base,
                             protocol,
                             &mut stack,
                         );
@@ -2278,9 +2344,10 @@ fn collect_inventoryable_components_from_stack(
                             if let Some(path) = request_path {
                                 walk_route_children(
                                     &route_frag.children,
-                                    &child_route_base,
+                                    child_route_base,
                                     &mut stack,
-                                    &mut ChildWalkCtx {
+                                    arena,
+                                    &ChildWalkCtx {
                                         request_path: path,
                                         protocol,
                                         route_index,
@@ -2331,55 +2398,66 @@ fn select_best_child_route(
 
 /// Walk nested route children to find matched routes and add their
 /// components to the inventory stack. Mirrors the handler's outlet rendering.
-fn walk_route_children(
-    children: &[WebUIFragmentRoute],
-    route_base: &str,
-    stack: &mut Vec<QueuedFragment>,
-    ctx: &mut ChildWalkCtx<'_>,
+fn walk_route_children<'protocol>(
+    children: &'protocol [WebUIFragmentRoute],
+    route_base: u32,
+    stack: &mut Vec<QueuedFragment<'protocol>>,
+    arena: &mut RouteBaseArena,
+    ctx: &ChildWalkCtx<'_>,
 ) {
     let mut current = children;
-    let mut base = route_base.to_string();
+    let mut base = route_base;
 
-    while let Some((idx, ref rm)) =
-        select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
-    {
-        let matched = &current[idx];
+    loop {
+        // Resolve the base before interning below so the arena's immutable
+        // borrow ends before the mutable one begins.
+        let matched =
+            select_best_child_route(current, ctx.request_path, arena.get(base), ctx.route_index);
+        let Some((idx, rm)) = matched else {
+            break;
+        };
+        let Some(matched) = current.get(idx) else {
+            break;
+        };
         if matched.fragment_id.is_empty() {
             break;
         }
 
-        let child_base = route_matcher::compute_route_base(ctx.request_path, rm.consumed_segments);
+        let child_base = arena.intern(&route_matcher::compute_route_base(
+            ctx.request_path,
+            rm.consumed_segments,
+        ));
 
         stack.push(QueuedFragment {
-            id: matched.fragment_id.clone(),
+            id: &matched.fragment_id,
             inventoryable: ctx
                 .protocol
                 .components
                 .get(&matched.fragment_id)
                 .is_some_and(has_template_payload),
-            route_base: child_base.clone(),
+            route_base: child_base,
         });
 
         if !matched.pending_component.is_empty() {
             stack.push(QueuedFragment {
-                id: matched.pending_component.clone(),
+                id: &matched.pending_component,
                 inventoryable: ctx
                     .protocol
                     .components
                     .get(&matched.pending_component)
                     .is_some_and(has_template_payload),
-                route_base: child_base.clone(),
+                route_base: child_base,
             });
         }
         if !matched.error_component.is_empty() {
             stack.push(QueuedFragment {
-                id: matched.error_component.clone(),
+                id: &matched.error_component,
                 inventoryable: ctx
                     .protocol
                     .components
                     .get(&matched.error_component)
                     .is_some_and(has_template_payload),
-                route_base: child_base.clone(),
+                route_base: child_base,
             });
         }
 
@@ -2399,25 +2477,25 @@ fn walk_route_children(
 /// renders if that fetch fails, so the client must already hold these templates
 /// for any navigable sibling — not only the currently active route. The walk is
 /// iterative because the framework forbids recursion in core paths.
-fn collect_route_boundary_components(
-    routes: &[WebUIFragmentRoute],
-    route_base: &str,
+fn collect_route_boundary_components<'protocol>(
+    routes: &'protocol [WebUIFragmentRoute],
+    route_base: u32,
     protocol: &WebUIProtocol,
-    stack: &mut Vec<QueuedFragment>,
+    stack: &mut Vec<QueuedFragment<'protocol>>,
 ) {
-    let mut remaining: Vec<&WebUIFragmentRoute> = routes.iter().collect();
+    let mut remaining: Vec<&'protocol WebUIFragmentRoute> = routes.iter().collect();
     while let Some(route) = remaining.pop() {
         for component in [&route.pending_component, &route.error_component] {
             if component.is_empty() {
                 continue;
             }
             stack.push(QueuedFragment {
-                id: component.clone(),
+                id: component,
                 inventoryable: protocol
                     .components
                     .get(component)
                     .is_some_and(has_template_payload),
-                route_base: route_base.to_string(),
+                route_base,
             });
         }
         remaining.extend(route.children.iter());
@@ -2437,10 +2515,11 @@ pub fn collect_nested_route_params(
     let protocol = protocol.protocol();
     let mut all_params = HashMap::new();
     let mut visited_fragments = HashSet::new();
+    let mut arena = RouteBaseArena::new();
     let mut stack = vec![QueuedFragment {
-        id: entry_id.to_string(),
+        id: entry_id,
         inventoryable: false,
-        route_base: "/".to_string(),
+        route_base: RouteBaseArena::ROOT,
     }];
 
     while let Some(queued) = stack.pop() {
@@ -2448,14 +2527,14 @@ pub fn collect_nested_route_params(
             continue;
         }
 
-        let Some(frag_list) = protocol.fragments.get(&queued.id) else {
+        let Some(frag_list) = protocol.fragments.get(queued.id) else {
             continue;
         };
 
         let matched_route = route_renderer::find_best_route_match(
             &frag_list.fragments,
             request_path,
-            &queued.route_base,
+            arena.get(queued.route_base),
             route_index,
         );
 
@@ -2463,23 +2542,23 @@ pub fn collect_nested_route_params(
             match frag.fragment.as_ref() {
                 Some(Fragment::Component(component)) => {
                     stack.push(QueuedFragment {
-                        id: component.fragment_id.clone(),
+                        id: &component.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::ForLoop(for_loop)) => {
                     stack.push(QueuedFragment {
-                        id: for_loop.fragment_id.clone(),
+                        id: &for_loop.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::IfCond(if_cond)) => {
                     stack.push(QueuedFragment {
-                        id: if_cond.fragment_id.clone(),
+                        id: &if_cond.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
 
@@ -2489,25 +2568,30 @@ pub fn collect_nested_route_params(
                         .is_some_and(|(best_key, _)| best_key == route_frag.fragment_id.as_str());
                     if is_selected && !route_frag.fragment_id.is_empty() {
                         if let Some((_, ref rm)) = matched_route {
-                            // Collect params from this route level
-                            all_params.extend(rm.params.clone());
+                            // Collect params from this route level. Cloning
+                            // entry-wise avoids allocating a throwaway map to
+                            // move them out of.
+                            for (name, value) in &rm.params {
+                                all_params.insert(name.clone(), value.clone());
+                            }
 
-                            let child_route_base = route_matcher::compute_route_base(
-                                request_path,
-                                rm.consumed_segments,
-                            );
+                            let child_route_base =
+                                arena.intern(&route_matcher::compute_route_base(
+                                    request_path,
+                                    rm.consumed_segments,
+                                ));
 
                             stack.push(QueuedFragment {
-                                id: route_frag.fragment_id.clone(),
+                                id: &route_frag.fragment_id,
                                 inventoryable: false,
-                                route_base: child_route_base.clone(),
+                                route_base: child_route_base,
                             });
 
                             // Walk nested children to collect params from deeper levels
                             collect_params_from_children(
                                 &route_frag.children,
                                 request_path,
-                                &child_route_base,
+                                arena.get(child_route_base),
                                 &mut all_params,
                                 route_index,
                             );
@@ -2587,9 +2671,9 @@ fn resolve_tag_templates(templates: &[String], params: &HashMap<String, String>)
 /// Single-pass graph walk that collects both inventoryable component names
 /// and the matched route chain. Eliminates the duplicate graph traversal
 /// that previously existed in `render_partial`.
-fn collect_inventory_and_chain(
-    protocol: &WebUIProtocol,
-    entry_id: &str,
+fn collect_inventory_and_chain<'protocol>(
+    protocol: &'protocol WebUIProtocol,
+    entry_id: &'protocol str,
     request_path: &str,
     index: &mut RequestProtocolIndex<'_>,
 ) -> (Vec<String>, Vec<RouteChainEntry>) {
@@ -2601,10 +2685,11 @@ fn collect_inventory_and_chain(
     let mut seen_components = HashSet::new();
     let mut component_ids: Vec<String> = Vec::new();
     let mut chain = Vec::new();
+    let mut arena = RouteBaseArena::new();
     let mut stack = vec![QueuedFragment {
-        id: entry_id.to_string(),
+        id: entry_id,
         inventoryable: false,
-        route_base: "/".to_string(),
+        route_base: RouteBaseArena::ROOT,
     }];
 
     while let Some(queued) = stack.pop() {
@@ -2612,22 +2697,22 @@ fn collect_inventory_and_chain(
             continue;
         }
 
-        if queued.inventoryable && seen_components.insert(queued.id.clone()) {
-            component_ids.push(queued.id.clone());
+        if queued.inventoryable && seen_components.insert(queued.id) {
+            component_ids.push(queued.id.to_string());
         }
 
         if !mark_fragment_visited(&mut visited_fragments, &queued, true) {
             continue;
         }
 
-        let Some(frag_list) = protocol.fragments.get(&queued.id) else {
+        let Some(frag_list) = protocol.fragments.get(queued.id) else {
             continue;
         };
 
         let matched_route = route_renderer::find_best_route_match(
             &frag_list.fragments,
             request_path,
-            &queued.route_base,
+            arena.get(queued.route_base),
             index.route_index,
         );
 
@@ -2636,32 +2721,32 @@ fn collect_inventory_and_chain(
                 Some(Fragment::Component(component)) => {
                     // Inventory: components are inventoryable
                     stack.push(QueuedFragment {
-                        id: component.fragment_id.clone(),
+                        id: &component.fragment_id,
                         inventoryable: true,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::ForLoop(for_loop)) => {
                     // Inventory: follow control-flow edges conservatively
                     stack.push(QueuedFragment {
-                        id: for_loop.fragment_id.clone(),
+                        id: &for_loop.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::IfCond(if_cond)) => {
                     stack.push(QueuedFragment {
-                        id: if_cond.fragment_id.clone(),
+                        id: &if_cond.fragment_id,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
 
                 Some(Fragment::Attribute(attr)) if !attr.template.is_empty() => {
                     stack.push(QueuedFragment {
-                        id: attr.template.clone(),
+                        id: &attr.template,
                         inventoryable: false,
-                        route_base: queued.route_base.clone(),
+                        route_base: queued.route_base,
                     });
                 }
                 Some(Fragment::Route(route_frag)) => {
@@ -2670,9 +2755,9 @@ fn collect_inventory_and_chain(
                         .is_some_and(|(best_key, _)| best_key == route_frag.fragment_id.as_str());
                     if is_selected && !route_frag.content_fragment_id.is_empty() {
                         stack.push(QueuedFragment {
-                            id: route_frag.content_fragment_id.clone(),
+                            id: &route_frag.content_fragment_id,
                             inventoryable: false,
-                            route_base: queued.route_base.clone(),
+                            route_base: queued.route_base,
                         });
                     }
                     if is_selected && !route_frag.fragment_id.is_empty() {
@@ -2691,10 +2776,11 @@ fn collect_inventory_and_chain(
                                 error_component: route_frag.error_component.clone(),
                             });
 
-                            let child_route_base = route_matcher::compute_route_base(
-                                request_path,
-                                rm.consumed_segments,
-                            );
+                            let child_route_base =
+                                arena.intern(&route_matcher::compute_route_base(
+                                    request_path,
+                                    rm.consumed_segments,
+                                ));
 
                             // Inventory: follow matched route component
                             let is_inventoryable = protocol
@@ -2702,14 +2788,14 @@ fn collect_inventory_and_chain(
                                 .get(&route_frag.fragment_id)
                                 .is_some_and(has_template_payload);
                             stack.push(QueuedFragment {
-                                id: route_frag.fragment_id.clone(),
+                                id: &route_frag.fragment_id,
                                 inventoryable: is_inventoryable,
-                                route_base: child_route_base.clone(),
+                                route_base: child_route_base,
                             });
 
                             collect_route_boundary_components(
                                 std::slice::from_ref(route_frag),
-                                &child_route_base,
+                                child_route_base,
                                 protocol,
                                 &mut stack,
                             );
@@ -2718,10 +2804,13 @@ fn collect_inventory_and_chain(
                             if !route_frag.children.is_empty() {
                                 walk_children_for_inventory_and_chain(
                                     &route_frag.children,
-                                    &child_route_base,
-                                    &mut stack,
-                                    &mut chain,
-                                    &mut ChildWalkCtx {
+                                    child_route_base,
+                                    ChainWalkSinks {
+                                        stack: &mut stack,
+                                        chain: &mut chain,
+                                        arena: &mut arena,
+                                    },
+                                    &ChildWalkCtx {
                                         request_path,
                                         protocol,
                                         route_index: index.route_index,
@@ -2739,31 +2828,54 @@ fn collect_inventory_and_chain(
     (component_ids, chain)
 }
 
-/// Walk nested route children, collecting both inventory and chain entries.
-fn walk_children_for_inventory_and_chain(
-    children: &[WebUIFragmentRoute],
-    route_base: &str,
-    stack: &mut Vec<QueuedFragment>,
-    chain: &mut Vec<RouteChainEntry>,
-    ctx: &mut ChildWalkCtx<'_>,
-) {
-    let mut current = children;
-    let mut base = route_base.to_string();
+/// Mutable sinks threaded through the inventory + chain child walk.
+///
+/// Bundled so the walk stays within the workspace's five-argument limit.
+struct ChainWalkSinks<'walk, 'protocol> {
+    stack: &'walk mut Vec<QueuedFragment<'protocol>>,
+    chain: &'walk mut Vec<RouteChainEntry>,
+    arena: &'walk mut RouteBaseArena,
+}
 
-    while let Some((idx, ref rm)) =
-        select_best_child_route(current, ctx.request_path, &base, ctx.route_index)
-    {
-        let matched = &current[idx];
+/// Walk nested route children, collecting both inventory and chain entries.
+fn walk_children_for_inventory_and_chain<'protocol>(
+    children: &'protocol [WebUIFragmentRoute],
+    route_base: u32,
+    sinks: ChainWalkSinks<'_, 'protocol>,
+    ctx: &ChildWalkCtx<'_>,
+) {
+    let ChainWalkSinks {
+        stack,
+        chain,
+        arena,
+    } = sinks;
+    let mut current = children;
+    let mut base = route_base;
+
+    loop {
+        // Resolve the base before interning below so the arena's immutable
+        // borrow ends before the mutable one begins.
+        let matched =
+            select_best_child_route(current, ctx.request_path, arena.get(base), ctx.route_index);
+        let Some((idx, rm)) = matched else {
+            break;
+        };
+        let Some(matched) = current.get(idx) else {
+            break;
+        };
         if matched.fragment_id.is_empty() {
             break;
         }
 
-        let child_base = route_matcher::compute_route_base(ctx.request_path, rm.consumed_segments);
+        let child_base = arena.intern(&route_matcher::compute_route_base(
+            ctx.request_path,
+            rm.consumed_segments,
+        ));
 
         chain.push(RouteChainEntry {
             component: matched.fragment_id.clone(),
             path: matched.path.clone(),
-            params: rm.params.clone(),
+            params: rm.params,
             exact: matched.exact,
             allowed_query: matched.allowed_query.clone(),
             keep_alive: matched.keep_alive,
@@ -2774,13 +2886,13 @@ fn walk_children_for_inventory_and_chain(
         });
 
         stack.push(QueuedFragment {
-            id: matched.fragment_id.clone(),
+            id: &matched.fragment_id,
             inventoryable: ctx
                 .protocol
                 .components
                 .get(&matched.fragment_id)
                 .is_some_and(has_template_payload),
-            route_base: child_base.clone(),
+            route_base: child_base,
         });
 
         if matched.children.is_empty() {

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -2091,21 +2091,48 @@ impl RouteBaseArena {
         }
     }
 
-    /// Intern `base`, reusing an existing slot when the path is already known.
+    /// Position of `base` when it has already been interned.
     ///
     /// The linear scan is deliberate: route nesting is shallow (a handful of
     /// levels), so scanning beats hashing and keeps the arena allocation-free
     /// after the first sighting of each level.
-    fn intern(&mut self, base: &str) -> u32 {
-        if let Some(position) = self.bases.iter().position(|known| known == base) {
-            // Arena length is bounded by route nesting depth.
-            #[allow(clippy::cast_possible_truncation)]
-            return position as u32;
-        }
+    fn find(&self, base: &str) -> Option<u32> {
+        // Arena length is bounded by route nesting depth.
         #[allow(clippy::cast_possible_truncation)]
+        self.bases
+            .iter()
+            .position(|known| known == base)
+            .map(|position| position as u32)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn push(&mut self, base: String) -> u32 {
         let id = self.bases.len() as u32;
-        self.bases.push(base.to_string());
+        self.bases.push(base);
         id
+    }
+
+    /// Intern a borrowed `base`, reusing an existing slot when already known.
+    ///
+    /// Use [`Self::intern_owned`] when the caller already owns the path, so a
+    /// first sighting moves it instead of copying it.
+    fn intern(&mut self, base: &str) -> u32 {
+        match self.find(base) {
+            Some(id) => id,
+            None => self.push(base.to_string()),
+        }
+    }
+
+    /// Intern an owned `base`, moving it in on first sighting.
+    ///
+    /// `route_matcher::compute_route_base` already returns an owned `String`,
+    /// so taking it by value keeps a newly discovered level to the one
+    /// allocation the caller had to make anyway.
+    fn intern_owned(&mut self, base: String) -> u32 {
+        match self.find(&base) {
+            Some(id) => id,
+            None => self.push(base),
+        }
     }
 
     fn get(&self, id: u32) -> &str {
@@ -2308,8 +2335,8 @@ fn collect_inventoryable_components_from_stack<'protocol>(
                     if is_selected && !route_frag.fragment_id.is_empty() {
                         // Compute new route base from consumed segments
                         let child_route_base = match (&matched_route, request_path) {
-                            (Some((_, rm)), Some(path)) => arena.intern(
-                                &route_matcher::compute_route_base(path, rm.consumed_segments),
+                            (Some((_, rm)), Some(path)) => arena.intern_owned(
+                                route_matcher::compute_route_base(path, rm.consumed_segments),
                             ),
                             _ => queued.route_base,
                         };
@@ -2423,7 +2450,7 @@ fn walk_route_children<'protocol>(
             break;
         }
 
-        let child_base = arena.intern(&route_matcher::compute_route_base(
+        let child_base = arena.intern_owned(route_matcher::compute_route_base(
             ctx.request_path,
             rm.consumed_segments,
         ));
@@ -2576,7 +2603,7 @@ pub fn collect_nested_route_params(
                             }
 
                             let child_route_base =
-                                arena.intern(&route_matcher::compute_route_base(
+                                arena.intern_owned(route_matcher::compute_route_base(
                                     request_path,
                                     rm.consumed_segments,
                                 ));
@@ -2777,7 +2804,7 @@ fn collect_inventory_and_chain<'protocol>(
                             });
 
                             let child_route_base =
-                                arena.intern(&route_matcher::compute_route_base(
+                                arena.intern_owned(route_matcher::compute_route_base(
                                     request_path,
                                     rm.consumed_segments,
                                 ));
@@ -2867,7 +2894,7 @@ fn walk_children_for_inventory_and_chain<'protocol>(
             break;
         }
 
-        let child_base = arena.intern(&route_matcher::compute_route_base(
+        let child_base = arena.intern_owned(route_matcher::compute_route_base(
             ctx.request_path,
             rm.consumed_segments,
         ));

--- a/crates/webui-handler/src/streaming/vm.rs
+++ b/crates/webui-handler/src/streaming/vm.rs
@@ -594,7 +594,7 @@ impl ContinuationVm {
                     {
                         self.render_boundary_free(context, |context| {
                             handler.process_component(
-                                component,
+                                &component.fragment_id,
                                 target,
                                 ComponentHostOrigin::ParserProduced,
                                 context,
@@ -794,7 +794,7 @@ impl ContinuationVm {
         }
 
         if !context.rendered_components.contains(&component.fragment_id) {
-            handler.emit_css_module(component, context)?;
+            handler.emit_css_module(&component.fragment_id, context)?;
             context
                 .rendered_components
                 .insert(component.fragment_id.clone());


### PR DESCRIPTION
## Why

Server memory is not cheap, and the handler's render path still paid a steady stream of avoidable heap allocations on every request. Following up on #510, this pass targets the remaining per-request allocation sources in `webui-handler` without giving up any throughput.

The largest one was hiding in the fragment-graph walks. Every walk (reachability, inventory, chain, nested params) queued a `QueuedFragment { id: String, route_base: String }` per graph **edge** and keyed its visited set on `(String, String)`, so traversing a component graph cost roughly four `String` allocations per edge. These are not startup-only paths: `collect_reachable_component_order_for_request` fires at the `body_end` boundary on every full render that has a hydration plugin attached, which is the standard configuration.

## What changed

**Allocation-free graph traversal.** `QueuedFragment` now borrows the protocol's fragment name (`&'protocol str`) and stores its route base as a `u32` index into a small interning arena, making the struct `Copy`. Route nesting is shallow, so the arena's linear dedup scan beats hashing and stops allocating after each level is seen once. The visited key becomes `(&'protocol str, Option<u32>)`, where `None` collapses every base into one bucket for route-insensitive walks, matching the previous empty-string sentinel. This required threading a `'protocol` lifetime through `collect_inventoryable_components_from_stack`, `walk_route_children`, `collect_route_boundary_components`, `collect_inventory_and_chain`, and `walk_children_for_inventory_and_chain`.

**Stack-rendered JSON scalars.** Interpolating a non-string signal called `Value::to_string()` and then ran the result through `encode_safe`. Numbers, booleans, and null can never contain HTML-significant bytes, so they now render through a fixed-capacity `ScalarBuffer` and skip escaping entirely. Applied to `write_signal_value`, dynamic attribute emission, and template attribute assembly.

**Residual per-route clones.** `route_base` is saved with `mem::replace` instead of a deep `Cow` clone (inside `is_matched`, `best_route` is always `Some`, so the slot is unconditionally overwritten). `process_component` and `emit_css_module` take `&str`, so generated route hosts no longer build a throwaway `WebUIFragmentComponent` just to pass a name. Nested route params merge entry-wise instead of cloning an entire `HashMap` only to move its entries out.

## Performance

Measured with `cargo xtask bench streaming-resource` (exact counts from a custom `GlobalAlloc`), release build, 2000 iterations per row.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| string allocs/run | 156 | 141 | -9.6% |
| streaming allocs/run | 170 | 155 | -8.8% |
| streaming POOLED allocs/run | 163 | 148 | -9.2% |
| streaming bytes/run | 43.7 KiB | 43.6 KiB | -0.2% |
| POOLED wall us/run @1000 (median, n=5) | 13.92 | 13.65 | -1.9%, within noise |
| Output size | 24152 B | 24152 B | unchanged |

Output bytes are byte-identical at all three scales, which is the correctness proof. Wall time improved alongside the allocation count, so nothing was traded away for the memory win.

> **Correction.** An earlier revision of this description listed `process RSS @1000 | 14.12 MiB | 12.83 MiB | -9.1%` as a headline metric. **That row was sampling noise and has been removed.** It was a single sample per build, and the benchmark's `process RSS` column turns out to be multimodal. Re-running the *identical* binary 8 times gives 12.66 / 12.73 / 12.94 / 13.20 / 13.70 / 13.97 / 13.98 / 14.02 MiB - a 1.36 MiB spread, which is wider than the 1.29 MiB "improvement" originally claimed. The column is dominated by where the allocator places the ~6.8 MiB scale-1000 fixture state, which is built before any render runs, so it is largely blind to the render path regardless. `allocs/run` and `bytes/run` are exact counts from a custom `GlobalAlloc` and are the numbers to judge this PR on. Tracked in #516.

> **Second correction, same cause.** The wall-time row originally read `15.46 -> 13.74 us, -11.1%`, also a single sample per build. A proper A/B - baseline built from `78b7617f` in a separate worktree, the two binaries run alternately five times each - gives medians of 13.92 vs 13.65 us (POOLED/1000) and 13.28 vs 13.05 us (string/1000), about **-1.9% and -1.7%, with the two ranges overlapping**. The original `15.46` baseline was a cold first-run outlier. The honest statement is that this PR shows **no measurable wall-time regression and possibly a small improvement that n=5 cannot separate from noise** - not the double-digit speedup first claimed.
>
> The same A/B re-confirms the allocation counts are exact and deterministic: **156 and 163 in all five baseline runs, 141 and 148 in all five patched runs, zero variance.** That is the result this PR rests on.

## Notes for reviewers

**These numbers understate the real-world gain.** The `streaming-resource` fixture renders the contact-book dashboard, whose output is ~24 KB whether the state carries 10, 100, or 1000 contacts, because the scaled `contacts` array is not rendered at `/`. That makes it a good zero-copy proof (state tree size does not affect render allocations) but it exercises a shallow route graph. Savings here scale with route depth and component-graph size, so apps with deeper route trees benefit proportionally more.

**`ScalarBuffer` overflow is reported, not truncated.** `write_str` returns `fmt::Error` rather than silently clipping, so `format_plain_json_scalar` declines and the caller falls back to the allocating path. The 48-byte capacity is comfortably above the 24-byte worst case for an f64 (`serde_json` is built without `arbitrary_precision`), so the fallback is unreachable in practice while staying correct if that ever changes. Added `scalar_buffer_tests` asserting byte-identical output versus `Value::to_string()` across `i64::MIN`, `i64::MAX`, `u64::MAX`, `f64` extremes, and `MIN_POSITIVE`, plus coverage that strings/arrays/objects correctly decline so nothing escapes unescaped.

**Deliberately left out of scope.** `context.route_children` is still a `Vec<WebUiFragmentRoute>` deep-cloned from the protocol per matched route, and `rendered_components` / the `local_vars` and `component_attrs` keys are still `String` despite always originating from `&'protocol str`. All three want the same fix, but it requires threading a lifetime through `SessionCore` and `ContinuationVm`, which are currently lifetime-free because they hold this data across streaming suspension. That is a real payoff but a much riskier refactor, so it belongs in its own PR rather than bundled here.

## Validation

- `cargo xtask check` (all phases pass)
- `cargo xtask bench streaming-resource`
- 489 handler tests pass, including the 3 new scalar-rendering tests

No public API, protocol schema, FFI surface, or user-facing behavior changed, so `DESIGN.md` and `docs/` need no updates. No new dependencies.

