### PR TITLE
perf: avoid cloning nested route trees

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -831,10 +831,10 @@ fn component_attr_source(attribute: &webui_protocol::WebUIFragmentAttribute) -> 
 /// Route level one step below `children[index]`.
 ///
 /// A borrowed level yields a borrowed sublevel, so descending through a route
-/// tree during a render never copies a `WebUiFragmentRoute`. Only a level a
-/// streaming continuation already materialized is cloned.
+/// tree during a render never copies a `WebUiFragmentRoute`. A level a
+/// streaming continuation already materialized transfers its child level.
 fn descend_into<'protocol>(
-    children: &RouteChildren<'protocol>,
+    children: &mut RouteChildren<'protocol>,
     index: usize,
 ) -> RouteChildren<'protocol> {
     match children {
@@ -842,8 +842,8 @@ fn descend_into<'protocol>(
             Some(route) => Cow::Borrowed(&route.children),
             None => Cow::Borrowed(&[]),
         },
-        Cow::Owned(routes) => match routes.get(index) {
-            Some(route) => Cow::Owned(route.children.clone()),
+        Cow::Owned(routes) => match routes.get_mut(index) {
+            Some(route) => Cow::Owned(std::mem::take(&mut route.children)),
             None => Cow::Borrowed(&[]),
         },
     }
@@ -2376,7 +2376,7 @@ impl WebUIHandler {
         // preserves the previous behavior exactly: a second `<outlet />` at
         // this level renders nothing. That is a latent bug tracked by #515, not
         // a property this function needs; fixing it belongs in its own change.
-        let children = std::mem::take(&mut context.route_children);
+        let mut children = std::mem::take(&mut context.route_children);
         if children.is_empty() {
             return Ok(());
         }
@@ -2402,6 +2402,7 @@ impl WebUIHandler {
         }
 
         if let Some((idx, ref rm)) = best {
+            let descended = descend_into(&mut children, idx);
             let Some(matched_child) = children.get(idx) else {
                 return Ok(());
             };
@@ -2415,7 +2416,7 @@ impl WebUIHandler {
                     );
                     std::mem::replace(&mut context.route_base, Cow::Owned(base))
                 });
-                context.route_children = descend_into(&children, idx);
+                context.route_children = descended;
 
                 // Emit matched <webui-route>
                 context.writer.write("<webui-route")?;
@@ -4189,9 +4190,9 @@ mod tests {
             }],
             ..Default::default()
         }];
-        let level = RouteChildren::Borrowed(&routes);
+        let mut level = RouteChildren::Borrowed(&routes);
 
-        let descended = descend_into(&level, 0);
+        let descended = descend_into(&mut level, 0);
 
         let Cow::Borrowed(children) = descended else {
             panic!("protocol-owned route children should remain borrowed");
@@ -4200,8 +4201,8 @@ mod tests {
     }
 
     #[test]
-    fn route_descent_keeps_parked_children_owned() {
-        let level = RouteChildren::Owned(vec![WebUiFragmentRoute {
+    fn route_descent_moves_parked_children() {
+        let mut level = RouteChildren::Owned(vec![WebUiFragmentRoute {
             children: vec![WebUiFragmentRoute {
                 fragment_id: "child".to_string(),
                 ..Default::default()
@@ -4209,12 +4210,19 @@ mod tests {
             ..Default::default()
         }]);
 
-        let descended = descend_into(&level, 0);
+        let descended = descend_into(&mut level, 0);
 
         let Cow::Owned(children) = descended else {
             panic!("parked route children must not borrow session-owned storage");
         };
         assert_eq!(children[0].fragment_id, "child");
+        let Cow::Owned(source) = level else {
+            panic!("the parked source level must stay owned");
+        };
+        assert!(
+            source[0].children.is_empty(),
+            "owned route children must move out instead of being cloned"
+        );
     }
 
     #[test]

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -2426,8 +2426,10 @@ impl WebUIHandler {
         context: &mut WebUIProcessContext<'protocol, '_, '_>,
     ) -> Result<()> {
         // Moved out so the matched child can render with the context pointing
-        // at its grandchildren. An outlet consumes its route level, so the
-        // level is not put back: nothing after this point renders against it.
+        // at its grandchildren. The level is deliberately not put back, which
+        // preserves the previous behavior exactly: a second `<outlet />` at
+        // this level renders nothing. That is a latent bug tracked by #515, not
+        // a property this function needs; fixing it belongs in its own change.
         let children = std::mem::take(&mut context.route_children);
         if children.is_empty() {
             return Ok(());
@@ -2524,8 +2526,9 @@ impl WebUIHandler {
                 if let Some(saved) = saved_route_base {
                     context.route_base = saved;
                 }
-                // The level this outlet consumed does not come back, matching
-                // the empty level the matched child was rendered against.
+                // Restores the empty level the matched child was rendered
+                // against, rather than the level this outlet matched. See the
+                // note at the top of this function and #515.
                 context.route_children = Cow::Borrowed(&[]);
             }
         }

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -475,49 +475,12 @@ impl VisibleLoopScope {
 
 #[derive(Clone, Copy)]
 struct LocalValueSources<'ctx, 'protocol, 'state> {
-    owned: &'ctx ScopeMap<'protocol>,
+    owned: &'ctx HashMap<String, Value>,
     borrowed: &'ctx BorrowedScope<'protocol, 'state>,
 }
 
-/// Name a render context binds a value or a render decision to.
-///
-/// Every name the handler records originates in the protocol, so the borrowed
-/// variant is what a render actually uses. The owned variant exists only for a
-/// suspended streaming continuation, whose parked scope outlives the borrow it
-/// was rendered from.
-pub(crate) type Name<'protocol> = Cow<'protocol, str>;
-
-/// Scope bindings materialized for one component or `<for>` body.
-pub(crate) type ScopeMap<'protocol> = HashMap<Name<'protocol>, Value>;
-
-/// Set of protocol names visited during a render.
-pub(crate) type NameSet<'protocol> = HashSet<Name<'protocol>>;
-
 /// Route level an `<outlet />` matches against.
 pub(crate) type RouteChildren<'protocol> = Cow<'protocol, [webui_protocol::WebUiFragmentRoute]>;
-
-/// Detach a scope map from the borrow it was rendered against.
-///
-/// Entries the render materialized are moved, not copied; only names still
-/// pointing into the protocol pay an allocation, and they pay it once because
-/// the result stays owned from then on. `target` keeps its bucket capacity, so
-/// a session that parks a scope on every suspension reuses one map.
-pub(crate) fn absorb_scope_map(target: &mut ScopeMap<'static>, source: ScopeMap<'_>) {
-    target.clear();
-    target.reserve(source.len());
-    for (name, value) in source {
-        target.insert(Cow::Owned(name.into_owned()), value);
-    }
-}
-
-/// Detach a name set from the borrow it was rendered against.
-pub(crate) fn absorb_name_set(target: &mut NameSet<'static>, source: NameSet<'_>) {
-    target.clear();
-    target.reserve(source.len());
-    for name in source {
-        target.insert(Cow::Owned(name.into_owned()));
-    }
-}
 
 #[derive(Default)]
 struct BorrowedScope<'protocol, 'state> {
@@ -596,12 +559,12 @@ impl<'protocol, 'state> BorrowedScope<'protocol, 'state> {
         self.overflow.clear();
     }
 
-    fn clone_into_owned(&self, target: &mut ScopeMap<'protocol>) {
+    fn clone_into_owned(&self, target: &mut HashMap<String, Value>) {
         for (name, value) in self.inline[..self.inline_len].iter().flatten() {
-            target.insert(Cow::Borrowed(name), (*value).clone());
+            target.insert((*name).to_owned(), (*value).clone());
         }
         for (name, value) in &self.overflow {
-            target.insert(Cow::Borrowed(name), (*value).clone());
+            target.insert((*name).to_owned(), (*value).clone());
         }
     }
 }
@@ -865,23 +828,6 @@ fn component_attr_source(attribute: &webui_protocol::WebUIFragmentAttribute) -> 
     }
 }
 
-/// Component a route level hosts at `index`, matching the level's own ownership.
-fn host_component_at<'protocol>(
-    children: &RouteChildren<'protocol>,
-    index: usize,
-) -> Name<'protocol> {
-    match children {
-        Cow::Borrowed(routes) => match routes.get(index) {
-            Some(route) => Cow::Borrowed(&route.fragment_id),
-            None => Cow::Borrowed(""),
-        },
-        Cow::Owned(routes) => match routes.get(index) {
-            Some(route) => Cow::Owned(route.fragment_id.clone()),
-            None => Cow::Borrowed(""),
-        },
-    }
-}
-
 /// Route level one step below `children[index]`.
 ///
 /// A borrowed level yields a borrowed sublevel, so descending through a route
@@ -930,7 +876,7 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     pub(crate) component_asset_style_links: &'protocol str,
     pub(crate) state: &'state Value,
     pub(crate) writer: &'output mut dyn ResponseWriter,
-    pub(crate) local_vars: ScopeMap<'protocol>,
+    pub(crate) local_vars: HashMap<String, Value>,
     /// Component-local values that still point into immutable request state.
     local_borrowed_vars: BorrowedScope<'protocol, 'state>,
     /// Borrowed loop bindings, in lexical order.
@@ -939,7 +885,7 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// bodies hide outer loop monikers while still allowing their own loops.
     visible_loop_scope: VisibleLoopScope,
     /// Accumulates component attribute values between attrStart and the component fragment.
-    pub(crate) component_attrs: ScopeMap<'protocol>,
+    pub(crate) component_attrs: HashMap<String, Value>,
     /// State-backed component attributes accumulated without cloning.
     component_borrowed_attrs: BorrowedScope<'protocol, 'state>,
     /// True only while parser-produced component opening-tag attributes are
@@ -957,7 +903,7 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// Component names visited during rendering (for selective f-template emission
     /// and CSS module dedup — only the first render of each component emits
     /// its `<script type="importmap">` data-URI tag).
-    pub(crate) rendered_components: NameSet<'protocol>,
+    pub(crate) rendered_components: HashSet<String>,
     /// Per-render plugin instance created from the handler's factory.
     pub(crate) plugin: Option<Box<dyn HandlerPlugin>>,
     /// Current position in the route tree for outlet-based rendering.
@@ -1060,10 +1006,10 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// local/attr map here instead of dropping it, so a sibling reuses the
     /// bucket capacity rather than reallocating a fresh `HashMap`. Bounded
     /// ([`SCOPE_POOL_CAP`]) and dropped with the context at request end.
-    pub(crate) scope_pool: Vec<ScopeMap<'protocol>>,
+    pub(crate) scope_pool: Vec<HashMap<String, Value>>,
     /// Resources delivered into the Document CSS tree. The empty set does not
     /// allocate, and streaming retains it across checkpoints.
-    pub(crate) document_style_resources: NameSet<'protocol>,
+    pub(crate) document_style_resources: HashSet<String>,
     /// Active Shadow roots and their route-activated resource indexes. The
     /// route vector allocates only when a matched Light route contributes CSS.
     pub(crate) shadow_style_roots: Vec<ShadowStyleRoot>,
@@ -1227,14 +1173,14 @@ fn push_escaped_html_attribute(output: &mut String, value: &str) {
 
 /// Take a cleared scope map from the pool, or a fresh empty one when the pool is
 /// empty. A fresh `HashMap` does not allocate until its first insert.
-fn take_scope_map<'protocol>(pool: &mut Vec<ScopeMap<'protocol>>) -> ScopeMap<'protocol> {
+fn take_scope_map(pool: &mut Vec<HashMap<String, Value>>) -> HashMap<String, Value> {
     pool.pop().unwrap_or_default()
 }
 
 /// Return a spent scope map to the pool, clearing it but retaining its bucket
 /// capacity for a sibling root to reuse. Drops the map once the pool is full so
 /// retained memory stays bounded.
-fn recycle_scope_map<'protocol>(pool: &mut Vec<ScopeMap<'protocol>>, mut map: ScopeMap<'protocol>) {
+fn recycle_scope_map(pool: &mut Vec<HashMap<String, Value>>, mut map: HashMap<String, Value>) {
     if pool.len() < SCOPE_POOL_CAP {
         map.clear();
         pool.push(map);
@@ -2375,7 +2321,7 @@ impl WebUIHandler {
                 }
                 Some(Fragment::Component(component)) => {
                     self.process_component(
-                        Cow::Borrowed(&component.fragment_id),
+                        &component.fragment_id,
                         fragment_list.target(index),
                         ComponentHostOrigin::ParserProduced,
                         context,
@@ -2459,8 +2405,7 @@ impl WebUIHandler {
             let Some(matched_child) = children.get(idx) else {
                 return Ok(());
             };
-            let host = host_component_at(&children, idx);
-            let comp = host.as_ref();
+            let comp = &matched_child.fragment_id;
 
             if !comp.is_empty() {
                 let saved_route_base = (rm.consumed_segments > 0).then(|| {
@@ -2511,12 +2456,7 @@ impl WebUIHandler {
                 prepare_generated_streaming_root(comp, context)?;
                 context.writer.write(">")?;
 
-                self.process_component(
-                    host.clone(),
-                    None,
-                    ComponentHostOrigin::HandlerGenerated,
-                    context,
-                )?;
+                self.process_component(comp, None, ComponentHostOrigin::HandlerGenerated, context)?;
 
                 context.writer.write("</")?;
                 context.writer.write(comp)?;
@@ -2661,7 +2601,7 @@ impl WebUIHandler {
                     "component style closure `{root}` references missing resource `{name}`"
                 )),
             })?;
-            if is_document_tree && !context.document_style_resources.insert(Cow::Borrowed(name)) {
+            if is_document_tree && !context.document_style_resources.insert(name.to_string()) {
                 continue;
             }
             if let Some(static_closure) = shadow_static_closure {
@@ -2991,7 +2931,7 @@ impl WebUIHandler {
                 context.writer.write(">")?;
 
                 self.process_component(
-                    Cow::Borrowed(&route_frag.fragment_id),
+                    &route_frag.fragment_id,
                     None,
                     ComponentHostOrigin::HandlerGenerated,
                     context,
@@ -3014,14 +2954,13 @@ impl WebUIHandler {
     }
 
     /// Process a component fragment.
-    fn process_component<'protocol>(
+    fn process_component(
         &self,
-        component: Name<'protocol>,
+        fragment_id: &str,
         target: Option<usize>,
         origin: ComponentHostOrigin,
-        context: &mut WebUIProcessContext<'protocol, '_, '_>,
+        context: &mut WebUIProcessContext,
     ) -> Result<()> {
-        let fragment_id = component.as_ref();
         if context.streaming.is_some() {
             consume_streaming_component_root(fragment_id, origin, context)?;
             // Capture only after root parity succeeds, so malformed protocols
@@ -3036,7 +2975,7 @@ impl WebUIHandler {
         // duplicate instance while keeping the set contents identical.
         if !context.rendered_components.contains(fragment_id) {
             self.emit_css_module(fragment_id, context)?;
-            context.rendered_components.insert(component.clone());
+            context.rendered_components.insert(fragment_id.to_string());
         }
 
         let owns_css_tree = Self::component_owns_css_tree(fragment_id, context.protocol);
@@ -3253,7 +3192,7 @@ impl WebUIHandler {
             }
         }
         if let Some(value) = saved_value {
-            context.local_vars.insert(Cow::Borrowed(item_name), value);
+            context.local_vars.insert(item_name.to_string(), value);
         }
         if let Some(value) = saved_borrowed_value {
             context.local_borrowed_vars.insert(item_name, value);
@@ -3290,19 +3229,23 @@ impl WebUIHandler {
             p.on_for_start(&for_loop.fragment_id, context.writer)?;
         }
 
-        // Hot-loop optimisation: the loop variable name is a protocol-owned
-        // `&str` key in `local_vars`, so installing it is allocation-free. The
-        // key is still installed ONCE with an empty placeholder and overwritten
-        // in-place each iteration via `get_mut`, which keeps the per-iteration
-        // work to a single O(1) value swap with no rehash.
+        // Hot-loop optimisation: the loop variable name is `String`-keyed
+        // in `local_vars`. The naive impl re-inserts (and so re-allocates
+        // the key) on every iteration — a 1000-item loop pays 2000 String
+        // clones for the key alone. Instead, we save the outer-scope
+        // value (if any) ONCE before the loop, install the key ONCE with
+        // an empty placeholder, then overwrite the value in-place each
+        // iteration via `get_mut`. Restoration at the end happens once.
         let item_name = for_loop.item.as_str();
         let saved_value = context.local_vars.remove(item_name);
         let saved_borrowed_value = context.local_borrowed_vars.remove(item_name);
         // Pre-insert the key so per-iteration `get_mut` is infallible.
+        // Cost: at most one `String::from(item_name)` for the lifetime
+        // of the loop, regardless of iteration count.
         if !items.is_empty() {
             context
                 .local_vars
-                .insert(Cow::Borrowed(item_name), Value::Null);
+                .insert(item_name.to_string(), Value::Null);
         }
         for (i, item) in items.into_iter().enumerate() {
             if let Some(p) = &mut context.plugin {
@@ -3324,7 +3267,7 @@ impl WebUIHandler {
         // Restore outer scope (or remove the placeholder we installed).
         match saved_value {
             Some(value) => {
-                context.local_vars.insert(Cow::Borrowed(item_name), value);
+                context.local_vars.insert(item_name.to_string(), value);
             }
             None => {
                 context.local_vars.remove(item_name);
@@ -3505,7 +3448,7 @@ impl WebUIHandler {
                 // condition flips true client-side.
                 if context.css_strategy == webui_protocol::CssStrategy::Module {
                     for name in &reachable {
-                        if !context.rendered_components.contains(name.as_str()) {
+                        if !context.rendered_components.contains(name) {
                             if let Some(css) = context
                                 .protocol
                                 .components
@@ -3806,7 +3749,7 @@ impl WebUIHandler {
                 context.component_borrowed_attrs.remove(name);
                 context
                     .component_attrs
-                    .insert(Cow::Borrowed(name), Value::Bool(condition_met));
+                    .insert(name.to_owned(), Value::Bool(condition_met));
             }
 
             if condition_met {
@@ -3828,7 +3771,7 @@ impl WebUIHandler {
                 context.component_borrowed_attrs.remove(name);
                 context
                     .component_attrs
-                    .insert(Cow::Borrowed(name), Value::String(raw_value));
+                    .insert(name.to_owned(), Value::String(raw_value));
             }
             return Ok(());
         }
@@ -3843,7 +3786,7 @@ impl WebUIHandler {
                     context.component_borrowed_attrs.remove(name);
                     context
                         .component_attrs
-                        .insert(Cow::Borrowed(name), Value::String(attr.value.clone()));
+                        .insert(name.to_owned(), Value::String(attr.value.clone()));
                 }
             } else if attr.complex {
                 // Complex attribute — resolve value, don't render to HTML, store as state
@@ -3869,7 +3812,7 @@ impl WebUIHandler {
                     } else if let Some(value) = self.resolve_value_owned(&attr.value, context) {
                         let name = component_name.ok_or_else(missing_component_attr_name_error)?;
                         context.component_borrowed_attrs.remove(name);
-                        context.component_attrs.insert(Cow::Borrowed(name), value);
+                        context.component_attrs.insert(name.to_owned(), value);
                     }
                 }
             } else {
@@ -3945,7 +3888,7 @@ impl WebUIHandler {
                         let name = component_name.ok_or_else(missing_component_attr_name_error)?;
                         context.component_borrowed_attrs.remove(name);
                         context.component_attrs.insert(
-                            Cow::Borrowed(name),
+                            name.to_owned(),
                             value
                                 .map(Cow::into_owned)
                                 .unwrap_or(Value::String(String::new())),
@@ -4238,6 +4181,43 @@ mod tests {
     }
 
     #[test]
+    fn route_descent_borrows_protocol_children() {
+        let routes = vec![WebUiFragmentRoute {
+            children: vec![WebUiFragmentRoute {
+                fragment_id: "child".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+        let level = RouteChildren::Borrowed(&routes);
+
+        let descended = descend_into(&level, 0);
+
+        let Cow::Borrowed(children) = descended else {
+            panic!("protocol-owned route children should remain borrowed");
+        };
+        assert!(std::ptr::eq(children, routes[0].children.as_slice()));
+    }
+
+    #[test]
+    fn route_descent_keeps_parked_children_owned() {
+        let level = RouteChildren::Owned(vec![WebUiFragmentRoute {
+            children: vec![WebUiFragmentRoute {
+                fragment_id: "child".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }]);
+
+        let descended = descend_into(&level, 0);
+
+        let Cow::Owned(children) = descended else {
+            panic!("parked route children must not borrow session-owned storage");
+        };
+        assert_eq!(children[0].fragment_id, "child");
+    }
+
+    #[test]
     fn borrowed_collection_reuses_state_array() {
         let state = test_json!({
             "items": [
@@ -4245,7 +4225,7 @@ mod tests {
                 {"name": "second"}
             ]
         });
-        let local_vars = ScopeMap::new();
+        let local_vars = HashMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let loop_vars = Vec::new();
         let items = resolve_borrowed_collection(
@@ -4268,8 +4248,7 @@ mod tests {
     #[test]
     fn owned_local_collection_keeps_precedence() {
         let state = test_json!({"items": [{"name": "global"}]});
-        let local_vars =
-            ScopeMap::from([(Cow::Borrowed("items"), test_json!([{"name": "local"}]))]);
+        let local_vars = HashMap::from([("items".to_string(), test_json!([{"name": "local"}]))]);
         let local_borrowed_vars = BorrowedScope::default();
         assert!(resolve_borrowed_collection(
             "items",
@@ -4290,7 +4269,7 @@ mod tests {
         let contacts = &state["teams"][0]["contacts"];
         let mut local_borrowed_vars = BorrowedScope::default();
         local_borrowed_vars.insert("contacts", contacts);
-        let local_vars = ScopeMap::new();
+        let local_vars = HashMap::new();
         let items = resolve_borrowed_collection(
             "contacts",
             &[],
@@ -4323,7 +4302,7 @@ mod tests {
             name: "item",
             value: item,
         }];
-        let local_vars = ScopeMap::new();
+        let local_vars = HashMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let children = resolve_borrowed_collection(
             "item.children",
@@ -4359,7 +4338,7 @@ mod tests {
                 value: &state["inner"],
             },
         ];
-        let local_vars = ScopeMap::new();
+        let local_vars = HashMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let sources = LocalValueSources {
             owned: &local_vars,
@@ -4428,7 +4407,7 @@ mod tests {
         ];
         let mut local_borrowed_vars = BorrowedScope::default();
         local_borrowed_vars.insert("borrowed", &state["borrowed"]);
-        let local_vars = ScopeMap::from([(Cow::Borrowed("owned"), test_json!({"name": "owned"}))]);
+        let local_vars = HashMap::from([("owned".to_string(), test_json!({"name": "owned"}))]);
         let sources = LocalValueSources {
             owned: &local_vars,
             borrowed: &local_borrowed_vars,

--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -475,8 +475,48 @@ impl VisibleLoopScope {
 
 #[derive(Clone, Copy)]
 struct LocalValueSources<'ctx, 'protocol, 'state> {
-    owned: &'ctx HashMap<String, Value>,
+    owned: &'ctx ScopeMap<'protocol>,
     borrowed: &'ctx BorrowedScope<'protocol, 'state>,
+}
+
+/// Name a render context binds a value or a render decision to.
+///
+/// Every name the handler records originates in the protocol, so the borrowed
+/// variant is what a render actually uses. The owned variant exists only for a
+/// suspended streaming continuation, whose parked scope outlives the borrow it
+/// was rendered from.
+pub(crate) type Name<'protocol> = Cow<'protocol, str>;
+
+/// Scope bindings materialized for one component or `<for>` body.
+pub(crate) type ScopeMap<'protocol> = HashMap<Name<'protocol>, Value>;
+
+/// Set of protocol names visited during a render.
+pub(crate) type NameSet<'protocol> = HashSet<Name<'protocol>>;
+
+/// Route level an `<outlet />` matches against.
+pub(crate) type RouteChildren<'protocol> = Cow<'protocol, [webui_protocol::WebUiFragmentRoute]>;
+
+/// Detach a scope map from the borrow it was rendered against.
+///
+/// Entries the render materialized are moved, not copied; only names still
+/// pointing into the protocol pay an allocation, and they pay it once because
+/// the result stays owned from then on. `target` keeps its bucket capacity, so
+/// a session that parks a scope on every suspension reuses one map.
+pub(crate) fn absorb_scope_map(target: &mut ScopeMap<'static>, source: ScopeMap<'_>) {
+    target.clear();
+    target.reserve(source.len());
+    for (name, value) in source {
+        target.insert(Cow::Owned(name.into_owned()), value);
+    }
+}
+
+/// Detach a name set from the borrow it was rendered against.
+pub(crate) fn absorb_name_set(target: &mut NameSet<'static>, source: NameSet<'_>) {
+    target.clear();
+    target.reserve(source.len());
+    for name in source {
+        target.insert(Cow::Owned(name.into_owned()));
+    }
 }
 
 #[derive(Default)]
@@ -556,12 +596,12 @@ impl<'protocol, 'state> BorrowedScope<'protocol, 'state> {
         self.overflow.clear();
     }
 
-    fn clone_into_owned(&self, target: &mut HashMap<String, Value>) {
+    fn clone_into_owned(&self, target: &mut ScopeMap<'protocol>) {
         for (name, value) in self.inline[..self.inline_len].iter().flatten() {
-            target.insert((*name).to_owned(), (*value).clone());
+            target.insert(Cow::Borrowed(name), (*value).clone());
         }
         for (name, value) in &self.overflow {
-            target.insert((*name).to_owned(), (*value).clone());
+            target.insert(Cow::Borrowed(name), (*value).clone());
         }
     }
 }
@@ -825,6 +865,44 @@ fn component_attr_source(attribute: &webui_protocol::WebUIFragmentAttribute) -> 
     }
 }
 
+/// Component a route level hosts at `index`, matching the level's own ownership.
+fn host_component_at<'protocol>(
+    children: &RouteChildren<'protocol>,
+    index: usize,
+) -> Name<'protocol> {
+    match children {
+        Cow::Borrowed(routes) => match routes.get(index) {
+            Some(route) => Cow::Borrowed(&route.fragment_id),
+            None => Cow::Borrowed(""),
+        },
+        Cow::Owned(routes) => match routes.get(index) {
+            Some(route) => Cow::Owned(route.fragment_id.clone()),
+            None => Cow::Borrowed(""),
+        },
+    }
+}
+
+/// Route level one step below `children[index]`.
+///
+/// A borrowed level yields a borrowed sublevel, so descending through a route
+/// tree during a render never copies a `WebUiFragmentRoute`. Only a level a
+/// streaming continuation already materialized is cloned.
+fn descend_into<'protocol>(
+    children: &RouteChildren<'protocol>,
+    index: usize,
+) -> RouteChildren<'protocol> {
+    match children {
+        Cow::Borrowed(routes) => match routes.get(index) {
+            Some(route) => Cow::Borrowed(&route.children),
+            None => Cow::Borrowed(&[]),
+        },
+        Cow::Owned(routes) => match routes.get(index) {
+            Some(route) => Cow::Owned(route.children.clone()),
+            None => Cow::Borrowed(&[]),
+        },
+    }
+}
+
 /// Fragment ID a fragment descends into, or `None` when it renders inline.
 fn fragment_target_id(fragment: &WebUIFragment) -> Option<&str> {
     match fragment.fragment.as_ref()? {
@@ -852,7 +930,7 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     pub(crate) component_asset_style_links: &'protocol str,
     pub(crate) state: &'state Value,
     pub(crate) writer: &'output mut dyn ResponseWriter,
-    pub(crate) local_vars: HashMap<String, Value>,
+    pub(crate) local_vars: ScopeMap<'protocol>,
     /// Component-local values that still point into immutable request state.
     local_borrowed_vars: BorrowedScope<'protocol, 'state>,
     /// Borrowed loop bindings, in lexical order.
@@ -861,7 +939,7 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// bodies hide outer loop monikers while still allowing their own loops.
     visible_loop_scope: VisibleLoopScope,
     /// Accumulates component attribute values between attrStart and the component fragment.
-    pub(crate) component_attrs: HashMap<String, Value>,
+    pub(crate) component_attrs: ScopeMap<'protocol>,
     /// State-backed component attributes accumulated without cloning.
     component_borrowed_attrs: BorrowedScope<'protocol, 'state>,
     /// True only while parser-produced component opening-tag attributes are
@@ -879,12 +957,17 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// Component names visited during rendering (for selective f-template emission
     /// and CSS module dedup — only the first render of each component emits
     /// its `<script type="importmap">` data-URI tag).
-    pub(crate) rendered_components: HashSet<String>,
+    pub(crate) rendered_components: NameSet<'protocol>,
     /// Per-render plugin instance created from the handler's factory.
     pub(crate) plugin: Option<Box<dyn HandlerPlugin>>,
     /// Current position in the route tree for outlet-based rendering.
     /// Contains the children of the currently matched route fragment.
-    pub(crate) route_children: Vec<webui_protocol::WebUiFragmentRoute>,
+    ///
+    /// A matched route's `children` is a recursive prost subtree, so the
+    /// borrowed variant avoids deep-cloning the whole remaining route tree on
+    /// every matched route of every request. Only a suspended streaming
+    /// continuation, which outlives the borrow, materializes the owned variant.
+    pub(crate) route_children: RouteChildren<'protocol>,
     /// Entry fragment ID — used to compute the initial inventory at head_end.
     /// Borrowed from `RenderOptions<'a>::entry_id` — zero-copy.
     pub(crate) entry_id: &'protocol str,
@@ -977,10 +1060,10 @@ pub(crate) struct WebUIProcessContext<'protocol, 'state, 'output> {
     /// local/attr map here instead of dropping it, so a sibling reuses the
     /// bucket capacity rather than reallocating a fresh `HashMap`. Bounded
     /// ([`SCOPE_POOL_CAP`]) and dropped with the context at request end.
-    pub(crate) scope_pool: Vec<HashMap<String, Value>>,
+    pub(crate) scope_pool: Vec<ScopeMap<'protocol>>,
     /// Resources delivered into the Document CSS tree. The empty set does not
     /// allocate, and streaming retains it across checkpoints.
-    pub(crate) document_style_resources: HashSet<String>,
+    pub(crate) document_style_resources: NameSet<'protocol>,
     /// Active Shadow roots and their route-activated resource indexes. The
     /// route vector allocates only when a matched Light route contributes CSS.
     pub(crate) shadow_style_roots: Vec<ShadowStyleRoot>,
@@ -1144,14 +1227,14 @@ fn push_escaped_html_attribute(output: &mut String, value: &str) {
 
 /// Take a cleared scope map from the pool, or a fresh empty one when the pool is
 /// empty. A fresh `HashMap` does not allocate until its first insert.
-fn take_scope_map(pool: &mut Vec<HashMap<String, Value>>) -> HashMap<String, Value> {
+fn take_scope_map<'protocol>(pool: &mut Vec<ScopeMap<'protocol>>) -> ScopeMap<'protocol> {
     pool.pop().unwrap_or_default()
 }
 
 /// Return a spent scope map to the pool, clearing it but retaining its bucket
 /// capacity for a sibling root to reuse. Drops the map once the pool is full so
 /// retained memory stays bounded.
-fn recycle_scope_map(pool: &mut Vec<HashMap<String, Value>>, mut map: HashMap<String, Value>) {
+fn recycle_scope_map<'protocol>(pool: &mut Vec<ScopeMap<'protocol>>, mut map: ScopeMap<'protocol>) {
     if pool.len() < SCOPE_POOL_CAP {
         map.clear();
         pool.push(map);
@@ -2292,7 +2375,7 @@ impl WebUIHandler {
                 }
                 Some(Fragment::Component(component)) => {
                     self.process_component(
-                        &component.fragment_id,
+                        Cow::Borrowed(&component.fragment_id),
                         fragment_list.target(index),
                         ComponentHostOrigin::ParserProduced,
                         context,
@@ -2338,8 +2421,14 @@ impl WebUIHandler {
     /// Matches children from the currently active route's `children` field
     /// against the request path, renders the matched child `<webui-route>`
     /// elements directly at this position (no wrapper element).
-    fn process_outlet(&self, context: &mut WebUIProcessContext) -> Result<()> {
-        let mut children = std::mem::take(&mut context.route_children);
+    fn process_outlet<'protocol>(
+        &self,
+        context: &mut WebUIProcessContext<'protocol, '_, '_>,
+    ) -> Result<()> {
+        // Moved out so the matched child can render with the context pointing
+        // at its grandchildren. An outlet consumes its route level, so the
+        // level is not put back: nothing after this point renders against it.
+        let children = std::mem::take(&mut context.route_children);
         if children.is_empty() {
             return Ok(());
         }
@@ -2364,18 +2453,12 @@ impl WebUIHandler {
             }
         }
 
-        // Extract grandchildren from the matched child to avoid cloning.
-        // We swap out the children vec so we can move it into context without
-        // cloning, then swap an empty vec back for the sibling rendering pass.
-        let grandchildren = if let Some((idx, _)) = &best {
-            std::mem::take(&mut children[*idx].children)
-        } else {
-            Vec::new()
-        };
-
         if let Some((idx, ref rm)) = best {
-            let matched_child = &children[idx];
-            let comp = &matched_child.fragment_id;
+            let Some(matched_child) = children.get(idx) else {
+                return Ok(());
+            };
+            let host = host_component_at(&children, idx);
+            let comp = host.as_ref();
 
             if !comp.is_empty() {
                 let saved_route_base = (rm.consumed_segments > 0).then(|| {
@@ -2385,9 +2468,7 @@ impl WebUIHandler {
                     );
                     std::mem::replace(&mut context.route_base, Cow::Owned(base))
                 });
-                let saved_route_children = std::mem::take(&mut context.route_children);
-
-                context.route_children = grandchildren;
+                context.route_children = descend_into(&children, idx);
 
                 // Emit matched <webui-route>
                 context.writer.write("<webui-route")?;
@@ -2428,7 +2509,12 @@ impl WebUIHandler {
                 prepare_generated_streaming_root(comp, context)?;
                 context.writer.write(">")?;
 
-                self.process_component(comp, None, ComponentHostOrigin::HandlerGenerated, context)?;
+                self.process_component(
+                    host.clone(),
+                    None,
+                    ComponentHostOrigin::HandlerGenerated,
+                    context,
+                )?;
 
                 context.writer.write("</")?;
                 context.writer.write(comp)?;
@@ -2438,7 +2524,9 @@ impl WebUIHandler {
                 if let Some(saved) = saved_route_base {
                     context.route_base = saved;
                 }
-                context.route_children = saved_route_children;
+                // The level this outlet consumed does not come back, matching
+                // the empty level the matched child was rendered against.
+                context.route_children = Cow::Borrowed(&[]);
             }
         }
 
@@ -2570,7 +2658,7 @@ impl WebUIHandler {
                     "component style closure `{root}` references missing resource `{name}`"
                 )),
             })?;
-            if is_document_tree && !context.document_style_resources.insert(name.to_string()) {
+            if is_document_tree && !context.document_style_resources.insert(Cow::Borrowed(name)) {
                 continue;
             }
             if let Some(static_closure) = shadow_static_closure {
@@ -2836,11 +2924,11 @@ impl WebUIHandler {
     }
 
     /// Process a route fragment — renders `<webui-route>` with matched/hidden state.
-    fn process_route(
+    fn process_route<'protocol>(
         &self,
-        route_frag: &webui_protocol::WebUiFragmentRoute,
+        route_frag: &'protocol webui_protocol::WebUiFragmentRoute,
         best_route: &Option<(String, route_matcher::RouteMatch)>,
-        context: &mut WebUIProcessContext,
+        context: &mut WebUIProcessContext<'protocol, '_, '_>,
     ) -> Result<()> {
         let is_matched = best_route
             .as_ref()
@@ -2873,8 +2961,10 @@ impl WebUIHandler {
                     route_matcher::compute_route_base(context.request_path, rm.consumed_segments);
                 std::mem::replace(&mut context.route_base, Cow::Owned(base))
             });
-            let saved_route_children = std::mem::take(&mut context.route_children);
-            context.route_children = route_frag.children.clone();
+            let saved_route_children = std::mem::replace(
+                &mut context.route_children,
+                Cow::Borrowed(&route_frag.children),
+            );
 
             if !route_frag.content_fragment_id.is_empty() {
                 self.process_fragment_target(None, &route_frag.content_fragment_id, context)?;
@@ -2898,7 +2988,7 @@ impl WebUIHandler {
                 context.writer.write(">")?;
 
                 self.process_component(
-                    &route_frag.fragment_id,
+                    Cow::Borrowed(&route_frag.fragment_id),
                     None,
                     ComponentHostOrigin::HandlerGenerated,
                     context,
@@ -2921,13 +3011,14 @@ impl WebUIHandler {
     }
 
     /// Process a component fragment.
-    fn process_component(
+    fn process_component<'protocol>(
         &self,
-        fragment_id: &str,
+        component: Name<'protocol>,
         target: Option<usize>,
         origin: ComponentHostOrigin,
-        context: &mut WebUIProcessContext,
+        context: &mut WebUIProcessContext<'protocol, '_, '_>,
     ) -> Result<()> {
+        let fragment_id = component.as_ref();
         if context.streaming.is_some() {
             consume_streaming_component_root(fragment_id, origin, context)?;
             // Capture only after root parity succeeds, so malformed protocols
@@ -2942,7 +3033,7 @@ impl WebUIHandler {
         // duplicate instance while keeping the set contents identical.
         if !context.rendered_components.contains(fragment_id) {
             self.emit_css_module(fragment_id, context)?;
-            context.rendered_components.insert(fragment_id.to_string());
+            context.rendered_components.insert(component.clone());
         }
 
         let owns_css_tree = Self::component_owns_css_tree(fragment_id, context.protocol);
@@ -3159,7 +3250,7 @@ impl WebUIHandler {
             }
         }
         if let Some(value) = saved_value {
-            context.local_vars.insert(item_name.to_string(), value);
+            context.local_vars.insert(Cow::Borrowed(item_name), value);
         }
         if let Some(value) = saved_borrowed_value {
             context.local_borrowed_vars.insert(item_name, value);
@@ -3196,23 +3287,19 @@ impl WebUIHandler {
             p.on_for_start(&for_loop.fragment_id, context.writer)?;
         }
 
-        // Hot-loop optimisation: the loop variable name is `String`-keyed
-        // in `local_vars`. The naive impl re-inserts (and so re-allocates
-        // the key) on every iteration — a 1000-item loop pays 2000 String
-        // clones for the key alone. Instead, we save the outer-scope
-        // value (if any) ONCE before the loop, install the key ONCE with
-        // an empty placeholder, then overwrite the value in-place each
-        // iteration via `get_mut`. Restoration at the end happens once.
+        // Hot-loop optimisation: the loop variable name is a protocol-owned
+        // `&str` key in `local_vars`, so installing it is allocation-free. The
+        // key is still installed ONCE with an empty placeholder and overwritten
+        // in-place each iteration via `get_mut`, which keeps the per-iteration
+        // work to a single O(1) value swap with no rehash.
         let item_name = for_loop.item.as_str();
         let saved_value = context.local_vars.remove(item_name);
         let saved_borrowed_value = context.local_borrowed_vars.remove(item_name);
         // Pre-insert the key so per-iteration `get_mut` is infallible.
-        // Cost: at most one `String::from(item_name)` for the lifetime
-        // of the loop, regardless of iteration count.
         if !items.is_empty() {
             context
                 .local_vars
-                .insert(item_name.to_string(), Value::Null);
+                .insert(Cow::Borrowed(item_name), Value::Null);
         }
         for (i, item) in items.into_iter().enumerate() {
             if let Some(p) = &mut context.plugin {
@@ -3234,7 +3321,7 @@ impl WebUIHandler {
         // Restore outer scope (or remove the placeholder we installed).
         match saved_value {
             Some(value) => {
-                context.local_vars.insert(item_name.to_string(), value);
+                context.local_vars.insert(Cow::Borrowed(item_name), value);
             }
             None => {
                 context.local_vars.remove(item_name);
@@ -3415,7 +3502,7 @@ impl WebUIHandler {
                 // condition flips true client-side.
                 if context.css_strategy == webui_protocol::CssStrategy::Module {
                     for name in &reachable {
-                        if !context.rendered_components.contains(name) {
+                        if !context.rendered_components.contains(name.as_str()) {
                             if let Some(css) = context
                                 .protocol
                                 .components
@@ -3716,7 +3803,7 @@ impl WebUIHandler {
                 context.component_borrowed_attrs.remove(name);
                 context
                     .component_attrs
-                    .insert(name.to_owned(), Value::Bool(condition_met));
+                    .insert(Cow::Borrowed(name), Value::Bool(condition_met));
             }
 
             if condition_met {
@@ -3738,7 +3825,7 @@ impl WebUIHandler {
                 context.component_borrowed_attrs.remove(name);
                 context
                     .component_attrs
-                    .insert(name.to_owned(), Value::String(raw_value));
+                    .insert(Cow::Borrowed(name), Value::String(raw_value));
             }
             return Ok(());
         }
@@ -3753,7 +3840,7 @@ impl WebUIHandler {
                     context.component_borrowed_attrs.remove(name);
                     context
                         .component_attrs
-                        .insert(name.to_owned(), Value::String(attr.value.clone()));
+                        .insert(Cow::Borrowed(name), Value::String(attr.value.clone()));
                 }
             } else if attr.complex {
                 // Complex attribute — resolve value, don't render to HTML, store as state
@@ -3779,7 +3866,7 @@ impl WebUIHandler {
                     } else if let Some(value) = self.resolve_value_owned(&attr.value, context) {
                         let name = component_name.ok_or_else(missing_component_attr_name_error)?;
                         context.component_borrowed_attrs.remove(name);
-                        context.component_attrs.insert(name.to_owned(), value);
+                        context.component_attrs.insert(Cow::Borrowed(name), value);
                     }
                 }
             } else {
@@ -3855,7 +3942,7 @@ impl WebUIHandler {
                         let name = component_name.ok_or_else(missing_component_attr_name_error)?;
                         context.component_borrowed_attrs.remove(name);
                         context.component_attrs.insert(
-                            name.to_owned(),
+                            Cow::Borrowed(name),
                             value
                                 .map(Cow::into_owned)
                                 .unwrap_or(Value::String(String::new())),
@@ -3975,7 +4062,7 @@ impl WebUIHandler {
             route_base: Cow::Borrowed("/"),
             rendered_components: HashSet::new(),
             plugin: self.plugin_factory.map(|f| f()),
-            route_children: Vec::new(),
+            route_children: Cow::Borrowed(&[]),
             entry_id: options.entry_id,
             // Same defensive normalisation as `handle()`. See the
             // doc-comment there for the CSP-outage rationale.
@@ -4155,7 +4242,7 @@ mod tests {
                 {"name": "second"}
             ]
         });
-        let local_vars = HashMap::new();
+        let local_vars = ScopeMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let loop_vars = Vec::new();
         let items = resolve_borrowed_collection(
@@ -4178,7 +4265,8 @@ mod tests {
     #[test]
     fn owned_local_collection_keeps_precedence() {
         let state = test_json!({"items": [{"name": "global"}]});
-        let local_vars = HashMap::from([("items".to_string(), test_json!([{"name": "local"}]))]);
+        let local_vars =
+            ScopeMap::from([(Cow::Borrowed("items"), test_json!([{"name": "local"}]))]);
         let local_borrowed_vars = BorrowedScope::default();
         assert!(resolve_borrowed_collection(
             "items",
@@ -4199,7 +4287,7 @@ mod tests {
         let contacts = &state["teams"][0]["contacts"];
         let mut local_borrowed_vars = BorrowedScope::default();
         local_borrowed_vars.insert("contacts", contacts);
-        let local_vars = HashMap::new();
+        let local_vars = ScopeMap::new();
         let items = resolve_borrowed_collection(
             "contacts",
             &[],
@@ -4232,7 +4320,7 @@ mod tests {
             name: "item",
             value: item,
         }];
-        let local_vars = HashMap::new();
+        let local_vars = ScopeMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let children = resolve_borrowed_collection(
             "item.children",
@@ -4268,7 +4356,7 @@ mod tests {
                 value: &state["inner"],
             },
         ];
-        let local_vars = HashMap::new();
+        let local_vars = ScopeMap::new();
         let local_borrowed_vars = BorrowedScope::default();
         let sources = LocalValueSources {
             owned: &local_vars,
@@ -4337,7 +4425,7 @@ mod tests {
         ];
         let mut local_borrowed_vars = BorrowedScope::default();
         local_borrowed_vars.insert("borrowed", &state["borrowed"]);
-        let local_vars = HashMap::from([("owned".to_string(), test_json!({"name": "owned"}))]);
+        let local_vars = ScopeMap::from([(Cow::Borrowed("owned"), test_json!({"name": "owned"}))]);
         let sources = LocalValueSources {
             owned: &local_vars,
             borrowed: &local_borrowed_vars,

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1435,12 +1435,12 @@ pub fn encode_inventory(inv: &[u8]) -> String {
 
 /// Encode the inventory bitfield for a known set of rendered components.
 pub(crate) fn encode_component_inventory(
-    component_names: &crate::NameSet<'_>,
+    component_names: &HashSet<String>,
     index: &HashMap<String, u32>,
 ) -> String {
     let mut inventory = Vec::new();
     for name in component_names {
-        if let Some(&idx) = index.get(name.as_ref()) {
+        if let Some(&idx) = index.get(name.as_str()) {
             set_component(&mut inventory, idx);
         }
     }

--- a/crates/webui-handler/src/route_handler.rs
+++ b/crates/webui-handler/src/route_handler.rs
@@ -1435,12 +1435,12 @@ pub fn encode_inventory(inv: &[u8]) -> String {
 
 /// Encode the inventory bitfield for a known set of rendered components.
 pub(crate) fn encode_component_inventory(
-    component_names: &HashSet<String>,
+    component_names: &crate::NameSet<'_>,
     index: &HashMap<String, u32>,
 ) -> String {
     let mut inventory = Vec::new();
     for name in component_names {
-        if let Some(&idx) = index.get(name.as_str()) {
+        if let Some(&idx) = index.get(name.as_ref()) {
             set_component(&mut inventory, idx);
         }
     }

--- a/crates/webui-handler/src/streaming/inventory.rs
+++ b/crates/webui-handler/src/streaming/inventory.rs
@@ -420,7 +420,7 @@ mod tests {
             route_base: std::borrow::Cow::Borrowed("/account"),
             rendered_components: std::collections::HashSet::new(),
             plugin: None,
-            route_children: Vec::new(),
+            route_children: std::borrow::Cow::Borrowed(&[]),
             entry_id: "index.html",
             nonce: None,
             component_index,

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -358,14 +358,20 @@ pub(crate) struct SessionCore {
     /// True between a committed occurrence and the `advance` that writes the
     /// parent bytes following it.
     awaiting_advance: bool,
-    local_vars: HashMap<String, Value>,
-    component_attrs: HashMap<String, Value>,
+    /// Scope and render bookkeeping parked between host calls.
+    ///
+    /// A render borrows these names from the protocol; a suspended session
+    /// outlives that borrow, so what it parks is detached from it. Detaching
+    /// moves every entry and allocates only for names a render newly bound,
+    /// which is the same allocation the owned map used to pay on insert.
+    local_vars: crate::ScopeMap<'static>,
+    component_attrs: crate::ScopeMap<'static>,
     route_base: Option<String>,
-    rendered_components: HashSet<String>,
-    document_style_resources: HashSet<String>,
+    rendered_components: crate::NameSet<'static>,
+    document_style_resources: crate::NameSet<'static>,
     shadow_style_roots: Vec<crate::ShadowStyleRoot>,
     plugin: Option<Box<dyn HandlerPlugin>>,
-    route_children: Vec<webui_protocol::WebUiFragmentRoute>,
+    route_children: crate::RouteChildren<'static>,
     head_end_emitted: bool,
     body_start_emitted: bool,
     component_asset_styles_emitted: bool,
@@ -376,7 +382,6 @@ pub(crate) struct SessionCore {
     reachable_components: Option<Vec<String>>,
     streaming: Option<StreamingProgress>,
     json_scratch: Vec<u8>,
-    scope_pool: Vec<HashMap<String, Value>>,
 }
 
 pub(crate) struct SessionCall<'call, 'data> {
@@ -408,7 +413,7 @@ impl SessionCore {
             document_style_resources: HashSet::new(),
             shadow_style_roots: Vec::new(),
             plugin: handler.plugin_factory.map(|factory| factory()),
-            route_children: Vec::new(),
+            route_children: Cow::Owned(Vec::new()),
             head_end_emitted: false,
             body_start_emitted: false,
             component_asset_styles_emitted: false,
@@ -422,7 +427,6 @@ impl SessionCore {
                 protocol.style_resource_index().len(),
             )),
             json_scratch: Vec::new(),
-            scope_pool: Vec::new(),
         })
     }
 
@@ -716,21 +720,33 @@ impl SessionCore {
             reachable_components: std::mem::take(&mut self.reachable_components),
             streaming: Some(&mut streaming),
             json_scratch: std::mem::take(&mut self.json_scratch),
-            scope_pool: std::mem::take(&mut self.scope_pool),
+            // Sibling component scopes are recycled within a step. A parked
+            // scope is detached from the protocol borrow it was rendered
+            // against, so a pooled map cannot outlive the step that shaped it.
+            scope_pool: Vec::new(),
             document_style_resources: std::mem::take(&mut self.document_style_resources),
             shadow_style_roots: std::mem::take(&mut self.shadow_style_roots),
             borrowed_scope_pool: Vec::new(),
         };
         let result = operation(&mut self.vm, &mut context);
-        self.local_vars = std::mem::take(&mut context.local_vars);
-        self.component_attrs = std::mem::take(&mut context.component_attrs);
+        crate::absorb_scope_map(
+            &mut self.local_vars,
+            std::mem::take(&mut context.local_vars),
+        );
+        crate::absorb_scope_map(
+            &mut self.component_attrs,
+            std::mem::take(&mut context.component_attrs),
+        );
         self.route_base = match std::mem::replace(&mut context.route_base, Cow::Borrowed("/")) {
             Cow::Owned(base) => Some(base),
             Cow::Borrowed(_) => None,
         };
-        self.rendered_components = std::mem::take(&mut context.rendered_components);
+        crate::absorb_name_set(
+            &mut self.rendered_components,
+            std::mem::take(&mut context.rendered_components),
+        );
         self.plugin = context.plugin.take();
-        self.route_children = std::mem::take(&mut context.route_children);
+        self.route_children = Cow::Owned(std::mem::take(&mut context.route_children).into_owned());
         self.head_end_emitted = context.head_end_emitted;
         self.body_start_emitted = context.body_start_emitted;
         self.component_asset_styles_emitted = context.component_asset_styles_emitted;
@@ -741,9 +757,11 @@ impl SessionCore {
             std::mem::take(&mut context.route_document_style_targets);
         self.reachable_components = std::mem::take(&mut context.reachable_components);
         self.json_scratch = std::mem::take(&mut context.json_scratch);
-        self.scope_pool = std::mem::take(&mut context.scope_pool);
         self.shadow_style_roots = std::mem::take(&mut context.shadow_style_roots);
-        self.document_style_resources = std::mem::take(&mut context.document_style_resources);
+        crate::absorb_name_set(
+            &mut self.document_style_resources,
+            std::mem::take(&mut context.document_style_resources),
+        );
         self.streaming = Some(streaming.into_progress());
         result
     }

--- a/crates/webui-handler/src/streaming/session.rs
+++ b/crates/webui-handler/src/streaming/session.rs
@@ -358,17 +358,11 @@ pub(crate) struct SessionCore {
     /// True between a committed occurrence and the `advance` that writes the
     /// parent bytes following it.
     awaiting_advance: bool,
-    /// Scope and render bookkeeping parked between host calls.
-    ///
-    /// A render borrows these names from the protocol; a suspended session
-    /// outlives that borrow, so what it parks is detached from it. Detaching
-    /// moves every entry and allocates only for names a render newly bound,
-    /// which is the same allocation the owned map used to pay on insert.
-    local_vars: crate::ScopeMap<'static>,
-    component_attrs: crate::ScopeMap<'static>,
+    local_vars: HashMap<String, Value>,
+    component_attrs: HashMap<String, Value>,
     route_base: Option<String>,
-    rendered_components: crate::NameSet<'static>,
-    document_style_resources: crate::NameSet<'static>,
+    rendered_components: HashSet<String>,
+    document_style_resources: HashSet<String>,
     shadow_style_roots: Vec<crate::ShadowStyleRoot>,
     plugin: Option<Box<dyn HandlerPlugin>>,
     route_children: crate::RouteChildren<'static>,
@@ -382,6 +376,7 @@ pub(crate) struct SessionCore {
     reachable_components: Option<Vec<String>>,
     streaming: Option<StreamingProgress>,
     json_scratch: Vec<u8>,
+    scope_pool: Vec<HashMap<String, Value>>,
 }
 
 pub(crate) struct SessionCall<'call, 'data> {
@@ -427,6 +422,7 @@ impl SessionCore {
                 protocol.style_resource_index().len(),
             )),
             json_scratch: Vec::new(),
+            scope_pool: Vec::new(),
         })
     }
 
@@ -720,31 +716,19 @@ impl SessionCore {
             reachable_components: std::mem::take(&mut self.reachable_components),
             streaming: Some(&mut streaming),
             json_scratch: std::mem::take(&mut self.json_scratch),
-            // Sibling component scopes are recycled within a step. A parked
-            // scope is detached from the protocol borrow it was rendered
-            // against, so a pooled map cannot outlive the step that shaped it.
-            scope_pool: Vec::new(),
+            scope_pool: std::mem::take(&mut self.scope_pool),
             document_style_resources: std::mem::take(&mut self.document_style_resources),
             shadow_style_roots: std::mem::take(&mut self.shadow_style_roots),
             borrowed_scope_pool: Vec::new(),
         };
         let result = operation(&mut self.vm, &mut context);
-        crate::absorb_scope_map(
-            &mut self.local_vars,
-            std::mem::take(&mut context.local_vars),
-        );
-        crate::absorb_scope_map(
-            &mut self.component_attrs,
-            std::mem::take(&mut context.component_attrs),
-        );
+        self.local_vars = std::mem::take(&mut context.local_vars);
+        self.component_attrs = std::mem::take(&mut context.component_attrs);
         self.route_base = match std::mem::replace(&mut context.route_base, Cow::Borrowed("/")) {
             Cow::Owned(base) => Some(base),
             Cow::Borrowed(_) => None,
         };
-        crate::absorb_name_set(
-            &mut self.rendered_components,
-            std::mem::take(&mut context.rendered_components),
-        );
+        self.rendered_components = std::mem::take(&mut context.rendered_components);
         self.plugin = context.plugin.take();
         self.route_children = Cow::Owned(std::mem::take(&mut context.route_children).into_owned());
         self.head_end_emitted = context.head_end_emitted;
@@ -757,11 +741,9 @@ impl SessionCore {
             std::mem::take(&mut context.route_document_style_targets);
         self.reachable_components = std::mem::take(&mut context.reachable_components);
         self.json_scratch = std::mem::take(&mut context.json_scratch);
+        self.scope_pool = std::mem::take(&mut context.scope_pool);
         self.shadow_style_roots = std::mem::take(&mut context.shadow_style_roots);
-        crate::absorb_name_set(
-            &mut self.document_style_resources,
-            std::mem::take(&mut context.document_style_resources),
-        );
+        self.document_style_resources = std::mem::take(&mut context.document_style_resources);
         self.streaming = Some(streaming.into_progress());
         result
     }
@@ -969,6 +951,42 @@ mod tests {
 
     fn options<'a>() -> RenderOptions<'a> {
         RenderOptions::new("index.html", "/")
+    }
+
+    #[test]
+    fn session_parks_owned_routes_and_retains_scope_pool() -> Result<()> {
+        let protocol = boundary_protocol(2, StateProjectionMode::Keys);
+        let handler = WebUIHandler::new();
+        let state = test_json!({ "count": 3, "title": "pooled" });
+        let render_options = options();
+        let mut sink = TestSink {
+            output: String::new(),
+        };
+        let mut response = handler.stream_response(&protocol, &render_options, &mut sink)?;
+
+        let first = response.start(&state)?;
+        assert!(matches!(response.core.route_children, Cow::Owned(_)));
+        let Some(boundary) = first.boundary else {
+            panic!("the first boundary should suspend");
+        };
+
+        response.resume(boundary.instance_id, &state, BoundaryMode::Final)?;
+        assert!(matches!(response.core.route_children, Cow::Owned(_)));
+        let pooled_capacity = response
+            .core
+            .scope_pool
+            .first()
+            .map(HashMap::capacity)
+            .unwrap_or_else(|| panic!("the completed component should recycle its scope map"));
+
+        response.advance()?;
+        assert!(matches!(response.core.route_children, Cow::Owned(_)));
+        assert_eq!(
+            response.core.scope_pool.first().map(HashMap::capacity),
+            Some(pooled_capacity),
+            "a suspension step must preserve the scope-map pool"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/webui-handler/src/streaming/vm.rs
+++ b/crates/webui-handler/src/streaming/vm.rs
@@ -243,7 +243,7 @@ enum Frame {
 }
 
 struct ComponentEndFrame {
-    saved_local_vars: HashMap<String, Value>,
+    saved_local_vars: crate::ScopeMap<'static>,
     component_slot: u32,
     owns_css_tree: bool,
 }
@@ -456,7 +456,7 @@ impl ContinuationVm {
                 } => {
                     context.writer.write("</webui-route>")?;
                     context.route_base = Cow::Owned(saved_route_base.into_string());
-                    context.route_children = saved_route_children;
+                    context.route_children = Cow::Owned(saved_route_children);
                 }
                 Frame::Outlet(frame) => self.step_outlet(frame, handler, protocol, context)?,
             }
@@ -594,7 +594,7 @@ impl ContinuationVm {
                     {
                         self.render_boundary_free(context, |context| {
                             handler.process_component(
-                                &component.fragment_id,
+                                Cow::Borrowed(&component.fragment_id),
                                 target,
                                 ComponentHostOrigin::ParserProduced,
                                 context,
@@ -793,11 +793,14 @@ impl ContinuationVm {
             self.record_component(&component.fragment_id, context)?;
         }
 
-        if !context.rendered_components.contains(&component.fragment_id) {
+        if !context
+            .rendered_components
+            .contains(component.fragment_id.as_str())
+        {
             handler.emit_css_module(&component.fragment_id, context)?;
             context
                 .rendered_components
-                .insert(component.fragment_id.clone());
+                .insert(Cow::Owned(component.fragment_id.clone()));
         }
         let slot = fragment_slot(protocol, &component.fragment_id)?;
         let owns_css_tree =
@@ -805,7 +808,11 @@ impl ContinuationVm {
         if owns_css_tree {
             WebUIHandler::push_shadow_style_root(&component.fragment_id, context)?;
         }
-        let saved_local_vars = std::mem::take(&mut context.local_vars);
+        let mut saved_local_vars = crate::ScopeMap::new();
+        crate::absorb_scope_map(
+            &mut saved_local_vars,
+            std::mem::take(&mut context.local_vars),
+        );
         let mut saved_component_attrs = std::mem::replace(
             &mut context.component_attrs,
             crate::take_scope_map(&mut context.scope_pool),
@@ -899,11 +906,11 @@ impl ContinuationVm {
         if let Some(plugin) = context.plugin.as_mut() {
             plugin.on_for_start(&for_loop.fragment_id, context.writer)?;
         }
-        let saved_value = context.local_vars.remove(&for_loop.item);
+        let saved_value = context.local_vars.remove(for_loop.item.as_str());
         if !items.is_empty() {
             context
                 .local_vars
-                .insert(for_loop.item.clone(), Value::Null);
+                .insert(Cow::Owned(for_loop.item.clone()), Value::Null);
         }
         self.open_repeats = self
             .open_repeats
@@ -950,7 +957,9 @@ impl ContinuationVm {
         }
         match frame.saved_value {
             Some(value) => {
-                context.local_vars.insert(frame.item_name.into(), value);
+                context
+                    .local_vars
+                    .insert(Cow::Owned(frame.item_name.into()), value);
             }
             None => {
                 context.local_vars.remove(frame.item_name.as_ref());
@@ -1319,8 +1328,11 @@ impl ContinuationVm {
         )
         .into_owned()
         .into_boxed_str();
-        let saved_route_children =
-            std::mem::replace(&mut context.route_children, route.children.clone());
+        let saved_route_children = std::mem::replace(
+            &mut context.route_children,
+            Cow::Owned(route.children.clone()),
+        )
+        .into_owned();
         self.push(Frame::RouteEnd {
             saved_route_base,
             saved_route_children,
@@ -1338,7 +1350,7 @@ impl ContinuationVm {
     }
 
     fn begin_outlet(&mut self, context: &mut WebUIProcessContext<'_, '_, '_>) -> Result<()> {
-        let routes = std::mem::take(&mut context.route_children);
+        let routes = std::mem::take(&mut context.route_children).into_owned();
         if routes.is_empty() {
             return Ok(());
         }

--- a/crates/webui-handler/src/streaming/vm.rs
+++ b/crates/webui-handler/src/streaming/vm.rs
@@ -243,7 +243,7 @@ enum Frame {
 }
 
 struct ComponentEndFrame {
-    saved_local_vars: crate::ScopeMap<'static>,
+    saved_local_vars: HashMap<String, Value>,
     component_slot: u32,
     owns_css_tree: bool,
 }
@@ -594,7 +594,7 @@ impl ContinuationVm {
                     {
                         self.render_boundary_free(context, |context| {
                             handler.process_component(
-                                Cow::Borrowed(&component.fragment_id),
+                                &component.fragment_id,
                                 target,
                                 ComponentHostOrigin::ParserProduced,
                                 context,
@@ -793,14 +793,11 @@ impl ContinuationVm {
             self.record_component(&component.fragment_id, context)?;
         }
 
-        if !context
-            .rendered_components
-            .contains(component.fragment_id.as_str())
-        {
+        if !context.rendered_components.contains(&component.fragment_id) {
             handler.emit_css_module(&component.fragment_id, context)?;
             context
                 .rendered_components
-                .insert(Cow::Owned(component.fragment_id.clone()));
+                .insert(component.fragment_id.clone());
         }
         let slot = fragment_slot(protocol, &component.fragment_id)?;
         let owns_css_tree =
@@ -808,11 +805,7 @@ impl ContinuationVm {
         if owns_css_tree {
             WebUIHandler::push_shadow_style_root(&component.fragment_id, context)?;
         }
-        let mut saved_local_vars = crate::ScopeMap::new();
-        crate::absorb_scope_map(
-            &mut saved_local_vars,
-            std::mem::take(&mut context.local_vars),
-        );
+        let saved_local_vars = std::mem::take(&mut context.local_vars);
         let mut saved_component_attrs = std::mem::replace(
             &mut context.component_attrs,
             crate::take_scope_map(&mut context.scope_pool),
@@ -906,11 +899,11 @@ impl ContinuationVm {
         if let Some(plugin) = context.plugin.as_mut() {
             plugin.on_for_start(&for_loop.fragment_id, context.writer)?;
         }
-        let saved_value = context.local_vars.remove(for_loop.item.as_str());
+        let saved_value = context.local_vars.remove(&for_loop.item);
         if !items.is_empty() {
             context
                 .local_vars
-                .insert(Cow::Owned(for_loop.item.clone()), Value::Null);
+                .insert(for_loop.item.clone(), Value::Null);
         }
         self.open_repeats = self
             .open_repeats
@@ -957,9 +950,7 @@ impl ContinuationVm {
         }
         match frame.saved_value {
             Some(value) => {
-                context
-                    .local_vars
-                    .insert(Cow::Owned(frame.item_name.into()), value);
+                context.local_vars.insert(frame.item_name.into(), value);
             }
             None => {
                 context.local_vars.remove(frame.item_name.as_ref());

--- a/crates/webui-handler/tests/streaming.rs
+++ b/crates/webui-handler/tests/streaming.rs
@@ -740,6 +740,48 @@ fn selected_route_component_can_suspend_inside_generated_host() {
 }
 
 #[test]
+fn boundary_free_component_descends_owned_nested_routes() {
+    let protocol = parsed_protocol(
+        &document(concat!(
+            r#"<route path="/" component="route-shell">"#,
+            r#"<route path="sections/:sectionId" component="section-page">"#,
+            r#"<route path="topics/:topicId" component="topic-page">"#,
+            r#"<route path="lessons/:lessonId" component="lesson-page"></route>"#,
+            "</route></route></route>",
+        )),
+        &[
+            (
+                "route-shell",
+                concat!(
+                    "<layout-shell></layout-shell>",
+                    r#"<boundary name="ready"><p>ready</p></boundary>"#,
+                ),
+            ),
+            ("layout-shell", "<main><outlet /></main>"),
+            (
+                "section-page",
+                "<h2>Section</h2><section><outlet /></section>",
+            ),
+            ("topic-page", "<h3>Topic</h3><article><outlet /></article>"),
+            ("lesson-page", "<p>Lesson</p>"),
+        ],
+    );
+    let mut session = new_session(protocol, "/sections/alpha/topics/beta/lessons/gamma");
+
+    let start = session.start(&test_json!({})).unwrap();
+
+    assert_eq!(start.boundary.as_ref().unwrap().name.as_ref(), "ready");
+    let html = String::from_utf8(start.bytes).unwrap();
+    let section = html.find("<h2>Section</h2>").unwrap();
+    let topic = html.find("<h3>Topic</h3>").unwrap();
+    let lesson = html.find("<p>Lesson</p>").unwrap();
+    assert!(section < topic && topic < lesson, "{html}");
+    assert!(html.contains(r#"<webui-route path="sections/:sectionId""#));
+    assert!(html.contains(r#"<webui-route path="topics/:topicId""#));
+    assert!(html.contains(r#"<webui-route path="lessons/:lessonId""#));
+}
+
+#[test]
 fn selected_route_component_hydration_keys_survive_frozen_state() {
     let entry = document(concat!(
         r#"<route path="/selected" component="selected-page"></route>"#,


### PR DESCRIPTION
Matched route descent deep-cloned the entire remaining `WebUiFragmentRoute` subtree. Because each route recursively owns strings, child vectors, cache tags, and invalidation data, the cost grows with route depth and sibling count on every request.

This change keeps protocol-owned route levels borrowed during ordinary rendering and materializes them only when a streaming continuation must outlive that borrow.

## Approach

- Represent the active route level as `Cow<'protocol, [WebUiFragmentRoute]>`.
- Borrow child levels directly while descending protocol-owned routes.
- Keep parked `SessionCore` and `ContinuationVm` route levels owned across host calls.
- Move children out of an already-owned route with `mem::take` instead of recursively cloning them.
- Preserve the existing second-`<outlet />` behavior exactly; its latent bug remains isolated in #515.

The scope maps and name sets deliberately remain `String`-keyed, and the scope-map pool remains live across suspension steps. An earlier broad `Cow<str>` prototype improved one-step rendering but a real three-boundary session exposed a deterministic regression: 243 to 249 allocations and 25,081 to 29,539 allocated bytes per run. That design was rejected rather than accepting a streaming trade-off.

## Exact allocation results

Baseline is the current stacked base, #511 at `e908d327`. Counts come from the benchmark counting allocator and were deterministic across repeated runs.

`streaming_resource_bench`, scale 1000:

| Path | Before allocs / bytes | After allocs / bytes | Output |
|---|---:|---:|---:|
| string | 141 / 31,237 | 127 / 29,488 | 24,152 B |
| streaming one-step | 155 / 44,637 | 141 / 42,888 | 24,152 B |
| streaming one-step POOLED | 148 / 8,893 | 134 / 7,144 | 24,152 B |

The same 14-allocation and 1,749-byte reduction holds at scales 10 and 100. Output remains byte-identical at all scales: 24,114 / 24,134 / 24,152 B.

Nested routes:

| Request path | Before allocs / bytes | After allocs / bytes | Output |
|---|---:|---:|---:|
| `/` | 58 / 8,418 | 49 / 7,662 | 3,366 B |
| `/sections/a` | 86 / 9,944 | 77 / 9,188 | 3,902 B |
| `/sections/a/topics/b` | 107 / 11,388 | 98 / 10,632 | 4,455 B |
| `/sections/a/topics/b/lessons/c` | 138 / 18,121 | 129 / 17,365 | 4,740 B |

Each route output length and checksum is identical before and after.

## Suspension regression checks

The existing benchmark's streaming rows do not encounter a runtime boundary, so they cannot validate state parked across host calls. #517 tracks adding a durable suspending case. This PR was additionally measured with two real `StreamingSession` probes:

| Session path | Before allocs / bytes | After allocs / bytes | Output |
|---|---:|---:|---:|
| Three boundaries with populated scopes | 243 / 25,081 | 243 / 25,081 | 4,940 B |
| VM-owned nested routes delegated to ordinary outlets | 233 / 24,687 | 233 / 24,687 | 2,144 B |

Both paths exactly match the base for allocations, allocated bytes, and output. The nested-route probe specifically covers the borrowed-to-owned transition and caught an intermediate recursive clone before the final move-based implementation restored exact parity.

## Wall time

No speedup is claimed. Separately built release binaries were run in alternating order, n=9 per build and path, with warm-ups. Every distribution overlaps, so the defensible result is **no measurable wall-time regression**.

| Path, wall us/run | Before median [range] | After median [range] |
|---|---:|---:|
| resource string/1000 | 13.02 [12.87-13.76] | 12.85 [12.52-13.15] |
| resource POOLED/1000 | 13.64 [13.56-13.87] | 13.49 [13.08-13.80] |
| deepest ordinary route | 7.300 [7.237-7.391] | 7.179 [7.096-7.350] |
| VM-owned nested streaming route | 11.013 [10.906-11.092] | 11.056 [10.990-11.623] |

RSS is intentionally omitted from the comparison because #516 demonstrates that the current column is multimodal and dominated by fixture construction. Exact allocator counts are unaffected by that issue.

## Validation

- `cargo test -p microsoft-webui-handler`: 457 unit and 36 integration tests passed.
- `cargo xtask check`: full workspace gate passed.
- Added tests for borrowed pointer identity, move-based owned descent, owned session parking, scope-pool retention across suspension, and the `ContinuationVm` to ordinary-render nested outlet path.
- Independent performance review found no remaining correctness, lifetime, or allocation regression.

No public API or behavioral contract changed, so no `DESIGN.md` or developer-doc update is required.

---

Stacked on #511 and targeting `mohamedmansour-reduce-handler-render-allocations`. Review #511 first.