### PR TITLE
Improve benchmark telemetry and dev-server watching

### DIFF
--- a/crates/webui-dev-server/src/watch.rs
+++ b/crates/webui-dev-server/src/watch.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use notify::{
+    event::{AccessKind, AccessMode},
     Event, EventHandler, EventKind, RecommendedWatcher, RecursiveMode, Watcher, WatcherKind,
 };
 use notify_debouncer_mini::{
@@ -38,7 +39,7 @@ impl Watcher for ContentChangeWatcher {
     fn new<F: EventHandler>(mut event_handler: F, config: notify::Config) -> notify::Result<Self> {
         RecommendedWatcher::new(
             move |event| {
-                if matches!(&event, Ok(event) if is_access_event(event)) {
+                if matches!(&event, Ok(event) if is_read_only_access_event(event)) {
                     return;
                 }
                 event_handler.handle_event(event);
@@ -65,8 +66,15 @@ impl Watcher for ContentChangeWatcher {
     }
 }
 
-fn is_access_event(event: &Event) -> bool {
-    matches!(event.kind, EventKind::Access(_))
+fn is_read_only_access_event(event: &Event) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Access(
+            AccessKind::Read
+                | AccessKind::Open(AccessMode::Read)
+                | AccessKind::Close(AccessMode::Read)
+        )
+    )
 }
 
 /// Configuration for [`spawn_watcher`].
@@ -428,13 +436,28 @@ mod tests {
     }
 
     #[test]
-    fn access_events_are_not_content_changes() {
-        use notify::event::{AccessKind, ModifyKind};
+    fn read_only_access_events_are_not_content_changes() {
+        use notify::event::ModifyKind;
 
-        assert!(is_access_event(&Event::new(EventKind::Access(
-            AccessKind::Any
-        ))));
-        assert!(!is_access_event(&Event::new(EventKind::Modify(
+        for kind in [
+            AccessKind::Read,
+            AccessKind::Open(AccessMode::Read),
+            AccessKind::Close(AccessMode::Read),
+        ] {
+            assert!(is_read_only_access_event(&Event::new(EventKind::Access(
+                kind
+            ))));
+        }
+        for kind in [
+            AccessKind::Any,
+            AccessKind::Open(AccessMode::Write),
+            AccessKind::Close(AccessMode::Write),
+        ] {
+            assert!(!is_read_only_access_event(&Event::new(EventKind::Access(
+                kind
+            ))));
+        }
+        assert!(!is_read_only_access_event(&Event::new(EventKind::Modify(
             ModifyKind::Any
         ))));
     }

--- a/crates/webui-dev-server/src/watch.rs
+++ b/crates/webui-dev-server/src/watch.rs
@@ -16,9 +16,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use notify::RecommendedWatcher;
-use notify::RecursiveMode;
-use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+use notify::{
+    Event, EventHandler, EventKind, RecommendedWatcher, RecursiveMode, Watcher, WatcherKind,
+};
+use notify_debouncer_mini::{
+    new_debouncer_opt, Config as DebouncerConfig, DebounceEventResult, Debouncer,
+};
 
 /// Owns the watcher background thread. Drop to stop watching.
 ///
@@ -26,7 +29,44 @@ use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 /// debouncer struct; dropping the struct kills the thread. Consumers
 /// should hold this handle for the lifetime of their server.
 pub struct WatcherHandle {
-    _debouncer: Debouncer<RecommendedWatcher>,
+    _debouncer: Debouncer<ContentChangeWatcher>,
+}
+
+struct ContentChangeWatcher(RecommendedWatcher);
+
+impl Watcher for ContentChangeWatcher {
+    fn new<F: EventHandler>(mut event_handler: F, config: notify::Config) -> notify::Result<Self> {
+        RecommendedWatcher::new(
+            move |event| {
+                if matches!(&event, Ok(event) if is_access_event(event)) {
+                    return;
+                }
+                event_handler.handle_event(event);
+            },
+            config,
+        )
+        .map(Self)
+    }
+
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> notify::Result<()> {
+        self.0.watch(path, recursive_mode)
+    }
+
+    fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+        self.0.unwatch(path)
+    }
+
+    fn configure(&mut self, config: notify::Config) -> notify::Result<bool> {
+        self.0.configure(config)
+    }
+
+    fn kind() -> WatcherKind {
+        RecommendedWatcher::kind()
+    }
+}
+
+fn is_access_event(event: &Event) -> bool {
+    matches!(event.kind, EventKind::Access(_))
 }
 
 /// Configuration for [`spawn_watcher`].
@@ -100,39 +140,52 @@ where
     let mut content_hashes: HashMap<PathBuf, u64> = HashMap::new();
     let retry_unchanged_when = cfg.retry_unchanged_when.clone();
     let explicit_filter = explicit_files.clone();
-    let mut debouncer = new_debouncer(cfg.debounce, move |res: DebounceEventResult| match res {
-        Ok(events) => {
-            // Filter out ignored paths and dedupe (notify can emit
-            // duplicate events for the same path within a window).
-            let mut paths: Vec<PathBuf> = Vec::with_capacity(events.len());
-            let mut seen: HashSet<PathBuf> = HashSet::with_capacity(events.len());
-            for e in events {
-                if should_ignore_event(&e.path, &ignore, &explicit_filter) {
-                    continue;
+    let notify_config = notify::Config::default().with_follow_symlinks(false);
+    let debouncer_config = DebouncerConfig::default()
+        .with_timeout(cfg.debounce)
+        .with_notify_config(notify_config);
+    let mut debouncer = new_debouncer_opt::<_, ContentChangeWatcher>(
+        debouncer_config,
+        move |res: DebounceEventResult| match res {
+            Ok(events) => {
+                // Filter out ignored paths and dedupe (notify can emit
+                // duplicate events for the same path within a window).
+                let mut paths: Vec<PathBuf> = Vec::with_capacity(events.len());
+                let mut seen: HashSet<PathBuf> = HashSet::with_capacity(events.len());
+                for e in events {
+                    if should_ignore_event(&e.path, &ignore, &explicit_filter) {
+                        continue;
+                    }
+                    if seen.insert(e.path.clone()) {
+                        paths.push(e.path);
+                    }
                 }
-                if seen.insert(e.path.clone()) {
-                    paths.push(e.path);
+                // Recursive backends emit directory metadata events alongside
+                // file writes. Existing directories are not source changes and
+                // would otherwise retrigger a rebuild after every build; keep
+                // missing paths so directory/file deletions still rebuild.
+                paths.retain(|path| !path.is_dir());
+                // Drop paths whose content is byte-identical to the last event.
+                // Editors fire a write on every Ctrl+S even when nothing changed;
+                // rebuilding then is pure wasted work, so a no-op save triggers no
+                // rebuild at all in the clean state. When the caller reports that a
+                // rebuild error is active, unchanged events are allowed through so a
+                // no-op save can retry transient failures. Deletions and oversized
+                // files always count as changed (see `content_changed`).
+                let retry_unchanged = retry_unchanged_when
+                    .as_ref()
+                    .is_some_and(|predicate| predicate());
+                paths
+                    .retain(|path| should_forward_path(&mut content_hashes, path, retry_unchanged));
+                if !paths.is_empty() {
+                    on_event(paths);
                 }
             }
-            // Drop paths whose content is byte-identical to the last event.
-            // Editors fire a write on every Ctrl+S even when nothing changed;
-            // rebuilding then is pure wasted work, so a no-op save triggers no
-            // rebuild at all in the clean state. When the caller reports that a
-            // rebuild error is active, unchanged events are allowed through so a
-            // no-op save can retry transient failures. Deletions and oversized
-            // files always count as changed (see `content_changed`).
-            let retry_unchanged = retry_unchanged_when
-                .as_ref()
-                .is_some_and(|predicate| predicate());
-            paths.retain(|path| should_forward_path(&mut content_hashes, path, retry_unchanged));
-            if !paths.is_empty() {
-                on_event(paths);
+            Err(e) => {
+                eprintln!("watcher error: {e:?}");
             }
-        }
-        Err(e) => {
-            eprintln!("watcher error: {e:?}");
-        }
-    })
+        },
+    )
     .context("Cannot start file watcher")?;
 
     let mut watched_roots = Vec::with_capacity(cfg.paths.len());
@@ -221,7 +274,12 @@ fn is_ignored(event_path: &Path, ignore: &[PathBuf]) -> bool {
         let only_one_component = components.next().is_none();
         if let (Some(first), true) = (first, only_one_component) {
             let name = first.as_os_str();
-            if candidate.components().any(|c| c.as_os_str() == name) {
+            // Check the lexical event path before its canonical form. pnpm
+            // dependencies are symlinks, so canonicalization removes the
+            // `node_modules` component that identifies the ignored subtree.
+            if event_path.components().any(|c| c.as_os_str() == name)
+                || candidate.components().any(|c| c.as_os_str() == name)
+            {
                 return true;
             }
         } else if candidate.starts_with(root) {
@@ -367,6 +425,39 @@ mod tests {
         ));
         assert!(is_ignored(Path::new("/repo/.git/HEAD"), &ignore));
         assert!(!is_ignored(Path::new("/repo/src/index.ts"), &ignore));
+    }
+
+    #[test]
+    fn access_events_are_not_content_changes() {
+        use notify::event::{AccessKind, ModifyKind};
+
+        assert!(is_access_event(&Event::new(EventKind::Access(
+            AccessKind::Any
+        ))));
+        assert!(!is_access_event(&Event::new(EventKind::Modify(
+            ModifyKind::Any
+        ))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_ignored_matches_node_modules_symlink_path() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let package = dir.path().join("packages/example");
+        let node_modules = dir.path().join("node_modules");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::create_dir(&node_modules).unwrap();
+        std::fs::write(package.join("index.js"), "export {};").unwrap();
+        symlink(&package, node_modules.join("example")).unwrap();
+
+        let linked_file = node_modules.join("example/index.js");
+        let canonical = std::fs::canonicalize(&linked_file).unwrap();
+        assert!(!canonical
+            .components()
+            .any(|component| component.as_os_str() == "node_modules"));
+        assert!(is_ignored(&linked_file, &[PathBuf::from("node_modules")]));
     }
 
     #[test]

--- a/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.css
+++ b/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.css
@@ -128,16 +128,50 @@
 
 .benchmark-bars {
   display: grid;
-  gap: 10px;
+  gap: 0;
   margin-top: var(--docs-space-xl);
+}
+
+.benchmark-telemetry-header {
+  display: grid;
+  grid-template-columns: 2.5ch minmax(145px, 0.9fr) minmax(120px, 1.35fr) minmax(96px, auto);
+  gap: 12px;
+  margin-top: var(--docs-space-xl);
+  padding: 0 0 6px;
+  border-bottom: 1px solid var(--docs-color-border);
+}
+
+.benchmark-telemetry-header + .benchmark-bars {
+  margin-top: 0;
+}
+
+.benchmark-telemetry-header-values {
+  display: grid;
+  grid-column: 2 / -1;
+  grid-template-columns: repeat(2, minmax(88px, max-content)) 76px;
+  justify-content: end;
+  gap: var(--docs-space-m);
+  color: var(--docs-color-text-3);
+  font-size: var(--docs-font-size-xs);
+  text-align: right;
+}
+
+.benchmark-telemetry-header-values small {
+  font-size: inherit;
+  font-weight: var(--docs-font-weight-normal);
 }
 
 .benchmark-row {
   display: grid;
   grid-template-columns: 2.5ch minmax(145px, 0.9fr) minmax(120px, 1.35fr) minmax(96px, auto);
-  gap: 12px;
+  gap: 7px 12px;
   align-items: center;
   min-height: 42px;
+  padding: 10px 0;
+}
+
+.benchmark-row + .benchmark-row {
+  border-top: 1px solid var(--docs-color-border);
 }
 
 .benchmark-rank {
@@ -149,23 +183,11 @@
 }
 
 .benchmark-label {
-  display: grid;
-  gap: 2px;
   min-width: 0;
   color: var(--docs-color-text-2);
   font-size: var(--docs-font-size-s);
   font-weight: var(--docs-font-weight-medium);
   line-height: 1.25;
-}
-
-.benchmark-label small {
-  overflow: hidden;
-  color: var(--docs-color-text-3);
-  font-family: var(--docs-font-mono);
-  font-size: var(--docs-font-size-xs);
-  font-weight: var(--docs-font-weight-normal);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .benchmark-track {
@@ -195,6 +217,228 @@
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
+}
+
+.benchmark-server-telemetry {
+  display: grid;
+  grid-column: 2 / -1;
+  grid-template-columns: minmax(0, 1fr) 76px;
+  gap: var(--docs-space-m);
+  align-items: start;
+  min-width: 0;
+}
+
+.benchmark-memory-summary {
+  display: grid;
+  grid-row: 1;
+  grid-column: 1;
+  grid-template-columns: repeat(2, minmax(88px, max-content));
+  gap: var(--docs-space-m);
+  justify-content: end;
+  min-width: 0;
+  margin: 0;
+  font-family: var(--docs-font-mono);
+  font-size: var(--docs-font-size-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.benchmark-server-stat {
+  display: flex;
+  gap: 0.35em;
+  align-items: baseline;
+  color: var(--docs-color-text-3);
+  white-space: nowrap;
+}
+
+.benchmark-server-stat strong {
+  color: var(--docs-color-text-2);
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.benchmark-server-stat small {
+  font-size: 9px;
+}
+
+.benchmark-telemetry-details {
+  min-width: 0;
+  color: var(--docs-color-text-3);
+  font-size: var(--docs-font-size-xs);
+}
+
+.benchmark-telemetry-details[open] {
+  grid-column: 1 / -1;
+}
+
+.benchmark-server-details {
+  display: grid;
+  grid-row: 1;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1fr) 76px;
+  pointer-events: none;
+}
+
+.benchmark-server-details summary {
+  grid-row: 1;
+  grid-column: 2;
+  pointer-events: auto;
+}
+
+.benchmark-server-details .benchmark-detail-panel {
+  grid-row: 2;
+  grid-column: 1 / -1;
+  pointer-events: auto;
+}
+
+.benchmark-metric-details {
+  grid-column: 2 / -1;
+  justify-self: end;
+}
+
+.benchmark-metric-details[open] {
+  grid-column: 2 / -1;
+  justify-self: stretch;
+}
+
+.benchmark-telemetry-details summary {
+  cursor: pointer;
+  text-align: right;
+}
+
+.benchmark-telemetry-details summary:hover {
+  color: var(--docs-color-text-2);
+}
+
+.benchmark-telemetry-details summary:focus-visible {
+  outline: 2px solid var(--docs-color-brand);
+  outline-offset: 2px;
+}
+
+.benchmark-detail-panel {
+  margin: var(--docs-space-s) 0 0;
+  padding: var(--docs-space-m) var(--docs-space-l) var(--docs-space-l);
+  background: var(--docs-color-bg-alt);
+  border: 1px solid var(--docs-color-border);
+  border-radius: 4px;
+}
+
+.benchmark-run-profile {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0;
+  margin: 0;
+  font-size: var(--docs-font-size-xs);
+  line-height: 1.5;
+}
+
+.benchmark-detail-part {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: var(--docs-space-xs) var(--docs-space-m);
+  border-left: 1px solid var(--docs-color-border);
+}
+
+.benchmark-detail-part:first-child {
+  padding-left: 0;
+  border-left: 0;
+}
+
+.benchmark-run-profile[data-enhanced] > .benchmark-detail-fallback {
+  display: none;
+}
+
+.benchmark-run-profile[data-enhanced] > .benchmark-detail-generated:nth-child(2) {
+  padding-left: 0;
+  border-left: 0;
+}
+
+.benchmark-detail-part-wide {
+  grid-column: 1 / -1;
+  padding-right: 0;
+  padding-left: 0;
+  border-top: 1px solid var(--docs-color-border);
+  border-left: 0;
+}
+
+.benchmark-detail-part-wide:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.benchmark-run-profile dt {
+  color: var(--docs-color-text-3);
+  font-weight: var(--docs-font-weight-medium);
+}
+
+.benchmark-run-profile dd {
+  margin: 0;
+  color: var(--docs-color-text);
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.benchmark-detail-heading {
+  display: flex;
+  gap: var(--docs-space-s);
+  justify-content: space-between;
+  align-items: baseline;
+  margin: var(--docs-space-m) 0 var(--docs-space-s);
+  padding-top: var(--docs-space-m);
+  border-top: 1px solid var(--docs-color-border);
+  color: var(--docs-color-text);
+  font-size: var(--docs-font-size-xs);
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.benchmark-lifecycle-values {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0;
+  margin: 0;
+  font-family: var(--docs-font-mono);
+  font-size: var(--docs-font-size-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.benchmark-lifecycle-values > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: var(--docs-space-xs) var(--docs-space-m);
+  border-left: 1px solid var(--docs-color-border);
+}
+
+.benchmark-lifecycle-values > div:first-child {
+  padding-left: 0;
+  border-left: 0;
+}
+
+.benchmark-lifecycle-values dt {
+  color: var(--docs-color-text-3);
+}
+
+.benchmark-lifecycle-values dd {
+  margin: 0;
+  color: var(--docs-color-text);
+  font-size: var(--docs-font-size-s);
+  font-weight: var(--docs-font-weight-semibold);
+}
+
+.benchmark-telemetry-unavailable {
+  grid-column: 1 / -1;
+  min-width: 0;
+  margin: 0;
+  color: var(--docs-color-text-3);
+  font-family: var(--docs-font-mono);
+  font-size: var(--docs-font-size-xs);
+  line-height: 1.35;
+}
+
+.benchmark-telemetry-unavailable strong {
+  color: var(--docs-color-text-2);
+}
+
+.benchmark-telemetry-unavailable span {
+  margin-left: 0.45em;
 }
 
 .benchmark-unavailable {
@@ -238,6 +482,11 @@
     grid-template-columns: 2.5ch minmax(118px, 0.8fr) minmax(80px, 1fr) minmax(90px, auto);
     gap: var(--docs-space-s);
   }
+
+  .benchmark-telemetry-header {
+    grid-template-columns: 2.5ch minmax(118px, 0.8fr) minmax(80px, 1fr) minmax(90px, auto);
+    gap: var(--docs-space-s);
+  }
 }
 
 @media (max-width: 600px) {
@@ -257,6 +506,60 @@
 
   .benchmark-value {
     grid-column: 3;
+  }
+
+  .benchmark-telemetry-header {
+    display: none;
+  }
+
+  .benchmark-telemetry-header + .benchmark-bars {
+    margin-top: var(--docs-space-xl);
+  }
+
+  .benchmark-server-telemetry {
+    grid-row: 3;
+    grid-column: 2 / -1;
+  }
+
+  .benchmark-metric-details {
+    grid-row: 3;
+    grid-column: 2 / -1;
+  }
+
+  .benchmark-memory-summary {
+    gap: var(--docs-space-s);
+  }
+
+  .benchmark-server-stat {
+    display: grid;
+    gap: 1px;
+    text-align: right;
+  }
+
+  .benchmark-lifecycle-values {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .benchmark-lifecycle-values > div {
+    padding: var(--docs-space-s) 0;
+    border-top: 1px solid var(--docs-color-border);
+    border-left: 0;
+  }
+
+  .benchmark-lifecycle-values > div:nth-child(-n + 2) {
+    border-top: 0;
+  }
+
+  .benchmark-lifecycle-values > div:nth-child(even) {
+    padding-left: var(--docs-space-m);
+    border-left: 1px solid var(--docs-color-border);
+  }
+
+  .benchmark-telemetry-unavailable span {
+    display: block;
+    margin-top: 0.2em;
+    overflow: visible;
+    white-space: normal;
   }
 }
 

--- a/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.html
+++ b/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.html
@@ -33,6 +33,18 @@
     </div>
   </div>
 
+  <if
+    condition="benchmarks.selectedMetric == 'noStreamingRequestsPerSecond' || benchmarks.selectedMetric == 'streamingRequestsPerSecond'"
+  >
+    <div class="benchmark-telemetry-header" aria-hidden="true">
+      <div class="benchmark-telemetry-header-values">
+        <span>Peak RSS <small>MiB</small></span>
+        <span>CPU / req <small>ms</small></span>
+        <span></span>
+      </div>
+    </div>
+  </if>
+
   <div class="benchmark-bars" role="list" aria-label="{{benchmarks.selectedMetricLabel}} ranking">
     <for each="row in benchmarks.rows">
       <div
@@ -41,10 +53,7 @@
         aria-label="{{row.rank}}. {{row.label}}, {{row.activeDetail}}: {{row.activeValueDisplay}} {{row.activeUnit}}"
       >
         <span class="benchmark-rank" aria-hidden="true">{{row.rank}}</span>
-        <span class="benchmark-label">
-          <span>{{row.label}}</span>
-          <small>{{row.activeDetail}}</small>
-        </span>
+        <span class="benchmark-label">{{row.label}}</span>
         <span class="benchmark-track" aria-hidden="true">
           <if condition="row.activeAvailable">
             <if condition="row.primary">
@@ -56,6 +65,190 @@
           </if>
         </span>
         <span class="benchmark-value">{{row.activeValueDisplay}} {{row.activeUnit}}</span>
+
+        <if condition="benchmarks.selectedMetric == 'noStreamingRequestsPerSecond'">
+          <div class="benchmark-server-telemetry">
+            <if condition="row.metrics.noStreamingRequestsPerSecond.serverTelemetry.available">
+              <div class="benchmark-memory-summary">
+                <span class="benchmark-server-stat">
+                  <span>Peak</span>
+                  <strong>
+                    {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.peakRssBytes.valueDisplay}}
+                  </strong>
+                  <small>MiB</small>
+                </span>
+                <span class="benchmark-server-stat">
+                  <span>CPU</span>
+                  <strong>
+                    {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.valueDisplay}}
+                  </strong>
+                  <small>ms/req</small>
+                </span>
+              </div>
+              <details class="benchmark-telemetry-details benchmark-server-details">
+                <summary>Details</summary>
+                <div class="benchmark-detail-panel">
+                  <dl class="benchmark-run-profile" data-benchmark-detail>
+                    <div
+                      class="benchmark-detail-part benchmark-detail-part-wide benchmark-detail-fallback"
+                    >
+                      <dt>Benchmark data</dt>
+                      <dd>{{row.activeDetail}}</dd>
+                    </div>
+                  </dl>
+                  <p class="benchmark-detail-heading">Server resource lifecycle</p>
+                  <dl class="benchmark-lifecycle-values" aria-label="Server resource lifecycle">
+                    <div>
+                      <dt>Startup</dt>
+                      <dd>
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.startupRssBytes.valueDisplay}}
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.startupRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Post-warmup</dt>
+                      <dd>
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.postWarmupRssBytes.valueDisplay}}
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.postWarmupRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Peak</dt>
+                      <dd>
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.peakRssBytes.valueDisplay}}
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.peakRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Post-settle</dt>
+                      <dd>
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.postSettleRssBytes.valueDisplay}}
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.postSettleRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>CPU / request</dt>
+                      <dd>
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.valueDisplay}}
+                        {{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.unit}}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </details>
+            </if>
+            <if condition="!row.metrics.noStreamingRequestsPerSecond.serverTelemetry.available">
+              <p
+                class="benchmark-telemetry-unavailable"
+                title="{{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.reason}}"
+              >
+                <strong>Server telemetry unavailable</strong>
+                <span>{{row.metrics.noStreamingRequestsPerSecond.serverTelemetry.reason}}</span>
+              </p>
+            </if>
+          </div>
+        </if>
+
+        <if condition="benchmarks.selectedMetric == 'streamingRequestsPerSecond'">
+          <div class="benchmark-server-telemetry">
+            <if condition="row.metrics.streamingRequestsPerSecond.serverTelemetry.available">
+              <div class="benchmark-memory-summary">
+                <span class="benchmark-server-stat">
+                  <span>Peak</span>
+                  <strong>
+                    {{row.metrics.streamingRequestsPerSecond.serverTelemetry.peakRssBytes.valueDisplay}}
+                  </strong>
+                  <small>MiB</small>
+                </span>
+                <span class="benchmark-server-stat">
+                  <span>CPU</span>
+                  <strong>
+                    {{row.metrics.streamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.valueDisplay}}
+                  </strong>
+                  <small>ms/req</small>
+                </span>
+              </div>
+              <details class="benchmark-telemetry-details benchmark-server-details">
+                <summary>Details</summary>
+                <div class="benchmark-detail-panel">
+                  <dl class="benchmark-run-profile" data-benchmark-detail>
+                    <div
+                      class="benchmark-detail-part benchmark-detail-part-wide benchmark-detail-fallback"
+                    >
+                      <dt>Benchmark data</dt>
+                      <dd>{{row.activeDetail}}</dd>
+                    </div>
+                  </dl>
+                  <p class="benchmark-detail-heading">Server resource lifecycle</p>
+                  <dl class="benchmark-lifecycle-values" aria-label="Server resource lifecycle">
+                    <div>
+                      <dt>Startup</dt>
+                      <dd>
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.startupRssBytes.valueDisplay}}
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.startupRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Post-warmup</dt>
+                      <dd>
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.postWarmupRssBytes.valueDisplay}}
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.postWarmupRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Peak</dt>
+                      <dd>
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.peakRssBytes.valueDisplay}}
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.peakRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Post-settle</dt>
+                      <dd>
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.postSettleRssBytes.valueDisplay}}
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.postSettleRssBytes.unit}}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>CPU / request</dt>
+                      <dd>
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.valueDisplay}}
+                        {{row.metrics.streamingRequestsPerSecond.serverTelemetry.cpuMillisecondsPerRequest.unit}}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </details>
+            </if>
+            <if condition="!row.metrics.streamingRequestsPerSecond.serverTelemetry.available">
+              <p
+                class="benchmark-telemetry-unavailable"
+                title="{{row.metrics.streamingRequestsPerSecond.serverTelemetry.reason}}"
+              >
+                <strong>Server telemetry unavailable</strong>
+                <span>{{row.metrics.streamingRequestsPerSecond.serverTelemetry.reason}}</span>
+              </p>
+            </if>
+          </div>
+        </if>
+
+        <if
+          condition="benchmarks.selectedMetric != 'noStreamingRequestsPerSecond' && benchmarks.selectedMetric != 'streamingRequestsPerSecond'"
+        >
+          <details class="benchmark-telemetry-details benchmark-metric-details">
+            <summary>Details</summary>
+            <div class="benchmark-detail-panel">
+              <dl class="benchmark-run-profile" data-benchmark-detail>
+                <div
+                  class="benchmark-detail-part benchmark-detail-part-wide benchmark-detail-fallback"
+                >
+                  <dt>Benchmark data</dt>
+                  <dd>{{row.activeDetail}}</dd>
+                </div>
+              </dl>
+            </div>
+          </details>
+        </if>
       </div>
     </for>
   </div>

--- a/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.ts
+++ b/docs/.webui-press/components/benchmark-explorer/benchmark-explorer.ts
@@ -46,16 +46,67 @@ interface BenchmarkData {
   rows: BenchmarkRow[];
 }
 
+interface BenchmarkDetailPart {
+  label: string;
+  value: string;
+  wide: boolean;
+}
+
 const EMPTY_DATA: BenchmarkData = {
   methodology: "",
   link: "",
-  selectedMetric: "requestsPerSecond",
+  selectedMetric: "noStreamingRequestsPerSecond",
   selectedMetricLabel: "",
   selectedMetricDescription: "",
   hasUnavailable: false,
   metrics: [],
   rows: [],
 };
+
+const DETAIL_SEPARATOR = " · ";
+const MAD_PREFIX = "MAD ";
+const P95_PREFIX = "p95 ";
+const SATURATION_PREFIX = "saturation warning: ";
+
+function benchmarkDetailParts(detail: string): BenchmarkDetailPart[] {
+  const segments = detail.split(DETAIL_SEPARATOR);
+  return segments.map((segment, index) => {
+    if (segment.startsWith(MAD_PREFIX)) {
+      return {
+        label: "Variability (MAD)",
+        value: segment.slice(MAD_PREFIX.length),
+        wide: false,
+      };
+    }
+    if (segment.startsWith(P95_PREFIX)) {
+      return {
+        label: "Tail latency (p95)",
+        value: segment.slice(P95_PREFIX.length),
+        wide: false,
+      };
+    }
+    if (segment.startsWith(SATURATION_PREFIX)) {
+      return {
+        label: "Saturation warning",
+        value: segment.slice(SATURATION_PREFIX.length),
+        wide: true,
+      };
+    }
+    if (segment.includes(" B natural")) {
+      return { label: "Response size", value: segment, wide: false };
+    }
+    if (segment.includes(" isolated runs")) {
+      return { label: "Samples", value: segment, wide: false };
+    }
+    if (segments.length >= 5 && index === 0) {
+      return { label: "Renderer", value: segment, wide: false };
+    }
+    if (segments.length >= 5 && index === 1) {
+      return { label: "Server", value: segment, wide: false };
+    }
+    return { label: "Benchmark data", value: segment, wide: false };
+  });
+}
 
 function metricValue(row: BenchmarkRow, metricId: string): MetricValue {
   return row.metrics[metricId] ?? {
@@ -125,6 +176,11 @@ function rankedRows(
 export class BenchmarkExplorer extends WebUIElement {
   @observable benchmarks: BenchmarkData = EMPTY_DATA;
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.enhanceBenchmarkDetails();
+  }
+
   selectMetric(event: Event): void {
     const target = event.currentTarget;
     if (!(target instanceof HTMLButtonElement)) return;
@@ -152,6 +208,49 @@ export class BenchmarkExplorer extends WebUIElement {
       metrics,
       rows,
     };
+    this.$flushUpdates();
+    this.enhanceBenchmarkDetails();
+  }
+
+  private enhanceBenchmarkDetails(): void {
+    const profiles = this.shadowRoot?.querySelectorAll<HTMLElement>(
+      "[data-benchmark-detail]",
+    );
+    if (!profiles) return;
+
+    for (const profile of profiles) {
+      const detail = profile
+        .querySelector(".benchmark-detail-fallback dd")
+        ?.textContent
+        ?.trim();
+      if (!detail) continue;
+
+      for (
+        const generated of profile.querySelectorAll(
+          ".benchmark-detail-generated",
+        )
+      ) {
+        generated.remove();
+      }
+
+      const fragment = document.createDocumentFragment();
+      for (const part of benchmarkDetailParts(detail)) {
+        const group = document.createElement("div");
+        group.className = part.wide
+          ? "benchmark-detail-part benchmark-detail-part-wide benchmark-detail-generated"
+          : "benchmark-detail-part benchmark-detail-generated";
+
+        const term = document.createElement("dt");
+        term.textContent = part.label;
+        const description = document.createElement("dd");
+        description.textContent = part.value;
+        group.append(term, description);
+        fragment.append(group);
+      }
+
+      profile.append(fragment);
+      profile.dataset.enhanced = "true";
+    }
   }
 }
 

--- a/docs/.webui-press/state/benchmark-summary.json
+++ b/docs/.webui-press/state/benchmark-summary.json
@@ -1,16 +1,16 @@
 {
   "benchmarks": {
     "asyncDataBoundary": {
-      "canonicalWebuiVersion": "0.0.27",
-      "notes": "The progressive suite continues to measure each product's existing native progressive/streaming boundaries unchanged. A dedicated above-the-fold-shell / below-the-fold-async-list workload driven by WebUI's resumable StreamingSession boundary API is intentionally not implemented against canonical WebUI 0.0.27, because that API is not part of this release. This is disclosed capability metadata, not an active measurement.",
+      "canonicalWebuiVersion": "0.0.28",
+      "notes": "The progressive suite continues to measure each product's existing native progressive/streaming boundaries unchanged. A dedicated above-the-fold-shell / below-the-fold-async-list workload driven by WebUI's resumable StreamingSession boundary API is intentionally not implemented yet against canonical WebUI 0.0.28. This is disclosed capability metadata, not an active measurement.",
       "requiredCapability": "StreamingSession resumable async data-boundary API",
-      "status": "deferred-pending-webui-release"
+      "status": "available-pending-benchmark-implementation"
     },
     "description": "Compare the same product workload in complete and progressive response modes, then inspect the three browser cost metrics that matter most.",
     "hasUnavailable": false,
     "link": "/webui/guide/concepts/performance/",
     "methodology": "100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes",
-    "metricSummary": "WebUI / Light DOM / Rust / Actix records the highest median, 26.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 314.25 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 345.5% higher; the 1,175.1 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Nuxt, WebUI / Node node:http, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
+    "metricSummary": "WebUI / Light DOM / Rust / Actix records the highest median, 26.3% ahead of WebUI / Shadow DOM / Rust / Actix; the 331.75 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 399.0% higher; the 1,274.05 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Astro + Preact, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
     "metrics": [
       {
         "available": true,
@@ -21,7 +21,7 @@
         "label": "No Streaming RPS",
         "methodology": "100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes",
         "selected": true,
-        "summary": "WebUI / Light DOM / Rust / Actix records the highest median, 26.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 314.25 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 345.5% higher; the 1,175.1 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Nuxt, WebUI / Node node:http, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
+        "summary": "WebUI / Light DOM / Rust / Actix records the highest median, 26.3% ahead of WebUI / Shadow DOM / Rust / Actix; the 331.75 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 399.0% higher; the 1,274.05 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Astro + Preact, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
         "unit": "req/s"
       },
       {
@@ -33,7 +33,7 @@
         "label": "Streaming RPS",
         "methodology": "100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes",
         "selected": false,
-        "summary": "WebUI / Light DOM / Rust / Actix records the highest median, 26.8% ahead of WebUI / Shadow DOM / Rust / Actix; the 247.7 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, Preact, WebUI / Light DOM / Rust / Actix is 201.2% higher; the 782.7 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for WebUI / Node node:http; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
+        "summary": "WebUI / Light DOM / Rust / Actix records the highest median, 27.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 296.7 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, Preact, WebUI / Light DOM / Rust / Actix is 282.6% higher; the 1,025.55 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Next.js, WebUI / Light DOM / Node node:http, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.",
         "unit": "req/s"
       },
       {
@@ -43,9 +43,9 @@
         "directionLabel": "lower is better",
         "id": "largestContentfulPaintMs",
         "label": "LCP",
-        "methodology": "Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
+        "methodology": "Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
         "selected": false,
-        "summary": "WebUI / Bun.serve and WebUI / Light DOM / Rust / Actix have the same median; the measured ordering is tied.",
+        "summary": "WebUI / Light DOM / Deno.serve records the lowest median, 3.0% below WebUI / Light DOM / Bun.serve; the 2 ms gap is within their combined 6 ms MAD, so the measured ordering overlaps run noise.",
         "unit": "ms"
       },
       {
@@ -55,9 +55,9 @@
         "directionLabel": "lower is better",
         "id": "jsHeapUsedBytes",
         "label": "JS Heap",
-        "methodology": "Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
+        "methodology": "Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
         "selected": false,
-        "summary": "WebUI / Deno.serve records the lowest median, 0.0% below WebUI / Light DOM / Rust / Actix; the <0.01 MiB gap exceeds their combined <0.01 MiB MAD.",
+        "summary": "WebUI / Light DOM / Deno.serve records the lowest median, 0.0% below WebUI / Light DOM / Bun.serve; the <0.01 MiB gap is within their combined <0.01 MiB MAD, so the measured ordering overlaps run noise.",
         "unit": "MiB"
       },
       {
@@ -67,51 +67,277 @@
         "directionLabel": "lower is better",
         "id": "rendererPrivateBytes",
         "label": "Renderer Private MB",
-        "methodology": "Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
+        "methodology": "Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling",
         "selected": false,
-        "summary": "WebUI / Bun.serve records the lowest median, 2.0% below WebUI / Node node:http; the 0.82 MiB gap is within their combined 1.87 MiB MAD, so the measured ordering overlaps run noise.",
+        "summary": "WebUI / Light DOM / Bun.serve records the lowest median, 0.7% below WebUI / Light DOM / Node node:http; the 0.41 MiB gap is within their combined 1.57 MiB MAD, so the measured ordering overlaps run noise.",
         "unit": "MiB"
       }
     ],
     "rows": [
       {
         "activeAvailable": true,
-        "activeDetail": "webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 45.01 ms · 329,988-330,685 B natural",
+        "activeDetail": "webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 44.81 ms · 329,202-329,899 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "1,515.25",
+        "activeValueDisplay": "1,593.4",
         "activeWidth": "100.0%",
         "caseId": "webui-rust-actix",
         "label": "WebUI / Light DOM / Rust / Actix",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 45.01 ms · 329,988-330,685 B natural",
-            "value": 1515.25,
-            "valueDisplay": "1,515.25"
+            "detail": "webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 44.81 ms · 329,202-329,899 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 0.63 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 0.6279025982176478,
+                  "median": 0.6279025982176478,
+                  "min": 0.6279025982176478,
+                  "p95": 0.6279025982176478
+                },
+                "unit": "ms/req",
+                "value": 0.6279025982176478,
+                "valueDisplay": "0.63"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 59.84 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 62746624,
+                  "median": 62746624,
+                  "min": 62746624,
+                  "p95": 62746624
+                },
+                "unit": "MiB",
+                "value": 62746624,
+                "valueDisplay": "59.84"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 128.12 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 134340608,
+                  "median": 134340608,
+                  "min": 134340608,
+                  "p95": 134340608
+                },
+                "unit": "MiB",
+                "value": 134340608,
+                "valueDisplay": "128.12"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 128.12 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 134340608,
+                  "median": 134340608,
+                  "min": 134340608,
+                  "p95": 134340608
+                },
+                "unit": "MiB",
+                "value": 134340608,
+                "valueDisplay": "128.12"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 105.77 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 110911488,
+                  "median": 110911488,
+                  "min": 110911488,
+                  "p95": 110911488
+                },
+                "unit": "MiB",
+                "value": 110911488,
+                "valueDisplay": "105.77"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 59.84 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 62746624,
+                  "median": 62746624,
+                  "min": 62746624,
+                  "p95": 62746624
+                },
+                "unit": "MiB",
+                "value": 62746624,
+                "valueDisplay": "59.84"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 68.28 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 71593984,
+                  "median": 71593984,
+                  "min": 71593984,
+                  "p95": 71593984
+                },
+                "unit": "MiB",
+                "value": 71593984,
+                "valueDisplay": "68.28"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 1593.4,
+            "valueDisplay": "1,593.4"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler StreamingResponse (Rust) · actix-web · MAD 0 req/s · p95 55.38 ms · 337,914-338,643 B natural",
-            "value": 1171.6999999999998,
-            "valueDisplay": "1,171.7"
+            "detail": "webui-handler StreamingResponse (Rust) · actix-web · MAD 0 req/s · p95 50.87 ms · 337,114-337,843 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 0.72 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 0.7184270229392488,
+                  "median": 0.7184270229392488,
+                  "min": 0.7184270229392488,
+                  "p95": 0.7184270229392488
+                },
+                "unit": "ms/req",
+                "value": 0.7184270229392488,
+                "valueDisplay": "0.72"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 40.76 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 42741760,
+                  "median": 42741760,
+                  "min": 42741760,
+                  "p95": 42741760
+                },
+                "unit": "MiB",
+                "value": 42741760,
+                "valueDisplay": "40.76"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 128.97 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 135233536,
+                  "median": 135233536,
+                  "min": 135233536,
+                  "p95": 135233536
+                },
+                "unit": "MiB",
+                "value": 135233536,
+                "valueDisplay": "128.97"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 128.97 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 135233536,
+                  "median": 135233536,
+                  "min": 135233536,
+                  "p95": 135233536
+                },
+                "unit": "MiB",
+                "value": 135233536,
+                "valueDisplay": "128.97"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 114.37 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 119922688,
+                  "median": 119922688,
+                  "min": 119922688,
+                  "p95": 119922688
+                },
+                "unit": "MiB",
+                "value": 119922688,
+                "valueDisplay": "114.37"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 40.76 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 42741760,
+                  "median": 42741760,
+                  "min": 42741760,
+                  "p95": 42741760
+                },
+                "unit": "MiB",
+                "value": 42741760,
+                "valueDisplay": "40.76"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 88.21 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 92491776,
+                  "median": 92491776,
+                  "min": 92491776,
+                  "p95": 92491776
+                },
+                "unit": "MiB",
+                "value": 92491776,
+                "valueDisplay": "88.21"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 1388.45,
+            "valueDisplay": "1,388.45"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 140 ms",
-            "value": 140,
-            "valueDisplay": "140"
+            "detail": "10 isolated runs · MAD 4 ms · p95 76 ms",
+            "value": 68,
+            "valueDisplay": "68"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.16 MiB",
-            "value": 2188984,
-            "valueDisplay": "2.09"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB",
+            "value": 2204666,
+            "valueDisplay": "2.1"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.29 MiB · p95 46.73 MiB",
-            "value": 44687360,
-            "valueDisplay": "42.62"
+            "detail": "10 isolated runs · MAD 0.74 MiB · p95 61.62 MiB",
+            "value": 61323264,
+            "valueDisplay": "58.48"
           }
         },
         "primary": true,
@@ -119,42 +345,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 56.54 ms · 483,598-485,019 B natural",
+        "activeDetail": "webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 55.55 ms · 483,598-485,019 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "1,201",
-        "activeWidth": "79.3%",
+        "activeValueDisplay": "1,261.65",
+        "activeWidth": "79.2%",
         "caseId": "webui-shadowdom-rust-actix",
         "label": "WebUI / Shadow DOM / Rust / Actix",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 56.54 ms · 483,598-485,019 B natural",
-            "value": 1201,
-            "valueDisplay": "1,201"
+            "detail": "webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 55.55 ms · 483,598-485,019 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 0.79 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 0.7938017675266517,
+                  "median": 0.7938017675266517,
+                  "min": 0.7938017675266517,
+                  "p95": 0.7938017675266517
+                },
+                "unit": "ms/req",
+                "value": 0.7938017675266517,
+                "valueDisplay": "0.79"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 103.65 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 108683264,
+                  "median": 108683264,
+                  "min": 108683264,
+                  "p95": 108683264
+                },
+                "unit": "MiB",
+                "value": 108683264,
+                "valueDisplay": "103.65"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 153.42 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 160874496,
+                  "median": 160874496,
+                  "min": 160874496,
+                  "p95": 160874496
+                },
+                "unit": "MiB",
+                "value": 160874496,
+                "valueDisplay": "153.42"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 145.42 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 152485888,
+                  "median": 152485888,
+                  "min": 152485888,
+                  "p95": 152485888
+                },
+                "unit": "MiB",
+                "value": 152485888,
+                "valueDisplay": "145.42"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 115.77 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 121389056,
+                  "median": 121389056,
+                  "min": 121389056,
+                  "p95": 121389056
+                },
+                "unit": "MiB",
+                "value": 121389056,
+                "valueDisplay": "115.77"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 95.65 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 100294656,
+                  "median": 100294656,
+                  "min": 100294656,
+                  "p95": 100294656
+                },
+                "unit": "MiB",
+                "value": 100294656,
+                "valueDisplay": "95.65"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 49.77 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 52191232,
+                  "median": 52191232,
+                  "min": 52191232,
+                  "p95": 52191232
+                },
+                "unit": "MiB",
+                "value": 52191232,
+                "valueDisplay": "49.77"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 1261.65,
+            "valueDisplay": "1,261.65"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler StreamingResponse (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 70.59 ms · 491,524-492,977 B natural",
-            "value": 924,
-            "valueDisplay": "924"
+            "detail": "webui-handler StreamingResponse (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 65.06 ms · 491,524-492,977 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 0.91 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 0.9132127318525304,
+                  "median": 0.9132127318525304,
+                  "min": 0.9132127318525304,
+                  "p95": 0.9132127318525304
+                },
+                "unit": "ms/req",
+                "value": 0.9132127318525304,
+                "valueDisplay": "0.91"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 69.07 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 72425472,
+                  "median": 72425472,
+                  "min": 72425472,
+                  "p95": 72425472
+                },
+                "unit": "MiB",
+                "value": 72425472,
+                "valueDisplay": "69.07"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 150.58 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 157892608,
+                  "median": 157892608,
+                  "min": 157892608,
+                  "p95": 157892608
+                },
+                "unit": "MiB",
+                "value": 157892608,
+                "valueDisplay": "150.58"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 148.65 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 155869184,
+                  "median": 155869184,
+                  "min": 155869184,
+                  "p95": 155869184
+                },
+                "unit": "MiB",
+                "value": 155869184,
+                "valueDisplay": "148.65"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 120.67 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 126529536,
+                  "median": 126529536,
+                  "min": 126529536,
+                  "p95": 126529536
+                },
+                "unit": "MiB",
+                "value": 126529536,
+                "valueDisplay": "120.67"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 67.14 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 70402048,
+                  "median": 70402048,
+                  "min": 70402048,
+                  "p95": 70402048
+                },
+                "unit": "MiB",
+                "value": 70402048,
+                "valueDisplay": "67.14"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 81.51 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 85467136,
+                  "median": 85467136,
+                  "min": 85467136,
+                  "p95": 85467136
+                },
+                "unit": "MiB",
+                "value": 85467136,
+                "valueDisplay": "81.51"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 1091.75,
+            "valueDisplay": "1,091.75"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 172 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 8 ms · p95 116 ms",
+            "value": 84,
+            "valueDisplay": "84"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.43 MiB",
-            "value": 2545576,
-            "valueDisplay": "2.43"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.45 MiB",
+            "value": 2568326,
+            "valueDisplay": "2.45"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.57 MiB · p95 49.15 MiB",
-            "value": 48629760,
-            "valueDisplay": "46.38"
+            "detail": "10 isolated runs · MAD 0.76 MiB · p95 67 MiB",
+            "value": 68249600,
+            "valueDisplay": "65.09"
           }
         },
         "primary": true,
@@ -162,42 +614,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.38 ms · 596,601-598,231 B natural",
+        "activeDetail": "webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.13 ms · 596,601-598,231 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "926.7",
-        "activeWidth": "61.2%",
+        "activeValueDisplay": "976.75",
+        "activeWidth": "61.3%",
         "caseId": "webui-fast-rust-actix",
         "label": "WebUI / FAST V3 / Rust / Actix",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.38 ms · 596,601-598,231 B natural",
-            "value": 926.7,
-            "valueDisplay": "926.7"
+            "detail": "webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.13 ms · 596,601-598,231 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 1.03 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 1.0258510366009725,
+                  "median": 1.0258510366009725,
+                  "min": 1.0258510366009725,
+                  "p95": 1.0258510366009725
+                },
+                "unit": "ms/req",
+                "value": 1.0258510366009725,
+                "valueDisplay": "1.03"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 71.73 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 75210752,
+                  "median": 75210752,
+                  "min": 75210752,
+                  "p95": 75210752
+                },
+                "unit": "MiB",
+                "value": 75210752,
+                "valueDisplay": "71.73"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 133.2 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 139673600,
+                  "median": 139673600,
+                  "min": 139673600,
+                  "p95": 139673600
+                },
+                "unit": "MiB",
+                "value": 139673600,
+                "valueDisplay": "133.2"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 124.18 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 130211840,
+                  "median": 130211840,
+                  "min": 130211840,
+                  "p95": 130211840
+                },
+                "unit": "MiB",
+                "value": 130211840,
+                "valueDisplay": "124.18"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 133.2 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 139673600,
+                  "median": 139673600,
+                  "min": 139673600,
+                  "p95": 139673600
+                },
+                "unit": "MiB",
+                "value": 139673600,
+                "valueDisplay": "133.2"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 62.7 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 65748992,
+                  "median": 65748992,
+                  "min": 65748992,
+                  "p95": 65748992
+                },
+                "unit": "MiB",
+                "value": 65748992,
+                "valueDisplay": "62.7"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 61.48 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 64462848,
+                  "median": 64462848,
+                  "min": 64462848,
+                  "p95": 64462848
+                },
+                "unit": "MiB",
+                "value": 64462848,
+                "valueDisplay": "61.48"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 976.75,
+            "valueDisplay": "976.75"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "webui-handler chunked ResponseWriter (Rust, FAST V3) · actix-web · MAD 0 req/s · p95 153.22 ms · 596,601-598,231 B natural",
-            "value": 433.25,
-            "valueDisplay": "433.25"
+            "detail": "webui-handler chunked ResponseWriter (Rust, FAST V3) · actix-web · MAD 0 req/s · p95 108.43 ms · 596,601-598,231 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 1.6 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 1.5975385598977063,
+                  "median": 1.5975385598977063,
+                  "min": 1.5975385598977063,
+                  "p95": 1.5975385598977063
+                },
+                "unit": "ms/req",
+                "value": 1.5975385598977063,
+                "valueDisplay": "1.6"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 85.7 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 89862144,
+                  "median": 89862144,
+                  "min": 89862144,
+                  "p95": 89862144
+                },
+                "unit": "MiB",
+                "value": 89862144,
+                "valueDisplay": "85.7"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 156.61 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 164216832,
+                  "median": 164216832,
+                  "min": 164216832,
+                  "p95": 164216832
+                },
+                "unit": "MiB",
+                "value": 164216832,
+                "valueDisplay": "156.61"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 149.77 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 157048832,
+                  "median": 157048832,
+                  "min": 157048832,
+                  "p95": 157048832
+                },
+                "unit": "MiB",
+                "value": 157048832,
+                "valueDisplay": "149.77"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 154.93 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 162455552,
+                  "median": 162455552,
+                  "min": 162455552,
+                  "p95": 162455552
+                },
+                "unit": "MiB",
+                "value": 162455552,
+                "valueDisplay": "154.93"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 78.86 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 82694144,
+                  "median": 82694144,
+                  "min": 82694144,
+                  "p95": 82694144
+                },
+                "unit": "MiB",
+                "value": 82694144,
+                "valueDisplay": "78.86"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 70.91 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 74354688,
+                  "median": 74354688,
+                  "min": 74354688,
+                  "p95": 74354688
+                },
+                "unit": "MiB",
+                "value": 74354688,
+                "valueDisplay": "70.91"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 625.6500000000001,
+            "valueDisplay": "625.65"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 156 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 6 ms · p95 104 ms",
+            "value": 88,
+            "valueDisplay": "88"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 5.15 MiB",
-            "value": 5390702,
-            "valueDisplay": "5.14"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 5.24 MiB",
+            "value": 5478080,
+            "valueDisplay": "5.22"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.48 MiB · p95 59.16 MiB",
-            "value": 57163776,
-            "valueDisplay": "54.52"
+            "detail": "10 isolated runs · MAD 0.3 MiB · p95 71.79 MiB",
+            "value": 73490432,
+            "valueDisplay": "70.09"
           }
         },
         "primary": true,
@@ -205,42 +883,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 180.93 ms · 329,988-330,685 B natural",
+        "activeDetail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 127.89 ms · 329,202-329,899 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "590.9",
-        "activeWidth": "39.0%",
-        "caseId": "webui-deno-serve",
-        "label": "WebUI / Deno.serve",
+        "activeValueDisplay": "609.45",
+        "activeWidth": "38.2%",
+        "caseId": "webui-node-http",
+        "label": "WebUI / Light DOM / Node node:http",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 180.93 ms · 329,988-330,685 B natural",
-            "value": 590.9000000000001,
-            "valueDisplay": "590.9"
+            "detail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 127.89 ms · 329,202-329,899 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 1.64 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 1.6449257527278693,
+                  "median": 1.6449257527278693,
+                  "min": 1.6449257527278693,
+                  "p95": 1.6449257527278693
+                },
+                "unit": "ms/req",
+                "value": 1.6449257527278693,
+                "valueDisplay": "1.64"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 86.57 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 90779648,
+                  "median": 90779648,
+                  "min": 90779648,
+                  "p95": 90779648
+                },
+                "unit": "MiB",
+                "value": 90779648,
+                "valueDisplay": "86.57"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 382.15 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 400711680,
+                  "median": 400711680,
+                  "min": 400711680,
+                  "p95": 400711680
+                },
+                "unit": "MiB",
+                "value": 400711680,
+                "valueDisplay": "382.15"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 355.75 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 373026816,
+                  "median": 373026816,
+                  "min": 373026816,
+                  "p95": 373026816
+                },
+                "unit": "MiB",
+                "value": 373026816,
+                "valueDisplay": "355.75"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 362.34 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 379936768,
+                  "median": 379936768,
+                  "min": 379936768,
+                  "p95": 379936768
+                },
+                "unit": "MiB",
+                "value": 379936768,
+                "valueDisplay": "362.34"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 60.17 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 63094784,
+                  "median": 63094784,
+                  "min": 63094784,
+                  "p95": 63094784
+                },
+                "unit": "MiB",
+                "value": 63094784,
+                "valueDisplay": "60.17"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 295.57 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 309932032,
+                  "median": 309932032,
+                  "min": 309932032,
+                  "p95": 309932032
+                },
+                "unit": "MiB",
+                "value": 309932032,
+                "valueDisplay": "295.57"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 609.45,
+            "valueDisplay": "609.45"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 193.58 ms · 337,914-338,643 B natural",
-            "value": 505.54999999999995,
-            "valueDisplay": "505.55"
+            "detail": "@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 189.99 ms · 337,114-337,843 B natural · saturation warning: the 128-connection probe was 6.0% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 2.31 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 2.3086661295891355,
+                  "median": 2.3086661295891355,
+                  "min": 2.3086661295891355,
+                  "p95": 2.3086661295891355
+                },
+                "unit": "ms/req",
+                "value": 2.3086661295891355,
+                "valueDisplay": "2.31"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 217.42 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 227983360,
+                  "median": 227983360,
+                  "min": 227983360,
+                  "p95": 227983360
+                },
+                "unit": "MiB",
+                "value": 227983360,
+                "valueDisplay": "217.42"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 558.25 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 585367552,
+                  "median": 585367552,
+                  "min": 585367552,
+                  "p95": 585367552
+                },
+                "unit": "MiB",
+                "value": 585367552,
+                "valueDisplay": "558.25"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 556.28 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 583303168,
+                  "median": 583303168,
+                  "min": 583303168,
+                  "p95": 583303168
+                },
+                "unit": "MiB",
+                "value": 583303168,
+                "valueDisplay": "556.28"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 512.17 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 537051136,
+                  "median": 537051136,
+                  "min": 537051136,
+                  "p95": 537051136
+                },
+                "unit": "MiB",
+                "value": 537051136,
+                "valueDisplay": "512.17"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 215.45 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 225918976,
+                  "median": 225918976,
+                  "min": 225918976,
+                  "p95": 225918976
+                },
+                "unit": "MiB",
+                "value": 225918976,
+                "valueDisplay": "215.45"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 340.83 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 357384192,
+                  "median": 357384192,
+                  "min": 357384192,
+                  "p95": 357384192
+                },
+                "unit": "MiB",
+                "value": 357384192,
+                "valueDisplay": "340.83"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 434.45,
+            "valueDisplay": "434.45"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 6 ms · p95 256 ms",
-            "value": 146,
-            "valueDisplay": "146"
+            "detail": "10 isolated runs · MAD 4 ms · p95 100 ms",
+            "value": 66,
+            "valueDisplay": "66"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.16 MiB",
-            "value": 2187908,
-            "valueDisplay": "2.09"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB",
+            "value": 2203760,
+            "valueDisplay": "2.1"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.67 MiB · p95 46.13 MiB",
-            "value": 44328960,
-            "valueDisplay": "42.28"
+            "detail": "10 isolated runs · MAD 0.74 MiB · p95 60.96 MiB",
+            "value": 60893184,
+            "valueDisplay": "58.07"
           }
         },
         "primary": true,
@@ -248,42 +1152,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 122.7 ms · 329,988-330,685 B natural",
+        "activeDetail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 142.74 ms · 329,202-329,899 B natural · saturation warning: the 128-connection probe was 8.5% faster",
         "activeUnit": "req/s",
-        "activeValueDisplay": "577.65",
-        "activeWidth": "38.1%",
+        "activeValueDisplay": "563.3",
+        "activeWidth": "35.4%",
         "caseId": "webui-bun-serve",
-        "label": "WebUI / Bun.serve",
+        "label": "WebUI / Light DOM / Bun.serve",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 122.7 ms · 329,988-330,685 B natural",
-            "value": 577.6500000000001,
-            "valueDisplay": "577.65"
+            "detail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 142.74 ms · 329,202-329,899 B natural · saturation warning: the 128-connection probe was 8.5% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 1.78 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 1.7814663589561512,
+                  "median": 1.7814663589561512,
+                  "min": 1.7814663589561512,
+                  "p95": 1.7814663589561512
+                },
+                "unit": "ms/req",
+                "value": 1.7814663589561512,
+                "valueDisplay": "1.78"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 82.29 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 86282240,
+                  "median": 86282240,
+                  "min": 86282240,
+                  "p95": 86282240
+                },
+                "unit": "MiB",
+                "value": 86282240,
+                "valueDisplay": "82.29"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 160.53 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 168329216,
+                  "median": 168329216,
+                  "min": 168329216,
+                  "p95": 168329216
+                },
+                "unit": "MiB",
+                "value": 168329216,
+                "valueDisplay": "160.53"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 127.52 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 133713920,
+                  "median": 133713920,
+                  "min": 133713920,
+                  "p95": 133713920
+                },
+                "unit": "MiB",
+                "value": 133713920,
+                "valueDisplay": "127.52"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 130.56 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 136904704,
+                  "median": 136904704,
+                  "min": 136904704,
+                  "p95": 136904704
+                },
+                "unit": "MiB",
+                "value": 136904704,
+                "valueDisplay": "130.56"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 49.27 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 51666944,
+                  "median": 51666944,
+                  "min": 51666944,
+                  "p95": 51666944
+                },
+                "unit": "MiB",
+                "value": 51666944,
+                "valueDisplay": "49.27"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 78.25 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 82046976,
+                  "median": 82046976,
+                  "min": 82046976,
+                  "p95": 82046976
+                },
+                "unit": "MiB",
+                "value": 82046976,
+                "valueDisplay": "78.25"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 563.3,
+            "valueDisplay": "563.3"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 154.83 ms · 337,914-338,643 B natural",
-            "value": 460,
-            "valueDisplay": "460"
+            "detail": "@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 167.96 ms · 337,114-337,843 B natural · saturation warning: the 128-connection probe was 9.3% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 2.18 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 2.179904513888889,
+                  "median": 2.179904513888889,
+                  "min": 2.179904513888889,
+                  "p95": 2.179904513888889
+                },
+                "unit": "ms/req",
+                "value": 2.179904513888889,
+                "valueDisplay": "2.18"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 167.33 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 175460352,
+                  "median": 175460352,
+                  "min": 175460352,
+                  "p95": 175460352
+                },
+                "unit": "MiB",
+                "value": 175460352,
+                "valueDisplay": "167.33"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 273.53 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 286814208,
+                  "median": 286814208,
+                  "min": 286814208,
+                  "p95": 286814208
+                },
+                "unit": "MiB",
+                "value": 286814208,
+                "valueDisplay": "273.53"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 254.84 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 267214848,
+                  "median": 267214848,
+                  "min": 267214848,
+                  "p95": 267214848
+                },
+                "unit": "MiB",
+                "value": 267214848,
+                "valueDisplay": "254.84"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 239.35 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 250978304,
+                  "median": 250978304,
+                  "min": 250978304,
+                  "p95": 250978304
+                },
+                "unit": "MiB",
+                "value": 250978304,
+                "valueDisplay": "239.35"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 148.64 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 155860992,
+                  "median": 155860992,
+                  "min": 155860992,
+                  "p95": 155860992
+                },
+                "unit": "MiB",
+                "value": 155860992,
+                "valueDisplay": "148.64"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 106.2 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 111353856,
+                  "median": 111353856,
+                  "min": 111353856,
+                  "p95": 111353856
+                },
+                "unit": "MiB",
+                "value": 111353856,
+                "valueDisplay": "106.2"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 460.8,
+            "valueDisplay": "460.8"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 240 ms",
-            "value": 140,
-            "valueDisplay": "140"
+            "detail": "10 isolated runs · MAD 2 ms · p95 76 ms",
+            "value": 66,
+            "valueDisplay": "66"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.03 MiB · p95 2.16 MiB",
-            "value": 2224312,
-            "valueDisplay": "2.12"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB",
+            "value": 2203604,
+            "valueDisplay": "2.1"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.81 MiB · p95 43.59 MiB",
-            "value": 43337728,
-            "valueDisplay": "41.33"
+            "detail": "10 isolated runs · MAD 0.83 MiB · p95 61.82 MiB",
+            "value": 60465152,
+            "valueDisplay": "57.66"
           }
         },
         "primary": true,
@@ -291,42 +1421,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 148.25 ms · 329,988-330,685 B natural · saturation warning: the 128-connection probe was 16.1% faster",
+        "activeDetail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 147.18 ms · 329,202-329,899 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "458.5",
-        "activeWidth": "30.3%",
-        "caseId": "webui-node-http",
-        "label": "WebUI / Node node:http",
+        "activeValueDisplay": "554.6",
+        "activeWidth": "34.8%",
+        "caseId": "webui-deno-serve",
+        "label": "WebUI / Light DOM / Deno.serve",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.render (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 148.25 ms · 329,988-330,685 B natural · saturation warning: the 128-connection probe was 16.1% faster",
-            "value": 458.5,
-            "valueDisplay": "458.5"
+            "detail": "@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 147.18 ms · 329,202-329,899 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 1.81 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 1.8085106382978724,
+                  "median": 1.8085106382978724,
+                  "min": 1.8085106382978724,
+                  "p95": 1.8085106382978724
+                },
+                "unit": "ms/req",
+                "value": 1.8085106382978724,
+                "valueDisplay": "1.81"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 157.83 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 165498880,
+                  "median": 165498880,
+                  "min": 165498880,
+                  "p95": 165498880
+                },
+                "unit": "MiB",
+                "value": 165498880,
+                "valueDisplay": "157.83"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 276.41 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 289832960,
+                  "median": 289832960,
+                  "min": 289832960,
+                  "p95": 289832960
+                },
+                "unit": "MiB",
+                "value": 289832960,
+                "valueDisplay": "276.41"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 225.35 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 236298240,
+                  "median": 236298240,
+                  "min": 236298240,
+                  "p95": 236298240
+                },
+                "unit": "MiB",
+                "value": 236298240,
+                "valueDisplay": "225.35"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 268.82 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 281874432,
+                  "median": 281874432,
+                  "min": 281874432,
+                  "p95": 281874432
+                },
+                "unit": "MiB",
+                "value": 281874432,
+                "valueDisplay": "268.82"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 106.78 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 111964160,
+                  "median": 111964160,
+                  "min": 111964160,
+                  "p95": 111964160
+                },
+                "unit": "MiB",
+                "value": 111964160,
+                "valueDisplay": "106.78"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 118.57 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 124334080,
+                  "median": 124334080,
+                  "min": 124334080,
+                  "p95": 124334080
+                },
+                "unit": "MiB",
+                "value": 124334080,
+                "valueDisplay": "118.57"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 554.6,
+            "valueDisplay": "554.6"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 200 ms · 337,914-338,643 B natural · saturation warning: the 128-connection probe was 13.1% faster",
-            "value": 370.35,
-            "valueDisplay": "370.35"
+            "detail": "@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 242.37 ms · 337,114-337,843 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 2.4 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 2.4037536092396534,
+                  "median": 2.4037536092396534,
+                  "min": 2.4037536092396534,
+                  "p95": 2.4037536092396534
+                },
+                "unit": "ms/req",
+                "value": 2.4037536092396534,
+                "valueDisplay": "2.4"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 235.63 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 247070720,
+                  "median": 247070720,
+                  "min": 247070720,
+                  "p95": 247070720
+                },
+                "unit": "MiB",
+                "value": 247070720,
+                "valueDisplay": "235.63"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 384.94 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 403640320,
+                  "median": 403640320,
+                  "min": 403640320,
+                  "p95": 403640320
+                },
+                "unit": "MiB",
+                "value": 403640320,
+                "valueDisplay": "384.94"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 373.33 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 391467008,
+                  "median": 391467008,
+                  "min": 391467008,
+                  "p95": 391467008
+                },
+                "unit": "MiB",
+                "value": 391467008,
+                "valueDisplay": "373.33"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 318.46 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 333934592,
+                  "median": 333934592,
+                  "min": 333934592,
+                  "p95": 333934592
+                },
+                "unit": "MiB",
+                "value": 333934592,
+                "valueDisplay": "318.46"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 224.02 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 234897408,
+                  "median": 234897408,
+                  "min": 234897408,
+                  "p95": 234897408
+                },
+                "unit": "MiB",
+                "value": 234897408,
+                "valueDisplay": "224.02"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 149.32 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 156569600,
+                  "median": 156569600,
+                  "min": 156569600,
+                  "p95": 156569600
+                },
+                "unit": "MiB",
+                "value": 156569600,
+                "valueDisplay": "149.32"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 415.6,
+            "valueDisplay": "415.6"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 8 ms · p95 156 ms",
-            "value": 148,
-            "valueDisplay": "148"
+            "detail": "10 isolated runs · MAD 4 ms · p95 76 ms",
+            "value": 64,
+            "valueDisplay": "64"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.03 MiB · p95 2.16 MiB",
-            "value": 2224806,
-            "valueDisplay": "2.12"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB",
+            "value": 2203584,
+            "valueDisplay": "2.1"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.06 MiB · p95 46.46 MiB",
-            "value": 44199936,
-            "valueDisplay": "42.15"
+            "detail": "10 isolated runs · MAD 1.55 MiB · p95 61.57 MiB",
+            "value": 62160896,
+            "valueDisplay": "59.28"
           }
         },
         "primary": true,
@@ -334,42 +1690,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "react-dom/server renderToString · node:http · MAD 0 req/s · p95 224.44 ms · 334,118-334,824 B natural",
+        "activeDetail": "react-dom/server renderToString · node:http · MAD 0 req/s · p95 235.72 ms · 334,118-334,824 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "340.15",
-        "activeWidth": "22.4%",
+        "activeValueDisplay": "319.35",
+        "activeWidth": "20.0%",
         "caseId": "react",
         "label": "React",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "react-dom/server renderToString · node:http · MAD 0 req/s · p95 224.44 ms · 334,118-334,824 B natural",
-            "value": 340.15,
-            "valueDisplay": "340.15"
+            "detail": "react-dom/server renderToString · node:http · MAD 0 req/s · p95 235.72 ms · 334,118-334,824 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 3.13 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 3.129794895882261,
+                  "median": 3.129794895882261,
+                  "min": 3.129794895882261,
+                  "p95": 3.129794895882261
+                },
+                "unit": "ms/req",
+                "value": 3.129794895882261,
+                "valueDisplay": "3.13"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 70.85 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 74293248,
+                  "median": 74293248,
+                  "min": 74293248,
+                  "p95": 74293248
+                },
+                "unit": "MiB",
+                "value": 74293248,
+                "valueDisplay": "70.85"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 382.64 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 401227776,
+                  "median": 401227776,
+                  "min": 401227776,
+                  "p95": 401227776
+                },
+                "unit": "MiB",
+                "value": 401227776,
+                "valueDisplay": "382.64"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 353.81 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 370999296,
+                  "median": 370999296,
+                  "min": 370999296,
+                  "p95": 370999296
+                },
+                "unit": "MiB",
+                "value": 370999296,
+                "valueDisplay": "353.81"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 301.49 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 316137472,
+                  "median": 316137472,
+                  "min": 316137472,
+                  "p95": 316137472
+                },
+                "unit": "MiB",
+                "value": 316137472,
+                "valueDisplay": "301.49"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 42.02 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 44064768,
+                  "median": 44064768,
+                  "min": 44064768,
+                  "p95": 44064768
+                },
+                "unit": "MiB",
+                "value": 44064768,
+                "valueDisplay": "42.02"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 311.79 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 326934528,
+                  "median": 326934528,
+                  "min": 326934528,
+                  "p95": 326934528
+                },
+                "unit": "MiB",
+                "value": 326934528,
+                "valueDisplay": "311.79"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 319.35,
+            "valueDisplay": "319.35"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "react-dom/server renderToReadableStream · node:http · MAD 0 req/s · p95 323.74 ms · 334,118-334,824 B natural",
-            "value": 249.85,
-            "valueDisplay": "249.85"
+            "detail": "react-dom/server renderToReadableStream · node:http · MAD 0 req/s · p95 252.8 ms · 334,118-334,824 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 3.74 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 3.7371663244353184,
+                  "median": 3.7371663244353184,
+                  "min": 3.7371663244353184,
+                  "p95": 3.7371663244353184
+                },
+                "unit": "ms/req",
+                "value": 3.7371663244353184,
+                "valueDisplay": "3.74"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 294.4 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 308703232,
+                  "median": 308703232,
+                  "min": 308703232,
+                  "p95": 308703232
+                },
+                "unit": "MiB",
+                "value": 308703232,
+                "valueDisplay": "294.4"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 585.79 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 614244352,
+                  "median": 614244352,
+                  "min": 614244352,
+                  "p95": 614244352
+                },
+                "unit": "MiB",
+                "value": 614244352,
+                "valueDisplay": "585.79"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 587.95 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 616509440,
+                  "median": 616509440,
+                  "min": 616509440,
+                  "p95": 616509440
+                },
+                "unit": "MiB",
+                "value": 616509440,
+                "valueDisplay": "587.95"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 311.67 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 326811648,
+                  "median": 326811648,
+                  "min": 326811648,
+                  "p95": 326811648
+                },
+                "unit": "MiB",
+                "value": 326811648,
+                "valueDisplay": "311.67"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 296.56 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 310968320,
+                  "median": 310968320,
+                  "min": 310968320,
+                  "p95": 310968320
+                },
+                "unit": "MiB",
+                "value": 310968320,
+                "valueDisplay": "296.56"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 291.39 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 305541120,
+                  "median": 305541120,
+                  "min": 305541120,
+                  "p95": 305541120
+                },
+                "unit": "MiB",
+                "value": 305541120,
+                "valueDisplay": "291.39"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 267.85,
+            "valueDisplay": "267.85"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 172 ms",
-            "value": 172,
-            "valueDisplay": "172"
+            "detail": "10 isolated runs · MAD 4 ms · p95 88 ms",
+            "value": 84,
+            "valueDisplay": "84"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.9 MiB",
-            "value": 3041670,
-            "valueDisplay": "2.9"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.92 MiB",
+            "value": 3060656,
+            "valueDisplay": "2.92"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.46 MiB · p95 51.02 MiB",
-            "value": 49543168,
-            "valueDisplay": "47.25"
+            "detail": "10 isolated runs · MAD 0.24 MiB · p95 65.33 MiB",
+            "value": 66816000,
+            "valueDisplay": "63.72"
           }
         },
         "primary": false,
@@ -377,42 +1959,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 216.6 ms · 333,940-334,646 B natural",
+        "activeDetail": "preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 228.15 ms · 333,940-334,646 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "338.4",
-        "activeWidth": "22.3%",
+        "activeValueDisplay": "317.6",
+        "activeWidth": "19.9%",
         "caseId": "preact",
         "label": "Preact",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 216.6 ms · 333,940-334,646 B natural",
-            "value": 338.4,
-            "valueDisplay": "338.4"
+            "detail": "preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 228.15 ms · 333,940-334,646 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 3.15 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 3.1533375314861463,
+                  "median": 3.1533375314861463,
+                  "min": 3.1533375314861463,
+                  "p95": 3.1533375314861463
+                },
+                "unit": "ms/req",
+                "value": 3.1533375314861463,
+                "valueDisplay": "3.15"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 86.63 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 90836992,
+                  "median": 90836992,
+                  "min": 90836992,
+                  "p95": 90836992
+                },
+                "unit": "MiB",
+                "value": 90836992,
+                "valueDisplay": "86.63"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 375.95 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 394215424,
+                  "median": 394215424,
+                  "min": 394215424,
+                  "p95": 394215424
+                },
+                "unit": "MiB",
+                "value": 394215424,
+                "valueDisplay": "375.95"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 365.94 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 383717376,
+                  "median": 383717376,
+                  "min": 383717376,
+                  "p95": 383717376
+                },
+                "unit": "MiB",
+                "value": 383717376,
+                "valueDisplay": "365.94"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 328.78 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 344748032,
+                  "median": 344748032,
+                  "min": 344748032,
+                  "p95": 344748032
+                },
+                "unit": "MiB",
+                "value": 344748032,
+                "valueDisplay": "328.78"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 76.62 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 80338944,
+                  "median": 80338944,
+                  "min": 80338944,
+                  "p95": 80338944
+                },
+                "unit": "MiB",
+                "value": 80338944,
+                "valueDisplay": "76.62"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 289.32 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 303378432,
+                  "median": 303378432,
+                  "min": 303378432,
+                  "p95": 303378432
+                },
+                "unit": "MiB",
+                "value": 303378432,
+                "valueDisplay": "289.32"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 317.6,
+            "valueDisplay": "317.6"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "preact-render-to-string renderToReadableStream · node:http · MAD 0 req/s · p95 191.35 ms · 333,940-334,646 B natural",
-            "value": 389,
-            "valueDisplay": "389"
+            "detail": "preact-render-to-string renderToReadableStream · node:http · MAD 0 req/s · p95 208.25 ms · 333,940-334,646 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 2.75 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 2.754202259575641,
+                  "median": 2.754202259575641,
+                  "min": 2.754202259575641,
+                  "p95": 2.754202259575641
+                },
+                "unit": "ms/req",
+                "value": 2.754202259575641,
+                "valueDisplay": "2.75"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 62.54 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 65576960,
+                  "median": 65576960,
+                  "min": 65576960,
+                  "p95": 65576960
+                },
+                "unit": "MiB",
+                "value": 65576960,
+                "valueDisplay": "62.54"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 354.59 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 371818496,
+                  "median": 371818496,
+                  "min": 371818496,
+                  "p95": 371818496
+                },
+                "unit": "MiB",
+                "value": 371818496,
+                "valueDisplay": "354.59"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 339.33 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 355815424,
+                  "median": 355815424,
+                  "min": 355815424,
+                  "p95": 355815424
+                },
+                "unit": "MiB",
+                "value": 355815424,
+                "valueDisplay": "339.33"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 309.59 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 324624384,
+                  "median": 324624384,
+                  "min": 324624384,
+                  "p95": 324624384
+                },
+                "unit": "MiB",
+                "value": 324624384,
+                "valueDisplay": "309.59"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 47.28 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 49573888,
+                  "median": 49573888,
+                  "min": 49573888,
+                  "p95": 49573888
+                },
+                "unit": "MiB",
+                "value": 49573888,
+                "valueDisplay": "47.28"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 292.05 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 306241536,
+                  "median": 306241536,
+                  "min": 306241536,
+                  "p95": 306241536
+                },
+                "unit": "MiB",
+                "value": 306241536,
+                "valueDisplay": "292.05"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 362.9,
+            "valueDisplay": "362.9"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 8 ms · p95 172 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 2 ms · p95 88 ms",
+            "value": 82,
+            "valueDisplay": "82"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.38 MiB",
-            "value": 2494908,
-            "valueDisplay": "2.38"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.4 MiB",
+            "value": 2512624,
+            "valueDisplay": "2.4"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.39 MiB · p95 48.57 MiB",
-            "value": 49383424,
-            "valueDisplay": "47.1"
+            "detail": "10 isolated runs · MAD 0.26 MiB · p95 61.85 MiB",
+            "value": 63969280,
+            "valueDisplay": "61.01"
           }
         },
         "primary": false,
@@ -420,42 +2228,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "solid-js/web renderToString · node:http · MAD 0 req/s · p95 256.71 ms · 378,043-378,863 B natural",
+        "activeDetail": "solid-js/web renderToString · node:http · MAD 0 req/s · p95 266.84 ms · 378,043-378,863 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "301.6",
-        "activeWidth": "19.9%",
+        "activeValueDisplay": "280.7",
+        "activeWidth": "17.6%",
         "caseId": "solid",
         "label": "Solid",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "solid-js/web renderToString · node:http · MAD 0 req/s · p95 256.71 ms · 378,043-378,863 B natural",
-            "value": 301.6,
-            "valueDisplay": "301.6"
+            "detail": "solid-js/web renderToString · node:http · MAD 0 req/s · p95 266.84 ms · 378,043-378,863 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 3.56 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 3.560741004631279,
+                  "median": 3.560741004631279,
+                  "min": 3.560741004631279,
+                  "p95": 3.560741004631279
+                },
+                "unit": "ms/req",
+                "value": 3.560741004631279,
+                "valueDisplay": "3.56"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 270.17 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 283295744,
+                  "median": 283295744,
+                  "min": 283295744,
+                  "p95": 283295744
+                },
+                "unit": "MiB",
+                "value": 283295744,
+                "valueDisplay": "270.17"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 563.66 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 591044608,
+                  "median": 591044608,
+                  "min": 591044608,
+                  "p95": 591044608
+                },
+                "unit": "MiB",
+                "value": 591044608,
+                "valueDisplay": "563.66"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 548.67 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 575320064,
+                  "median": 575320064,
+                  "min": 575320064,
+                  "p95": 575320064
+                },
+                "unit": "MiB",
+                "value": 575320064,
+                "valueDisplay": "548.67"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 520.95 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 546258944,
+                  "median": 546258944,
+                  "min": 546258944,
+                  "p95": 546258944
+                },
+                "unit": "MiB",
+                "value": 546258944,
+                "valueDisplay": "520.95"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 255.18 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 267571200,
+                  "median": 267571200,
+                  "min": 267571200,
+                  "p95": 267571200
+                },
+                "unit": "MiB",
+                "value": 267571200,
+                "valueDisplay": "255.18"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 293.49 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 307748864,
+                  "median": 307748864,
+                  "min": 307748864,
+                  "p95": 307748864
+                },
+                "unit": "MiB",
+                "value": 307748864,
+                "valueDisplay": "293.49"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 280.7,
+            "valueDisplay": "280.7"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "solid-js/web renderToStream · node:http · MAD 0 req/s · p95 297.38 ms · 378,043-378,863 B natural",
-            "value": 251.85,
-            "valueDisplay": "251.85"
+            "detail": "solid-js/web renderToStream · node:http · MAD 0 req/s · p95 336.8 ms · 378,043-378,863 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 4.12 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 4.124433456942728,
+                  "median": 4.124433456942728,
+                  "min": 4.124433456942728,
+                  "p95": 4.124433456942728
+                },
+                "unit": "ms/req",
+                "value": 4.124433456942728,
+                "valueDisplay": "4.12"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 391.52 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 410537984,
+                  "median": 410537984,
+                  "min": 410537984,
+                  "p95": 410537984
+                },
+                "unit": "MiB",
+                "value": 410537984,
+                "valueDisplay": "391.52"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 692.25 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 725880832,
+                  "median": 725880832,
+                  "min": 725880832,
+                  "p95": 725880832
+                },
+                "unit": "MiB",
+                "value": 725880832,
+                "valueDisplay": "692.25"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 555.38 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 582352896,
+                  "median": 582352896,
+                  "min": 582352896,
+                  "p95": 582352896
+                },
+                "unit": "MiB",
+                "value": 582352896,
+                "valueDisplay": "555.38"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 555.98 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 582983680,
+                  "median": 582983680,
+                  "min": 582983680,
+                  "p95": 582983680
+                },
+                "unit": "MiB",
+                "value": 582983680,
+                "valueDisplay": "555.98"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 254.64 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 267010048,
+                  "median": 267010048,
+                  "min": 267010048,
+                  "p95": 267010048
+                },
+                "unit": "MiB",
+                "value": 267010048,
+                "valueDisplay": "254.64"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 300.73 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 315342848,
+                  "median": 315342848,
+                  "min": 315342848,
+                  "p95": 315342848
+                },
+                "unit": "MiB",
+                "value": 315342848,
+                "valueDisplay": "300.73"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 242.7,
+            "valueDisplay": "242.7"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 272 ms",
-            "value": 172,
-            "valueDisplay": "172"
+            "detail": "10 isolated runs · MAD 8 ms · p95 136 ms",
+            "value": 124,
+            "valueDisplay": "124"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 4.61 MiB",
-            "value": 4831520,
-            "valueDisplay": "4.61"
+            "detail": "10 isolated runs · MAD 0 MiB · p95 4.64 MiB",
+            "value": 4864128,
+            "valueDisplay": "4.64"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.42 MiB · p95 61.89 MiB",
-            "value": 56750080,
-            "valueDisplay": "54.12"
+            "detail": "10 isolated runs · MAD 0.36 MiB · p95 69.4 MiB",
+            "value": 71872512,
+            "valueDisplay": "68.54"
           }
         },
         "primary": false,
@@ -463,42 +2497,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 266.94 ms · 341,230-341,908 B natural",
+        "activeDetail": "@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 281.61 ms · 341,230-341,908 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "287.75",
-        "activeWidth": "19.0%",
+        "activeValueDisplay": "265.2",
+        "activeWidth": "16.6%",
         "caseId": "vue",
         "label": "Vue",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 266.94 ms · 341,230-341,908 B natural",
-            "value": 287.75,
-            "valueDisplay": "287.75"
+            "detail": "@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 281.61 ms · 341,230-341,908 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 3.77 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 3.77262443438914,
+                  "median": 3.77262443438914,
+                  "min": 3.77262443438914,
+                  "p95": 3.77262443438914
+                },
+                "unit": "ms/req",
+                "value": 3.77262443438914,
+                "valueDisplay": "3.77"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 119.66 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 125476864,
+                  "median": 125476864,
+                  "min": 125476864,
+                  "p95": 125476864
+                },
+                "unit": "MiB",
+                "value": 125476864,
+                "valueDisplay": "119.66"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 430.88 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 451805184,
+                  "median": 451805184,
+                  "min": 451805184,
+                  "p95": 451805184
+                },
+                "unit": "MiB",
+                "value": 451805184,
+                "valueDisplay": "430.88"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 405.75 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 425459712,
+                  "median": 425459712,
+                  "min": 425459712,
+                  "p95": 425459712
+                },
+                "unit": "MiB",
+                "value": 425459712,
+                "valueDisplay": "405.75"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 343.74 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 360439808,
+                  "median": 360439808,
+                  "min": 360439808,
+                  "p95": 360439808
+                },
+                "unit": "MiB",
+                "value": 360439808,
+                "valueDisplay": "343.74"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 94.54 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 99131392,
+                  "median": 99131392,
+                  "min": 99131392,
+                  "p95": 99131392
+                },
+                "unit": "MiB",
+                "value": 99131392,
+                "valueDisplay": "94.54"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 311.21 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 326328320,
+                  "median": 326328320,
+                  "min": 326328320,
+                  "p95": 326328320
+                },
+                "unit": "MiB",
+                "value": 326328320,
+                "valueDisplay": "311.21"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 265.2,
+            "valueDisplay": "265.2"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "@vue/server-renderer renderToWebStream · node:http · MAD 0 req/s · p95 1,711.29 ms · 341,230-341,908 B natural",
-            "value": 49.85,
-            "valueDisplay": "49.85"
+            "detail": "@vue/server-renderer renderToWebStream · node:http · MAD 0 req/s · p95 455.23 ms · 341,230-341,908 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 8.72 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 8.724423160644319,
+                  "median": 8.724423160644319,
+                  "min": 8.724423160644319,
+                  "p95": 8.724423160644319
+                },
+                "unit": "ms/req",
+                "value": 8.724423160644319,
+                "valueDisplay": "8.72"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 108.14 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 113393664,
+                  "median": 113393664,
+                  "min": 113393664,
+                  "p95": 113393664
+                },
+                "unit": "MiB",
+                "value": 113393664,
+                "valueDisplay": "108.14"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 407.99 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 427806720,
+                  "median": 427806720,
+                  "min": 427806720,
+                  "p95": 427806720
+                },
+                "unit": "MiB",
+                "value": 427806720,
+                "valueDisplay": "407.99"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 404.9 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 424566784,
+                  "median": 424566784,
+                  "min": 424566784,
+                  "p95": 424566784
+                },
+                "unit": "MiB",
+                "value": 424566784,
+                "valueDisplay": "404.9"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 328.53 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 344485888,
+                  "median": 344485888,
+                  "min": 344485888,
+                  "p95": 344485888
+                },
+                "unit": "MiB",
+                "value": 344485888,
+                "valueDisplay": "328.53"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 105.05 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 110153728,
+                  "median": 110153728,
+                  "min": 110153728,
+                  "p95": 110153728
+                },
+                "unit": "MiB",
+                "value": 110153728,
+                "valueDisplay": "105.05"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 299.85 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 314413056,
+                  "median": 314413056,
+                  "min": 314413056,
+                  "p95": 314413056
+                },
+                "unit": "MiB",
+                "value": 314413056,
+                "valueDisplay": "299.85"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 114.85,
+            "valueDisplay": "114.85"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 172 ms",
-            "value": 172,
-            "valueDisplay": "172"
+            "detail": "10 isolated runs · MAD 4 ms · p95 92 ms",
+            "value": 84,
+            "valueDisplay": "84"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.49 MiB",
-            "value": 2613330,
-            "valueDisplay": "2.49"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.66 MiB",
+            "value": 2792756,
+            "valueDisplay": "2.66"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.68 MiB · p95 50.16 MiB",
-            "value": 47779840,
-            "valueDisplay": "45.57"
+            "detail": "10 isolated runs · MAD 0.35 MiB · p95 62.98 MiB",
+            "value": 64987136,
+            "valueDisplay": "61.98"
           }
         },
         "primary": false,
@@ -506,42 +2766,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 276.55 ms · 334,661-335,367 B natural",
+        "activeDetail": "react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 300.07 ms · 334,661-335,367 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "262.95",
-        "activeWidth": "17.4%",
+        "activeValueDisplay": "239.25",
+        "activeWidth": "15.0%",
         "caseId": "react-tanstack",
         "label": "React + TanStack Router",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 276.55 ms · 334,661-335,367 B natural",
-            "value": 262.95,
-            "valueDisplay": "262.95"
+            "detail": "react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 300.07 ms · 334,661-335,367 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 4.19 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 4.185997910135841,
+                  "median": 4.185997910135841,
+                  "min": 4.185997910135841,
+                  "p95": 4.185997910135841
+                },
+                "unit": "ms/req",
+                "value": 4.185997910135841,
+                "valueDisplay": "4.19"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 108.43 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 113692672,
+                  "median": 113692672,
+                  "min": 113692672,
+                  "p95": 113692672
+                },
+                "unit": "MiB",
+                "value": 113692672,
+                "valueDisplay": "108.43"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 445.49 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 467132416,
+                  "median": 467132416,
+                  "min": 467132416,
+                  "p95": 467132416
+                },
+                "unit": "MiB",
+                "value": 467132416,
+                "valueDisplay": "445.49"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 412.28 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 432304128,
+                  "median": 432304128,
+                  "min": 432304128,
+                  "p95": 432304128
+                },
+                "unit": "MiB",
+                "value": 432304128,
+                "valueDisplay": "412.28"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 335.57 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 351866880,
+                  "median": 351866880,
+                  "min": 351866880,
+                  "p95": 351866880
+                },
+                "unit": "MiB",
+                "value": 351866880,
+                "valueDisplay": "335.57"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 75.21 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 78864384,
+                  "median": 78864384,
+                  "min": 78864384,
+                  "p95": 78864384
+                },
+                "unit": "MiB",
+                "value": 78864384,
+                "valueDisplay": "75.21"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 337.07 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 353439744,
+                  "median": 353439744,
+                  "min": 353439744,
+                  "p95": 353439744
+                },
+                "unit": "MiB",
+                "value": 353439744,
+                "valueDisplay": "337.07"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 239.25,
+            "valueDisplay": "239.25"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "react-dom/server stream + @tanstack/react-router renderRouterToStream · node:http · MAD 0 req/s · p95 389.03 ms · 334,661-335,367 B natural",
-            "value": 189.35,
-            "valueDisplay": "189.35"
+            "detail": "react-dom/server stream + @tanstack/react-router renderRouterToStream · node:http · MAD 0 req/s · p95 337.78 ms · 334,661-335,367 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 4.49 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 4.490024658148397,
+                  "median": 4.490024658148397,
+                  "min": 4.490024658148397,
+                  "p95": 4.490024658148397
+                },
+                "unit": "ms/req",
+                "value": 4.490024658148397,
+                "valueDisplay": "4.49"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 140.23 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 147038208,
+                  "median": 147038208,
+                  "min": 147038208,
+                  "p95": 147038208
+                },
+                "unit": "MiB",
+                "value": 147038208,
+                "valueDisplay": "140.23"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 452.59 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 474578944,
+                  "median": 474578944,
+                  "min": 474578944,
+                  "p95": 474578944
+                },
+                "unit": "MiB",
+                "value": 474578944,
+                "valueDisplay": "452.59"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 434.69 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 455806976,
+                  "median": 455806976,
+                  "min": 455806976,
+                  "p95": 455806976
+                },
+                "unit": "MiB",
+                "value": 455806976,
+                "valueDisplay": "434.69"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 383.45 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 402075648,
+                  "median": 402075648,
+                  "min": 402075648,
+                  "p95": 402075648
+                },
+                "unit": "MiB",
+                "value": 402075648,
+                "valueDisplay": "383.45"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 122.32 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 128266240,
+                  "median": 128266240,
+                  "min": 128266240,
+                  "p95": 128266240
+                },
+                "unit": "MiB",
+                "value": 128266240,
+                "valueDisplay": "122.32"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 312.37 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 327540736,
+                  "median": 327540736,
+                  "min": 327540736,
+                  "p95": 327540736
+                },
+                "unit": "MiB",
+                "value": 327540736,
+                "valueDisplay": "312.37"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 223.05,
+            "valueDisplay": "223.05"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 16 ms · p95 256 ms",
-            "value": 182,
-            "valueDisplay": "182"
+            "detail": "10 isolated runs · MAD 4 ms · p95 92 ms",
+            "value": 84,
+            "valueDisplay": "84"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 3.34 MiB",
-            "value": 3442956,
-            "valueDisplay": "3.28"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 3.3 MiB",
+            "value": 3462630,
+            "valueDisplay": "3.3"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.15 MiB · p95 52.17 MiB",
-            "value": 51046400,
-            "valueDisplay": "48.68"
+            "detail": "10 isolated runs · MAD 0.18 MiB · p95 65.86 MiB",
+            "value": 68110336,
+            "valueDisplay": "64.96"
           }
         },
         "primary": false,
@@ -549,42 +3035,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 334.1 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 5.4% faster",
+        "activeDetail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 340.34 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 16.3% faster",
         "activeUnit": "req/s",
-        "activeValueDisplay": "211.35",
-        "activeWidth": "13.9%",
+        "activeValueDisplay": "198.7",
+        "activeWidth": "12.5%",
         "caseId": "sveltekit",
         "label": "SvelteKit",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 334.1 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 5.4% faster",
-            "value": 211.35000000000002,
-            "valueDisplay": "211.35"
+            "detail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 340.34 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 16.3% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 5.04 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 5.0402617010568695,
+                  "median": 5.0402617010568695,
+                  "min": 5.0402617010568695,
+                  "p95": 5.0402617010568695
+                },
+                "unit": "ms/req",
+                "value": 5.0402617010568695,
+                "valueDisplay": "5.04"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 207.11 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 217169920,
+                  "median": 217169920,
+                  "min": 217169920,
+                  "p95": 217169920
+                },
+                "unit": "MiB",
+                "value": 217169920,
+                "valueDisplay": "207.11"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 372.59 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 390684672,
+                  "median": 390684672,
+                  "min": 390684672,
+                  "p95": 390684672
+                },
+                "unit": "MiB",
+                "value": 390684672,
+                "valueDisplay": "372.59"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 371.81 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 389869568,
+                  "median": 389869568,
+                  "min": 389869568,
+                  "p95": 389869568
+                },
+                "unit": "MiB",
+                "value": 389869568,
+                "valueDisplay": "371.81"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 316.41 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 331780096,
+                  "median": 331780096,
+                  "min": 331780096,
+                  "p95": 331780096
+                },
+                "unit": "MiB",
+                "value": 331780096,
+                "valueDisplay": "316.41"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 206.33 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 216354816,
+                  "median": 216354816,
+                  "min": 216354816,
+                  "p95": 216354816
+                },
+                "unit": "MiB",
+                "value": 216354816,
+                "valueDisplay": "206.33"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 165.48 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 173514752,
+                  "median": 173514752,
+                  "min": 173514752,
+                  "p95": 173514752
+                },
+                "unit": "MiB",
+                "value": 173514752,
+                "valueDisplay": "165.48"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 198.7,
+            "valueDisplay": "198.7"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 341.91 ms · 303,354-303,888 B natural",
-            "value": 213.5,
-            "valueDisplay": "213.5"
+            "detail": "SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 368.77 ms · 303,354-303,888 B natural · saturation warning: the 128-connection probe was 5.9% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 5.68 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 5.6785917092561045,
+                  "median": 5.6785917092561045,
+                  "min": 5.6785917092561045,
+                  "p95": 5.6785917092561045
+                },
+                "unit": "ms/req",
+                "value": 5.6785917092561045,
+                "valueDisplay": "5.68"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 206.27 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 216285184,
+                  "median": 216285184,
+                  "min": 216285184,
+                  "p95": 216285184
+                },
+                "unit": "MiB",
+                "value": 216285184,
+                "valueDisplay": "206.27"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 369.1 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 387031040,
+                  "median": 387031040,
+                  "min": 387031040,
+                  "p95": 387031040
+                },
+                "unit": "MiB",
+                "value": 387031040,
+                "valueDisplay": "369.1"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 357.02 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 374362112,
+                  "median": 374362112,
+                  "min": 374362112,
+                  "p95": 374362112
+                },
+                "unit": "MiB",
+                "value": 374362112,
+                "valueDisplay": "357.02"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 317 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 332394496,
+                  "median": 332394496,
+                  "min": 332394496,
+                  "p95": 332394496
+                },
+                "unit": "MiB",
+                "value": 332394496,
+                "valueDisplay": "317"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 194.18 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 203616256,
+                  "median": 203616256,
+                  "min": 203616256,
+                  "p95": 203616256
+                },
+                "unit": "MiB",
+                "value": 203616256,
+                "valueDisplay": "194.18"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 162.84 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 170745856,
+                  "median": 170745856,
+                  "min": 170745856,
+                  "p95": 170745856
+                },
+                "unit": "MiB",
+                "value": 170745856,
+                "valueDisplay": "162.84"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 176.1,
+            "valueDisplay": "176.1"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 172 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 6 ms · p95 96 ms",
+            "value": 86,
+            "valueDisplay": "86"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 4.85 MiB",
-            "value": 5080782,
-            "valueDisplay": "4.85"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 4.84 MiB",
+            "value": 5076142,
+            "valueDisplay": "4.84"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 1.24 MiB · p95 54 MiB",
-            "value": 53147648,
-            "valueDisplay": "50.69"
+            "detail": "10 isolated runs · MAD 0.48 MiB · p95 68.09 MiB",
+            "value": 70533120,
+            "valueDisplay": "67.27"
           }
         },
         "primary": false,
@@ -592,42 +3304,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 507 ms · 313,520-314,093 B natural",
+        "activeDetail": "Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 511.95 ms · 313,487-314,060 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "140.8",
-        "activeWidth": "9.3%",
+        "activeValueDisplay": "138.4",
+        "activeWidth": "8.7%",
         "caseId": "next",
         "label": "Next.js",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 507 ms · 313,520-314,093 B natural",
-            "value": 140.8,
-            "valueDisplay": "140.8"
+            "detail": "Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 511.95 ms · 313,487-314,060 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 7.24 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 7.236271676300578,
+                  "median": 7.236271676300578,
+                  "min": 7.236271676300578,
+                  "p95": 7.236271676300578
+                },
+                "unit": "ms/req",
+                "value": 7.236271676300578,
+                "valueDisplay": "7.24"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 268.32 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 281354240,
+                  "median": 281354240,
+                  "min": 281354240,
+                  "p95": 281354240
+                },
+                "unit": "MiB",
+                "value": 281354240,
+                "valueDisplay": "268.32"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 456.79 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 478973952,
+                  "median": 478973952,
+                  "min": 478973952,
+                  "p95": 478973952
+                },
+                "unit": "MiB",
+                "value": 478973952,
+                "valueDisplay": "456.79"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 412.05 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 432062464,
+                  "median": 432062464,
+                  "min": 432062464,
+                  "p95": 432062464
+                },
+                "unit": "MiB",
+                "value": 432062464,
+                "valueDisplay": "412.05"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 388.91 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 407797760,
+                  "median": 407797760,
+                  "min": 407797760,
+                  "p95": 407797760
+                },
+                "unit": "MiB",
+                "value": 407797760,
+                "valueDisplay": "388.91"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 223.58 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 234442752,
+                  "median": 234442752,
+                  "min": 234442752,
+                  "p95": 234442752
+                },
+                "unit": "MiB",
+                "value": 234442752,
+                "valueDisplay": "223.58"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 188.46 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 197619712,
+                  "median": 197619712,
+                  "min": 197619712,
+                  "p95": 197619712
+                },
+                "unit": "MiB",
+                "value": 197619712,
+                "valueDisplay": "188.46"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 138.4,
+            "valueDisplay": "138.4"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "Next.js production App Router streaming SSR · next start · MAD 0 req/s · p95 470.77 ms · 313,520-314,093 B natural",
-            "value": 153.05,
-            "valueDisplay": "153.05"
+            "detail": "Next.js production App Router streaming SSR · next start · MAD 0 req/s · p95 500.92 ms · 313,487-314,060 B natural · saturation warning: the 128-connection probe was 6.7% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 7.07 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 7.07274011299435,
+                  "median": 7.07274011299435,
+                  "min": 7.07274011299435,
+                  "p95": 7.07274011299435
+                },
+                "unit": "ms/req",
+                "value": 7.07274011299435,
+                "valueDisplay": "7.07"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 287.74 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 301715456,
+                  "median": 301715456,
+                  "min": 301715456,
+                  "p95": 301715456
+                },
+                "unit": "MiB",
+                "value": 301715456,
+                "valueDisplay": "287.74"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 475.85 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 498966528,
+                  "median": 498966528,
+                  "min": 498966528,
+                  "p95": 498966528
+                },
+                "unit": "MiB",
+                "value": 498966528,
+                "valueDisplay": "475.85"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 433.12 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 454156288,
+                  "median": 454156288,
+                  "min": 454156288,
+                  "p95": 454156288
+                },
+                "unit": "MiB",
+                "value": 454156288,
+                "valueDisplay": "433.12"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 428.27 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 449069056,
+                  "median": 449069056,
+                  "min": 449069056,
+                  "p95": 449069056
+                },
+                "unit": "MiB",
+                "value": 449069056,
+                "valueDisplay": "428.27"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 245 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 256905216,
+                  "median": 256905216,
+                  "min": 256905216,
+                  "p95": 256905216
+                },
+                "unit": "MiB",
+                "value": 256905216,
+                "valueDisplay": "245"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 188.11 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 197251072,
+                  "median": 197251072,
+                  "min": 197251072,
+                  "p95": 197251072
+                },
+                "unit": "MiB",
+                "value": 197251072,
+                "valueDisplay": "188.11"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 141.6,
+            "valueDisplay": "141.6"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 304 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 6 ms · p95 132 ms",
+            "value": 92,
+            "valueDisplay": "92"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 3.67 MiB",
-            "value": 3848304,
-            "valueDisplay": "3.67"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 3.7 MiB",
+            "value": 3874340,
+            "valueDisplay": "3.69"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.96 MiB · p95 51.33 MiB",
-            "value": 51953664,
-            "valueDisplay": "49.55"
+            "detail": "10 isolated runs · MAD 0.13 MiB · p95 66.62 MiB",
+            "value": 69007360,
+            "valueDisplay": "65.81"
           }
         },
         "primary": false,
@@ -635,42 +3573,268 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 834.51 ms · 280,229-280,941 B natural · saturation warning: the 128-connection probe was 11.6% faster",
+        "activeDetail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 552.62 ms · 280,229-280,941 B natural",
         "activeUnit": "req/s",
-        "activeValueDisplay": "83.5",
-        "activeWidth": "5.5%",
+        "activeValueDisplay": "76",
+        "activeWidth": "4.8%",
         "caseId": "nuxt",
         "label": "Nuxt",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 834.51 ms · 280,229-280,941 B natural · saturation warning: the 128-connection probe was 11.6% faster",
-            "value": 83.5,
-            "valueDisplay": "83.5"
+            "detail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 552.62 ms · 280,229-280,941 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 13.2 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 13.203947368421053,
+                  "median": 13.203947368421053,
+                  "min": 13.203947368421053,
+                  "p95": 13.203947368421053
+                },
+                "unit": "ms/req",
+                "value": 13.203947368421053,
+                "valueDisplay": "13.2"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 179.98 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 188719104,
+                  "median": 188719104,
+                  "min": 188719104,
+                  "p95": 188719104
+                },
+                "unit": "MiB",
+                "value": 188719104,
+                "valueDisplay": "179.98"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 473.44 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 496439296,
+                  "median": 496439296,
+                  "min": 496439296,
+                  "p95": 496439296
+                },
+                "unit": "MiB",
+                "value": 496439296,
+                "valueDisplay": "473.44"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 446.88 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 468586496,
+                  "median": 468586496,
+                  "min": 468586496,
+                  "p95": 468586496
+                },
+                "unit": "MiB",
+                "value": 468586496,
+                "valueDisplay": "446.88"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 430.12 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 451014656,
+                  "median": 451014656,
+                  "min": 451014656,
+                  "p95": 451014656
+                },
+                "unit": "MiB",
+                "value": 451014656,
+                "valueDisplay": "430.12"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 153.41 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 160866304,
+                  "median": 160866304,
+                  "min": 160866304,
+                  "p95": 160866304
+                },
+                "unit": "MiB",
+                "value": 160866304,
+                "valueDisplay": "153.41"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 293.46 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 307720192,
+                  "median": 307720192,
+                  "min": 307720192,
+                  "p95": 307720192
+                },
+                "unit": "MiB",
+                "value": 307720192,
+                "valueDisplay": "293.46"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 76,
+            "valueDisplay": "76"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 792.19 ms · 280,229-280,941 B natural",
-            "value": 84.4,
-            "valueDisplay": "84.4"
+            "detail": "Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 572.65 ms · 280,229-280,941 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 13.55 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 13.547297297297296,
+                  "median": 13.547297297297296,
+                  "min": 13.547297297297296,
+                  "p95": 13.547297297297296
+                },
+                "unit": "ms/req",
+                "value": 13.547297297297296,
+                "valueDisplay": "13.55"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 358.94 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 376373248,
+                  "median": 376373248,
+                  "min": 376373248,
+                  "p95": 376373248
+                },
+                "unit": "MiB",
+                "value": 376373248,
+                "valueDisplay": "358.94"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 653.83 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 685588480,
+                  "median": 685588480,
+                  "min": 685588480,
+                  "p95": 685588480
+                },
+                "unit": "MiB",
+                "value": 685588480,
+                "valueDisplay": "653.83"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 574.91 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 602836992,
+                  "median": 602836992,
+                  "min": 602836992,
+                  "p95": 602836992
+                },
+                "unit": "MiB",
+                "value": 602836992,
+                "valueDisplay": "574.91"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 588.54 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 617132032,
+                  "median": 617132032,
+                  "min": 617132032,
+                  "p95": 617132032
+                },
+                "unit": "MiB",
+                "value": 617132032,
+                "valueDisplay": "588.54"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 280.02 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 293621760,
+                  "median": 293621760,
+                  "min": 293621760,
+                  "p95": 293621760
+                },
+                "unit": "MiB",
+                "value": 293621760,
+                "valueDisplay": "280.02"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 294.89 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 309215232,
+                  "median": 309215232,
+                  "min": 309215232,
+                  "p95": 309215232
+                },
+                "unit": "MiB",
+                "value": 309215232,
+                "valueDisplay": "294.89"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 74,
+            "valueDisplay": "74"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 16 ms · p95 288 ms",
-            "value": 174,
-            "valueDisplay": "174"
+            "detail": "10 isolated runs · MAD 6 ms · p95 108 ms",
+            "value": 94,
+            "valueDisplay": "94"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 3.43 MiB",
-            "value": 3599622,
-            "valueDisplay": "3.43"
+            "detail": "10 isolated runs · MAD 0 MiB · p95 3.45 MiB",
+            "value": 3616128,
+            "valueDisplay": "3.45"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.25 MiB · p95 48.02 MiB",
-            "value": 50059264,
-            "valueDisplay": "47.74"
+            "detail": "10 isolated runs · MAD 0.29 MiB · p95 65.24 MiB",
+            "value": 67778560,
+            "valueDisplay": "64.64"
           }
         },
         "primary": false,
@@ -678,70 +3842,565 @@
       },
       {
         "activeAvailable": true,
-        "activeDetail": "Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 914.4 ms · 462,724-463,582 B natural",
+        "activeDetail": "Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 911.86 ms · 463,485-464,344 B natural · saturation warning: the 128-connection probe was 9.6% faster",
         "activeUnit": "req/s",
-        "activeValueDisplay": "75.8",
-        "activeWidth": "5.0%",
+        "activeValueDisplay": "70.5",
+        "activeWidth": "4.4%",
         "caseId": "astro",
         "label": "Astro + Preact",
         "metrics": {
           "noStreamingRequestsPerSecond": {
             "available": true,
-            "detail": "Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 914.4 ms · 462,724-463,582 B natural",
-            "value": 75.8,
-            "valueDisplay": "75.8"
+            "detail": "Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 911.86 ms · 463,485-464,344 B natural · saturation warning: the 128-connection probe was 9.6% faster",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 14.23 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 14.22695035460993,
+                  "median": 14.22695035460993,
+                  "min": 14.22695035460993,
+                  "p95": 14.22695035460993
+                },
+                "unit": "ms/req",
+                "value": 14.22695035460993,
+                "valueDisplay": "14.23"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 254.24 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 266592256,
+                  "median": 266592256,
+                  "min": 266592256,
+                  "p95": 266592256
+                },
+                "unit": "MiB",
+                "value": 266592256,
+                "valueDisplay": "254.24"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 580.63 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 608837632,
+                  "median": 608837632,
+                  "min": 608837632,
+                  "p95": 608837632
+                },
+                "unit": "MiB",
+                "value": 608837632,
+                "valueDisplay": "580.63"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 536.42 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 562475008,
+                  "median": 562475008,
+                  "min": 562475008,
+                  "p95": 562475008
+                },
+                "unit": "MiB",
+                "value": 562475008,
+                "valueDisplay": "536.42"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 368.86 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 386781184,
+                  "median": 386781184,
+                  "min": 386781184,
+                  "p95": 386781184
+                },
+                "unit": "MiB",
+                "value": 386781184,
+                "valueDisplay": "368.86"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 210.03 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 220229632,
+                  "median": 220229632,
+                  "min": 220229632,
+                  "p95": 220229632
+                },
+                "unit": "MiB",
+                "value": 220229632,
+                "valueDisplay": "210.03"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 326.39 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 342245376,
+                  "median": 342245376,
+                  "min": 342245376,
+                  "p95": 342245376
+                },
+                "unit": "MiB",
+                "value": 342245376,
+                "valueDisplay": "326.39"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 70.5,
+            "valueDisplay": "70.5"
           },
           "streamingRequestsPerSecond": {
             "available": true,
-            "detail": "Astro production streaming SSR + @astrojs/preact island · @astrojs/node standalone · MAD 0 req/s · p95 853.22 ms · 462,723-463,582 B natural",
-            "value": 80.05,
-            "valueDisplay": "80.05"
+            "detail": "Astro production streaming SSR + @astrojs/preact island · @astrojs/node standalone · MAD 0 req/s · p95 899.67 ms · 463,485-464,343 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 13.99 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 13.991625959525472,
+                  "median": 13.991625959525472,
+                  "min": 13.991625959525472,
+                  "p95": 13.991625959525472
+                },
+                "unit": "ms/req",
+                "value": 13.991625959525472,
+                "valueDisplay": "13.99"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 202.26 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 212082688,
+                  "median": 212082688,
+                  "min": 212082688,
+                  "p95": 212082688
+                },
+                "unit": "MiB",
+                "value": 212082688,
+                "valueDisplay": "202.26"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 528.61 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 554287104,
+                  "median": 554287104,
+                  "min": 554287104,
+                  "p95": 554287104
+                },
+                "unit": "MiB",
+                "value": 554287104,
+                "valueDisplay": "528.61"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 546.57 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 573120512,
+                  "median": 573120512,
+                  "min": 573120512,
+                  "p95": 573120512
+                },
+                "unit": "MiB",
+                "value": 573120512,
+                "valueDisplay": "546.57"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 373.93 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 392097792,
+                  "median": 392097792,
+                  "min": 392097792,
+                  "p95": 392097792
+                },
+                "unit": "MiB",
+                "value": 392097792,
+                "valueDisplay": "373.93"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 220.22 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 230916096,
+                  "median": 230916096,
+                  "min": 230916096,
+                  "p95": 230916096
+                },
+                "unit": "MiB",
+                "value": 230916096,
+                "valueDisplay": "220.22"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 326.35 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 342204416,
+                  "median": 342204416,
+                  "min": 342204416,
+                  "p95": 342204416
+                },
+                "unit": "MiB",
+                "value": 342204416,
+                "valueDisplay": "326.35"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 71.65,
+            "valueDisplay": "71.65"
           },
           "largestContentfulPaintMs": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0 ms · p95 172 ms",
-            "value": 156,
-            "valueDisplay": "156"
+            "detail": "10 isolated runs · MAD 8 ms · p95 156 ms",
+            "value": 100,
+            "valueDisplay": "100"
           },
           "jsHeapUsedBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.4 MiB",
-            "value": 2517114,
-            "valueDisplay": "2.4"
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.44 MiB",
+            "value": 2557792,
+            "valueDisplay": "2.44"
           },
           "rendererPrivateBytes": {
             "available": true,
-            "detail": "10 isolated runs · MAD 0.98 MiB · p95 52.8 MiB",
-            "value": 50317312,
-            "valueDisplay": "47.99"
+            "detail": "10 isolated runs · MAD 0.34 MiB · p95 62.38 MiB",
+            "value": 64112640,
+            "valueDisplay": "61.14"
           }
         },
         "primary": false,
         "rank": "15"
+      },
+      {
+        "activeAvailable": true,
+        "activeDetail": "@lit-labs/ssr render (collected RenderResult) · node:http · MAD 0 req/s · p95 559.83 ms · 1,357,852-1,363,128 B natural",
+        "activeUnit": "req/s",
+        "activeValueDisplay": "69.9",
+        "activeWidth": "4.4%",
+        "caseId": "lit",
+        "label": "Lit",
+        "metrics": {
+          "noStreamingRequestsPerSecond": {
+            "available": true,
+            "detail": "@lit-labs/ssr render (collected RenderResult) · node:http · MAD 0 req/s · p95 559.83 ms · 1,357,852-1,363,128 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 14.33 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 14.334763948497853,
+                  "median": 14.334763948497853,
+                  "min": 14.334763948497853,
+                  "p95": 14.334763948497853
+                },
+                "unit": "ms/req",
+                "value": 14.334763948497853,
+                "valueDisplay": "14.33"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 56.08 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 58802176,
+                  "median": 58802176,
+                  "min": 58802176,
+                  "p95": 58802176
+                },
+                "unit": "MiB",
+                "value": 58802176,
+                "valueDisplay": "56.08"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 339.64 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 356134912,
+                  "median": 356134912,
+                  "min": 356134912,
+                  "p95": 356134912
+                },
+                "unit": "MiB",
+                "value": 356134912,
+                "valueDisplay": "339.64"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 319.87 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 335409152,
+                  "median": 335409152,
+                  "min": 335409152,
+                  "p95": 335409152
+                },
+                "unit": "MiB",
+                "value": 335409152,
+                "valueDisplay": "319.87"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 300.81 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 315424768,
+                  "median": 315424768,
+                  "min": 315424768,
+                  "p95": 315424768
+                },
+                "unit": "MiB",
+                "value": 315424768,
+                "valueDisplay": "300.81"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 36.31 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 38076416,
+                  "median": 38076416,
+                  "min": 38076416,
+                  "p95": 38076416
+                },
+                "unit": "MiB",
+                "value": 38076416,
+                "valueDisplay": "36.31"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 283.56 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 297332736,
+                  "median": 297332736,
+                  "min": 297332736,
+                  "p95": 297332736
+                },
+                "unit": "MiB",
+                "value": 297332736,
+                "valueDisplay": "283.56"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 69.9,
+            "valueDisplay": "69.9"
+          },
+          "streamingRequestsPerSecond": {
+            "available": true,
+            "detail": "@lit-labs/ssr RenderResultReadable (declarative shadow DOM) · node:http · MAD 0 req/s · p95 1,451.62 ms · 1,357,852-1,363,128 B natural",
+            "serverTelemetry": {
+              "available": true,
+              "availableRounds": 1,
+              "cpuMillisecondsPerRequest": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 ms/req · p95 118.12 ms/req",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 118.11764705882354,
+                  "median": 118.11764705882354,
+                  "min": 118.11764705882354,
+                  "p95": 118.11764705882354
+                },
+                "unit": "ms/req",
+                "value": 118.11764705882354,
+                "valueDisplay": "118.12"
+              },
+              "loadDeltaPeakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 28.07 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 29433856,
+                  "median": 29433856,
+                  "min": 29433856,
+                  "p95": 29433856
+                },
+                "unit": "MiB",
+                "value": 29433856,
+                "valueDisplay": "28.07"
+              },
+              "peakRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 368.8 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 386715648,
+                  "median": 386715648,
+                  "min": 386715648,
+                  "p95": 386715648
+                },
+                "unit": "MiB",
+                "value": 386715648,
+                "valueDisplay": "368.8"
+              },
+              "postSettleRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 338.05 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 354471936,
+                  "median": 354471936,
+                  "min": 354471936,
+                  "p95": 354471936
+                },
+                "unit": "MiB",
+                "value": 354471936,
+                "valueDisplay": "338.05"
+              },
+              "postWarmupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 345.2 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 361971712,
+                  "median": 361971712,
+                  "min": 361971712,
+                  "p95": 361971712
+                },
+                "unit": "MiB",
+                "value": 361971712,
+                "valueDisplay": "345.2"
+              },
+              "reason": null,
+              "reasons": [],
+              "retainedRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 -2.68 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": -2809856,
+                  "median": -2809856,
+                  "min": -2809856,
+                  "p95": -2809856
+                },
+                "unit": "MiB",
+                "value": -2809856,
+                "valueDisplay": "-2.68"
+              },
+              "startupRssBytes": {
+                "available": true,
+                "detail": "1 measured round · MAD 0 MiB · p95 340.73 MiB",
+                "statistics": {
+                  "count": 1,
+                  "mad": 0,
+                  "max": 357281792,
+                  "median": 357281792,
+                  "min": 357281792,
+                  "p95": 357281792
+                },
+                "unit": "MiB",
+                "value": 357281792,
+                "valueDisplay": "340.73"
+              },
+              "status": "available",
+              "unavailableRounds": 0
+            },
+            "value": 8.5,
+            "valueDisplay": "8.5"
+          },
+          "largestContentfulPaintMs": {
+            "available": true,
+            "detail": "10 isolated runs · MAD 6 ms · p95 108 ms",
+            "value": 78,
+            "valueDisplay": "78"
+          },
+          "jsHeapUsedBytes": {
+            "available": true,
+            "detail": "10 isolated runs · MAD <0.01 MiB · p95 2.87 MiB",
+            "value": 3007974,
+            "valueDisplay": "2.87"
+          },
+          "rendererPrivateBytes": {
+            "available": true,
+            "detail": "10 isolated runs · MAD 1.01 MiB · p95 75.23 MiB",
+            "value": 76871680,
+            "valueDisplay": "73.31"
+          }
+        },
+        "primary": false,
+        "rank": "16"
       }
     ],
     "responseMode": "comparison",
     "saturationWarnings": {
       "noStreaming": [
         {
-          "caseId": "nuxt",
-          "gainPercent": 11.619718309859154,
-          "label": "Nuxt",
+          "caseId": "astro",
+          "gainPercent": 9.569377990430622,
+          "label": "Astro + Preact",
           "measuredConnections": 64,
           "probeConnections": 128,
           "reason": "Throughput was still increasing at the largest connection count"
         },
         {
-          "caseId": "webui-node-http",
-          "gainPercent": 16.079873883342092,
-          "label": "WebUI / Node node:http",
+          "caseId": "webui-bun-serve",
+          "gainPercent": 8.47535697835099,
+          "label": "WebUI / Light DOM / Bun.serve",
           "measuredConnections": 64,
           "probeConnections": 128,
           "reason": "Throughput was still increasing at the largest connection count"
         },
         {
           "caseId": "sveltekit",
-          "gainPercent": 5.4499366286438535,
+          "gainPercent": 16.261398176291795,
           "label": "SvelteKit",
           "measuredConnections": 64,
           "probeConnections": 128,
@@ -750,9 +4409,33 @@
       ],
       "streaming": [
         {
+          "caseId": "next",
+          "gainPercent": 6.666666666666667,
+          "label": "Next.js",
+          "measuredConnections": 64,
+          "probeConnections": 128,
+          "reason": "Throughput was still increasing at the largest connection count"
+        },
+        {
           "caseId": "webui-node-http",
-          "gainPercent": 13.109128345916265,
-          "label": "WebUI / Node node:http",
+          "gainPercent": 5.974652987326494,
+          "label": "WebUI / Light DOM / Node node:http",
+          "measuredConnections": 64,
+          "probeConnections": 128,
+          "reason": "Throughput was still increasing at the largest connection count"
+        },
+        {
+          "caseId": "webui-bun-serve",
+          "gainPercent": 9.252217997465145,
+          "label": "WebUI / Light DOM / Bun.serve",
+          "measuredConnections": 64,
+          "probeConnections": 128,
+          "reason": "Throughput was still increasing at the largest connection count"
+        },
+        {
+          "caseId": "sveltekit",
+          "gainPercent": 5.92,
+          "label": "SvelteKit",
           "measuredConnections": 64,
           "probeConnections": 128,
           "reason": "Throughput was still increasing at the largest connection count"
@@ -766,7 +4449,18 @@
     "responseModes": [
       "complete",
       "progressive"
-    ]
+    ],
+    "selectiveRefresh": {
+      "baseCommit": "365f0046ba5e718b185817b83dc7d57b90bb57b2",
+      "caseIds": [
+        "webui-bun-serve",
+        "webui-deno-serve",
+        "webui-node-http"
+      ],
+      "refreshedAt": "2026-09-04T03:28:11.463Z",
+      "refreshedCommit": "25729eac3583397746585b938dfe5cf300922b39",
+      "statement": "Only the listed cases were rerun. Every other row retains its prior official measurement."
+    }
   },
-  "benchmarksJson": "{\"asyncDataBoundary\":{\"canonicalWebuiVersion\":\"0.0.27\",\"notes\":\"The progressive suite continues to measure each product's existing native progressive/streaming boundaries unchanged. A dedicated above-the-fold-shell / below-the-fold-async-list workload driven by WebUI's resumable StreamingSession boundary API is intentionally not implemented against canonical WebUI 0.0.27, because that API is not part of this release. This is disclosed capability metadata, not an active measurement.\",\"requiredCapability\":\"StreamingSession resumable async data-boundary API\",\"status\":\"deferred-pending-webui-release\"},\"description\":\"Compare the same product workload in complete and progressive response modes, then inspect the three browser cost metrics that matter most.\",\"hasUnavailable\":false,\"link\":\"/webui/guide/concepts/performance/\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"metricSummary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 26.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 314.25 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 345.5% higher; the 1,175.1 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Nuxt, WebUI / Node node:http, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"metrics\":[{\"available\":true,\"description\":\"Dynamic SSR throughput when each framework sends one fully collected HTML response without progressive boundaries.\",\"direction\":\"higher\",\"directionLabel\":\"higher is better\",\"id\":\"noStreamingRequestsPerSecond\",\"label\":\"No Streaming RPS\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"selected\":true,\"summary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 26.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 314.25 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 345.5% higher; the 1,175.1 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Nuxt, WebUI / Node node:http, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"unit\":\"req/s\"},{\"available\":true,\"description\":\"Dynamic SSR throughput while native progressive or streaming boundaries remain enabled.\",\"direction\":\"higher\",\"directionLabel\":\"higher is better\",\"id\":\"streamingRequestsPerSecond\",\"label\":\"Streaming RPS\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"selected\":false,\"summary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 26.8% ahead of WebUI / Shadow DOM / Rust / Actix; the 247.7 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, Preact, WebUI / Light DOM / Rust / Actix is 201.2% higher; the 782.7 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for WebUI / Node node:http; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"unit\":\"req/s\"},{\"available\":true,\"description\":\"Pre-interaction largest contentful paint from navigation start across ten isolated Chromium runs.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"largestContentfulPaintMs\",\"label\":\"LCP\",\"methodology\":\"Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Bun.serve and WebUI / Light DOM / Rust / Actix have the same median; the measured ordering is tied.\",\"unit\":\"ms\"},{\"available\":true,\"description\":\"Post-readiness JavaScript heap used after an explicit Chromium garbage collection.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"jsHeapUsedBytes\",\"label\":\"JS Heap\",\"methodology\":\"Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Deno.serve records the lowest median, 0.0% below WebUI / Light DOM / Rust / Actix; the <0.01 MiB gap exceeds their combined <0.01 MiB MAD.\",\"unit\":\"MiB\"},{\"available\":true,\"description\":\"Private bytes attributed to the isolated Chromium renderer process after readiness.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"rendererPrivateBytes\",\"label\":\"Renderer Private MB\",\"methodology\":\"Chromium 149.0.7827.55 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Bun.serve records the lowest median, 2.0% below WebUI / Node node:http; the 0.82 MiB gap is within their combined 1.87 MiB MAD, so the measured ordering overlaps run noise.\",\"unit\":\"MiB\"}],\"rows\":[{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 45.01 ms · 329,988-330,685 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"1,515.25\",\"activeWidth\":\"100.0%\",\"caseId\":\"webui-rust-actix\",\"label\":\"WebUI / Light DOM / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 45.01 ms · 329,988-330,685 B natural\",\"value\":1515.25,\"valueDisplay\":\"1,515.25\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler StreamingResponse (Rust) · actix-web · MAD 0 req/s · p95 55.38 ms · 337,914-338,643 B natural\",\"value\":1171.6999999999998,\"valueDisplay\":\"1,171.7\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 140 ms\",\"value\":140,\"valueDisplay\":\"140\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.16 MiB\",\"value\":2188984,\"valueDisplay\":\"2.09\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.29 MiB · p95 46.73 MiB\",\"value\":44687360,\"valueDisplay\":\"42.62\"}},\"primary\":true,\"rank\":\"1\"},{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 56.54 ms · 483,598-485,019 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"1,201\",\"activeWidth\":\"79.3%\",\"caseId\":\"webui-shadowdom-rust-actix\",\"label\":\"WebUI / Shadow DOM / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 56.54 ms · 483,598-485,019 B natural\",\"value\":1201,\"valueDisplay\":\"1,201\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler StreamingResponse (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 70.59 ms · 491,524-492,977 B natural\",\"value\":924,\"valueDisplay\":\"924\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 172 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.43 MiB\",\"value\":2545576,\"valueDisplay\":\"2.43\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.57 MiB · p95 49.15 MiB\",\"value\":48629760,\"valueDisplay\":\"46.38\"}},\"primary\":true,\"rank\":\"2\"},{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.38 ms · 596,601-598,231 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"926.7\",\"activeWidth\":\"61.2%\",\"caseId\":\"webui-fast-rust-actix\",\"label\":\"WebUI / FAST V3 / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.38 ms · 596,601-598,231 B natural\",\"value\":926.7,\"valueDisplay\":\"926.7\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler chunked ResponseWriter (Rust, FAST V3) · actix-web · MAD 0 req/s · p95 153.22 ms · 596,601-598,231 B natural\",\"value\":433.25,\"valueDisplay\":\"433.25\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 156 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 5.15 MiB\",\"value\":5390702,\"valueDisplay\":\"5.14\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.48 MiB · p95 59.16 MiB\",\"value\":57163776,\"valueDisplay\":\"54.52\"}},\"primary\":true,\"rank\":\"3\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 180.93 ms · 329,988-330,685 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"590.9\",\"activeWidth\":\"39.0%\",\"caseId\":\"webui-deno-serve\",\"label\":\"WebUI / Deno.serve\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 180.93 ms · 329,988-330,685 B natural\",\"value\":590.9000000000001,\"valueDisplay\":\"590.9\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 193.58 ms · 337,914-338,643 B natural\",\"value\":505.54999999999995,\"valueDisplay\":\"505.55\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 256 ms\",\"value\":146,\"valueDisplay\":\"146\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.16 MiB\",\"value\":2187908,\"valueDisplay\":\"2.09\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.67 MiB · p95 46.13 MiB\",\"value\":44328960,\"valueDisplay\":\"42.28\"}},\"primary\":true,\"rank\":\"4\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 122.7 ms · 329,988-330,685 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"577.65\",\"activeWidth\":\"38.1%\",\"caseId\":\"webui-bun-serve\",\"label\":\"WebUI / Bun.serve\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 122.7 ms · 329,988-330,685 B natural\",\"value\":577.6500000000001,\"valueDisplay\":\"577.65\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 154.83 ms · 337,914-338,643 B natural\",\"value\":460,\"valueDisplay\":\"460\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 240 ms\",\"value\":140,\"valueDisplay\":\"140\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.03 MiB · p95 2.16 MiB\",\"value\":2224312,\"valueDisplay\":\"2.12\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.81 MiB · p95 43.59 MiB\",\"value\":43337728,\"valueDisplay\":\"41.33\"}},\"primary\":true,\"rank\":\"5\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 148.25 ms · 329,988-330,685 B natural · saturation warning: the 128-connection probe was 16.1% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"458.5\",\"activeWidth\":\"30.3%\",\"caseId\":\"webui-node-http\",\"label\":\"WebUI / Node node:http\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 148.25 ms · 329,988-330,685 B natural · saturation warning: the 128-connection probe was 16.1% faster\",\"value\":458.5,\"valueDisplay\":\"458.5\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (request-materialized Node-API state) · node:http · MAD 0 req/s · p95 200 ms · 337,914-338,643 B natural · saturation warning: the 128-connection probe was 13.1% faster\",\"value\":370.35,\"valueDisplay\":\"370.35\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 8 ms · p95 156 ms\",\"value\":148,\"valueDisplay\":\"148\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.03 MiB · p95 2.16 MiB\",\"value\":2224806,\"valueDisplay\":\"2.12\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.06 MiB · p95 46.46 MiB\",\"value\":44199936,\"valueDisplay\":\"42.15\"}},\"primary\":true,\"rank\":\"6\"},{\"activeAvailable\":true,\"activeDetail\":\"react-dom/server renderToString · node:http · MAD 0 req/s · p95 224.44 ms · 334,118-334,824 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"340.15\",\"activeWidth\":\"22.4%\",\"caseId\":\"react\",\"label\":\"React\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToString · node:http · MAD 0 req/s · p95 224.44 ms · 334,118-334,824 B natural\",\"value\":340.15,\"valueDisplay\":\"340.15\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToReadableStream · node:http · MAD 0 req/s · p95 323.74 ms · 334,118-334,824 B natural\",\"value\":249.85,\"valueDisplay\":\"249.85\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 172 ms\",\"value\":172,\"valueDisplay\":\"172\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.9 MiB\",\"value\":3041670,\"valueDisplay\":\"2.9\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.46 MiB · p95 51.02 MiB\",\"value\":49543168,\"valueDisplay\":\"47.25\"}},\"primary\":false,\"rank\":\"7\"},{\"activeAvailable\":true,\"activeDetail\":\"preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 216.6 ms · 333,940-334,646 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"338.4\",\"activeWidth\":\"22.3%\",\"caseId\":\"preact\",\"label\":\"Preact\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 216.6 ms · 333,940-334,646 B natural\",\"value\":338.4,\"valueDisplay\":\"338.4\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"preact-render-to-string renderToReadableStream · node:http · MAD 0 req/s · p95 191.35 ms · 333,940-334,646 B natural\",\"value\":389,\"valueDisplay\":\"389\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 8 ms · p95 172 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.38 MiB\",\"value\":2494908,\"valueDisplay\":\"2.38\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.39 MiB · p95 48.57 MiB\",\"value\":49383424,\"valueDisplay\":\"47.1\"}},\"primary\":false,\"rank\":\"8\"},{\"activeAvailable\":true,\"activeDetail\":\"solid-js/web renderToString · node:http · MAD 0 req/s · p95 256.71 ms · 378,043-378,863 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"301.6\",\"activeWidth\":\"19.9%\",\"caseId\":\"solid\",\"label\":\"Solid\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"solid-js/web renderToString · node:http · MAD 0 req/s · p95 256.71 ms · 378,043-378,863 B natural\",\"value\":301.6,\"valueDisplay\":\"301.6\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"solid-js/web renderToStream · node:http · MAD 0 req/s · p95 297.38 ms · 378,043-378,863 B natural\",\"value\":251.85,\"valueDisplay\":\"251.85\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 272 ms\",\"value\":172,\"valueDisplay\":\"172\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 4.61 MiB\",\"value\":4831520,\"valueDisplay\":\"4.61\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.42 MiB · p95 61.89 MiB\",\"value\":56750080,\"valueDisplay\":\"54.12\"}},\"primary\":false,\"rank\":\"9\"},{\"activeAvailable\":true,\"activeDetail\":\"@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 266.94 ms · 341,230-341,908 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"287.75\",\"activeWidth\":\"19.0%\",\"caseId\":\"vue\",\"label\":\"Vue\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 266.94 ms · 341,230-341,908 B natural\",\"value\":287.75,\"valueDisplay\":\"287.75\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@vue/server-renderer renderToWebStream · node:http · MAD 0 req/s · p95 1,711.29 ms · 341,230-341,908 B natural\",\"value\":49.85,\"valueDisplay\":\"49.85\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 172 ms\",\"value\":172,\"valueDisplay\":\"172\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.49 MiB\",\"value\":2613330,\"valueDisplay\":\"2.49\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.68 MiB · p95 50.16 MiB\",\"value\":47779840,\"valueDisplay\":\"45.57\"}},\"primary\":false,\"rank\":\"10\"},{\"activeAvailable\":true,\"activeDetail\":\"react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 276.55 ms · 334,661-335,367 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"262.95\",\"activeWidth\":\"17.4%\",\"caseId\":\"react-tanstack\",\"label\":\"React + TanStack Router\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 276.55 ms · 334,661-335,367 B natural\",\"value\":262.95,\"valueDisplay\":\"262.95\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server stream + @tanstack/react-router renderRouterToStream · node:http · MAD 0 req/s · p95 389.03 ms · 334,661-335,367 B natural\",\"value\":189.35,\"valueDisplay\":\"189.35\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 16 ms · p95 256 ms\",\"value\":182,\"valueDisplay\":\"182\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 3.34 MiB\",\"value\":3442956,\"valueDisplay\":\"3.28\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.15 MiB · p95 52.17 MiB\",\"value\":51046400,\"valueDisplay\":\"48.68\"}},\"primary\":false,\"rank\":\"11\"},{\"activeAvailable\":true,\"activeDetail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 334.1 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 5.4% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"211.35\",\"activeWidth\":\"13.9%\",\"caseId\":\"sveltekit\",\"label\":\"SvelteKit\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 334.1 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 5.4% faster\",\"value\":211.35000000000002,\"valueDisplay\":\"211.35\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 341.91 ms · 303,354-303,888 B natural\",\"value\":213.5,\"valueDisplay\":\"213.5\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 172 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 4.85 MiB\",\"value\":5080782,\"valueDisplay\":\"4.85\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.24 MiB · p95 54 MiB\",\"value\":53147648,\"valueDisplay\":\"50.69\"}},\"primary\":false,\"rank\":\"12\"},{\"activeAvailable\":true,\"activeDetail\":\"Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 507 ms · 313,520-314,093 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"140.8\",\"activeWidth\":\"9.3%\",\"caseId\":\"next\",\"label\":\"Next.js\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 507 ms · 313,520-314,093 B natural\",\"value\":140.8,\"valueDisplay\":\"140.8\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Next.js production App Router streaming SSR · next start · MAD 0 req/s · p95 470.77 ms · 313,520-314,093 B natural\",\"value\":153.05,\"valueDisplay\":\"153.05\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 304 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 3.67 MiB\",\"value\":3848304,\"valueDisplay\":\"3.67\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.96 MiB · p95 51.33 MiB\",\"value\":51953664,\"valueDisplay\":\"49.55\"}},\"primary\":false,\"rank\":\"13\"},{\"activeAvailable\":true,\"activeDetail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 834.51 ms · 280,229-280,941 B natural · saturation warning: the 128-connection probe was 11.6% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"83.5\",\"activeWidth\":\"5.5%\",\"caseId\":\"nuxt\",\"label\":\"Nuxt\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 834.51 ms · 280,229-280,941 B natural · saturation warning: the 128-connection probe was 11.6% faster\",\"value\":83.5,\"valueDisplay\":\"83.5\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 792.19 ms · 280,229-280,941 B natural\",\"value\":84.4,\"valueDisplay\":\"84.4\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 16 ms · p95 288 ms\",\"value\":174,\"valueDisplay\":\"174\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 3.43 MiB\",\"value\":3599622,\"valueDisplay\":\"3.43\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.25 MiB · p95 48.02 MiB\",\"value\":50059264,\"valueDisplay\":\"47.74\"}},\"primary\":false,\"rank\":\"14\"},{\"activeAvailable\":true,\"activeDetail\":\"Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 914.4 ms · 462,724-463,582 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"75.8\",\"activeWidth\":\"5.0%\",\"caseId\":\"astro\",\"label\":\"Astro + Preact\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 914.4 ms · 462,724-463,582 B natural\",\"value\":75.8,\"valueDisplay\":\"75.8\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Astro production streaming SSR + @astrojs/preact island · @astrojs/node standalone · MAD 0 req/s · p95 853.22 ms · 462,723-463,582 B natural\",\"value\":80.05,\"valueDisplay\":\"80.05\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 ms · p95 172 ms\",\"value\":156,\"valueDisplay\":\"156\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.4 MiB\",\"value\":2517114,\"valueDisplay\":\"2.4\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.98 MiB · p95 52.8 MiB\",\"value\":50317312,\"valueDisplay\":\"47.99\"}},\"primary\":false,\"rank\":\"15\"}],\"responseMode\":\"comparison\",\"saturationWarnings\":{\"noStreaming\":[{\"caseId\":\"nuxt\",\"gainPercent\":11.619718309859154,\"label\":\"Nuxt\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"webui-node-http\",\"gainPercent\":16.079873883342092,\"label\":\"WebUI / Node node:http\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"sveltekit\",\"gainPercent\":5.4499366286438535,\"label\":\"SvelteKit\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"}],\"streaming\":[{\"caseId\":\"webui-node-http\",\"gainPercent\":13.109128345916265,\"label\":\"WebUI / Node node:http\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"}]},\"selectedMetric\":\"noStreamingRequestsPerSecond\",\"selectedMetricDescription\":\"Dynamic SSR throughput when each framework sends one fully collected HTML response without progressive boundaries.\",\"selectedMetricLabel\":\"No Streaming RPS\",\"title\":\"Complete response or streaming boundaries. Choose the metric.\",\"responseModes\":[\"complete\",\"progressive\"]}"
+  "benchmarksJson": "{\"asyncDataBoundary\":{\"canonicalWebuiVersion\":\"0.0.28\",\"notes\":\"The progressive suite continues to measure each product's existing native progressive/streaming boundaries unchanged. A dedicated above-the-fold-shell / below-the-fold-async-list workload driven by WebUI's resumable StreamingSession boundary API is intentionally not implemented yet against canonical WebUI 0.0.28. This is disclosed capability metadata, not an active measurement.\",\"requiredCapability\":\"StreamingSession resumable async data-boundary API\",\"status\":\"available-pending-benchmark-implementation\"},\"description\":\"Compare the same product workload in complete and progressive response modes, then inspect the three browser cost metrics that matter most.\",\"hasUnavailable\":false,\"link\":\"/webui/guide/concepts/performance/\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"metricSummary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 26.3% ahead of WebUI / Shadow DOM / Rust / Actix; the 331.75 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 399.0% higher; the 1,274.05 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Astro + Preact, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"metrics\":[{\"available\":true,\"description\":\"Dynamic SSR throughput when each framework sends one fully collected HTML response without progressive boundaries.\",\"direction\":\"higher\",\"directionLabel\":\"higher is better\",\"id\":\"noStreamingRequestsPerSecond\",\"label\":\"No Streaming RPS\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"selected\":true,\"summary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 26.3% ahead of WebUI / Shadow DOM / Rust / Actix; the 331.75 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, React, WebUI / Light DOM / Rust / Actix is 399.0% higher; the 1,274.05 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Astro + Preact, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"unit\":\"req/s\"},{\"available\":true,\"description\":\"Dynamic SSR throughput while native progressive or streaming boundaries remain enabled.\",\"direction\":\"higher\",\"directionLabel\":\"higher is better\",\"id\":\"streamingRequestsPerSecond\",\"label\":\"Streaming RPS\",\"methodology\":\"100 todos · 13 component types · 32 warm structural variants · current UTC state materialized per request · 64 connections from 2 load workers · 1 server process/worker pinned to 1 CPU · 1 × 20 s measured round · dynamic SSR · natural bytes\",\"selected\":false,\"summary\":\"WebUI / Light DOM / Rust / Actix records the highest median, 27.2% ahead of WebUI / Shadow DOM / Rust / Actix; the 296.7 req/s gap exceeds their combined 0 req/s MAD. Against the fastest non-WebUI row, Preact, WebUI / Light DOM / Rust / Actix is 282.6% higher; the 1,025.55 req/s gap exceeds their combined 0 req/s MAD. Fixed 64-connection results are retained for Next.js, WebUI / Light DOM / Node node:http, WebUI / Light DOM / Bun.serve, SvelteKit; their 128-connection saturation probes were still rising, so those throughput values are lower bounds.\",\"unit\":\"req/s\"},{\"available\":true,\"description\":\"Pre-interaction largest contentful paint from navigation start across ten isolated Chromium runs.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"largestContentfulPaintMs\",\"label\":\"LCP\",\"methodology\":\"Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Light DOM / Deno.serve records the lowest median, 3.0% below WebUI / Light DOM / Bun.serve; the 2 ms gap is within their combined 6 ms MAD, so the measured ordering overlaps run noise.\",\"unit\":\"ms\"},{\"available\":true,\"description\":\"Post-readiness JavaScript heap used after an explicit Chromium garbage collection.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"jsHeapUsedBytes\",\"label\":\"JS Heap\",\"methodology\":\"Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Light DOM / Deno.serve records the lowest median, 0.0% below WebUI / Light DOM / Bun.serve; the <0.01 MiB gap is within their combined <0.01 MiB MAD, so the measured ordering overlaps run noise.\",\"unit\":\"MiB\"},{\"available\":true,\"description\":\"Private bytes attributed to the isolated Chromium renderer process after readiness.\",\"direction\":\"lower\",\"directionLabel\":\"lower is better\",\"id\":\"rendererPrivateBytes\",\"label\":\"Renderer Private MB\",\"methodology\":\"Chromium 151.0.7922.34 · 1,440×900 viewport · 10 randomized cold-cache navigations · fresh foreground process/context/page per sample · native occlusion throttling disabled · no CPU or network throttling\",\"selected\":false,\"summary\":\"WebUI / Light DOM / Bun.serve records the lowest median, 0.7% below WebUI / Light DOM / Node node:http; the 0.41 MiB gap is within their combined 1.57 MiB MAD, so the measured ordering overlaps run noise.\",\"unit\":\"MiB\"}],\"rows\":[{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 44.81 ms · 329,202-329,899 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"1,593.4\",\"activeWidth\":\"100.0%\",\"caseId\":\"webui-rust-actix\",\"label\":\"WebUI / Light DOM / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust) · actix-web · MAD 0 req/s · p95 44.81 ms · 329,202-329,899 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 0.63 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":0.6279025982176478,\"median\":0.6279025982176478,\"min\":0.6279025982176478,\"p95\":0.6279025982176478},\"unit\":\"ms/req\",\"value\":0.6279025982176478,\"valueDisplay\":\"0.63\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 59.84 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":62746624,\"median\":62746624,\"min\":62746624,\"p95\":62746624},\"unit\":\"MiB\",\"value\":62746624,\"valueDisplay\":\"59.84\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 128.12 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":134340608,\"median\":134340608,\"min\":134340608,\"p95\":134340608},\"unit\":\"MiB\",\"value\":134340608,\"valueDisplay\":\"128.12\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 128.12 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":134340608,\"median\":134340608,\"min\":134340608,\"p95\":134340608},\"unit\":\"MiB\",\"value\":134340608,\"valueDisplay\":\"128.12\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 105.77 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":110911488,\"median\":110911488,\"min\":110911488,\"p95\":110911488},\"unit\":\"MiB\",\"value\":110911488,\"valueDisplay\":\"105.77\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 59.84 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":62746624,\"median\":62746624,\"min\":62746624,\"p95\":62746624},\"unit\":\"MiB\",\"value\":62746624,\"valueDisplay\":\"59.84\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 68.28 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":71593984,\"median\":71593984,\"min\":71593984,\"p95\":71593984},\"unit\":\"MiB\",\"value\":71593984,\"valueDisplay\":\"68.28\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":1593.4,\"valueDisplay\":\"1,593.4\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler StreamingResponse (Rust) · actix-web · MAD 0 req/s · p95 50.87 ms · 337,114-337,843 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 0.72 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":0.7184270229392488,\"median\":0.7184270229392488,\"min\":0.7184270229392488,\"p95\":0.7184270229392488},\"unit\":\"ms/req\",\"value\":0.7184270229392488,\"valueDisplay\":\"0.72\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 40.76 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":42741760,\"median\":42741760,\"min\":42741760,\"p95\":42741760},\"unit\":\"MiB\",\"value\":42741760,\"valueDisplay\":\"40.76\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 128.97 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":135233536,\"median\":135233536,\"min\":135233536,\"p95\":135233536},\"unit\":\"MiB\",\"value\":135233536,\"valueDisplay\":\"128.97\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 128.97 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":135233536,\"median\":135233536,\"min\":135233536,\"p95\":135233536},\"unit\":\"MiB\",\"value\":135233536,\"valueDisplay\":\"128.97\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 114.37 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":119922688,\"median\":119922688,\"min\":119922688,\"p95\":119922688},\"unit\":\"MiB\",\"value\":119922688,\"valueDisplay\":\"114.37\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 40.76 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":42741760,\"median\":42741760,\"min\":42741760,\"p95\":42741760},\"unit\":\"MiB\",\"value\":42741760,\"valueDisplay\":\"40.76\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 88.21 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":92491776,\"median\":92491776,\"min\":92491776,\"p95\":92491776},\"unit\":\"MiB\",\"value\":92491776,\"valueDisplay\":\"88.21\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":1388.45,\"valueDisplay\":\"1,388.45\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 76 ms\",\"value\":68,\"valueDisplay\":\"68\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB\",\"value\":2204666,\"valueDisplay\":\"2.1\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.74 MiB · p95 61.62 MiB\",\"value\":61323264,\"valueDisplay\":\"58.48\"}},\"primary\":true,\"rank\":\"1\"},{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 55.55 ms · 483,598-485,019 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"1,261.65\",\"activeWidth\":\"79.2%\",\"caseId\":\"webui-shadowdom-rust-actix\",\"label\":\"WebUI / Shadow DOM / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 55.55 ms · 483,598-485,019 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 0.79 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":0.7938017675266517,\"median\":0.7938017675266517,\"min\":0.7938017675266517,\"p95\":0.7938017675266517},\"unit\":\"ms/req\",\"value\":0.7938017675266517,\"valueDisplay\":\"0.79\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 103.65 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":108683264,\"median\":108683264,\"min\":108683264,\"p95\":108683264},\"unit\":\"MiB\",\"value\":108683264,\"valueDisplay\":\"103.65\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 153.42 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":160874496,\"median\":160874496,\"min\":160874496,\"p95\":160874496},\"unit\":\"MiB\",\"value\":160874496,\"valueDisplay\":\"153.42\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 145.42 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":152485888,\"median\":152485888,\"min\":152485888,\"p95\":152485888},\"unit\":\"MiB\",\"value\":152485888,\"valueDisplay\":\"145.42\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 115.77 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":121389056,\"median\":121389056,\"min\":121389056,\"p95\":121389056},\"unit\":\"MiB\",\"value\":121389056,\"valueDisplay\":\"115.77\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 95.65 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":100294656,\"median\":100294656,\"min\":100294656,\"p95\":100294656},\"unit\":\"MiB\",\"value\":100294656,\"valueDisplay\":\"95.65\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 49.77 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":52191232,\"median\":52191232,\"min\":52191232,\"p95\":52191232},\"unit\":\"MiB\",\"value\":52191232,\"valueDisplay\":\"49.77\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":1261.65,\"valueDisplay\":\"1,261.65\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler StreamingResponse (Rust, Shadow DOM) · actix-web · MAD 0 req/s · p95 65.06 ms · 491,524-492,977 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 0.91 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":0.9132127318525304,\"median\":0.9132127318525304,\"min\":0.9132127318525304,\"p95\":0.9132127318525304},\"unit\":\"ms/req\",\"value\":0.9132127318525304,\"valueDisplay\":\"0.91\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 69.07 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":72425472,\"median\":72425472,\"min\":72425472,\"p95\":72425472},\"unit\":\"MiB\",\"value\":72425472,\"valueDisplay\":\"69.07\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 150.58 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":157892608,\"median\":157892608,\"min\":157892608,\"p95\":157892608},\"unit\":\"MiB\",\"value\":157892608,\"valueDisplay\":\"150.58\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 148.65 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":155869184,\"median\":155869184,\"min\":155869184,\"p95\":155869184},\"unit\":\"MiB\",\"value\":155869184,\"valueDisplay\":\"148.65\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 120.67 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":126529536,\"median\":126529536,\"min\":126529536,\"p95\":126529536},\"unit\":\"MiB\",\"value\":126529536,\"valueDisplay\":\"120.67\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 67.14 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":70402048,\"median\":70402048,\"min\":70402048,\"p95\":70402048},\"unit\":\"MiB\",\"value\":70402048,\"valueDisplay\":\"67.14\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 81.51 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":85467136,\"median\":85467136,\"min\":85467136,\"p95\":85467136},\"unit\":\"MiB\",\"value\":85467136,\"valueDisplay\":\"81.51\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":1091.75,\"valueDisplay\":\"1,091.75\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 8 ms · p95 116 ms\",\"value\":84,\"valueDisplay\":\"84\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.45 MiB\",\"value\":2568326,\"valueDisplay\":\"2.45\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.76 MiB · p95 67 MiB\",\"value\":68249600,\"valueDisplay\":\"65.09\"}},\"primary\":true,\"rank\":\"2\"},{\"activeAvailable\":true,\"activeDetail\":\"webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.13 ms · 596,601-598,231 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"976.75\",\"activeWidth\":\"61.3%\",\"caseId\":\"webui-fast-rust-actix\",\"label\":\"WebUI / FAST V3 / Rust / Actix\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler render (Rust, FAST V3, single response) · actix-web · MAD 0 req/s · p95 72.13 ms · 596,601-598,231 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 1.03 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":1.0258510366009725,\"median\":1.0258510366009725,\"min\":1.0258510366009725,\"p95\":1.0258510366009725},\"unit\":\"ms/req\",\"value\":1.0258510366009725,\"valueDisplay\":\"1.03\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 71.73 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":75210752,\"median\":75210752,\"min\":75210752,\"p95\":75210752},\"unit\":\"MiB\",\"value\":75210752,\"valueDisplay\":\"71.73\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 133.2 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":139673600,\"median\":139673600,\"min\":139673600,\"p95\":139673600},\"unit\":\"MiB\",\"value\":139673600,\"valueDisplay\":\"133.2\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 124.18 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":130211840,\"median\":130211840,\"min\":130211840,\"p95\":130211840},\"unit\":\"MiB\",\"value\":130211840,\"valueDisplay\":\"124.18\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 133.2 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":139673600,\"median\":139673600,\"min\":139673600,\"p95\":139673600},\"unit\":\"MiB\",\"value\":139673600,\"valueDisplay\":\"133.2\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 62.7 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":65748992,\"median\":65748992,\"min\":65748992,\"p95\":65748992},\"unit\":\"MiB\",\"value\":65748992,\"valueDisplay\":\"62.7\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 61.48 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":64462848,\"median\":64462848,\"min\":64462848,\"p95\":64462848},\"unit\":\"MiB\",\"value\":64462848,\"valueDisplay\":\"61.48\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":976.75,\"valueDisplay\":\"976.75\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"webui-handler chunked ResponseWriter (Rust, FAST V3) · actix-web · MAD 0 req/s · p95 108.43 ms · 596,601-598,231 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 1.6 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":1.5975385598977063,\"median\":1.5975385598977063,\"min\":1.5975385598977063,\"p95\":1.5975385598977063},\"unit\":\"ms/req\",\"value\":1.5975385598977063,\"valueDisplay\":\"1.6\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 85.7 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":89862144,\"median\":89862144,\"min\":89862144,\"p95\":89862144},\"unit\":\"MiB\",\"value\":89862144,\"valueDisplay\":\"85.7\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 156.61 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":164216832,\"median\":164216832,\"min\":164216832,\"p95\":164216832},\"unit\":\"MiB\",\"value\":164216832,\"valueDisplay\":\"156.61\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 149.77 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":157048832,\"median\":157048832,\"min\":157048832,\"p95\":157048832},\"unit\":\"MiB\",\"value\":157048832,\"valueDisplay\":\"149.77\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 154.93 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":162455552,\"median\":162455552,\"min\":162455552,\"p95\":162455552},\"unit\":\"MiB\",\"value\":162455552,\"valueDisplay\":\"154.93\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 78.86 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":82694144,\"median\":82694144,\"min\":82694144,\"p95\":82694144},\"unit\":\"MiB\",\"value\":82694144,\"valueDisplay\":\"78.86\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 70.91 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":74354688,\"median\":74354688,\"min\":74354688,\"p95\":74354688},\"unit\":\"MiB\",\"value\":74354688,\"valueDisplay\":\"70.91\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":625.6500000000001,\"valueDisplay\":\"625.65\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 104 ms\",\"value\":88,\"valueDisplay\":\"88\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 5.24 MiB\",\"value\":5478080,\"valueDisplay\":\"5.22\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.3 MiB · p95 71.79 MiB\",\"value\":73490432,\"valueDisplay\":\"70.09\"}},\"primary\":true,\"rank\":\"3\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 127.89 ms · 329,202-329,899 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"609.45\",\"activeWidth\":\"38.2%\",\"caseId\":\"webui-node-http\",\"label\":\"WebUI / Light DOM / Node node:http\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 127.89 ms · 329,202-329,899 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 1.64 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":1.6449257527278693,\"median\":1.6449257527278693,\"min\":1.6449257527278693,\"p95\":1.6449257527278693},\"unit\":\"ms/req\",\"value\":1.6449257527278693,\"valueDisplay\":\"1.64\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 86.57 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":90779648,\"median\":90779648,\"min\":90779648,\"p95\":90779648},\"unit\":\"MiB\",\"value\":90779648,\"valueDisplay\":\"86.57\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 382.15 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":400711680,\"median\":400711680,\"min\":400711680,\"p95\":400711680},\"unit\":\"MiB\",\"value\":400711680,\"valueDisplay\":\"382.15\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 355.75 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":373026816,\"median\":373026816,\"min\":373026816,\"p95\":373026816},\"unit\":\"MiB\",\"value\":373026816,\"valueDisplay\":\"355.75\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 362.34 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":379936768,\"median\":379936768,\"min\":379936768,\"p95\":379936768},\"unit\":\"MiB\",\"value\":379936768,\"valueDisplay\":\"362.34\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 60.17 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":63094784,\"median\":63094784,\"min\":63094784,\"p95\":63094784},\"unit\":\"MiB\",\"value\":63094784,\"valueDisplay\":\"60.17\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 295.57 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":309932032,\"median\":309932032,\"min\":309932032,\"p95\":309932032},\"unit\":\"MiB\",\"value\":309932032,\"valueDisplay\":\"295.57\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":609.45,\"valueDisplay\":\"609.45\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · node:http · MAD 0 req/s · p95 189.99 ms · 337,114-337,843 B natural · saturation warning: the 128-connection probe was 6.0% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 2.31 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":2.3086661295891355,\"median\":2.3086661295891355,\"min\":2.3086661295891355,\"p95\":2.3086661295891355},\"unit\":\"ms/req\",\"value\":2.3086661295891355,\"valueDisplay\":\"2.31\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 217.42 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":227983360,\"median\":227983360,\"min\":227983360,\"p95\":227983360},\"unit\":\"MiB\",\"value\":227983360,\"valueDisplay\":\"217.42\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 558.25 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":585367552,\"median\":585367552,\"min\":585367552,\"p95\":585367552},\"unit\":\"MiB\",\"value\":585367552,\"valueDisplay\":\"558.25\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 556.28 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":583303168,\"median\":583303168,\"min\":583303168,\"p95\":583303168},\"unit\":\"MiB\",\"value\":583303168,\"valueDisplay\":\"556.28\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 512.17 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":537051136,\"median\":537051136,\"min\":537051136,\"p95\":537051136},\"unit\":\"MiB\",\"value\":537051136,\"valueDisplay\":\"512.17\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 215.45 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":225918976,\"median\":225918976,\"min\":225918976,\"p95\":225918976},\"unit\":\"MiB\",\"value\":225918976,\"valueDisplay\":\"215.45\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 340.83 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":357384192,\"median\":357384192,\"min\":357384192,\"p95\":357384192},\"unit\":\"MiB\",\"value\":357384192,\"valueDisplay\":\"340.83\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":434.45,\"valueDisplay\":\"434.45\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 100 ms\",\"value\":66,\"valueDisplay\":\"66\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB\",\"value\":2203760,\"valueDisplay\":\"2.1\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.74 MiB · p95 60.96 MiB\",\"value\":60893184,\"valueDisplay\":\"58.07\"}},\"primary\":true,\"rank\":\"4\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 142.74 ms · 329,202-329,899 B natural · saturation warning: the 128-connection probe was 8.5% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"563.3\",\"activeWidth\":\"35.4%\",\"caseId\":\"webui-bun-serve\",\"label\":\"WebUI / Light DOM / Bun.serve\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 142.74 ms · 329,202-329,899 B natural · saturation warning: the 128-connection probe was 8.5% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 1.78 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":1.7814663589561512,\"median\":1.7814663589561512,\"min\":1.7814663589561512,\"p95\":1.7814663589561512},\"unit\":\"ms/req\",\"value\":1.7814663589561512,\"valueDisplay\":\"1.78\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 82.29 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":86282240,\"median\":86282240,\"min\":86282240,\"p95\":86282240},\"unit\":\"MiB\",\"value\":86282240,\"valueDisplay\":\"82.29\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 160.53 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":168329216,\"median\":168329216,\"min\":168329216,\"p95\":168329216},\"unit\":\"MiB\",\"value\":168329216,\"valueDisplay\":\"160.53\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 127.52 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":133713920,\"median\":133713920,\"min\":133713920,\"p95\":133713920},\"unit\":\"MiB\",\"value\":133713920,\"valueDisplay\":\"127.52\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 130.56 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":136904704,\"median\":136904704,\"min\":136904704,\"p95\":136904704},\"unit\":\"MiB\",\"value\":136904704,\"valueDisplay\":\"130.56\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 49.27 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":51666944,\"median\":51666944,\"min\":51666944,\"p95\":51666944},\"unit\":\"MiB\",\"value\":51666944,\"valueDisplay\":\"49.27\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 78.25 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":82046976,\"median\":82046976,\"min\":82046976,\"p95\":82046976},\"unit\":\"MiB\",\"value\":82046976,\"valueDisplay\":\"78.25\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":563.3,\"valueDisplay\":\"563.3\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · Bun.serve · MAD 0 req/s · p95 167.96 ms · 337,114-337,843 B natural · saturation warning: the 128-connection probe was 9.3% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 2.18 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":2.179904513888889,\"median\":2.179904513888889,\"min\":2.179904513888889,\"p95\":2.179904513888889},\"unit\":\"ms/req\",\"value\":2.179904513888889,\"valueDisplay\":\"2.18\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 167.33 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":175460352,\"median\":175460352,\"min\":175460352,\"p95\":175460352},\"unit\":\"MiB\",\"value\":175460352,\"valueDisplay\":\"167.33\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 273.53 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":286814208,\"median\":286814208,\"min\":286814208,\"p95\":286814208},\"unit\":\"MiB\",\"value\":286814208,\"valueDisplay\":\"273.53\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 254.84 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":267214848,\"median\":267214848,\"min\":267214848,\"p95\":267214848},\"unit\":\"MiB\",\"value\":267214848,\"valueDisplay\":\"254.84\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 239.35 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":250978304,\"median\":250978304,\"min\":250978304,\"p95\":250978304},\"unit\":\"MiB\",\"value\":250978304,\"valueDisplay\":\"239.35\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 148.64 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":155860992,\"median\":155860992,\"min\":155860992,\"p95\":155860992},\"unit\":\"MiB\",\"value\":155860992,\"valueDisplay\":\"148.64\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 106.2 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":111353856,\"median\":111353856,\"min\":111353856,\"p95\":111353856},\"unit\":\"MiB\",\"value\":111353856,\"valueDisplay\":\"106.2\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":460.8,\"valueDisplay\":\"460.8\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 2 ms · p95 76 ms\",\"value\":66,\"valueDisplay\":\"66\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB\",\"value\":2203604,\"valueDisplay\":\"2.1\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.83 MiB · p95 61.82 MiB\",\"value\":60465152,\"valueDisplay\":\"57.66\"}},\"primary\":true,\"rank\":\"5\"},{\"activeAvailable\":true,\"activeDetail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 147.18 ms · 329,202-329,899 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"554.6\",\"activeWidth\":\"34.8%\",\"caseId\":\"webui-deno-serve\",\"label\":\"WebUI / Light DOM / Deno.serve\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.render (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 147.18 ms · 329,202-329,899 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 1.81 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":1.8085106382978724,\"median\":1.8085106382978724,\"min\":1.8085106382978724,\"p95\":1.8085106382978724},\"unit\":\"ms/req\",\"value\":1.8085106382978724,\"valueDisplay\":\"1.81\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 157.83 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":165498880,\"median\":165498880,\"min\":165498880,\"p95\":165498880},\"unit\":\"MiB\",\"value\":165498880,\"valueDisplay\":\"157.83\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 276.41 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":289832960,\"median\":289832960,\"min\":289832960,\"p95\":289832960},\"unit\":\"MiB\",\"value\":289832960,\"valueDisplay\":\"276.41\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 225.35 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":236298240,\"median\":236298240,\"min\":236298240,\"p95\":236298240},\"unit\":\"MiB\",\"value\":236298240,\"valueDisplay\":\"225.35\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 268.82 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":281874432,\"median\":281874432,\"min\":281874432,\"p95\":281874432},\"unit\":\"MiB\",\"value\":281874432,\"valueDisplay\":\"268.82\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 106.78 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":111964160,\"median\":111964160,\"min\":111964160,\"p95\":111964160},\"unit\":\"MiB\",\"value\":111964160,\"valueDisplay\":\"106.78\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 118.57 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":124334080,\"median\":124334080,\"min\":124334080,\"p95\":124334080},\"unit\":\"MiB\",\"value\":124334080,\"valueDisplay\":\"118.57\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":554.6,\"valueDisplay\":\"554.6\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@microsoft/webui Protocol.streamResponse (Light DOM, request-materialized Node-API state) · Deno.serve · MAD 0 req/s · p95 242.37 ms · 337,114-337,843 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 2.4 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":2.4037536092396534,\"median\":2.4037536092396534,\"min\":2.4037536092396534,\"p95\":2.4037536092396534},\"unit\":\"ms/req\",\"value\":2.4037536092396534,\"valueDisplay\":\"2.4\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 235.63 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":247070720,\"median\":247070720,\"min\":247070720,\"p95\":247070720},\"unit\":\"MiB\",\"value\":247070720,\"valueDisplay\":\"235.63\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 384.94 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":403640320,\"median\":403640320,\"min\":403640320,\"p95\":403640320},\"unit\":\"MiB\",\"value\":403640320,\"valueDisplay\":\"384.94\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 373.33 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":391467008,\"median\":391467008,\"min\":391467008,\"p95\":391467008},\"unit\":\"MiB\",\"value\":391467008,\"valueDisplay\":\"373.33\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 318.46 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":333934592,\"median\":333934592,\"min\":333934592,\"p95\":333934592},\"unit\":\"MiB\",\"value\":333934592,\"valueDisplay\":\"318.46\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 224.02 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":234897408,\"median\":234897408,\"min\":234897408,\"p95\":234897408},\"unit\":\"MiB\",\"value\":234897408,\"valueDisplay\":\"224.02\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 149.32 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":156569600,\"median\":156569600,\"min\":156569600,\"p95\":156569600},\"unit\":\"MiB\",\"value\":156569600,\"valueDisplay\":\"149.32\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":415.6,\"valueDisplay\":\"415.6\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 76 ms\",\"value\":64,\"valueDisplay\":\"64\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.1 MiB\",\"value\":2203584,\"valueDisplay\":\"2.1\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.55 MiB · p95 61.57 MiB\",\"value\":62160896,\"valueDisplay\":\"59.28\"}},\"primary\":true,\"rank\":\"6\"},{\"activeAvailable\":true,\"activeDetail\":\"react-dom/server renderToString · node:http · MAD 0 req/s · p95 235.72 ms · 334,118-334,824 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"319.35\",\"activeWidth\":\"20.0%\",\"caseId\":\"react\",\"label\":\"React\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToString · node:http · MAD 0 req/s · p95 235.72 ms · 334,118-334,824 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 3.13 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":3.129794895882261,\"median\":3.129794895882261,\"min\":3.129794895882261,\"p95\":3.129794895882261},\"unit\":\"ms/req\",\"value\":3.129794895882261,\"valueDisplay\":\"3.13\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 70.85 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":74293248,\"median\":74293248,\"min\":74293248,\"p95\":74293248},\"unit\":\"MiB\",\"value\":74293248,\"valueDisplay\":\"70.85\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 382.64 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":401227776,\"median\":401227776,\"min\":401227776,\"p95\":401227776},\"unit\":\"MiB\",\"value\":401227776,\"valueDisplay\":\"382.64\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 353.81 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":370999296,\"median\":370999296,\"min\":370999296,\"p95\":370999296},\"unit\":\"MiB\",\"value\":370999296,\"valueDisplay\":\"353.81\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 301.49 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":316137472,\"median\":316137472,\"min\":316137472,\"p95\":316137472},\"unit\":\"MiB\",\"value\":316137472,\"valueDisplay\":\"301.49\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 42.02 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":44064768,\"median\":44064768,\"min\":44064768,\"p95\":44064768},\"unit\":\"MiB\",\"value\":44064768,\"valueDisplay\":\"42.02\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 311.79 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":326934528,\"median\":326934528,\"min\":326934528,\"p95\":326934528},\"unit\":\"MiB\",\"value\":326934528,\"valueDisplay\":\"311.79\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":319.35,\"valueDisplay\":\"319.35\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToReadableStream · node:http · MAD 0 req/s · p95 252.8 ms · 334,118-334,824 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 3.74 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":3.7371663244353184,\"median\":3.7371663244353184,\"min\":3.7371663244353184,\"p95\":3.7371663244353184},\"unit\":\"ms/req\",\"value\":3.7371663244353184,\"valueDisplay\":\"3.74\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 294.4 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":308703232,\"median\":308703232,\"min\":308703232,\"p95\":308703232},\"unit\":\"MiB\",\"value\":308703232,\"valueDisplay\":\"294.4\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 585.79 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":614244352,\"median\":614244352,\"min\":614244352,\"p95\":614244352},\"unit\":\"MiB\",\"value\":614244352,\"valueDisplay\":\"585.79\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 587.95 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":616509440,\"median\":616509440,\"min\":616509440,\"p95\":616509440},\"unit\":\"MiB\",\"value\":616509440,\"valueDisplay\":\"587.95\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 311.67 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":326811648,\"median\":326811648,\"min\":326811648,\"p95\":326811648},\"unit\":\"MiB\",\"value\":326811648,\"valueDisplay\":\"311.67\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 296.56 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":310968320,\"median\":310968320,\"min\":310968320,\"p95\":310968320},\"unit\":\"MiB\",\"value\":310968320,\"valueDisplay\":\"296.56\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 291.39 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":305541120,\"median\":305541120,\"min\":305541120,\"p95\":305541120},\"unit\":\"MiB\",\"value\":305541120,\"valueDisplay\":\"291.39\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":267.85,\"valueDisplay\":\"267.85\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 88 ms\",\"value\":84,\"valueDisplay\":\"84\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.92 MiB\",\"value\":3060656,\"valueDisplay\":\"2.92\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.24 MiB · p95 65.33 MiB\",\"value\":66816000,\"valueDisplay\":\"63.72\"}},\"primary\":false,\"rank\":\"7\"},{\"activeAvailable\":true,\"activeDetail\":\"preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 228.15 ms · 333,940-334,646 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"317.6\",\"activeWidth\":\"19.9%\",\"caseId\":\"preact\",\"label\":\"Preact\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"preact-render-to-string renderToString · node:http · MAD 0 req/s · p95 228.15 ms · 333,940-334,646 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 3.15 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":3.1533375314861463,\"median\":3.1533375314861463,\"min\":3.1533375314861463,\"p95\":3.1533375314861463},\"unit\":\"ms/req\",\"value\":3.1533375314861463,\"valueDisplay\":\"3.15\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 86.63 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":90836992,\"median\":90836992,\"min\":90836992,\"p95\":90836992},\"unit\":\"MiB\",\"value\":90836992,\"valueDisplay\":\"86.63\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 375.95 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":394215424,\"median\":394215424,\"min\":394215424,\"p95\":394215424},\"unit\":\"MiB\",\"value\":394215424,\"valueDisplay\":\"375.95\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 365.94 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":383717376,\"median\":383717376,\"min\":383717376,\"p95\":383717376},\"unit\":\"MiB\",\"value\":383717376,\"valueDisplay\":\"365.94\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 328.78 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":344748032,\"median\":344748032,\"min\":344748032,\"p95\":344748032},\"unit\":\"MiB\",\"value\":344748032,\"valueDisplay\":\"328.78\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 76.62 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":80338944,\"median\":80338944,\"min\":80338944,\"p95\":80338944},\"unit\":\"MiB\",\"value\":80338944,\"valueDisplay\":\"76.62\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 289.32 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":303378432,\"median\":303378432,\"min\":303378432,\"p95\":303378432},\"unit\":\"MiB\",\"value\":303378432,\"valueDisplay\":\"289.32\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":317.6,\"valueDisplay\":\"317.6\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"preact-render-to-string renderToReadableStream · node:http · MAD 0 req/s · p95 208.25 ms · 333,940-334,646 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 2.75 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":2.754202259575641,\"median\":2.754202259575641,\"min\":2.754202259575641,\"p95\":2.754202259575641},\"unit\":\"ms/req\",\"value\":2.754202259575641,\"valueDisplay\":\"2.75\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 62.54 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":65576960,\"median\":65576960,\"min\":65576960,\"p95\":65576960},\"unit\":\"MiB\",\"value\":65576960,\"valueDisplay\":\"62.54\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 354.59 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":371818496,\"median\":371818496,\"min\":371818496,\"p95\":371818496},\"unit\":\"MiB\",\"value\":371818496,\"valueDisplay\":\"354.59\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 339.33 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":355815424,\"median\":355815424,\"min\":355815424,\"p95\":355815424},\"unit\":\"MiB\",\"value\":355815424,\"valueDisplay\":\"339.33\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 309.59 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":324624384,\"median\":324624384,\"min\":324624384,\"p95\":324624384},\"unit\":\"MiB\",\"value\":324624384,\"valueDisplay\":\"309.59\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 47.28 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":49573888,\"median\":49573888,\"min\":49573888,\"p95\":49573888},\"unit\":\"MiB\",\"value\":49573888,\"valueDisplay\":\"47.28\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 292.05 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":306241536,\"median\":306241536,\"min\":306241536,\"p95\":306241536},\"unit\":\"MiB\",\"value\":306241536,\"valueDisplay\":\"292.05\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":362.9,\"valueDisplay\":\"362.9\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 2 ms · p95 88 ms\",\"value\":82,\"valueDisplay\":\"82\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.4 MiB\",\"value\":2512624,\"valueDisplay\":\"2.4\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.26 MiB · p95 61.85 MiB\",\"value\":63969280,\"valueDisplay\":\"61.01\"}},\"primary\":false,\"rank\":\"8\"},{\"activeAvailable\":true,\"activeDetail\":\"solid-js/web renderToString · node:http · MAD 0 req/s · p95 266.84 ms · 378,043-378,863 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"280.7\",\"activeWidth\":\"17.6%\",\"caseId\":\"solid\",\"label\":\"Solid\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"solid-js/web renderToString · node:http · MAD 0 req/s · p95 266.84 ms · 378,043-378,863 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 3.56 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":3.560741004631279,\"median\":3.560741004631279,\"min\":3.560741004631279,\"p95\":3.560741004631279},\"unit\":\"ms/req\",\"value\":3.560741004631279,\"valueDisplay\":\"3.56\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 270.17 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":283295744,\"median\":283295744,\"min\":283295744,\"p95\":283295744},\"unit\":\"MiB\",\"value\":283295744,\"valueDisplay\":\"270.17\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 563.66 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":591044608,\"median\":591044608,\"min\":591044608,\"p95\":591044608},\"unit\":\"MiB\",\"value\":591044608,\"valueDisplay\":\"563.66\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 548.67 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":575320064,\"median\":575320064,\"min\":575320064,\"p95\":575320064},\"unit\":\"MiB\",\"value\":575320064,\"valueDisplay\":\"548.67\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 520.95 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":546258944,\"median\":546258944,\"min\":546258944,\"p95\":546258944},\"unit\":\"MiB\",\"value\":546258944,\"valueDisplay\":\"520.95\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 255.18 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":267571200,\"median\":267571200,\"min\":267571200,\"p95\":267571200},\"unit\":\"MiB\",\"value\":267571200,\"valueDisplay\":\"255.18\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 293.49 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":307748864,\"median\":307748864,\"min\":307748864,\"p95\":307748864},\"unit\":\"MiB\",\"value\":307748864,\"valueDisplay\":\"293.49\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":280.7,\"valueDisplay\":\"280.7\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"solid-js/web renderToStream · node:http · MAD 0 req/s · p95 336.8 ms · 378,043-378,863 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 4.12 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":4.124433456942728,\"median\":4.124433456942728,\"min\":4.124433456942728,\"p95\":4.124433456942728},\"unit\":\"ms/req\",\"value\":4.124433456942728,\"valueDisplay\":\"4.12\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 391.52 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":410537984,\"median\":410537984,\"min\":410537984,\"p95\":410537984},\"unit\":\"MiB\",\"value\":410537984,\"valueDisplay\":\"391.52\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 692.25 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":725880832,\"median\":725880832,\"min\":725880832,\"p95\":725880832},\"unit\":\"MiB\",\"value\":725880832,\"valueDisplay\":\"692.25\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 555.38 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":582352896,\"median\":582352896,\"min\":582352896,\"p95\":582352896},\"unit\":\"MiB\",\"value\":582352896,\"valueDisplay\":\"555.38\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 555.98 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":582983680,\"median\":582983680,\"min\":582983680,\"p95\":582983680},\"unit\":\"MiB\",\"value\":582983680,\"valueDisplay\":\"555.98\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 254.64 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":267010048,\"median\":267010048,\"min\":267010048,\"p95\":267010048},\"unit\":\"MiB\",\"value\":267010048,\"valueDisplay\":\"254.64\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 300.73 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":315342848,\"median\":315342848,\"min\":315342848,\"p95\":315342848},\"unit\":\"MiB\",\"value\":315342848,\"valueDisplay\":\"300.73\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":242.7,\"valueDisplay\":\"242.7\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 8 ms · p95 136 ms\",\"value\":124,\"valueDisplay\":\"124\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 MiB · p95 4.64 MiB\",\"value\":4864128,\"valueDisplay\":\"4.64\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.36 MiB · p95 69.4 MiB\",\"value\":71872512,\"valueDisplay\":\"68.54\"}},\"primary\":false,\"rank\":\"9\"},{\"activeAvailable\":true,\"activeDetail\":\"@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 281.61 ms · 341,230-341,908 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"265.2\",\"activeWidth\":\"16.6%\",\"caseId\":\"vue\",\"label\":\"Vue\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@vue/server-renderer renderToString · node:http · MAD 0 req/s · p95 281.61 ms · 341,230-341,908 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 3.77 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":3.77262443438914,\"median\":3.77262443438914,\"min\":3.77262443438914,\"p95\":3.77262443438914},\"unit\":\"ms/req\",\"value\":3.77262443438914,\"valueDisplay\":\"3.77\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 119.66 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":125476864,\"median\":125476864,\"min\":125476864,\"p95\":125476864},\"unit\":\"MiB\",\"value\":125476864,\"valueDisplay\":\"119.66\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 430.88 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":451805184,\"median\":451805184,\"min\":451805184,\"p95\":451805184},\"unit\":\"MiB\",\"value\":451805184,\"valueDisplay\":\"430.88\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 405.75 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":425459712,\"median\":425459712,\"min\":425459712,\"p95\":425459712},\"unit\":\"MiB\",\"value\":425459712,\"valueDisplay\":\"405.75\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 343.74 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":360439808,\"median\":360439808,\"min\":360439808,\"p95\":360439808},\"unit\":\"MiB\",\"value\":360439808,\"valueDisplay\":\"343.74\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 94.54 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":99131392,\"median\":99131392,\"min\":99131392,\"p95\":99131392},\"unit\":\"MiB\",\"value\":99131392,\"valueDisplay\":\"94.54\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 311.21 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":326328320,\"median\":326328320,\"min\":326328320,\"p95\":326328320},\"unit\":\"MiB\",\"value\":326328320,\"valueDisplay\":\"311.21\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":265.2,\"valueDisplay\":\"265.2\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@vue/server-renderer renderToWebStream · node:http · MAD 0 req/s · p95 455.23 ms · 341,230-341,908 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 8.72 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":8.724423160644319,\"median\":8.724423160644319,\"min\":8.724423160644319,\"p95\":8.724423160644319},\"unit\":\"ms/req\",\"value\":8.724423160644319,\"valueDisplay\":\"8.72\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 108.14 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":113393664,\"median\":113393664,\"min\":113393664,\"p95\":113393664},\"unit\":\"MiB\",\"value\":113393664,\"valueDisplay\":\"108.14\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 407.99 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":427806720,\"median\":427806720,\"min\":427806720,\"p95\":427806720},\"unit\":\"MiB\",\"value\":427806720,\"valueDisplay\":\"407.99\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 404.9 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":424566784,\"median\":424566784,\"min\":424566784,\"p95\":424566784},\"unit\":\"MiB\",\"value\":424566784,\"valueDisplay\":\"404.9\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 328.53 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":344485888,\"median\":344485888,\"min\":344485888,\"p95\":344485888},\"unit\":\"MiB\",\"value\":344485888,\"valueDisplay\":\"328.53\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 105.05 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":110153728,\"median\":110153728,\"min\":110153728,\"p95\":110153728},\"unit\":\"MiB\",\"value\":110153728,\"valueDisplay\":\"105.05\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 299.85 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":314413056,\"median\":314413056,\"min\":314413056,\"p95\":314413056},\"unit\":\"MiB\",\"value\":314413056,\"valueDisplay\":\"299.85\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":114.85,\"valueDisplay\":\"114.85\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 92 ms\",\"value\":84,\"valueDisplay\":\"84\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.66 MiB\",\"value\":2792756,\"valueDisplay\":\"2.66\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.35 MiB · p95 62.98 MiB\",\"value\":64987136,\"valueDisplay\":\"61.98\"}},\"primary\":false,\"rank\":\"10\"},{\"activeAvailable\":true,\"activeDetail\":\"react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 300.07 ms · 334,661-335,367 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"239.25\",\"activeWidth\":\"15.0%\",\"caseId\":\"react-tanstack\",\"label\":\"React + TanStack Router\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server renderToString + @tanstack/react-router renderRouterToString · node:http · MAD 0 req/s · p95 300.07 ms · 334,661-335,367 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 4.19 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":4.185997910135841,\"median\":4.185997910135841,\"min\":4.185997910135841,\"p95\":4.185997910135841},\"unit\":\"ms/req\",\"value\":4.185997910135841,\"valueDisplay\":\"4.19\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 108.43 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":113692672,\"median\":113692672,\"min\":113692672,\"p95\":113692672},\"unit\":\"MiB\",\"value\":113692672,\"valueDisplay\":\"108.43\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 445.49 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":467132416,\"median\":467132416,\"min\":467132416,\"p95\":467132416},\"unit\":\"MiB\",\"value\":467132416,\"valueDisplay\":\"445.49\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 412.28 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":432304128,\"median\":432304128,\"min\":432304128,\"p95\":432304128},\"unit\":\"MiB\",\"value\":432304128,\"valueDisplay\":\"412.28\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 335.57 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":351866880,\"median\":351866880,\"min\":351866880,\"p95\":351866880},\"unit\":\"MiB\",\"value\":351866880,\"valueDisplay\":\"335.57\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 75.21 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":78864384,\"median\":78864384,\"min\":78864384,\"p95\":78864384},\"unit\":\"MiB\",\"value\":78864384,\"valueDisplay\":\"75.21\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 337.07 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":353439744,\"median\":353439744,\"min\":353439744,\"p95\":353439744},\"unit\":\"MiB\",\"value\":353439744,\"valueDisplay\":\"337.07\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":239.25,\"valueDisplay\":\"239.25\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"react-dom/server stream + @tanstack/react-router renderRouterToStream · node:http · MAD 0 req/s · p95 337.78 ms · 334,661-335,367 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 4.49 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":4.490024658148397,\"median\":4.490024658148397,\"min\":4.490024658148397,\"p95\":4.490024658148397},\"unit\":\"ms/req\",\"value\":4.490024658148397,\"valueDisplay\":\"4.49\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 140.23 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":147038208,\"median\":147038208,\"min\":147038208,\"p95\":147038208},\"unit\":\"MiB\",\"value\":147038208,\"valueDisplay\":\"140.23\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 452.59 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":474578944,\"median\":474578944,\"min\":474578944,\"p95\":474578944},\"unit\":\"MiB\",\"value\":474578944,\"valueDisplay\":\"452.59\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 434.69 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":455806976,\"median\":455806976,\"min\":455806976,\"p95\":455806976},\"unit\":\"MiB\",\"value\":455806976,\"valueDisplay\":\"434.69\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 383.45 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":402075648,\"median\":402075648,\"min\":402075648,\"p95\":402075648},\"unit\":\"MiB\",\"value\":402075648,\"valueDisplay\":\"383.45\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 122.32 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":128266240,\"median\":128266240,\"min\":128266240,\"p95\":128266240},\"unit\":\"MiB\",\"value\":128266240,\"valueDisplay\":\"122.32\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 312.37 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":327540736,\"median\":327540736,\"min\":327540736,\"p95\":327540736},\"unit\":\"MiB\",\"value\":327540736,\"valueDisplay\":\"312.37\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":223.05,\"valueDisplay\":\"223.05\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 4 ms · p95 92 ms\",\"value\":84,\"valueDisplay\":\"84\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 3.3 MiB\",\"value\":3462630,\"valueDisplay\":\"3.3\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.18 MiB · p95 65.86 MiB\",\"value\":68110336,\"valueDisplay\":\"64.96\"}},\"primary\":false,\"rank\":\"11\"},{\"activeAvailable\":true,\"activeDetail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 340.34 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 16.3% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"198.7\",\"activeWidth\":\"12.5%\",\"caseId\":\"sveltekit\",\"label\":\"SvelteKit\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 340.34 ms · 303,353-303,887 B natural · saturation warning: the 128-connection probe was 16.3% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 5.04 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":5.0402617010568695,\"median\":5.0402617010568695,\"min\":5.0402617010568695,\"p95\":5.0402617010568695},\"unit\":\"ms/req\",\"value\":5.0402617010568695,\"valueDisplay\":\"5.04\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 207.11 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":217169920,\"median\":217169920,\"min\":217169920,\"p95\":217169920},\"unit\":\"MiB\",\"value\":217169920,\"valueDisplay\":\"207.11\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 372.59 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":390684672,\"median\":390684672,\"min\":390684672,\"p95\":390684672},\"unit\":\"MiB\",\"value\":390684672,\"valueDisplay\":\"372.59\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 371.81 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":389869568,\"median\":389869568,\"min\":389869568,\"p95\":389869568},\"unit\":\"MiB\",\"value\":389869568,\"valueDisplay\":\"371.81\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 316.41 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":331780096,\"median\":331780096,\"min\":331780096,\"p95\":331780096},\"unit\":\"MiB\",\"value\":331780096,\"valueDisplay\":\"316.41\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 206.33 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":216354816,\"median\":216354816,\"min\":216354816,\"p95\":216354816},\"unit\":\"MiB\",\"value\":216354816,\"valueDisplay\":\"206.33\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 165.48 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":173514752,\"median\":173514752,\"min\":173514752,\"p95\":173514752},\"unit\":\"MiB\",\"value\":173514752,\"valueDisplay\":\"165.48\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":198.7,\"valueDisplay\":\"198.7\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"SvelteKit production SSR (buffered synchronous route) · @sveltejs/adapter-node · MAD 0 req/s · p95 368.77 ms · 303,354-303,888 B natural · saturation warning: the 128-connection probe was 5.9% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 5.68 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":5.6785917092561045,\"median\":5.6785917092561045,\"min\":5.6785917092561045,\"p95\":5.6785917092561045},\"unit\":\"ms/req\",\"value\":5.6785917092561045,\"valueDisplay\":\"5.68\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 206.27 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":216285184,\"median\":216285184,\"min\":216285184,\"p95\":216285184},\"unit\":\"MiB\",\"value\":216285184,\"valueDisplay\":\"206.27\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 369.1 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":387031040,\"median\":387031040,\"min\":387031040,\"p95\":387031040},\"unit\":\"MiB\",\"value\":387031040,\"valueDisplay\":\"369.1\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 357.02 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":374362112,\"median\":374362112,\"min\":374362112,\"p95\":374362112},\"unit\":\"MiB\",\"value\":374362112,\"valueDisplay\":\"357.02\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 317 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":332394496,\"median\":332394496,\"min\":332394496,\"p95\":332394496},\"unit\":\"MiB\",\"value\":332394496,\"valueDisplay\":\"317\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 194.18 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":203616256,\"median\":203616256,\"min\":203616256,\"p95\":203616256},\"unit\":\"MiB\",\"value\":203616256,\"valueDisplay\":\"194.18\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 162.84 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":170745856,\"median\":170745856,\"min\":170745856,\"p95\":170745856},\"unit\":\"MiB\",\"value\":170745856,\"valueDisplay\":\"162.84\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":176.1,\"valueDisplay\":\"176.1\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 96 ms\",\"value\":86,\"valueDisplay\":\"86\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 4.84 MiB\",\"value\":5076142,\"valueDisplay\":\"4.84\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.48 MiB · p95 68.09 MiB\",\"value\":70533120,\"valueDisplay\":\"67.27\"}},\"primary\":false,\"rank\":\"12\"},{\"activeAvailable\":true,\"activeDetail\":\"Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 511.95 ms · 313,487-314,060 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"138.4\",\"activeWidth\":\"8.7%\",\"caseId\":\"next\",\"label\":\"Next.js\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Next.js production App Router SSR (fully collected at the framework's own Node http.Server response boundary before the response completes) · next start · MAD 0 req/s · p95 511.95 ms · 313,487-314,060 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 7.24 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":7.236271676300578,\"median\":7.236271676300578,\"min\":7.236271676300578,\"p95\":7.236271676300578},\"unit\":\"ms/req\",\"value\":7.236271676300578,\"valueDisplay\":\"7.24\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 268.32 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":281354240,\"median\":281354240,\"min\":281354240,\"p95\":281354240},\"unit\":\"MiB\",\"value\":281354240,\"valueDisplay\":\"268.32\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 456.79 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":478973952,\"median\":478973952,\"min\":478973952,\"p95\":478973952},\"unit\":\"MiB\",\"value\":478973952,\"valueDisplay\":\"456.79\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 412.05 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":432062464,\"median\":432062464,\"min\":432062464,\"p95\":432062464},\"unit\":\"MiB\",\"value\":432062464,\"valueDisplay\":\"412.05\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 388.91 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":407797760,\"median\":407797760,\"min\":407797760,\"p95\":407797760},\"unit\":\"MiB\",\"value\":407797760,\"valueDisplay\":\"388.91\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 223.58 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":234442752,\"median\":234442752,\"min\":234442752,\"p95\":234442752},\"unit\":\"MiB\",\"value\":234442752,\"valueDisplay\":\"223.58\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 188.46 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":197619712,\"median\":197619712,\"min\":197619712,\"p95\":197619712},\"unit\":\"MiB\",\"value\":197619712,\"valueDisplay\":\"188.46\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":138.4,\"valueDisplay\":\"138.4\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Next.js production App Router streaming SSR · next start · MAD 0 req/s · p95 500.92 ms · 313,487-314,060 B natural · saturation warning: the 128-connection probe was 6.7% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 7.07 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":7.07274011299435,\"median\":7.07274011299435,\"min\":7.07274011299435,\"p95\":7.07274011299435},\"unit\":\"ms/req\",\"value\":7.07274011299435,\"valueDisplay\":\"7.07\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 287.74 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":301715456,\"median\":301715456,\"min\":301715456,\"p95\":301715456},\"unit\":\"MiB\",\"value\":301715456,\"valueDisplay\":\"287.74\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 475.85 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":498966528,\"median\":498966528,\"min\":498966528,\"p95\":498966528},\"unit\":\"MiB\",\"value\":498966528,\"valueDisplay\":\"475.85\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 433.12 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":454156288,\"median\":454156288,\"min\":454156288,\"p95\":454156288},\"unit\":\"MiB\",\"value\":454156288,\"valueDisplay\":\"433.12\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 428.27 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":449069056,\"median\":449069056,\"min\":449069056,\"p95\":449069056},\"unit\":\"MiB\",\"value\":449069056,\"valueDisplay\":\"428.27\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 245 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":256905216,\"median\":256905216,\"min\":256905216,\"p95\":256905216},\"unit\":\"MiB\",\"value\":256905216,\"valueDisplay\":\"245\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 188.11 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":197251072,\"median\":197251072,\"min\":197251072,\"p95\":197251072},\"unit\":\"MiB\",\"value\":197251072,\"valueDisplay\":\"188.11\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":141.6,\"valueDisplay\":\"141.6\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 132 ms\",\"value\":92,\"valueDisplay\":\"92\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 3.7 MiB\",\"value\":3874340,\"valueDisplay\":\"3.69\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.13 MiB · p95 66.62 MiB\",\"value\":69007360,\"valueDisplay\":\"65.81\"}},\"primary\":false,\"rank\":\"13\"},{\"activeAvailable\":true,\"activeDetail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 552.62 ms · 280,229-280,941 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"76\",\"activeWidth\":\"4.8%\",\"caseId\":\"nuxt\",\"label\":\"Nuxt\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 552.62 ms · 280,229-280,941 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 13.2 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":13.203947368421053,\"median\":13.203947368421053,\"min\":13.203947368421053,\"p95\":13.203947368421053},\"unit\":\"ms/req\",\"value\":13.203947368421053,\"valueDisplay\":\"13.2\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 179.98 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":188719104,\"median\":188719104,\"min\":188719104,\"p95\":188719104},\"unit\":\"MiB\",\"value\":188719104,\"valueDisplay\":\"179.98\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 473.44 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":496439296,\"median\":496439296,\"min\":496439296,\"p95\":496439296},\"unit\":\"MiB\",\"value\":496439296,\"valueDisplay\":\"473.44\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 446.88 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":468586496,\"median\":468586496,\"min\":468586496,\"p95\":468586496},\"unit\":\"MiB\",\"value\":468586496,\"valueDisplay\":\"446.88\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 430.12 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":451014656,\"median\":451014656,\"min\":451014656,\"p95\":451014656},\"unit\":\"MiB\",\"value\":451014656,\"valueDisplay\":\"430.12\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 153.41 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":160866304,\"median\":160866304,\"min\":160866304,\"p95\":160866304},\"unit\":\"MiB\",\"value\":160866304,\"valueDisplay\":\"153.41\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 293.46 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":307720192,\"median\":307720192,\"min\":307720192,\"p95\":307720192},\"unit\":\"MiB\",\"value\":307720192,\"valueDisplay\":\"293.46\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":76,\"valueDisplay\":\"76\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Nuxt production SSR (buffered synchronous route) · nitro node-server · MAD 0 req/s · p95 572.65 ms · 280,229-280,941 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 13.55 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":13.547297297297296,\"median\":13.547297297297296,\"min\":13.547297297297296,\"p95\":13.547297297297296},\"unit\":\"ms/req\",\"value\":13.547297297297296,\"valueDisplay\":\"13.55\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 358.94 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":376373248,\"median\":376373248,\"min\":376373248,\"p95\":376373248},\"unit\":\"MiB\",\"value\":376373248,\"valueDisplay\":\"358.94\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 653.83 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":685588480,\"median\":685588480,\"min\":685588480,\"p95\":685588480},\"unit\":\"MiB\",\"value\":685588480,\"valueDisplay\":\"653.83\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 574.91 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":602836992,\"median\":602836992,\"min\":602836992,\"p95\":602836992},\"unit\":\"MiB\",\"value\":602836992,\"valueDisplay\":\"574.91\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 588.54 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":617132032,\"median\":617132032,\"min\":617132032,\"p95\":617132032},\"unit\":\"MiB\",\"value\":617132032,\"valueDisplay\":\"588.54\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 280.02 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":293621760,\"median\":293621760,\"min\":293621760,\"p95\":293621760},\"unit\":\"MiB\",\"value\":293621760,\"valueDisplay\":\"280.02\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 294.89 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":309215232,\"median\":309215232,\"min\":309215232,\"p95\":309215232},\"unit\":\"MiB\",\"value\":309215232,\"valueDisplay\":\"294.89\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":74,\"valueDisplay\":\"74\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 108 ms\",\"value\":94,\"valueDisplay\":\"94\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0 MiB · p95 3.45 MiB\",\"value\":3616128,\"valueDisplay\":\"3.45\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.29 MiB · p95 65.24 MiB\",\"value\":67778560,\"valueDisplay\":\"64.64\"}},\"primary\":false,\"rank\":\"14\"},{\"activeAvailable\":true,\"activeDetail\":\"Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 911.86 ms · 463,485-464,344 B natural · saturation warning: the 128-connection probe was 9.6% faster\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"70.5\",\"activeWidth\":\"4.4%\",\"caseId\":\"astro\",\"label\":\"Astro + Preact\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Astro production SSR + @astrojs/preact island (fully collected at the framework's own Node http.Server response boundary before the response completes) · @astrojs/node standalone · MAD 0 req/s · p95 911.86 ms · 463,485-464,344 B natural · saturation warning: the 128-connection probe was 9.6% faster\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 14.23 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":14.22695035460993,\"median\":14.22695035460993,\"min\":14.22695035460993,\"p95\":14.22695035460993},\"unit\":\"ms/req\",\"value\":14.22695035460993,\"valueDisplay\":\"14.23\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 254.24 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":266592256,\"median\":266592256,\"min\":266592256,\"p95\":266592256},\"unit\":\"MiB\",\"value\":266592256,\"valueDisplay\":\"254.24\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 580.63 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":608837632,\"median\":608837632,\"min\":608837632,\"p95\":608837632},\"unit\":\"MiB\",\"value\":608837632,\"valueDisplay\":\"580.63\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 536.42 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":562475008,\"median\":562475008,\"min\":562475008,\"p95\":562475008},\"unit\":\"MiB\",\"value\":562475008,\"valueDisplay\":\"536.42\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 368.86 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":386781184,\"median\":386781184,\"min\":386781184,\"p95\":386781184},\"unit\":\"MiB\",\"value\":386781184,\"valueDisplay\":\"368.86\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 210.03 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":220229632,\"median\":220229632,\"min\":220229632,\"p95\":220229632},\"unit\":\"MiB\",\"value\":220229632,\"valueDisplay\":\"210.03\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 326.39 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":342245376,\"median\":342245376,\"min\":342245376,\"p95\":342245376},\"unit\":\"MiB\",\"value\":342245376,\"valueDisplay\":\"326.39\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":70.5,\"valueDisplay\":\"70.5\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"Astro production streaming SSR + @astrojs/preact island · @astrojs/node standalone · MAD 0 req/s · p95 899.67 ms · 463,485-464,343 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 13.99 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":13.991625959525472,\"median\":13.991625959525472,\"min\":13.991625959525472,\"p95\":13.991625959525472},\"unit\":\"ms/req\",\"value\":13.991625959525472,\"valueDisplay\":\"13.99\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 202.26 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":212082688,\"median\":212082688,\"min\":212082688,\"p95\":212082688},\"unit\":\"MiB\",\"value\":212082688,\"valueDisplay\":\"202.26\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 528.61 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":554287104,\"median\":554287104,\"min\":554287104,\"p95\":554287104},\"unit\":\"MiB\",\"value\":554287104,\"valueDisplay\":\"528.61\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 546.57 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":573120512,\"median\":573120512,\"min\":573120512,\"p95\":573120512},\"unit\":\"MiB\",\"value\":573120512,\"valueDisplay\":\"546.57\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 373.93 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":392097792,\"median\":392097792,\"min\":392097792,\"p95\":392097792},\"unit\":\"MiB\",\"value\":392097792,\"valueDisplay\":\"373.93\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 220.22 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":230916096,\"median\":230916096,\"min\":230916096,\"p95\":230916096},\"unit\":\"MiB\",\"value\":230916096,\"valueDisplay\":\"220.22\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 326.35 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":342204416,\"median\":342204416,\"min\":342204416,\"p95\":342204416},\"unit\":\"MiB\",\"value\":342204416,\"valueDisplay\":\"326.35\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":71.65,\"valueDisplay\":\"71.65\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 8 ms · p95 156 ms\",\"value\":100,\"valueDisplay\":\"100\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.44 MiB\",\"value\":2557792,\"valueDisplay\":\"2.44\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 0.34 MiB · p95 62.38 MiB\",\"value\":64112640,\"valueDisplay\":\"61.14\"}},\"primary\":false,\"rank\":\"15\"},{\"activeAvailable\":true,\"activeDetail\":\"@lit-labs/ssr render (collected RenderResult) · node:http · MAD 0 req/s · p95 559.83 ms · 1,357,852-1,363,128 B natural\",\"activeUnit\":\"req/s\",\"activeValueDisplay\":\"69.9\",\"activeWidth\":\"4.4%\",\"caseId\":\"lit\",\"label\":\"Lit\",\"metrics\":{\"noStreamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@lit-labs/ssr render (collected RenderResult) · node:http · MAD 0 req/s · p95 559.83 ms · 1,357,852-1,363,128 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 14.33 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":14.334763948497853,\"median\":14.334763948497853,\"min\":14.334763948497853,\"p95\":14.334763948497853},\"unit\":\"ms/req\",\"value\":14.334763948497853,\"valueDisplay\":\"14.33\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 56.08 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":58802176,\"median\":58802176,\"min\":58802176,\"p95\":58802176},\"unit\":\"MiB\",\"value\":58802176,\"valueDisplay\":\"56.08\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 339.64 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":356134912,\"median\":356134912,\"min\":356134912,\"p95\":356134912},\"unit\":\"MiB\",\"value\":356134912,\"valueDisplay\":\"339.64\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 319.87 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":335409152,\"median\":335409152,\"min\":335409152,\"p95\":335409152},\"unit\":\"MiB\",\"value\":335409152,\"valueDisplay\":\"319.87\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 300.81 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":315424768,\"median\":315424768,\"min\":315424768,\"p95\":315424768},\"unit\":\"MiB\",\"value\":315424768,\"valueDisplay\":\"300.81\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 36.31 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":38076416,\"median\":38076416,\"min\":38076416,\"p95\":38076416},\"unit\":\"MiB\",\"value\":38076416,\"valueDisplay\":\"36.31\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 283.56 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":297332736,\"median\":297332736,\"min\":297332736,\"p95\":297332736},\"unit\":\"MiB\",\"value\":297332736,\"valueDisplay\":\"283.56\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":69.9,\"valueDisplay\":\"69.9\"},\"streamingRequestsPerSecond\":{\"available\":true,\"detail\":\"@lit-labs/ssr RenderResultReadable (declarative shadow DOM) · node:http · MAD 0 req/s · p95 1,451.62 ms · 1,357,852-1,363,128 B natural\",\"serverTelemetry\":{\"available\":true,\"availableRounds\":1,\"cpuMillisecondsPerRequest\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 ms/req · p95 118.12 ms/req\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":118.11764705882354,\"median\":118.11764705882354,\"min\":118.11764705882354,\"p95\":118.11764705882354},\"unit\":\"ms/req\",\"value\":118.11764705882354,\"valueDisplay\":\"118.12\"},\"loadDeltaPeakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 28.07 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":29433856,\"median\":29433856,\"min\":29433856,\"p95\":29433856},\"unit\":\"MiB\",\"value\":29433856,\"valueDisplay\":\"28.07\"},\"peakRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 368.8 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":386715648,\"median\":386715648,\"min\":386715648,\"p95\":386715648},\"unit\":\"MiB\",\"value\":386715648,\"valueDisplay\":\"368.8\"},\"postSettleRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 338.05 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":354471936,\"median\":354471936,\"min\":354471936,\"p95\":354471936},\"unit\":\"MiB\",\"value\":354471936,\"valueDisplay\":\"338.05\"},\"postWarmupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 345.2 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":361971712,\"median\":361971712,\"min\":361971712,\"p95\":361971712},\"unit\":\"MiB\",\"value\":361971712,\"valueDisplay\":\"345.2\"},\"reason\":null,\"reasons\":[],\"retainedRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 -2.68 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":-2809856,\"median\":-2809856,\"min\":-2809856,\"p95\":-2809856},\"unit\":\"MiB\",\"value\":-2809856,\"valueDisplay\":\"-2.68\"},\"startupRssBytes\":{\"available\":true,\"detail\":\"1 measured round · MAD 0 MiB · p95 340.73 MiB\",\"statistics\":{\"count\":1,\"mad\":0,\"max\":357281792,\"median\":357281792,\"min\":357281792,\"p95\":357281792},\"unit\":\"MiB\",\"value\":357281792,\"valueDisplay\":\"340.73\"},\"status\":\"available\",\"unavailableRounds\":0},\"value\":8.5,\"valueDisplay\":\"8.5\"},\"largestContentfulPaintMs\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 6 ms · p95 108 ms\",\"value\":78,\"valueDisplay\":\"78\"},\"jsHeapUsedBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD <0.01 MiB · p95 2.87 MiB\",\"value\":3007974,\"valueDisplay\":\"2.87\"},\"rendererPrivateBytes\":{\"available\":true,\"detail\":\"10 isolated runs · MAD 1.01 MiB · p95 75.23 MiB\",\"value\":76871680,\"valueDisplay\":\"73.31\"}},\"primary\":false,\"rank\":\"16\"}],\"responseMode\":\"comparison\",\"saturationWarnings\":{\"noStreaming\":[{\"caseId\":\"astro\",\"gainPercent\":9.569377990430622,\"label\":\"Astro + Preact\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"webui-bun-serve\",\"gainPercent\":8.47535697835099,\"label\":\"WebUI / Light DOM / Bun.serve\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"sveltekit\",\"gainPercent\":16.261398176291795,\"label\":\"SvelteKit\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"}],\"streaming\":[{\"caseId\":\"next\",\"gainPercent\":6.666666666666667,\"label\":\"Next.js\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"webui-node-http\",\"gainPercent\":5.974652987326494,\"label\":\"WebUI / Light DOM / Node node:http\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"webui-bun-serve\",\"gainPercent\":9.252217997465145,\"label\":\"WebUI / Light DOM / Bun.serve\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"},{\"caseId\":\"sveltekit\",\"gainPercent\":5.92,\"label\":\"SvelteKit\",\"measuredConnections\":64,\"probeConnections\":128,\"reason\":\"Throughput was still increasing at the largest connection count\"}]},\"selectedMetric\":\"noStreamingRequestsPerSecond\",\"selectedMetricDescription\":\"Dynamic SSR throughput when each framework sends one fully collected HTML response without progressive boundaries.\",\"selectedMetricLabel\":\"No Streaming RPS\",\"title\":\"Complete response or streaming boundaries. Choose the metric.\",\"responseModes\":[\"complete\",\"progressive\"],\"selectiveRefresh\":{\"baseCommit\":\"365f0046ba5e718b185817b83dc7d57b90bb57b2\",\"caseIds\":[\"webui-bun-serve\",\"webui-deno-serve\",\"webui-node-http\"],\"refreshedAt\":\"2026-09-04T03:28:11.463Z\",\"refreshedCommit\":\"25729eac3583397746585b938dfe5cf300922b39\",\"statement\":\"Only the listed cases were rerun. Every other row retains its prior official measurement.\"}}"
 }


### PR DESCRIPTION
The benchmark homepage needs server resource data that remains easy to compare, and the docs development server must stay idle when recursive watchers encounter read-only activity through workspace links.

## Summary

- Filter access-only and existing-directory watcher events before debounce, disable recursive symlink traversal, and retain lexical `node_modules` exclusions for linked pnpm workspaces.
- Add regression coverage for read events and pnpm-style symlink trees.
- Publish regenerated benchmark telemetry with compact Peak RSS and CPU/request columns for RPS rankings.
- Move benchmark methodology and complete server resource lifecycle values into an accessible, responsive Details disclosure.
- Correct the benchmark explorer default to No Streaming RPS and keep metric-specific ranking updates structured.

## Validation

- `cargo xtask check`
