### PR TITLE
fix: render reachable-component ordering deterministically

### DIFF
--- a/crates/webui-handler/src/lib.rs
+++ b/crates/webui-handler/src/lib.rs
@@ -3428,19 +3428,19 @@ impl WebUIHandler {
                 // round-trip. The graph walker follows conditional and loop branches
                 // unconditionally, but only descends into the matched route chain —
                 // components on other routes are delivered via SPA partial navigation.
-                let reachable = context
-                    .reachable_components
-                    .take()
-                    .unwrap_or_else(|| {
-                        crate::route_handler::collect_reachable_component_order_for_request(
-                            context.protocol,
-                            context.entry_id,
-                            context.request_path,
-                            context.route_index,
-                        )
-                    })
-                    .into_iter()
-                    .collect::<HashSet<_>>();
+                // Kept as the traversal-ordered `Vec` produced upstream (already
+                // deduplicated) rather than collected into a `HashSet`: downstream
+                // `<head>` CSS `<link>`/style-module emission order must stay
+                // deterministic across renders, not vary with the process's
+                // randomized hash seed.
+                let reachable = context.reachable_components.take().unwrap_or_else(|| {
+                    crate::route_handler::collect_reachable_component_order_for_request(
+                        context.protocol,
+                        context.entry_id,
+                        context.request_path,
+                        context.route_index,
+                    )
+                });
                 let state_selection =
                     collect_hydration_state(context.protocol, reachable.iter().map(String::as_str));
 
@@ -10114,6 +10114,80 @@ mod tests {
         assert!(
             !html.contains(r#"<script type="importmap""#),
             "Link strategy should not emit CSS module importmaps: {html}"
+        );
+    }
+
+    #[test]
+    fn link_strategy_emits_stylesheets_in_deterministic_document_order() {
+        // Regression: `css_hrefs`/`style_specs` must follow the traversal-ordered
+        // `reachable` list (a `Vec<String>`), never a `HashSet<String>` — whose
+        // iteration order depends on the process's randomized hash seed and can
+        // silently reorder `<link>` tags between renders/process restarts, which
+        // in turn can flip cascade-order-sensitive CSS (e.g. same-specificity
+        // `order`/`position` rules) and move on-page elements around.
+        let mut fragments = HashMap::new();
+        fragments.insert(
+            "index.html".to_string(),
+            FragmentList {
+                fragments: vec![
+                    WebUIFragment::raw("<html><head>".to_string()),
+                    structural_fragment("head_end"),
+                    WebUIFragment::raw(
+                        "</head><body><comp-a></comp-a><comp-b></comp-b><comp-c></comp-c>"
+                            .to_string(),
+                    ),
+                    WebUIFragment::component("comp-a"),
+                    WebUIFragment::component("comp-b"),
+                    WebUIFragment::component("comp-c"),
+                    structural_fragment("body_end"),
+                    WebUIFragment::raw("</body></html>".to_string()),
+                ],
+                contains_boundary: false,
+            },
+        );
+        for tag in ["comp-a", "comp-b", "comp-c"] {
+            fragments.insert(
+                tag.to_string(),
+                FragmentList {
+                    fragments: vec![WebUIFragment::raw(format!("<div>{tag}</div>"))],
+                    contains_boundary: false,
+                },
+            );
+        }
+
+        let mut protocol = WebUIProtocol::new(fragments);
+        protocol.set_css_strategy(webui_protocol::CssStrategy::Link);
+        for tag in ["comp-a", "comp-b", "comp-c"] {
+            let comp = protocol.components.entry(tag.to_string()).or_default();
+            comp.css_href = format!("{tag}.css");
+            comp.template_json = format!(r#"{{"h":"<div>{tag}</div>"}}"#);
+        }
+        protocol.populate_style_closures(&["index.html"]);
+
+        let state = test_json!({});
+        let mut writer = TestWriter::new();
+        handle(
+            &protocol,
+            &state,
+            &RenderOptions::new("index.html", "/"),
+            &mut writer,
+        )
+        .unwrap();
+        let html = writer.get_content();
+
+        let pos_a = html
+            .find(r#"href="comp-a.css""#)
+            .expect("comp-a.css link missing");
+        let pos_b = html
+            .find(r#"href="comp-b.css""#)
+            .expect("comp-b.css link missing");
+        let pos_c = html
+            .find(r#"href="comp-c.css""#)
+            .expect("comp-c.css link missing");
+        assert!(
+            pos_a < pos_b && pos_b < pos_c,
+            "stylesheet <link> tags must follow document/traversal order \
+             (comp-a, comp-b, comp-c), got positions {pos_a}, {pos_b}, {pos_c}: {html}"
         );
     }
 

--- a/crates/webui-handler/src/plugin/mod.rs
+++ b/crates/webui-handler/src/plugin/mod.rs
@@ -12,7 +12,6 @@ pub mod fast_v3;
 pub mod webui;
 
 use crate::{ResponseWriter, Result};
-use std::collections::HashSet;
 use webui_protocol::WebUIProtocol;
 
 /// Split WebUI component template payload used by SSR bootstrap emission.
@@ -29,8 +28,10 @@ pub struct WebUiTemplatePayload<'a> {
 pub struct BootstrapExtensionContext<'a> {
     /// Full protocol for plugins that need additional component metadata.
     pub protocol: &'a WebUIProtocol,
-    /// Route-reachable component tags for this render.
-    pub components: &'a HashSet<String>,
+    /// Route-reachable component tags for this render, in deterministic
+    /// traversal order (not a `HashSet`, whose iteration order varies with
+    /// the process's randomized hash seed).
+    pub components: &'a [String],
     /// Split WebUI template payloads collected for this render.
     pub payloads: &'a [WebUiTemplatePayload<'a>],
     /// CSP nonce for executable scripts, when configured.
@@ -145,7 +146,7 @@ pub trait HandlerPlugin: Send {
     fn emit_templates(
         &self,
         protocol: &WebUIProtocol,
-        components: &HashSet<String>,
+        components: &[String],
         _nonce: Option<&str>,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
@@ -161,7 +162,7 @@ pub trait HandlerPlugin: Send {
     fn collect_template_payloads<'a>(
         &self,
         _protocol: &'a WebUIProtocol,
-        _components: &HashSet<String>,
+        _components: &[String],
     ) -> Option<Vec<WebUiTemplatePayload<'a>>> {
         None
     }
@@ -170,7 +171,7 @@ pub trait HandlerPlugin: Send {
     ///
     /// The streaming checkpoint path captures the exact component tags rendered
     /// since the previous checkpoint as a borrowed `&[&str]`, avoiding the owned
-    /// `HashSet<String>` the ordinary body-end path builds. The default forwards
+    /// `Vec<String>` the ordinary body-end path builds. The default forwards
     /// to [`emit_component_templates_slice`] (verbatim FAST `<f-template>`
     /// emission).
     fn emit_templates_slice(
@@ -200,7 +201,7 @@ pub trait HandlerPlugin: Send {
     /// path, given only the already-collected template payloads.
     ///
     /// Unlike [`HandlerPlugin::emit_bootstrap_extension`], this takes no
-    /// `HashSet<String>` component set — the streaming checkpoint has already
+    /// `Vec<String>` component set — the streaming checkpoint has already
     /// projected the exact per-checkpoint payloads. The default is a no-op.
     fn emit_bootstrap_extension_payloads(
         &self,
@@ -230,7 +231,7 @@ pub trait HandlerPlugin: Send {
 /// Used by FAST parser plugins for `<f-template>` tags.
 pub(crate) fn emit_component_templates(
     protocol: &WebUIProtocol,
-    components: &HashSet<String>,
+    components: &[String],
     writer: &mut dyn ResponseWriter,
 ) -> Result<()> {
     for name in components {

--- a/crates/webui-handler/src/plugin/webui.rs
+++ b/crates/webui-handler/src/plugin/webui.rs
@@ -12,7 +12,6 @@
 
 use super::{BootstrapExtensionContext, HandlerPlugin};
 use crate::{ResponseWriter, Result};
-use std::collections::HashSet;
 use webui_protocol::WebUIProtocol;
 
 const REPEAT_START: &str = "<!--wr-->";
@@ -162,7 +161,7 @@ impl HandlerPlugin for WebUIHydrationPlugin {
     fn emit_templates(
         &self,
         protocol: &WebUIProtocol,
-        components: &HashSet<String>,
+        components: &[String],
         nonce: Option<&str>,
         writer: &mut dyn ResponseWriter,
     ) -> Result<()> {
@@ -188,7 +187,7 @@ impl HandlerPlugin for WebUIHydrationPlugin {
     fn collect_template_payloads<'a>(
         &self,
         protocol: &'a WebUIProtocol,
-        components: &HashSet<String>,
+        components: &[String],
     ) -> Option<Vec<super::WebUiTemplatePayload<'a>>> {
         webui_collect_payloads(protocol, components.iter().map(String::as_str))
     }
@@ -221,7 +220,7 @@ impl HandlerPlugin for WebUIHydrationPlugin {
 
 /// Emit non-split WebUI component templates inside a single `<script>` tag.
 ///
-/// Shared by the `HashSet`-based ordinary path and the `&[&str]`-based streaming
+/// Shared by the ordinary slice-based path and the `&[&str]`-based streaming
 /// path; the lookup-key lifetime `'b` is independent of the protocol so both
 /// callers pass borrowed tags without cloning.
 fn webui_emit_templates<'b>(
@@ -265,7 +264,7 @@ fn webui_emit_templates<'b>(
 /// Collect split WebUI template payloads for the given component tags.
 ///
 /// Returned payloads borrow the protocol (`'a`); the lookup-key lifetime `'b`
-/// is independent so both the `HashSet` and slice callers share this helper.
+/// is independent so both the ordinary slice and streaming callers share this helper.
 fn webui_collect_payloads<'a, 'b>(
     protocol: &'a WebUIProtocol,
     tags: impl Iterator<Item = &'b str>,
@@ -551,8 +550,7 @@ mod tests {
             .or_default()
             .template = iife_template("comp-c", "h:\"c\"");
 
-        let mut components = std::collections::HashSet::new();
-        components.insert("comp-a".to_string());
+        let components = vec!["comp-a".to_string()];
 
         let plugin = WebUIHydrationPlugin::new();
         plugin
@@ -585,7 +583,7 @@ mod tests {
             .entry("comp-a".to_string())
             .or_default()
             .template = iife_template("comp-a", "h:\"a\"");
-        let components = std::collections::HashSet::new();
+        let components: Vec<String> = Vec::new();
         let plugin = WebUIHydrationPlugin::new();
         plugin
             .emit_templates(&protocol, &components, None, &mut writer)
@@ -609,9 +607,7 @@ mod tests {
             .or_default()
             .template = iife_template("comp-b", "h:\"b\"");
 
-        let mut rendered = std::collections::HashSet::new();
-        rendered.insert("comp-a".to_string());
-        rendered.insert("comp-b".to_string());
+        let rendered = vec!["comp-a".to_string(), "comp-b".to_string()];
 
         let plugin = WebUIHydrationPlugin::new();
         plugin
@@ -637,8 +633,7 @@ mod tests {
             .entry("comp-a".to_string())
             .or_default()
             .template = String::new();
-        let mut rendered = std::collections::HashSet::new();
-        rendered.insert("comp-a".to_string());
+        let rendered = vec!["comp-a".to_string()];
         let plugin = WebUIHydrationPlugin::new();
         plugin
             .emit_templates(&protocol, &rendered, None, &mut writer)
@@ -650,8 +645,7 @@ mod tests {
     fn test_on_render_complete_unknown_component() {
         let mut writer = TestWriter::new();
         let protocol = webui_protocol::WebUIProtocol::new(std::collections::HashMap::new());
-        let mut rendered = std::collections::HashSet::new();
-        rendered.insert("nonexistent-comp".to_string());
+        let rendered = vec!["nonexistent-comp".to_string()];
         let plugin = WebUIHydrationPlugin::new();
         plugin
             .emit_templates(&protocol, &rendered, None, &mut writer)


### PR DESCRIPTION
## Problem

Route-reachable components were collected into a `HashSet<String>` before emitting:
- CSS `<link>` hrefs (Link CSS strategy)
- CSS module specifiers (Module CSS strategy)
- Component template payloads / non-split template emission

Rust's `HashSet` iteration order depends on a per-process randomized hash seed (`RandomState`), so this emission order could change between renders / process restarts, even though the underlying data was already deterministic: `collect_reachable_component_order_for_request` already returns a deduplicated, traversal-ordered `Vec<String>` (see its sibling `filter_needed_components` doc comment: "Input order is preserved... so downstream `<head>` CSS `<link>` emission follows document/traversal order").

If two components apply competing same-specificity CSS (`order`, `position`, `float`, etc.) to elements inside a `<for>` loop, cascade resolution flips depending on which stylesheet loaded last — this is the most plausible mechanism for `<for>`-repeated content visually landing in different positions across renders, since the `<for>` reconciliation itself (server `process_*_for_loop` and client `element/diff.ts`) is already fully array-order deterministic.

## Fix

- Keep `reachable` as the traversal-ordered `Vec<String>` already produced upstream instead of collecting it into a `HashSet<String>`.
- Updated `HandlerPlugin::emit_templates`, `HandlerPlugin::collect_template_payloads`, and `BootstrapExtensionContext::components` to take `&[String]` instead of `&HashSet<String>` to match (the streaming checkpoint path already used borrowed slices). This is a minor breaking change to the public `HandlerPlugin` trait for any external plugin implementors; behavior for the two built-in plugins (webui, FAST) is unchanged aside from now-deterministic ordering.
- Updated the WebUI plugin implementation and its unit tests accordingly.
- Added `link_strategy_emits_stylesheets_in_deterministic_document_order`, a regression test asserting stylesheet `<link>` tags follow declared component order.

## Code review checklist (framework change)

Applied the `code-review` skill checklist since this touches `webui-handler` core rendering:
- **Determinism (§2)**: matches the documented anti-pattern/fix directly — "Iterating `HashMap`/`HashSet` for order-dependent logic" → "use insertion order / explicit ordering field." Replaced the `HashSet<String>` with the already-ordered `Vec<String>`.
- **Allocation discipline (§4)**: net allocation *decrease* — removes the `.collect::<HashSet<_>>()` hash-table build entirely; the `&[String]` signature changes are zero-cost slice reborrows, no new clones.
- **Data structure selection (§5)**: order-dependent iteration should use `Vec`/insertion order, not `HashSet` — this fix aligns the code with that rule.
- **Cross-layer parity (§1)**: no client contract change — the client already looks up templates by tag name in a map (`window.__webui.templates[tagName]`), not by array position, so reordering the emitted payloads doesn't affect hydration correctness.

## Testing

- `cargo test -p microsoft-webui-handler` — 454 unit tests + 35 streaming tests pass, including the new regression test.
- `cargo xtask check` — full gate (license-headers, fmt, clippy, deny, test, build, wasm build, examples, docs) passes.


Closes #520

**Status: draft** — pending resolution of reviewer feedback questioning whether this ordering should be a guaranteed contract; see discussion on #520.
